### PR TITLE
Refactor Collection class a bit; Add Document tests

### DIFF
--- a/src/main/java/io/anserini/collection/CW09Collection.java
+++ b/src/main/java/io/anserini/collection/CW09Collection.java
@@ -29,6 +29,7 @@ public class CW09Collection extends WarcCollection<ClueWeb09WarcRecord> {
   public class FileSegment extends WarcCollection.FileSegment {
     private FileSegment(Path path) throws IOException {
       super(path);
+      dType = new ClueWeb09WarcRecord();
     }
 
     @Override

--- a/src/main/java/io/anserini/collection/CW12Collection.java
+++ b/src/main/java/io/anserini/collection/CW12Collection.java
@@ -29,6 +29,7 @@ public class CW12Collection extends WarcCollection<ClueWeb12WarcRecord> {
   public class FileSegment extends WarcCollection.FileSegment {
     public FileSegment(Path path) throws IOException {
       super(path);
+      dType = new ClueWeb12WarcRecord();
     }
 
     @Override

--- a/src/main/java/io/anserini/collection/Gov2Collection.java
+++ b/src/main/java/io/anserini/collection/Gov2Collection.java
@@ -31,8 +31,8 @@ import java.util.Set;
 public class Gov2Collection extends TrecwebCollection<TrecwebDocument> {
 
   public class FileSegment extends TrecwebCollection.FileSegment {
-    protected FileSegment(Path curInputFile) throws IOException {
-      super(curInputFile);
+    protected FileSegment(Path path) throws IOException {
+      super(path);
     }
   }
 

--- a/src/main/java/io/anserini/collection/TrecCollection.java
+++ b/src/main/java/io/anserini/collection/TrecCollection.java
@@ -16,10 +16,7 @@
 
 package io.anserini.collection;
 
-import io.anserini.document.SourceDocument;
 import io.anserini.document.TrecDocument;
-import org.apache.commons.compress.compressors.z.ZCompressorInputStream;
-
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
@@ -36,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.zip.GZIPInputStream;
+import org.apache.commons.compress.compressors.z.ZCompressorInputStream;
 
 /**
  * Class representing an instance of a TREC collection.

--- a/src/main/java/io/anserini/collection/TrecCollection.java
+++ b/src/main/java/io/anserini/collection/TrecCollection.java
@@ -16,6 +16,7 @@
 
 package io.anserini.collection;
 
+import io.anserini.document.SourceDocument;
 import io.anserini.document.TrecDocument;
 import org.apache.commons.compress.compressors.z.ZCompressorInputStream;
 
@@ -42,12 +43,10 @@ import java.util.zip.GZIPInputStream;
 public class TrecCollection<D extends TrecDocument> extends Collection {
 
   public class FileSegment extends Collection.FileSegment {
-    protected BufferedReader bufferedReader;
-    protected final int BUFFER_SIZE = 1 << 16; // 64K
 
-    protected FileSegment() {}
+    public FileSegment(Path path) throws IOException {
+      dType = new TrecDocument();
 
-    protected FileSegment(Path path) throws IOException {
       this.path = path;
       this.bufferedReader = null;
       String fileName = path.toString();
@@ -63,34 +62,6 @@ public class TrecCollection<D extends TrecDocument> extends Collection {
       } else { // plain text file
         bufferedReader = new BufferedReader(new FileReader(fileName));
       }
-    }
-
-    @Override
-    public void close() throws IOException {
-      atEOF = false;
-      if (bufferedReader != null) {
-        bufferedReader.close();
-      }
-    }
-
-    @Override
-    public boolean hasNext() {
-      return !atEOF;
-    }
-
-    @Override
-    public D next() {
-      TrecDocument doc = new TrecDocument();
-      try {
-        doc = (TrecDocument) doc.readNextRecord(bufferedReader);
-        if (doc == null) {
-          atEOF = true;
-          doc = null;
-        }
-      } catch (IOException e1) {
-        doc = null;
-      }
-      return (D) doc;
     }
   }
 

--- a/src/main/java/io/anserini/collection/TrecCoreCollection.java
+++ b/src/main/java/io/anserini/collection/TrecCoreCollection.java
@@ -34,10 +34,10 @@ public class TrecCoreCollection extends Collection<TrecCoreDocument> {
 
     @Override
     public TrecCoreDocument next() {
-      TrecCoreDocument doc = new TrecCoreDocument();
+      TrecCoreDocument doc = new TrecCoreDocument(new File(fileName));
       atEOF = true;
       try {
-        doc = (TrecCoreDocument) doc.readNextRecord(new File(fileName));
+        doc = (TrecCoreDocument) doc.readNextRecord(bufferedReader);
       } catch (IOException e) {
         doc = null;
       }

--- a/src/main/java/io/anserini/collection/TrecwebCollection.java
+++ b/src/main/java/io/anserini/collection/TrecwebCollection.java
@@ -32,47 +32,13 @@ import java.util.zip.GZIPInputStream;
 /**
  * Class representing an instance of a TREC web collection.
  */
-public abstract class TrecwebCollection<D extends TrecwebDocument> extends TrecCollection {
+public class TrecwebCollection<D extends TrecwebDocument> extends TrecCollection {
 
   public class FileSegment extends TrecCollection.FileSegment {
-    protected BufferedReader bufferedReader;
-    protected final int BUFFER_SIZE = 1 << 16; // 64K
 
-    protected FileSegment(Path path) throws IOException {
-      this.path = path;
-      this.bufferedReader = null;
-      String fileName = path.toString();
-      if (fileName.endsWith(".gz")) { //.gz
-        InputStream stream = new GZIPInputStream(
-            Files.newInputStream(path, StandardOpenOption.READ), BUFFER_SIZE);
-        bufferedReader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
-      } else { // in case user had already uncompressed the folder
-        bufferedReader = new BufferedReader(new FileReader(fileName));
-      }
-    }
-
-    @Override
-    public void close() throws IOException {
-      atEOF = false;
-      if (bufferedReader != null) {
-        bufferedReader.close();
-      }
-    }
-
-    @Override
-    public D next() {
-      TrecwebDocument doc = new TrecwebDocument();
-      try {
-        doc = (TrecwebDocument) doc.readNextRecord(bufferedReader);
-        if (doc == null) {
-          atEOF = true;
-          doc = null;
-        }
-      } catch (IOException e1) {
-        doc = null;
-      }
-      return (D) doc;
+    public FileSegment(Path path) throws IOException {
+      super(path);
+      dType = new TrecwebDocument();
     }
   }
-
 }

--- a/src/main/java/io/anserini/collection/WikipediaCollection.java
+++ b/src/main/java/io/anserini/collection/WikipediaCollection.java
@@ -34,7 +34,7 @@ import java.util.Set;
  * as a single bz2 file. Since a collection is assumed to be in a directory, place the bz2 file in
  * a directory prior to indexing.
  */
-public class WikipediaCollection extends Collection<WikipediaArticle> {
+public class WikipediaCollection<D extends WikipediaArticle> extends Collection {
 
   public class FileSegment extends Collection.FileSegment {
     private final WikipediaBz2DumpInputStream stream;
@@ -47,16 +47,6 @@ public class WikipediaCollection extends Collection<WikipediaArticle> {
       cleaner = new WikiCleanBuilder()
           .withLanguage(WikiLanguage.EN).withTitle(false)
           .withFooter(false).build();
-    }
-
-    @Override
-    public void close() throws IOException {
-      atEOF = false;
-    }
-
-    @Override
-    public boolean hasNext() {
-      return !atEOF;
     }
 
     @Override

--- a/src/main/java/io/anserini/document/SourceDocument.java
+++ b/src/main/java/io/anserini/document/SourceDocument.java
@@ -16,6 +16,10 @@
 
 package io.anserini.document;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.Iterator;
+
 /**
  * A raw document from a collection to be indexed. We explicitly distinguish a source document from
  * a Lucene document, which is the Lucene representation that is ready to be indexed.
@@ -42,4 +46,14 @@ public interface SourceDocument {
    * @return <code>true</code> if this document is meant to be indexed
    */
   boolean indexable();
+
+
+  /**
+   * We assume that one source document contains multiple records.
+   * These records are also of type SourceDocument and are split by
+   * type-dependent delimiters.
+   *
+   * @return the next record
+   */
+  SourceDocument readNextRecord(BufferedReader reader) throws IOException;
 }

--- a/src/main/java/io/anserini/document/TrecCoreDocument.java
+++ b/src/main/java/io/anserini/document/TrecCoreDocument.java
@@ -3,15 +3,27 @@ package io.anserini.document;
 import io.anserini.document.nyt.NYTCorpusDocument;
 import io.anserini.document.nyt.NYTCorpusDocumentParser;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.nio.Buffer;
 
 /**
  * A TREC Core document.
  */
-public class TrecCoreDocument implements  SourceDocument{
-  private String id;
-  private String contents;
+public class TrecCoreDocument implements SourceDocument {
+  protected String id;
+  protected String contents;
+  protected File file;
+
+  public TrecCoreDocument(File file) {
+    this.file = file;
+  }
+
+  @Override
+  public SourceDocument readNextRecord(BufferedReader bRdr) throws IOException {
+    return readNextRecord(file);
+  }
 
   public SourceDocument readNextRecord(File fileName) throws IOException {
     NYTCorpusDocumentParser nytParser = new NYTCorpusDocumentParser();

--- a/src/main/java/io/anserini/document/TrecDocument.java
+++ b/src/main/java/io/anserini/document/TrecDocument.java
@@ -42,6 +42,7 @@ public class TrecDocument implements SourceDocument {
   protected String id;
   protected String content;
 
+  @Override
   public SourceDocument readNextRecord(BufferedReader reader) throws IOException {
     StringBuilder builder = new StringBuilder();
     boolean found = false;
@@ -86,7 +87,12 @@ public class TrecDocument implements SourceDocument {
           }
         }
         if (inTag >= 0) {
-          builder.append(line).append("\n");
+          if (line.endsWith(endTags[inTag])) {
+            builder.append(line).append("\n");
+            inTag = -1;
+          } else {
+            builder.append(line).append("\n");
+          }
         }
       }
 
@@ -122,5 +128,7 @@ public class TrecDocument implements SourceDocument {
   }
 
   @Override
-  public boolean indexable() { return true; }
+  public boolean indexable() {
+    return true;
+  }
 }

--- a/src/main/java/io/anserini/document/TwitterDocument.java
+++ b/src/main/java/io/anserini/document/TwitterDocument.java
@@ -5,19 +5,35 @@ import com.google.gson.JsonParser;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 
 /**
  * A Twitter document (status).
  */
 public class TwitterDocument implements SourceDocument {
-  private String id;
-  private String contents;
+  private boolean keepRetweets;
+  protected String id;
+  protected String content;
 
   private static final Logger LOG = LogManager.getLogger(io.anserini.document.twitter.Status.class);
   private static final JsonParser JSON_PARSER = new JsonParser();
 
-  public SourceDocument readNextRecord(String json, boolean keepRetweets) throws IOException {
+  public TwitterDocument(boolean keepRetweets) {
+    super();
+    this.keepRetweets = keepRetweets;
+  }
+
+  @Override
+  public SourceDocument readNextRecord(BufferedReader reader) throws IOException {
+    String line = reader.readLine();
+    if (line == null) {
+      return null;
+    }
+    return readNextRecord(line);
+  }
+
+  public SourceDocument readNextRecord(String json) throws IOException {
     JsonObject obj = null;
     try {
       obj = (JsonObject) JSON_PARSER.parse(json);
@@ -40,7 +56,7 @@ public class TwitterDocument implements SourceDocument {
       }
     }
 
-    contents = obj.get("text").getAsString();
+    content = obj.get("text").getAsString();
     id = obj.get("id").getAsString();
     return this;
   }
@@ -52,7 +68,7 @@ public class TwitterDocument implements SourceDocument {
 
   @Override
   public String content() {
-    return contents;
+    return content;
   }
 
   @Override

--- a/src/main/java/io/anserini/document/WarcRecord.java
+++ b/src/main/java/io/anserini/document/WarcRecord.java
@@ -16,12 +16,20 @@
 
 package io.anserini.document;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+
 /**
  * Abstract base class for WARC records from ClueWeb09 and ClueWeb12.
  */
 public abstract class WarcRecord implements SourceDocument {
   public abstract String url();
   public abstract String type();
+
+  @Override
+  public SourceDocument readNextRecord(BufferedReader bRdr) throws IOException {
+    return null;
+  }
 
   @Override
   public boolean indexable() {

--- a/src/main/java/io/anserini/document/WikipediaArticle.java
+++ b/src/main/java/io/anserini/document/WikipediaArticle.java
@@ -16,6 +16,9 @@
 
 package io.anserini.document;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+
 /**
  * A Wikipedia article. The article title serves as the id.
  */
@@ -26,6 +29,12 @@ public class WikipediaArticle implements SourceDocument {
   public WikipediaArticle(String title, String contents) {
     this.title = title;
     this.contents = contents;
+
+  }
+
+  @Override
+  public SourceDocument readNextRecord(BufferedReader bRdr) throws IOException {
+    return null;
   }
 
   @Override

--- a/src/main/java/io/anserini/eval/EvalArgs.java
+++ b/src/main/java/io/anserini/eval/EvalArgs.java
@@ -21,6 +21,8 @@ public class EvalArgs {
           +" For example, -m map p.30 ndcg.20")
   String[] reqMetrics;
 
-  @Option(name = "-q", handler = BooleanOptionHandler.class, usage = "Print the internal document IDs of documents")
+  @Option(name = "-q", handler = BooleanOptionHandler.class,
+      usage = "In additional to print the average performance over all query topics, also " +
+          "print the per query performance")
   boolean printPerQuery;
 }

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -127,7 +127,7 @@ public final class IndexCollection {
         Collection.FileSegment iter = collection.createFileSegment(inputFile);
         while (iter.hasNext()) {
           SourceDocument d = (SourceDocument) iter.next();
-          if (d == null || !d.indexable()) {
+          if (d == null) {
             continue;
           }
 

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -127,7 +127,7 @@ public final class IndexCollection {
         Collection.FileSegment iter = collection.createFileSegment(inputFile);
         while (iter.hasNext()) {
           SourceDocument d = (SourceDocument) iter.next();
-          if (d == null) {
+          if (d == null || !d.indexable()) {
             continue;
           }
 

--- a/src/main/java/io/anserini/search/query/QaTopicReader.java
+++ b/src/main/java/io/anserini/search/query/QaTopicReader.java
@@ -1,5 +1,6 @@
 package io.anserini.search.query;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -17,16 +18,18 @@ public class QaTopicReader extends TopicReader {
   }
 
   @Override
-  public SortedMap<Integer, String> read() throws IOException {
+  public SortedMap<Integer, String> read(BufferedReader bRdr) throws IOException {
     SortedMap<Integer, String> map = new TreeMap<>();
-    List<String> lines = Files.readAllLines(topicFile, StandardCharsets.UTF_8);
+
 
     String pattern = "<QApairs id=\'(.*)\'>";
     Pattern r = Pattern.compile(pattern);
 
     String prevLine = "";
     String id = "";
-    for (String line : lines) {
+
+    String line;
+    while ((line = bRdr.readLine()) != null) {
       Matcher m = r.matcher(line);
 
       if (m.find()) {

--- a/src/main/java/io/anserini/search/query/TopicReader.java
+++ b/src/main/java/io/anserini/search/query/TopicReader.java
@@ -17,15 +17,38 @@ package io.anserini.search.query;
  * limitations under the License.
  */
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.SortedMap;
 
 public abstract class TopicReader {
   protected Path topicFile;
 
+  public TopicReader() {
+
+  }
+
   public TopicReader(Path topicFile) {
     this.topicFile = topicFile;
   }
-  abstract public SortedMap<Integer, String> read() throws IOException;
+
+  public SortedMap<Integer, String> read() throws IOException {
+    InputStream topics = Files.newInputStream(topicFile, StandardOpenOption.READ);
+    BufferedReader bRdr = new BufferedReader(new InputStreamReader(topics, StandardCharsets.UTF_8));
+    return read(bRdr);
+  }
+
+  public SortedMap<Integer, String> read(String str) throws IOException {
+    BufferedReader bRdr = new BufferedReader(new StringReader(str));
+    return read(bRdr);
+  }
+
+  abstract public SortedMap<Integer, String> read(BufferedReader bRdr) throws IOException;
 }

--- a/src/main/java/io/anserini/search/query/TrecTopicReader.java
+++ b/src/main/java/io/anserini/search/query/TrecTopicReader.java
@@ -21,6 +21,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,7 +30,7 @@ import java.util.HashMap;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-public class TrecTopicReader extends TopicReader{
+public class TrecTopicReader extends TopicReader {
 
   public TrecTopicReader(Path topicFile) {
     super(topicFile);
@@ -65,10 +66,20 @@ public class TrecTopicReader extends TopicReader{
 
   @Override
   public SortedMap<Integer, String> read() throws IOException {
-    SortedMap<Integer, String> map = new TreeMap<>();
-    // prepare topics
     InputStream topics = Files.newInputStream(topicFile, StandardOpenOption.READ);
     BufferedReader bRdr = new BufferedReader(new InputStreamReader(topics, StandardCharsets.UTF_8));
+    return read(bRdr);
+  }
+
+  @Override
+  public SortedMap<Integer, String> read(String str) throws IOException {
+    BufferedReader bRdr = new BufferedReader(new StringReader(str));
+    return read(bRdr);
+  }
+
+  @Override
+  public SortedMap<Integer, String> read(BufferedReader bRdr) throws IOException {
+    SortedMap<Integer, String> map = new TreeMap<>();
     StringBuilder sb;
     try {
       while (null!=(sb=read(bRdr,"<top>",null,false,false))) {
@@ -95,7 +106,7 @@ public class TrecTopicReader extends TopicReader{
           title = sb.substring(k+1).trim();
         }
 
-	// description
+	      // description
         read(bRdr,"<desc>",null,false,false);
         sb.setLength(0);
         String line = null;

--- a/src/main/java/io/anserini/search/query/WebxmlTopicReader.java
+++ b/src/main/java/io/anserini/search/query/WebxmlTopicReader.java
@@ -17,6 +17,7 @@ package io.anserini.search.query;
  * limitations under the License.
  */
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -26,10 +27,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 public class WebxmlTopicReader extends TopicReader{
-
-  public WebxmlTopicReader(Path topicFile) {
-    super(topicFile);
-  }
 
   private String extract(String line, String tag) {
     int i = line.indexOf(tag);
@@ -51,14 +48,15 @@ public class WebxmlTopicReader extends TopicReader{
    * @throws IOException
    */
   @Override
-  public SortedMap<Integer, String> read() throws IOException {
+  public SortedMap<Integer, String> read(BufferedReader bRdr) throws IOException {
     SortedMap<Integer, String> map = new TreeMap<>();
-    List<String> lines = Files.readAllLines(topicFile, StandardCharsets.UTF_8);
 
     String number = "";
     String query = "";
 
-    for (String line : lines) {
+    String line;
+
+    while ((line = bRdr.readLine()) != null) {
       line = line.trim();
       if (line.startsWith("<topic"))
         number = extract(line, "number");
@@ -68,7 +66,6 @@ public class WebxmlTopicReader extends TopicReader{
         map.put(Integer.parseInt(number), query);
     }
 
-    lines.clear();
     return map;
   }
 }

--- a/src/test/java/io/anserini/document/ClueWeb09WarcRecordTest.java
+++ b/src/test/java/io/anserini/document/ClueWeb09WarcRecordTest.java
@@ -1,0 +1,99 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.document;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import org.apache.tools.ant.filters.StringInputStream;
+import org.junit.Before;
+
+
+public class ClueWeb09WarcRecordTest extends DocumentTest {
+
+  @Before
+  public void setUP() throws Exception {
+    super.setUp();
+
+    // WARC-Type: warcinfo is not indexable
+    rawDocs.add(
+        "WARC/0.18\n" +
+        "WARC-Type: warcinfo\n" +
+        "WARC-Date: 2009-03-65T08:43:19-0800\n" +
+        "WARC-Record-ID: <urn:uuid:11111111-2222-3333-4444-555555555555>\n" +
+        "Content-Type: application/warc-fields\n" +
+        "Content-Length: 219\n" +
+        "\n" +
+        "software: Nutch 1.0-dev (modified for clueweb09)\n" +
+        "isPartOf: clueweb09-en\n" +
+        "description: clueweb09 crawl with WARC output\n" +
+        "format: WARC file version 0.18\n" +
+        "conformsTo: http://www.archive.org/documents/WarcFileFormat-0.18.html\n"
+    );
+
+    rawDocs.add(
+        "WARC/0.18\n" +
+        "WARC-Type: response\n" +
+        "WARC-Target-URI: http://clueweb09.test.com/\n" +
+        "WARC-Warcinfo-ID: 993d3969-9643-4934-b1c6-68d4dbe55b83\n" +
+        "WARC-Date: 2009-03-65T08:43:19-0800\n" +
+        "WARC-Record-ID: <urn:uuid:6f12f095-18a8-4415-8f04-ec2477be81d5>\n" +
+        "WARC-TREC-ID: clueweb09-az0000-00-00000\n" +
+        "Content-Type: application/http;msgtype=response\n" +
+        "WARC-Identified-Payload-Type: \n" +
+        "Content-Length: 345\n" + // The Content-Length MUST match the length of the record!!!
+        "\n" +
+        "HTTP/1.1 200 OK\n" +
+        "Content-Type: text/html\n" +
+        "Date: Tue, 13 Jan 2009 18:05:10 GMT\n" +
+        "Pragma: no-cache\n" +
+        "Cache-Control: no-cache, must-revalidate\n" +
+        "X-Powered-By: PHP/4.4.8\n" +
+        "Server: WebServerX\n" +
+        "Connection: close\n" +
+        "Last-Modified: Tue, 13 Jan 2009 18:05:10 GMT\n" +
+        "Expires: Mon, 20 Dec 1998 01:00:00 GMT\n" +
+        "Content-Length: 49\n" +
+        "\n" +
+        "<html>\n" +
+        "whatever here will be included\n" +
+        "</html>\n");
+
+    HashMap doc1 = new HashMap<String, String>();
+    doc1.put("id", null);
+    doc1.put("content", "software: Nutch 1.0-dev (modified for clueweb09)\n" +
+        "isPartOf: clueweb09-en\n" +
+        "description: clueweb09 crawl with WARC output\n" +
+        "format: WARC file version 0.18\n" +
+        "conformsTo: http://www.archive.org/documents/WarcFileFormat-0.18.html");
+    expected.add(doc1);
+
+    HashMap doc2 = new HashMap<String, String>();
+    doc2.put("id", "clueweb09-az0000-00-00000");
+    doc2.put("content", "\n<html>\n" +
+        "whatever here will be included\n" +
+        "</html>");
+    expected.add(doc2);
+  }
+
+  protected SourceDocument parse(String raw) throws IOException {
+    DataInputStream stream = new DataInputStream(new StringInputStream(raw));
+    ClueWeb09WarcRecord doc = new ClueWeb09WarcRecord();
+    doc = doc.readNextWarcRecord(stream, ClueWeb09WarcRecord.WARC_VERSION);
+    return doc;
+  }
+}

--- a/src/test/java/io/anserini/document/ClueWeb12WarcRecordTest.java
+++ b/src/test/java/io/anserini/document/ClueWeb12WarcRecordTest.java
@@ -1,0 +1,100 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.document;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+
+import org.apache.tools.ant.filters.StringInputStream;
+import org.junit.Before;
+
+
+public class ClueWeb12WarcRecordTest extends DocumentTest {
+
+  @Before
+  public void setUP() throws Exception {
+    super.setUp();
+
+    // WARC-Type: warcinfo is not indexable
+    rawDocs.add(
+        "WARC/1.0\n" +
+        "WARC-Type: warcinfo\n" +
+        "WARC-Date: 2009-03-65T08:43:19-0800\n" +
+        "WARC-Record-ID: <urn:uuid:11111111-2222-3333-4444-555555555555>\n" +
+        "Content-Type: application/warc-fields\n" +
+        "Content-Length: 219\n" +
+        "\n" +
+        "software: Nutch 1.0-dev (modified for clueweb09)\n" +
+        "isPartOf: clueweb09-en\n" +
+        "description: clueweb09 crawl with WARC output\n" +
+        "format: WARC file version 0.18\n" +
+        "conformsTo: http://www.archive.org/documents/WarcFileFormat-0.18.html\n"
+    );
+
+    rawDocs.add(
+        "WARC/1.0\n" +
+        "WARC-Type: response\n" +
+        "WARC-Target-URI: http://clueweb09.test.com/\n" +
+        "WARC-Warcinfo-ID: 993d3969-9643-4934-b1c6-68d4dbe55b83\n" +
+        "WARC-Date: 2009-03-65T08:43:19-0800\n" +
+        "WARC-Record-ID: <urn:uuid:6f12f095-18a8-4415-8f04-ec2477be81d5>\n" +
+        "WARC-TREC-ID: clueweb09-az0000-00-00000\n" +
+        "Content-Type: application/http;msgtype=response\n" +
+        "WARC-Identified-Payload-Type: \n" +
+        "Content-Length: 345\n" + // The Content-Length MUST match the length of the record!!!
+        "\n" +
+        "HTTP/1.1 200 OK\n" +
+        "Content-Type: text/html\n" +
+        "Date: Tue, 13 Jan 2009 18:05:10 GMT\n" +
+        "Pragma: no-cache\n" +
+        "Cache-Control: no-cache, must-revalidate\n" +
+        "X-Powered-By: PHP/4.4.8\n" +
+        "Server: WebServerX\n" +
+        "Connection: close\n" +
+        "Last-Modified: Tue, 13 Jan 2009 18:05:10 GMT\n" +
+        "Expires: Mon, 20 Dec 1998 01:00:00 GMT\n" +
+        "Content-Length: 49\n" +
+        "\n" +
+        "<html>\n" +
+        "whatever here will be included\n" +
+        "</html>\n");
+
+    HashMap doc1 = new HashMap<String, String>();
+    doc1.put("id", null);
+    doc1.put("content", "software: Nutch 1.0-dev (modified for clueweb09)\n" +
+        "isPartOf: clueweb09-en\n" +
+        "description: clueweb09 crawl with WARC output\n" +
+        "format: WARC file version 0.18\n" +
+        "conformsTo: http://www.archive.org/documents/WarcFileFormat-0.18.html");
+    expected.add(doc1);
+
+    HashMap doc2 = new HashMap<String, String>();
+    doc2.put("id", "clueweb09-az0000-00-00000");
+    doc2.put("content", "<html>\n" +
+        "whatever here will be included\n" +
+        "</html>");
+    expected.add(doc2);
+  }
+
+  protected SourceDocument parse(String raw) throws IOException {
+    DataInputStream stream = new DataInputStream(new StringInputStream(raw));
+    ClueWeb12WarcRecord doc = new ClueWeb12WarcRecord();
+    doc = doc.readNextWarcRecord(stream, ClueWeb12WarcRecord.WARC_VERSION);
+    return doc;
+  }
+}

--- a/src/test/java/io/anserini/document/DocumentTest.java
+++ b/src/test/java/io/anserini/document/DocumentTest.java
@@ -1,0 +1,56 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.document;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.lucene.util.LuceneTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DocumentTest<D extends SourceDocument> extends LuceneTestCase {
+  protected List<String> rawDocs;
+  protected List<Map<String, String>> expected;
+  protected D dType;
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    rawDocs = new ArrayList<String>();
+    expected = new ArrayList<Map<String, String>>();
+  }
+
+  protected SourceDocument parse(String raw) throws IOException {
+    BufferedReader bufferedReader = new BufferedReader(new StringReader(raw));
+    SourceDocument d;
+    d = dType.readNextRecord(bufferedReader);
+    return (D)d;
+  }
+
+  @Test
+  public void test() throws IOException {
+    for (int i = 0; i < rawDocs.size(); i++) {
+      SourceDocument parsed = parse(rawDocs.get(i));
+      assertEquals(parsed.id(), expected.get(i).get("id"));
+      assertEquals(parsed.content(), expected.get(i).get("content"));
+    }
+  }
+}

--- a/src/test/java/io/anserini/document/TrecDocumentTest.java
+++ b/src/test/java/io/anserini/document/TrecDocumentTest.java
@@ -1,0 +1,61 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.document;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.HashMap;
+import org.junit.Before;
+
+
+public class TrecDocumentTest extends DocumentTest {
+
+  @Before
+  public void setUP() throws Exception {
+    super.setUp();
+    dType = new TrecDocument();
+
+    rawDocs.add("<DOC>\n" +
+        "<DOCNO> AP-0001 </DOCNO>\n" +
+        "<FILEID>field id test and should NOT be included</FILEID>\n" +
+        "<FIRST>first test and should NOT be included</FIRST>\n" +
+        "<SECOND>second test and should NOT be included</SECOND>\n" +
+        "<HEAD>This is head and should NOT be included</HEAD>\n" +
+        "<HEADLINE>This is headline and should be included</HEADLINE>\n" +
+        "<DATELINE>AP</DATELINE>\n" +
+        "<TEXT>\n" +
+        "   Hopefully we \n" +
+        "get this\n" +
+        " right\n" +
+        "</TEXT>\n" +
+        "</DOC>\n");
+
+    HashMap doc1 = new HashMap<String, String>();
+    doc1.put("id", "AP-0001");
+    // ONLY "<TEXT>", "<HEADLINE>", "<TITLE>", "<HL>", "<HEAD>",
+    // "<TTL>", "<DD>", "<DATE>", "<LP>", "<LEADPARA>" will be included
+    doc1.put("content", "<HEAD>This is head and should NOT be included</HEAD>\n" +
+        "<HEADLINE>This is headline and should be included</HEADLINE>\n" +
+        "<TEXT>\n" +
+        "Hopefully we\n" +
+        "get this\n" +
+        "right\n" +
+        "</TEXT>");
+    expected.add(doc1);
+  }
+}

--- a/src/test/java/io/anserini/document/TrecwebDocumentTest.java
+++ b/src/test/java/io/anserini/document/TrecwebDocumentTest.java
@@ -1,0 +1,52 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.document;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.HashMap;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class TrecwebDocumentTest extends DocumentTest {
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    dType = new TrecwebDocument();
+
+    rawDocs.add("<DOC>\n" +
+        "<DOCNO> WEB-0001 </DOCNO>\n" +
+        "<DOCHDR>DOCHDR will NOT be \n" +
+        " included</DOCHDR>\n" +
+        "<html>Wh at ever here will be parsed \n" +
+        " <br> asdf <div>\n" +
+        "</html>\n" +
+        "</DOC>\n");
+
+    HashMap doc1 = new HashMap<String, String>();
+    doc1.put("id", "WEB-0001");
+    // <DOCHDR> Will NOT be included
+    doc1.put("content", "<html>Wh at ever here will be parsed\n" +
+        "<br> asdf <div>\n" +
+        "</html>");
+    expected.add(doc1);
+  }
+}

--- a/src/test/java/io/anserini/document/TwitterDocumentTest.java
+++ b/src/test/java/io/anserini/document/TwitterDocumentTest.java
@@ -1,0 +1,49 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.document;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.HashMap;
+
+import org.junit.Before;
+
+import io.anserini.document.DocumentTest;
+import io.anserini.document.SourceDocument;
+import io.anserini.document.TrecDocument;
+
+
+public class TwitterDocumentTest extends DocumentTest {
+
+  @Before
+  public void setUP() throws Exception {
+    super.setUp();
+    dType = new TwitterDocument(false);
+
+    rawDocs.add("{\"id\":" + 123456789 + ",\"text\":\"" + "this is the tweet contents."
+        + "\",\"user\":{\"screen_name\":\"foo\",\"name\":\"foo\"," +
+        "\"profile_image_url\":\"foo\",\"followers_count\":1,\"friends_count\":1," +
+        "\"statuses_count\":1},\"created_at\":\"Fri Feb 01 00:00:00 +0000 2013\"}"
+    );
+
+    HashMap doc1 = new HashMap<String, String>();
+    doc1.put("id", "123456789");
+    doc1.put("content", "this is the tweet contents.");
+    expected.add(doc1);
+  }
+}

--- a/src/test/java/io/anserini/document/WikipediaArticleTest.java
+++ b/src/test/java/io/anserini/document/WikipediaArticleTest.java
@@ -1,0 +1,105 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.document;
+
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
+import org.apache.tools.ant.filters.StringInputStream;
+import org.apache.tools.bzip2.CBZip2InputStream;
+import org.apache.tools.bzip2.CBZip2OutputStream;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.anserini.collection.Collection;
+import io.anserini.collection.WikipediaCollection;
+
+
+public class WikipediaArticleTest extends DocumentTest {
+  protected static Path tmpPath;
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    dType = new TrecwebDocument();
+
+    String doc = "<mediawiki xmlns=\"http://www.mediawiki.org/xml/export-0.10/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.mediawiki.org/xml/export-0.10/ http://www.mediawiki.org/xm\n" +
+        "l/export-0.10.xsd\" version=\"0.10\" xml:lang=\"en\">\n" +
+        "  <siteinfo>\n" +
+        "    <sitename>Wiktionary</sitename>\n" +
+        "    <dbname>enwiktionary</dbname>\n" +
+        "    <base>https://en.wiktionary.org/wiki/Wiktionary:Main_Page</base>\n" +
+        "    <generator>MediaWiki 1.31.0-wmf.26</generator>\n" +
+        "    <case>case-sensitive</case>\n" +
+        "    <namespaces>\n" +
+        "      <namespace key=\"-2\" case=\"case-sensitive\">Media</namespace>\n" +
+        "      <namespace key=\"-1\" case=\"first-letter\">Special</namespace>\n" +
+        "      <namespace key=\"0\" case=\"case-sensitive\" />\n" +
+        "      <namespace key=\"1\" case=\"case-sensitive\">Talk</namespace>\n" +
+        " .... " +
+        "    </namespaces>\n" +
+        "  </siteinfo>\n" +
+        "  <page>\n" +
+        "    <title>Wiktionary:Welcome, newcomers</title>\n" +
+        "    <ns>0</ns>\n" +
+        "    <id>7</id>\n" +
+        "<revision>\n" +
+        "      <id>28863815</id>\n" +
+        "      <parentid>18348012</parentid>\n" +
+        "      <timestamp>2014-08-24T22:39:11Z</timestamp>\n" +
+        "      <contributor>\n" +
+        "        <username>Ready Steady Yeti</username>\n" +
+        "        <id>1705268</id>\n" +
+        "      </contributor>\n" +
+        "      <comment>This link doesn't actually exist. If you don't believe me, check it yourself.</comment>\n" +
+        "      <model>wikitext</model>\n" +
+        "      <format>text/x-wiki</format>\n" +
+        "      <text xml:space=\"preserve\">this is the \n" +
+        " real content \n" +
+        "      </text>\n" +
+        "  </page>\n" +
+        "</mediawiki>";
+
+    tmpPath = createTempFile();
+    OutputStream fout = Files.newOutputStream(tmpPath);
+    BufferedOutputStream out = new BufferedOutputStream(fout);
+    BZip2CompressorOutputStream tmpOut = new BZip2CompressorOutputStream(out);
+    StringInputStream in = new StringInputStream(doc);
+    final byte[] buffer = new byte[2048];
+    int n = 0;
+    while (-1 != (n = in.read(buffer))) {
+      tmpOut.write(buffer, 0, n);
+    }
+    tmpOut.close();
+  }
+
+  @Test
+  public void test() throws IOException {
+    WikipediaCollection wc = new WikipediaCollection();
+    Collection.FileSegment iter = wc.createFileSegment(tmpPath);
+    SourceDocument parsed = iter.next();
+    assertEquals(parsed.id(), "Wiktionary:Welcome, newcomers");
+    assertEquals(parsed.content(), "Wiktionary:Welcome, newcomers.\nthis is the   real content");
+  }
+}

--- a/src/test/java/io/anserini/eval/MetricsTest.java
+++ b/src/test/java/io/anserini/eval/MetricsTest.java
@@ -36,7 +36,7 @@ public class MetricsTest extends LuceneTestCase {
 
   /**
    * MUST call super
-   * constructs the necessary rerankers and extractorchains
+   * constructs the necessary ranking list and judgements
    * @throws Exception
    */
   @Override


### PR DESCRIPTION
This PR mainly does two things:

1. Refactor `Collection` a bit so that adding new Collection class requires less effort. The primary change is to make a protected variable `dType` which of the type `D` so that we can keep the logic of `next()` in the abstract `Collection` class. The exceptions are CW09, CW12 and WikiAriticle which do not take `BufferReader` as the source of reading the next record. I manually test all types of collections and it works as expected.
```
public abstract class Collection<D extends SourceDocument> {
public abstract class FileSegment implements Iterator<D>, Closeable {
    protected Path path;
    protected BufferedReader bufferedReader;
    protected boolean atEOF = false;
    protected final int BUFFER_SIZE = 1 << 16; // 64K
    protected D dType;

    @Override
    public boolean hasNext() {
      return !atEOF;
    }

    @Override
    public D next() {
      SourceDocument d;
      try {
        d = dType.readNextRecord(bufferedReader);
        if (d == null) {
          atEOF = true;
          d = null;
        }
      } catch (IOException e) {
        d = null;
      }
      return (D)d;
    }

    @Override
    public void remove() {
      throw new UnsupportedOperationException();
    }

    @Override
    public void close() throws IOException {
      atEOF = false;
      if (bufferedReader != null) {
        bufferedReader.close();
      }
    }
  }
```
2. Add tests for most Document classes. 