### PR TITLE
Add uniqueDocId option to IndexCollection as per #258

### DIFF
--- a/docs/experiments-microblog.md
+++ b/docs/experiments-microblog.md
@@ -11,7 +11,8 @@ Indexing the Tweets2011 collection:
 ```
 nohup sh target/appassembler/bin/IndexCollection -collection TweetCollection -input \
 /path/to/Tweets2011/ -generator TweetGenerator  -index lucene-index.Tweets2011.pos+docvectors.keepUrls.stemming \
--threads 32 -storePositions -storeDocvectors -optimize -tweet.keepUrls -tweet.stemming > log.Tweets2011.keepUrls.stemming.txt &
+-threads 32 -storePositions -storeDocvectors -optimize -uniqueDocid -tweet.keepUrls -tweet.stemming \
+>& log.Tweets2011.keepUrls.stemming.txt &
 ```
 __NB:__ The process is backgrounded
 

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -29,6 +29,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.index.ConcurrentMergeScheduler;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.similarities.BM25Similarity;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
@@ -72,6 +73,11 @@ public final class IndexCollection {
     public String generatorClass;
 
     // optional arguments
+
+    @Option(name = "-uniqueDocId", usage = "remove duplicated documents with the same doc id when indexing. " +
+      "please note that this option may slow the indexing a lot and if you are sure there is no " +
+      "duplicated document ids in the corpus you shouldn't use this option.")
+    public boolean uniqueDocId = false;
 
     @Option(name = "-memorybuffer", usage = "memory buffer size")
     public int memorybufferSize = 2048;
@@ -152,7 +158,11 @@ public final class IndexCollection {
           Document doc = transformer.createDocument(d);
 
           if (doc != null) {
-            writer.addDocument(doc);
+            if (args.uniqueDocId) {
+              writer.updateDocument(new Term("id", d.id()), doc);
+            } else {
+              writer.addDocument(doc);
+            }
             cnt++;
           }
         }

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -74,10 +74,10 @@ public final class IndexCollection {
 
     // optional arguments
 
-    @Option(name = "-uniqueDocId", usage = "remove duplicated documents with the same doc id when indexing. " +
+    @Option(name = "-uniqueDocid", usage = "remove duplicated documents with the same doc id when indexing. " +
       "please note that this option may slow the indexing a lot and if you are sure there is no " +
       "duplicated document ids in the corpus you shouldn't use this option.")
-    public boolean uniqueDocId = false;
+    public boolean uniqueDocid = false;
 
     @Option(name = "-memorybuffer", usage = "memory buffer size")
     public int memorybufferSize = 2048;
@@ -158,7 +158,7 @@ public final class IndexCollection {
           Document doc = transformer.createDocument(d);
 
           if (doc != null) {
-            if (args.uniqueDocId) {
+            if (args.uniqueDocid) {
               writer.updateDocument(new Term("id", d.id()), doc);
             } else {
               writer.addDocument(doc);


### PR DESCRIPTION
Testing result on Microblog 2013: 

**Timing** 
master: `01:00:07`
this PR: `02:47:12`

**Index Stats**
master: 
```
documents:             203162948
documents (non-empty): 203160281
unique terms:          122988939
total terms:           2099261924
```

this PR:
```
documents:             203145941
documents (non-empty): 203143274
unique terms:          122988939
total terms:           2099082542
```
