### PR TITLE
Upgrading to Lucene 7.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <name>Anserini retrieval platform</name>
 
   <properties>
-    <LUCENE_VERSION>6.3.0</LUCENE_VERSION>
+    <LUCENE_VERSION>7.2.0</LUCENE_VERSION>
     <!-- see http://download.eclipse.org/jetty/ Jetty9 forces Java 1.8, which causes all sorts of headaches
     For display special characters such as emoji expression, please set JETTY_VERSION to 9.3.5.v20151012 -->
     <JETTY_VERSION>8.1.17.v20150415</JETTY_VERSION>

--- a/src/main/java/io/anserini/ltr/feature/base/TFIDFFeatureExtractor.java
+++ b/src/main/java/io/anserini/ltr/feature/base/TFIDFFeatureExtractor.java
@@ -55,7 +55,7 @@ public class TFIDFFeatureExtractor implements FeatureExtractor{
 
     // number of query tokens found
     // how many of our query tokens were found
-    float coord = similarity.coord(countMap.size(), context.getQueryTokens().size());
+    float coord = countMap.size() / context.getQueryTokens().size();
 
     for (String token : context.getQueryTokens()) {
       long termFreq = countMap.containsKey(token) ? countMap.get(token) : 0;

--- a/src/main/java/io/anserini/rts/TitleCoordSimilarity.java
+++ b/src/main/java/io/anserini/rts/TitleCoordSimilarity.java
@@ -7,18 +7,6 @@ import org.apache.lucene.util.BytesRef;
 public class TitleCoordSimilarity extends TFIDFSimilarity {
 
   @Override
-  public float coord(int overlap, int maxOverlap) {
-    // TODO Auto-generated method stub
-    return 1.0f / maxOverlap;
-  }
-
-  @Override
-  public float queryNorm(float sumOfSquaredWeights) {
-    // TODO Auto-generated method stub
-    return 1.0f;
-  }
-
-  @Override
   public float tf(float freq) {
     // TODO Auto-generated method stub
     if (freq > 0)
@@ -34,22 +22,10 @@ public class TitleCoordSimilarity extends TFIDFSimilarity {
   }
 
   @Override
-  public float lengthNorm(FieldInvertState state) {
+  public float lengthNorm(int var) {
     // TODO Auto-generated method stub
     // return state.getLength();
     return 1.0f;
-  }
-
-  @Override
-  public float decodeNormValue(long norm) {
-    // TODO Auto-generated method stub
-    return 1.0f;
-  }
-
-  @Override
-  public long encodeNormValue(float f) {
-    // TODO Auto-generated method stub
-    return (long) f;
   }
 
   @Override

--- a/src/main/java/io/anserini/rts/TitleExpansionSimilarity.java
+++ b/src/main/java/io/anserini/rts/TitleExpansionSimilarity.java
@@ -7,18 +7,6 @@ import org.apache.lucene.util.BytesRef;
 public class TitleExpansionSimilarity extends TFIDFSimilarity {
 
   @Override
-  public float coord(int overlap, int maxOverlap) {
-    // TODO Auto-generated method stub
-    return 1.0f;
-  }
-
-  @Override
-  public float queryNorm(float sumOfSquaredWeights) {
-    // TODO Auto-generated method stub
-    return 1;
-  }
-
-  @Override
   public float tf(float freq) {
     // TODO Auto-generated method stub
     if (freq > 0)
@@ -34,24 +22,11 @@ public class TitleExpansionSimilarity extends TFIDFSimilarity {
   }
 
   @Override
-  public float lengthNorm(FieldInvertState state) {
+  public float lengthNorm(int var) {
     // TODO Auto-generated method stub
     // return state.getLength();
     return 1.0f;
     // return state.getBoost();
-  }
-
-  @Override
-  public float decodeNormValue(long norm) {
-    // TODO Auto-generated method stub
-    // return (float)norm;
-    return 1.0f;
-  }
-
-  @Override
-  public long encodeNormValue(float f) {
-    // TODO Auto-generated method stub
-    return (long) f;
   }
 
   @Override

--- a/src/main/java/io/anserini/search/similarity/RankLibSimilarity.java
+++ b/src/main/java/io/anserini/search/similarity/RankLibSimilarity.java
@@ -18,7 +18,7 @@ public class RankLibSimilarity extends Similarity {
   }
 
   @Override
-  public SimWeight computeWeight(CollectionStatistics collectionStatistics, TermStatistics... termStatisticses) {
+  public SimWeight computeWeight(float weight, CollectionStatistics collectionStatistics, TermStatistics... termStatisticses) {
     return null;
   }
 

--- a/src/test/java/io/anserini/index/IndexerTest.java
+++ b/src/test/java/io/anserini/index/IndexerTest.java
@@ -158,6 +158,16 @@ public class IndexerTest {
       System.out.println("Getting custom postings reader...");
       return new MyFieldsProducer(in.getPostingsReader());
     }
+
+    @Override
+    public CacheHelper getReaderCacheHelper() {
+      return null;
+    }
+
+    @Override
+    public CacheHelper getCoreCacheHelper() {
+      return null;
+    }
   }
 
   // Custom class so we can intercept calls and potentially alter behavior.


### PR DESCRIPTION
Lucene has upgraded to 7.2.0 (we are with 6.3.0). 
AFAIK, they've changed the ranking similarity, e.g. BM25.
I've tested the impact using Robust04. Robust04 has 250 queries and thus makes it ideal to test the overall impact.

Some conclusions:

1. `IndexUtils` gives exactly the same numbers and the size of the folders differ a little bit.
```
$ ~/Anserini/target/appassembler/bin/IndexUtils -index disk45.cnt.pos -stats
Index statistics
----------------
documents:             528030
documents (non-empty): 528030
unique terms:          923435
total terms:           174540587
stored fields:
  contents (indexOption: DOCS_AND_FREQS_AND_POSITIONS, hasVectors: false, hasPayloads: false)
  id (indexOption: DOCS, hasVectors: false, hasPayloads: false)
$ ~/Anserini/target/appassembler/bin/IndexUtils -index ../index/disk45.cnt.pos/ -stats
Index statistics
----------------
documents:             528030
documents (non-empty): 528030
unique terms:          923435
total terms:           174540587
stored fields:
  contents (indexOption: DOCS_AND_FREQS_AND_POSITIONS, hasVectors: false, hasPayloads: false)
  id (indexOption: DOCS, hasVectors: false, hasPayloads: false)
```

2. New version can read old index but old version cannot read index generated from new version.

3. Search wise, I've tested 3 scenarios: using Lucene63 against Lucene63 index (`Lucene63`), using Lucene72 against Lucene72 index (`Lucene72`), using Lucene72 against Lucene63 index (`Lucene72_63`)

Version | Lucene63 | Lucene72 | Lucene72_63 
------|---------|--------------|----
Disk12 | 0.2267 | 0.2281 | 0.2267
Robust04 | 0.2499 | 0.2530 | 0.2499
AQUAINT | 0.2004 | 0.2031 | 0.2004
Wt10g | 0.1981 | 0.1993 | 0.1981
Gov2 | 0.3033 | 0.3056 | 0.3033
CW0b | 0.1405 | 0.1421 | 0.1405
CW12b13 | 0.1216 | 0.1233 | 0.1216

The difference is small enough to ignore.

And in the long term it is better to keep the pace with Lucene.