### PR TITLE
Add whitelistDocids option to indexing

### DIFF
--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -103,9 +103,8 @@ public final class IndexCollection {
     @Option(name = "-memorybuffer", usage = "memory buffer size")
     public int memorybufferSize = 2048;
 
-    @Option(name = "-whitelistFile", usage = "when specified only the docids contained in the " +
-      "file will be included in the index, one docid per line.")
-    public String whitelistFile = null;
+    @Option(name = "-whitelist", usage = "file containing docids, one per line; only specified docids will be indexed.")
+    public String whitelist = null;
 
     @Option(name = "-tweet.keepRetweets", usage = "boolean switch to keep retweets while indexing")
     public boolean tweetKeepRetweets = false;
@@ -206,7 +205,7 @@ public final class IndexCollection {
     LOG.info("Store transformed docs? " + args.storeTransformedDocs);
     LOG.info("Store raw docs? " + args.storeRawDocs);
     LOG.info("Optimize (merge segments)? " + args.optimize);
-    LOG.info("Whitelist File: " + args.whitelistFile);
+    LOG.info("Whitelist: " + args.whitelist);
 
     this.indexPath = Paths.get(args.index);
     if (!Files.exists(this.indexPath)) {
@@ -225,8 +224,8 @@ public final class IndexCollection {
     collection = (Collection) this.collectionClass.newInstance();
     collection.setCollectionPath(collectionPath);
 
-    if (args.whitelistFile != null) {
-      List<String> lines = FileUtils.readLines(new File(args.whitelistFile), "utf-8");
+    if (args.whitelist != null) {
+      List<String> lines = FileUtils.readLines(new File(args.whitelist), "utf-8");
       this.whitelistDocids = new HashSet(lines);
     } else {
       this.whitelistDocids = null;

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -20,6 +20,8 @@ import io.anserini.analysis.TweetAnalyzer;
 import io.anserini.collection.Collection;
 import io.anserini.document.SourceDocument;
 import io.anserini.index.generator.LuceneDocumentGenerator;
+
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -44,7 +46,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -73,18 +77,6 @@ public final class IndexCollection {
     public String generatorClass;
 
     // optional arguments
-
-    @Option(name = "-uniqueDocid", usage = "remove duplicated documents with the same doc id when indexing. " +
-      "please note that this option may slow the indexing a lot and if you are sure there is no " +
-      "duplicated document ids in the corpus you shouldn't use this option.")
-    public boolean uniqueDocid = false;
-
-    @Option(name = "-memorybuffer", usage = "memory buffer size")
-    public int memorybufferSize = 2048;
-
-    @Option(name = "-keepStopwords", usage = "boolean switch to keep stopwords")
-    public boolean keepStopwords = false;
-
     @Option(name = "-storePositions", usage = "boolean switch to index storePositions")
     public boolean storePositions = false;
 
@@ -99,6 +91,21 @@ public final class IndexCollection {
 
     @Option(name = "-optimize", usage = "boolean switch to optimize index (force merge)")
     public boolean optimize = false;
+
+    @Option(name = "-keepStopwords", usage = "boolean switch to keep stopwords")
+    public boolean keepStopwords = false;
+
+    @Option(name = "-uniqueDocid", usage = "remove duplicated documents with the same doc id when indexing. " +
+      "please note that this option may slow the indexing a lot and if you are sure there is no " +
+      "duplicated document ids in the corpus you shouldn't use this option.")
+    public boolean uniqueDocid = false;
+
+    @Option(name = "-memorybuffer", usage = "memory buffer size")
+    public int memorybufferSize = 2048;
+
+    @Option(name = "-whitelistFile", usage = "when specified only the docids contained in the " +
+      "file will be included in the index, one docid per line.")
+    public String whitelistFile = null;
 
     @Option(name = "-tweet.keepRetweets", usage = "boolean switch to keep retweets while indexing")
     public boolean tweetKeepRetweets = false;
@@ -157,7 +164,7 @@ public final class IndexCollection {
           @SuppressWarnings("unchecked") // Yes, we know what we're doing here.
           Document doc = transformer.createDocument(d);
 
-          if (doc != null) {
+          if (doc != null && (whitelistDocids == null || whitelistDocids.contains(d.id()))) {
             if (args.uniqueDocid) {
               writer.updateDocument(new Term("id", d.id()), doc);
             } else {
@@ -179,6 +186,7 @@ public final class IndexCollection {
   private final IndexCollection.Args args;
   private final Path indexPath;
   private final Path collectionPath;
+  private final Set whitelistDocids;
   private final Class collectionClass;
   private final Class transformerClass;
   private final Collection collection;
@@ -198,6 +206,7 @@ public final class IndexCollection {
     LOG.info("Store transformed docs? " + args.storeTransformedDocs);
     LOG.info("Store raw docs? " + args.storeRawDocs);
     LOG.info("Optimize (merge segments)? " + args.optimize);
+    LOG.info("Whitelist File: " + args.whitelistFile);
 
     this.indexPath = Paths.get(args.index);
     if (!Files.exists(this.indexPath)) {
@@ -215,6 +224,13 @@ public final class IndexCollection {
 
     collection = (Collection) this.collectionClass.newInstance();
     collection.setCollectionPath(collectionPath);
+
+    if (args.whitelistFile != null) {
+      List<String> lines = FileUtils.readLines(new File(args.whitelistFile), "utf-8");
+      this.whitelistDocids = new HashSet(lines);
+    } else {
+      this.whitelistDocids = null;
+    }
 
     this.counters = new Counters();
   }


### PR DESCRIPTION
This is useful if we'd like to only add specific documents to the index, e.g. when reproducing my TREC2013 web track. 
Tested on CW12 and disk12 (with and without)