### PR TITLE
Fix bug in TrecwebCollection; Other formatting fixes.

### DIFF
--- a/src/main/java/io/anserini/collection/CW09Collection.java
+++ b/src/main/java/io/anserini/collection/CW09Collection.java
@@ -17,14 +17,13 @@
 package io.anserini.collection;
 
 import io.anserini.document.ClueWeb09WarcRecord;
-
 import java.io.IOException;
 import java.nio.file.Path;
 
 /**
  * Class representing an instance of the ClueWeb09 collection.
 */
-public class CW09Collection extends WarcCollection<ClueWeb09WarcRecord> {
+public class CW09Collection extends WarcCollection {
 
   public class FileSegment extends WarcCollection.FileSegment {
     private FileSegment(Path path) throws IOException {

--- a/src/main/java/io/anserini/collection/CW12Collection.java
+++ b/src/main/java/io/anserini/collection/CW12Collection.java
@@ -17,14 +17,13 @@
 package io.anserini.collection;
 
 import io.anserini.document.ClueWeb12WarcRecord;
-
 import java.io.IOException;
 import java.nio.file.Path;
 
 /**
  * Class representing an instance of the ClueWeb12 collection.
  */
-public class CW12Collection extends WarcCollection<ClueWeb12WarcRecord> {
+public class CW12Collection extends WarcCollection {
 
   public class FileSegment extends WarcCollection.FileSegment {
     public FileSegment(Path path) throws IOException {

--- a/src/main/java/io/anserini/collection/Collection.java
+++ b/src/main/java/io/anserini/collection/Collection.java
@@ -17,9 +17,6 @@
 package io.anserini.collection;
 
 import io.anserini.document.SourceDocument;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
@@ -34,6 +31,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A static collection of documents, comprised of one or more {@code FileSegment}s.

--- a/src/main/java/io/anserini/collection/Gov2Collection.java
+++ b/src/main/java/io/anserini/collection/Gov2Collection.java
@@ -28,7 +28,7 @@ import java.util.Set;
 /**
  * Class representing an instance of the Gov2 collection.
  */
-public class Gov2Collection extends TrecwebCollection<TrecwebDocument> {
+public class Gov2Collection extends TrecwebCollection {
 
   public class FileSegment extends TrecwebCollection.FileSegment {
     protected FileSegment(Path path) throws IOException {
@@ -43,10 +43,5 @@ public class Gov2Collection extends TrecwebCollection<TrecwebDocument> {
 
     return discover(path, EMPTY_SET, EMPTY_SET, EMPTY_SET,
         allowedFileSuffix, skippedDirs);
-  }
-
-  @Override
-  public Collection.FileSegment createFileSegment(Path p) throws IOException {
-    return new FileSegment(p);
   }
 }

--- a/src/main/java/io/anserini/collection/TrecCollection.java
+++ b/src/main/java/io/anserini/collection/TrecCollection.java
@@ -38,7 +38,7 @@ import org.apache.commons.compress.compressors.z.ZCompressorInputStream;
 /**
  * Class representing an instance of a TREC collection.
  */
-public class TrecCollection<D extends TrecDocument> extends Collection {
+public class TrecCollection extends Collection<TrecDocument> {
 
   public class FileSegment extends Collection.FileSegment {
 

--- a/src/main/java/io/anserini/collection/TrecCoreCollection.java
+++ b/src/main/java/io/anserini/collection/TrecCoreCollection.java
@@ -1,7 +1,22 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.anserini.collection;
 
 import io.anserini.document.TrecCoreDocument;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/main/java/io/anserini/collection/TrecwebCollection.java
+++ b/src/main/java/io/anserini/collection/TrecwebCollection.java
@@ -32,4 +32,9 @@ public class TrecwebCollection extends TrecCollection  {
       dType = new TrecwebDocument();
     }
   }
+
+  @Override
+  public Collection.FileSegment createFileSegment(Path p) throws IOException {
+    return new FileSegment(p);
+  }
 }

--- a/src/main/java/io/anserini/collection/TrecwebCollection.java
+++ b/src/main/java/io/anserini/collection/TrecwebCollection.java
@@ -17,22 +17,13 @@
 package io.anserini.collection;
 
 import io.anserini.document.TrecwebDocument;
-
-import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.zip.GZIPInputStream;
 
 /**
  * Class representing an instance of a TREC web collection.
  */
-public class TrecwebCollection<D extends TrecwebDocument> extends TrecCollection {
+public class TrecwebCollection extends TrecCollection  {
 
   public class FileSegment extends TrecCollection.FileSegment {
 

--- a/src/main/java/io/anserini/collection/TwitterCollection.java
+++ b/src/main/java/io/anserini/collection/TwitterCollection.java
@@ -1,8 +1,23 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.anserini.collection;
 
 import io.anserini.document.SourceDocument;
 import io.anserini.document.TwitterDocument;
-
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -13,13 +28,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.zip.GZIPInputStream;
-
 import org.apache.commons.compress.compressors.z.ZCompressorInputStream;
 
 /**
  * Class representing an instance of a Twitter collection.
  */
-public class TwitterCollection<D extends TwitterDocument> extends Collection {
+public class TwitterCollection extends Collection<TwitterDocument> {
   protected boolean keepRetweets = false;
 
   public TwitterCollection(Boolean keepRetweets) {

--- a/src/main/java/io/anserini/collection/WarcCollection.java
+++ b/src/main/java/io/anserini/collection/WarcCollection.java
@@ -17,7 +17,6 @@
 package io.anserini.collection;
 
 import io.anserini.document.WarcRecord;
-
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -32,7 +31,7 @@ import java.util.zip.GZIPInputStream;
 /**
  * Abstract class representing an instance of a WARC collection.
  */
-public abstract class WarcCollection<D extends WarcRecord> extends Collection {
+public abstract class WarcCollection extends Collection<WarcRecord> {
 
   public abstract class FileSegment extends Collection.FileSegment {
     protected DataInputStream stream;

--- a/src/main/java/io/anserini/collection/WikipediaCollection.java
+++ b/src/main/java/io/anserini/collection/WikipediaCollection.java
@@ -17,24 +17,23 @@
 package io.anserini.collection;
 
 import io.anserini.document.WikipediaArticle;
-import org.wikiclean.WikiClean;
-import org.wikiclean.WikiClean.WikiLanguage;
-import org.wikiclean.WikiCleanBuilder;
-import org.wikiclean.WikipediaBz2DumpInputStream;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.wikiclean.WikiClean;
+import org.wikiclean.WikiClean.WikiLanguage;
+import org.wikiclean.WikiCleanBuilder;
+import org.wikiclean.WikipediaBz2DumpInputStream;
 
 /**
  * Class representing an instance of a Wikipedia collection. Note that Wikipedia dumps often come
  * as a single bz2 file. Since a collection is assumed to be in a directory, place the bz2 file in
  * a directory prior to indexing.
  */
-public class WikipediaCollection<D extends WikipediaArticle> extends Collection {
+public class WikipediaCollection extends Collection<WikipediaArticle> {
 
   public class FileSegment extends Collection.FileSegment {
     private final WikipediaBz2DumpInputStream stream;

--- a/src/main/java/io/anserini/collection/WtCollection.java
+++ b/src/main/java/io/anserini/collection/WtCollection.java
@@ -17,7 +17,6 @@
 package io.anserini.collection;
 
 import io.anserini.document.TrecwebDocument;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -28,7 +27,7 @@ import java.util.Set;
 /**
  * Class representing an instance of a Wt collection.
  */
-public class WtCollection<D extends TrecwebDocument> extends TrecwebCollection {
+public class WtCollection extends TrecwebCollection {
 
   public class FileSegment extends TrecwebCollection.FileSegment {
     public FileSegment(Path path) throws IOException {
@@ -42,10 +41,5 @@ public class WtCollection<D extends TrecwebDocument> extends TrecwebCollection {
 
     return discover(path, EMPTY_SET, EMPTY_SET,
         EMPTY_SET, EMPTY_SET, skippedDirs);
-  }
-
-  @Override
-  public Collection.FileSegment createFileSegment(Path p) throws IOException {
-    return new FileSegment(p);
   }
 }


### PR DESCRIPTION
There is a bug that if a class inherits a child of `Collection` (e.g. TrecCollection) and changes the `FileSegment` of that class, then the implementing class needs to implement its own `createFileSegment` method. Otherwise the FileSegment instance from its father class will be returned and will be actually used when indexing. 

```
@Override
public Collection.FileSegment createFileSegment(Path p) throws IOException {    
    return new FileSegment(p);
}
```