### PR TITLE
Add --index option to regression scripts to explicitly build index

### DIFF
--- a/src/main/python/run_regression_clueweb09b.py
+++ b/src/main/python/run_regression_clueweb09b.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import argparse
+
 from subprocess import call
 
 index_cmd = """
@@ -9,18 +11,18 @@ nohup sh target/appassembler/bin/IndexCollection -collection CW09Collection \
  -storePositions -storeDocvectors"""
 
 run_cmds = [ \
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw09b.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt -output run.web.51-100.bm25.txt -bm25",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw09b.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt -output run.web.101-150.bm25.txt -bm25",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw09b.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt -output run.web.151-200.bm25.txt -bm25",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw09b.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt -output run.web.51-100.bm25+rm3.txt -bm25 -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw09b.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt -output run.web.101-150.bm25+rm3.txt -bm25 -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw09b.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt -output run.web.151-200.bm25+rm3.txt -bm25 -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw09b.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt -output run.web.51-100.ql.txt -ql",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw09b.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt -output run.web.101-150.ql.txt -ql",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw09b.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt -output run.web.151-200.ql.txt -ql",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw09b.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt -output run.web.51-100.ql+rm3.txt -ql -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw09b.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt -output run.web.101-150.ql+rm3.txt -ql -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw09b.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt -output run.web.151-200.ql+rm3.txt -ql -rm3"]
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt -output run.web.51-100.bm25.txt -bm25",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt -output run.web.101-150.bm25.txt -bm25",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt -output run.web.151-200.bm25.txt -bm25",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt -output run.web.51-100.bm25+rm3.txt -bm25 -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt -output run.web.101-150.bm25+rm3.txt -bm25 -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt -output run.web.151-200.bm25+rm3.txt -bm25 -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt -output run.web.51-100.ql.txt -ql",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt -output run.web.101-150.ql.txt -ql",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt -output run.web.151-200.ql.txt -ql",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt -output run.web.51-100.ql+rm3.txt -ql -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt -output run.web.101-150.ql+rm3.txt -ql -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt -output run.web.151-200.ql+rm3.txt -ql -rm3"]
 
 
 t1_qrels = "src/main/resources/topics-and-qrels/qrels.web.51-100.txt"
@@ -37,9 +39,23 @@ def ndcg_eval(qrels, run):
     return round(float(os.popen("eval/gdeval.pl {} {} | grep 'amean' | sed 's/.*amean.//'".format(qrels, run)).read().split(',')[0]), 4)
 
 if __name__ == "__main__":
-    call(index_cmd, shell=True)
+    parser = argparse.ArgumentParser(description='Run regression tests on ClueWeb09b.')
+    parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
+    parser.set_defaults(index=False)
+
+    args = parser.parse_args()
+
+    # Decide if we're going to index from scratch. If not, use pre-stored index at known location.
+    if args.index == True:
+        call(index_cmd, shell=True)
+        index_path = 'lucene-index.cw09b.pos+docvectors'
+        print(args.index)
+    else:
+        index_path = '/tuna1/indexes/lucene-index.cw09b.pos+docvectors'
+
+    # Use the correct index path.
     for cmd in run_cmds:
-        call(cmd, shell=True)
+        call(cmd.format(index_path), shell=True)
 
     expected_t1_map = extract_value_from_doc("TREC 2010 Web Track: Topics 51-100", 1, 1)
     expected_t2_map = extract_value_from_doc("TREC 2011 Web Track: Topics 101-150", 1, 1)

--- a/src/main/python/run_regression_clueweb09b.py
+++ b/src/main/python/run_regression_clueweb09b.py
@@ -41,7 +41,6 @@ def ndcg_eval(qrels, run):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run regression tests on ClueWeb09b.')
     parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
-    parser.set_defaults(index=False)
 
     args = parser.parse_args()
 

--- a/src/main/python/run_regression_clueweb12-b13.py
+++ b/src/main/python/run_regression_clueweb12-b13.py
@@ -35,7 +35,6 @@ def ndcg_eval(qrels, run):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run regression tests on ClueWeb12-B13.')
     parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
-    parser.set_defaults(index=False)
 
     args = parser.parse_args()
 

--- a/src/main/python/run_regression_clueweb12-b13.py
+++ b/src/main/python/run_regression_clueweb12-b13.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import argparse
+
 from subprocess import call
 
 index_cmd = """
@@ -9,14 +11,14 @@ nohup sh target/appassembler/bin/IndexCollection -collection CW12Collection \
  -storePositions -storeDocvectors"""
 
 run_cmds = [ \
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw12b13.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -output run.web.201-250.bm25.txt -bm25",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw12b13.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -output run.web.251-300.bm25.txt -bm25",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw12b13.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -output run.web.201-250.bm25+rm3.txt -bm25 -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw12b13.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -output run.web.251-300.bm25+rm3.txt -bm25 -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw12b13.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -output run.web.201-250.ql.txt -ql",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw12b13.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -output run.web.251-300.ql.txt -ql",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw12b13.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -output run.web.201-250.ql+rm3.txt -ql -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index lucene-index.cw12b13.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -output run.web.251-300.ql+rm3.txt -ql -rm3"]
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -output run.web.201-250.bm25.txt -bm25",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -output run.web.251-300.bm25.txt -bm25",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -output run.web.201-250.bm25+rm3.txt -bm25 -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -output run.web.251-300.bm25+rm3.txt -bm25 -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -output run.web.201-250.ql.txt -ql",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -output run.web.251-300.ql.txt -ql",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -output run.web.201-250.ql+rm3.txt -ql -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Webxml -index {} -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -output run.web.251-300.ql+rm3.txt -ql -rm3"]
 
 t1_qrels = "src/main/resources/topics-and-qrels/qrels.web.201-250.txt"
 t2_qrels = "src/main/resources/topics-and-qrels/qrels.web.251-300.txt"
@@ -31,9 +33,23 @@ def ndcg_eval(qrels, run):
     return round(float(os.popen("eval/gdeval.pl {} {} | grep 'amean' | sed 's/.*amean.//'".format(qrels, run)).read().split(',')[0]), 4)
 
 if __name__ == "__main__":
-    call(index_cmd, shell=True)
+    parser = argparse.ArgumentParser(description='Run regression tests on ClueWeb12-B13.')
+    parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
+    parser.set_defaults(index=False)
+
+    args = parser.parse_args()
+
+    # Decide if we're going to index from scratch. If not, use pre-stored index at known location.
+    if args.index == True:
+        call(index_cmd, shell=True)
+        index_path = 'lucene-index.cw12b13.pos+docvectors'
+        print(args.index)
+    else:
+        index_path = '/tuna1/indexes/lucene-index.cw12b13.pos+docvectors'
+
+    # Use the correct index path.
     for cmd in run_cmds:
-        call(cmd, shell=True)
+        call(cmd.format(index_path), shell=True)
 
     expected_t1_map = extract_value_from_doc("TREC 2013 Web Track: Topics 201-250", 1, 1)
     expected_t2_map = extract_value_from_doc("TREC 2014 Web Track: Topics 251-300", 1, 1)

--- a/src/main/python/run_regression_clueweb12.py
+++ b/src/main/python/run_regression_clueweb12.py
@@ -35,7 +35,6 @@ def ndcg_eval(qrels, run):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run regression tests on ClueWeb12.')
     parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
-    parser.set_defaults(index=False)
 
     args = parser.parse_args()
 

--- a/src/main/python/run_regression_disks12.py
+++ b/src/main/python/run_regression_disks12.py
@@ -37,7 +37,6 @@ def trec_eval_metric(metric, qrels, run):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run regression tests on Disks 1 and 2.')
     parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
-    parser.set_defaults(index=False)
 
     args = parser.parse_args()
 

--- a/src/main/python/run_regression_disks12.py
+++ b/src/main/python/run_regression_disks12.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import argparse
+
 from subprocess import call
 
 index_cmd = """
@@ -8,7 +10,7 @@ target/appassembler/bin/IndexCollection -collection TrecCollection \
  -index lucene-index.disk12.pos+docvectors+rawdocs -threads 16 \
  -storePositions -storeDocvectors -storeRawDocs -optimize"""
 
-run_cmds = [ \
+run_cmds1 = [ \
     "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.51-100.txt -output run.disk12.51-100.bm25.txt -bm25",
     "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.101-150.txt -output run.disk12.101-150.bm25.txt -bm25",
     "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.151-200.txt -output run.disk12.151-200.bm25.txt -bm25",
@@ -22,6 +24,20 @@ run_cmds = [ \
     "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.101-150.txt -output run.disk12.101-150.ql+rm3.txt -ql -rm3",
     "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.151-200.txt -output run.disk12.151-200.ql+rm3.txt -ql -rm3"]
 
+run_cmds = [ \
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.51-100.txt -output run.disk12.51-100.bm25.txt -bm25",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.101-150.txt -output run.disk12.101-150.bm25.txt -bm25",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.151-200.txt -output run.disk12.151-200.bm25.txt -bm25",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.51-100.txt -output run.disk12.51-100.bm25+rm3.txt -bm25 -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.101-150.txt -output run.disk12.101-150.bm25+rm3.txt -bm25 -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.151-200.txt -output run.disk12.151-200.bm25+rm3.txt -bm25 -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.51-100.txt -output run.disk12.51-100.ql.txt -ql",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.101-150.txt -output run.disk12.101-150.ql.txt -ql",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.151-200.txt -output run.disk12.151-200.ql.txt -ql",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.51-100.txt -output run.disk12.51-100.ql+rm3.txt -ql -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.101-150.txt -output run.disk12.101-150.ql+rm3.txt -ql -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.151-200.txt -output run.disk12.151-200.ql+rm3.txt -ql -rm3"]
+
 t1_qrels = "src/main/resources/topics-and-qrels/qrels.51-100.txt"
 t2_qrels = "src/main/resources/topics-and-qrels/qrels.101-150.txt"
 t3_qrels = "src/main/resources/topics-and-qrels/qrels.151-200.txt"
@@ -33,9 +49,24 @@ def trec_eval_metric(metric, qrels, run):
     return float(os.popen("eval/trec_eval.9.0/trec_eval -m {} {} {}".format(metric, qrels, run)).read().split("\t")[2].strip())
 
 if __name__ == "__main__":
-    call(index_cmd, shell=True)
+    parser = argparse.ArgumentParser(description='Run regression tests on Disks 1 and 2.')
+    parser.add_argument('--index', dest='index', action='store_true')
+    parser.set_defaults(index=False)
+
+    args = parser.parse_args()
+
+    # Decide if we're going to index from scratch. If not, use pre-stored index at known location.
+    if args.index == True:
+        call(index_cmd, shell=True)
+        index_path = 'lucene-index.disk12.pos+docvectors+rawdocs'
+        print(args.index)
+    else:
+        index_path = '/tuna1/indexes/lucene-index.disk12.pos+docvectors+rawdocs'
+        print("Don't index")
+
+    # Use the correct index path.
     for cmd in run_cmds:
-        call(cmd, shell=True)
+        call(cmd.format(index_path), shell=True)
 
     expected_t1_map = extract_value_from_doc("TREC-1 Ad Hoc Track: Topics 51-100", 1, 1)
     expected_t2_map = extract_value_from_doc("TREC-2 Ad Hoc Track: Topics 101-150", 1, 1)

--- a/src/main/python/run_regression_disks12.py
+++ b/src/main/python/run_regression_disks12.py
@@ -10,20 +10,6 @@ target/appassembler/bin/IndexCollection -collection TrecCollection \
  -index lucene-index.disk12.pos+docvectors+rawdocs -threads 16 \
  -storePositions -storeDocvectors -storeRawDocs -optimize"""
 
-run_cmds1 = [ \
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.51-100.txt -output run.disk12.51-100.bm25.txt -bm25",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.101-150.txt -output run.disk12.101-150.bm25.txt -bm25",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.151-200.txt -output run.disk12.151-200.bm25.txt -bm25",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.51-100.txt -output run.disk12.51-100.bm25+rm3.txt -bm25 -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.101-150.txt -output run.disk12.101-150.bm25+rm3.txt -bm25 -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.151-200.txt -output run.disk12.151-200.bm25+rm3.txt -bm25 -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.51-100.txt -output run.disk12.51-100.ql.txt -ql",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.101-150.txt -output run.disk12.101-150.ql.txt -ql",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.151-200.txt -output run.disk12.151-200.ql.txt -ql",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.51-100.txt -output run.disk12.51-100.ql+rm3.txt -ql -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.101-150.txt -output run.disk12.101-150.ql+rm3.txt -ql -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.disk12.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.151-200.txt -output run.disk12.151-200.ql+rm3.txt -ql -rm3"]
-
 run_cmds = [ \
     "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.51-100.txt -output run.disk12.51-100.bm25.txt -bm25",
     "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.101-150.txt -output run.disk12.101-150.bm25.txt -bm25",
@@ -50,7 +36,7 @@ def trec_eval_metric(metric, qrels, run):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run regression tests on Disks 1 and 2.')
-    parser.add_argument('--index', dest='index', action='store_true')
+    parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
     parser.set_defaults(index=False)
 
     args = parser.parse_args()
@@ -62,7 +48,6 @@ if __name__ == "__main__":
         print(args.index)
     else:
         index_path = '/tuna1/indexes/lucene-index.disk12.pos+docvectors+rawdocs'
-        print("Don't index")
 
     # Use the correct index path.
     for cmd in run_cmds:

--- a/src/main/python/run_regression_gov2.py
+++ b/src/main/python/run_regression_gov2.py
@@ -37,7 +37,6 @@ def trec_eval_metric(metric, qrels, run):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run regression tests on Gov2.')
     parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
-    parser.set_defaults(index=False)
 
     args = parser.parse_args()
 

--- a/src/main/python/run_regression_gov2.py
+++ b/src/main/python/run_regression_gov2.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import argparse
+
 from subprocess import call
 
 index_cmd = """
@@ -9,18 +11,18 @@ nohup sh target/appassembler/bin/IndexCollection -collection Gov2Collection \
  -storePositions -storeDocvectors"""
 
 run_cmds = [ \
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.gov2.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.701-750.txt -output run.gov2.701-750.bm25.txt -bm25",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.gov2.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.751-800.txt -output run.gov2.751-800.bm25.txt -bm25",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.gov2.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.801-850.txt -output run.gov2.801-850.bm25.txt -bm25",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.gov2.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.701-750.txt -output run.gov2.701-750.bm25+rm3.txt -bm25 -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.gov2.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.751-800.txt -output run.gov2.751-800.bm25+rm3.txt -bm25 -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.gov2.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.801-850.txt -output run.gov2.801-850.bm25+rm3.txt -bm25 -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.gov2.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.701-750.txt -output run.gov2.701-750.ql.txt -ql",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.gov2.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.751-800.txt -output run.gov2.751-800.ql.txt -ql",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.gov2.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.801-850.txt -output run.gov2.801-850.ql.txt -ql",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.gov2.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.701-750.txt -output run.gov2.701-750.ql+rm3.txt -ql -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.gov2.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.751-800.txt -output run.gov2.751-800.ql+rm3.txt -ql -rm3",
-    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.gov2.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.801-850.txt -output run.gov2.801-850.ql+rm3.txt -ql -rm3"]
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.701-750.txt -output run.gov2.701-750.bm25.txt -bm25",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.751-800.txt -output run.gov2.751-800.bm25.txt -bm25",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.801-850.txt -output run.gov2.801-850.bm25.txt -bm25",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.701-750.txt -output run.gov2.701-750.bm25+rm3.txt -bm25 -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.751-800.txt -output run.gov2.751-800.bm25+rm3.txt -bm25 -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.801-850.txt -output run.gov2.801-850.bm25+rm3.txt -bm25 -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.701-750.txt -output run.gov2.701-750.ql.txt -ql",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.751-800.txt -output run.gov2.751-800.ql.txt -ql",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.801-850.txt -output run.gov2.801-850.ql.txt -ql",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.701-750.txt -output run.gov2.701-750.ql+rm3.txt -ql -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.751-800.txt -output run.gov2.751-800.ql+rm3.txt -ql -rm3",
+    "sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.801-850.txt -output run.gov2.801-850.ql+rm3.txt -ql -rm3"]
 
 t1_qrels = "src/main/resources/topics-and-qrels/qrels.701-750.txt"
 t2_qrels = "src/main/resources/topics-and-qrels/qrels.751-800.txt"
@@ -33,9 +35,23 @@ def trec_eval_metric(metric, qrels, run):
     return float(os.popen("eval/trec_eval.9.0/trec_eval -m {} {} {}".format(metric, qrels, run)).read().split("\t")[2].strip())
 
 if __name__ == "__main__":
-    call(index_cmd, shell=True)
+    parser = argparse.ArgumentParser(description='Run regression tests on Gov2.')
+    parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
+    parser.set_defaults(index=False)
+
+    args = parser.parse_args()
+
+    # Decide if we're going to index from scratch. If not, use pre-stored index at known location.
+    if args.index == True:
+        call(index_cmd, shell=True)
+        index_path = 'lucene-index.gov2.pos+docvectors'
+        print(args.index)
+    else:
+        index_path = '/tuna1/indexes/lucene-index.gov2.pos+docvectors'
+
+    # Use the correct index path.
     for cmd in run_cmds:
-        call(cmd, shell=True)
+        call(cmd.format(index_path), shell=True)
 
     expected_t1_map = extract_value_from_doc("TREC 2004 Terabyte Track: Topics 701-750", 1, 1)
     expected_t2_map = extract_value_from_doc("TREC 2005 Terabyte Track: Topics 751-800", 1, 1)

--- a/src/main/python/run_regression_robust04.py
+++ b/src/main/python/run_regression_robust04.py
@@ -27,7 +27,6 @@ def trec_eval_metric(metric, qrels, run):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run regression tests on Robust04.')
     parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
-    parser.set_defaults(index=False)
 
     args = parser.parse_args()
 

--- a/src/main/python/run_regression_robust04.py
+++ b/src/main/python/run_regression_robust04.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import argparse
+
 from subprocess import call
 
 index_cmd = """
@@ -9,10 +11,10 @@ nohup sh target/appassembler/bin/IndexCollection -collection TrecCollection \
  -storePositions -storeDocvectors -storeRawDocs -optimize"""
 
 run_cmds = [ \
-    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.robust04.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.robust04.301-450.601-700.txt -output run.disk45.301-450.601-700.bm25.txt -bm25",
-    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.robust04.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.robust04.301-450.601-700.txt -output run.disk45.301-450.601-700.bm25+rm3.txt -bm25 -rm3",
-    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.robust04.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.robust04.301-450.601-700.txt -output run.disk45.301-450.601-700.ql.txt -ql",
-    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.robust04.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.robust04.301-450.601-700.txt -output run.disk45.301-450.601-700.ql+rm3.txt -ql -rm3"]
+    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.robust04.301-450.601-700.txt -output run.disk45.301-450.601-700.bm25.txt -bm25",
+    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.robust04.301-450.601-700.txt -output run.disk45.301-450.601-700.bm25+rm3.txt -bm25 -rm3",
+    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.robust04.301-450.601-700.txt -output run.disk45.301-450.601-700.ql.txt -ql",
+    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.robust04.301-450.601-700.txt -output run.disk45.301-450.601-700.ql+rm3.txt -ql -rm3"]
 
 qrels = "src/main/resources/topics-and-qrels/qrels.robust2004.txt"
 
@@ -23,9 +25,23 @@ def trec_eval_metric(metric, qrels, run):
     return float(os.popen("eval/trec_eval.9.0/trec_eval -m {} {} {}".format(metric, qrels, run)).read().split("\t")[2].strip())
 
 if __name__ == "__main__":
-    call(index_cmd, shell=True)
+    parser = argparse.ArgumentParser(description='Run regression tests on Robust04.')
+    parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
+    parser.set_defaults(index=False)
+
+    args = parser.parse_args()
+
+    # Decide if we're going to index from scratch. If not, use pre-stored index at known location.
+    if args.index == True:
+        call(index_cmd, shell=True)
+        index_path = 'lucene-index.robust04.pos+docvectors+rawdocs'
+        print(args.index)
+    else:
+        index_path = '/tuna1/indexes/lucene-index.robust04.pos+docvectors+rawdocs'
+
+    # Use the correct index path.
     for cmd in run_cmds:
-        call(cmd, shell=True)
+        call(cmd.format(index_path), shell=True)
 
     expected_map = extract_value_from_doc("All Topics", 1, 1)
     actual_map = trec_eval_metric("map", qrels, "run.disk45.301-450.601-700.bm25.txt")

--- a/src/main/python/run_regression_robust05.py
+++ b/src/main/python/run_regression_robust05.py
@@ -27,7 +27,6 @@ def trec_eval_metric(metric, qrels, run):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run regression tests on Robust05.')
     parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
-    parser.set_defaults(index=False)
 
     args = parser.parse_args()
 

--- a/src/main/python/run_regression_robust05.py
+++ b/src/main/python/run_regression_robust05.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import argparse
+
 from subprocess import call
 
 index_cmd = """
@@ -9,10 +11,10 @@ nohup sh target/appassembler/bin/IndexCollection -collection TrecCollection \
  -storePositions -storeDocvectors -storeRawDocs -optimize"""
 
 run_cmds = [ \
-    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.aquaint.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.robust05.txt -output run.aquaint.robust05.bm25.txt -bm25",
-    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.aquaint.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.robust05.txt -output run.aquaint.robust05.bm25+rm3.txt -bm25 -rm3",
-    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.aquaint.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.robust05.txt -output run.aquaint.robust05.ql.txt -ql",
-    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.aquaint.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.robust05.txt -output run.aquaint.robust05.ql+rm3.txt -ql -rm3"]
+    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.robust05.txt -output run.aquaint.robust05.bm25.txt -bm25",
+    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.robust05.txt -output run.aquaint.robust05.bm25+rm3.txt -bm25 -rm3",
+    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.robust05.txt -output run.aquaint.robust05.ql.txt -ql",
+    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.robust05.txt -output run.aquaint.robust05.ql+rm3.txt -ql -rm3"]
 
 qrels = "src/main/resources/topics-and-qrels/qrels.robust2005.txt"
 
@@ -23,9 +25,23 @@ def trec_eval_metric(metric, qrels, run):
     return float(os.popen("eval/trec_eval.9.0/trec_eval -m {} {} {}".format(metric, qrels, run)).read().split("\t")[2].strip())
 
 if __name__ == "__main__":
-    call(index_cmd, shell=True)
+    parser = argparse.ArgumentParser(description='Run regression tests on Robust05.')
+    parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
+    parser.set_defaults(index=False)
+
+    args = parser.parse_args()
+
+    # Decide if we're going to index from scratch. If not, use pre-stored index at known location.
+    if args.index == True:
+        call(index_cmd, shell=True)
+        index_path = 'lucene-index.aquaint.pos+docvectors+rawdocs'
+        print(args.index)
+    else:
+        index_path = '/tuna1/indexes/lucene-index.aquaint.pos+docvectors+rawdocs'
+
+    # Use the correct index path.
     for cmd in run_cmds:
-        call(cmd, shell=True)
+        call(cmd.format(index_path), shell=True)
 
     expected_map = extract_value_from_doc("TREC 2005 Robust Track Topics", 1, 1)
     actual_map = trec_eval_metric("map", qrels, "run.aquaint.robust05.bm25.txt")

--- a/src/main/python/run_regression_tweets2011.py
+++ b/src/main/python/run_regression_tweets2011.py
@@ -33,7 +33,6 @@ def trec_eval_metric(metric, qrels, run):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run regression tests on Tweets2011.')
     parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
-    parser.set_defaults(index=False)
 
     args = parser.parse_args()
 

--- a/src/main/python/run_regression_tweets2011.py
+++ b/src/main/python/run_regression_tweets2011.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import argparse
+
 from subprocess import call
 
 index_cmd = """
@@ -9,14 +11,14 @@ nohup sh target/appassembler/bin/IndexCollection -collection TweetCollection \
  -storePositions -storeDocvectors -storeRawDocs -optimize -uniqueDocid -tweet.keepUrls -tweet.stemming"""
 
 run_cmds = [ \
-    "sh target/appassembler/bin/SearchCollection -searchtweets -topicreader Microblog -index lucene-index.tweets2011.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt -output run.mb11.bm25.txt -bm25 -hits 1000",
-    "sh target/appassembler/bin/SearchCollection -searchtweets -topicreader Microblog -index lucene-index.tweets2011.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt -output run.mb12.bm25.txt -bm25 -hits 1000",
-    "sh target/appassembler/bin/SearchCollection -searchtweets -topicreader Microblog -index lucene-index.tweets2011.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt -output run.mb11.bm25+rm3.txt -bm25 -rm3 -hits 1000",
-    "sh target/appassembler/bin/SearchCollection -searchtweets -topicreader Microblog -index lucene-index.tweets2011.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt -output run.mb12.bm25+rm3.txt -bm25 -rm3 -hits 1000",
-    "sh target/appassembler/bin/SearchCollection -searchtweets -topicreader Microblog -index lucene-index.tweets2011.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt -output run.mb11.ql.txt -ql -hits 1000",
-    "sh target/appassembler/bin/SearchCollection -searchtweets -topicreader Microblog -index lucene-index.tweets2011.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt -output run.mb12.ql.txt -ql -hits 1000",
-    "sh target/appassembler/bin/SearchCollection -searchtweets -topicreader Microblog -index lucene-index.tweets2011.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt -output run.mb11.ql+rm3.txt -ql -rm3 -hits 1000",
-    "sh target/appassembler/bin/SearchCollection -searchtweets -topicreader Microblog -index lucene-index.tweets2011.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt -output run.mb12.ql+rm3.txt -ql -rm3 -hits 1000"
+    "sh target/appassembler/bin/SearchCollection -searchtweets -topicreader Microblog -index {} -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt -output run.mb11.bm25.txt -bm25 -hits 1000",
+    "sh target/appassembler/bin/SearchCollection -searchtweets -topicreader Microblog -index {} -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt -output run.mb12.bm25.txt -bm25 -hits 1000",
+    "sh target/appassembler/bin/SearchCollection -searchtweets -topicreader Microblog -index {} -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt -output run.mb11.bm25+rm3.txt -bm25 -rm3 -hits 1000",
+    "sh target/appassembler/bin/SearchCollection -searchtweets -topicreader Microblog -index {} -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt -output run.mb12.bm25+rm3.txt -bm25 -rm3 -hits 1000",
+    "sh target/appassembler/bin/SearchCollection -searchtweets -topicreader Microblog -index {} -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt -output run.mb11.ql.txt -ql -hits 1000",
+    "sh target/appassembler/bin/SearchCollection -searchtweets -topicreader Microblog -index {} -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt -output run.mb12.ql.txt -ql -hits 1000",
+    "sh target/appassembler/bin/SearchCollection -searchtweets -topicreader Microblog -index {} -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt -output run.mb11.ql+rm3.txt -ql -rm3 -hits 1000",
+    "sh target/appassembler/bin/SearchCollection -searchtweets -topicreader Microblog -index {} -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt -output run.mb12.ql+rm3.txt -ql -rm3 -hits 1000"
 ]
 
 t1_qrels = "src/main/resources/topics-and-qrels/qrels.microblog2011.txt"
@@ -29,9 +31,23 @@ def trec_eval_metric(metric, qrels, run):
     return float(os.popen("eval/trec_eval.9.0/trec_eval -m {} {} {}".format(metric, qrels, run)).read().split("\t")[2].strip())
 
 if __name__ == "__main__":
-    call(index_cmd, shell=True)
+    parser = argparse.ArgumentParser(description='Run regression tests on Tweets2011.')
+    parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
+    parser.set_defaults(index=False)
+
+    args = parser.parse_args()
+
+    # Decide if we're going to index from scratch. If not, use pre-stored index at known location.
+    if args.index == True:
+        call(index_cmd, shell=True)
+        index_path = 'lucene-index.tweets2011.pos+docvectors+rawdocs'
+        print(args.index)
+    else:
+        index_path = '/tuna1/indexes/lucene-index.tweets2011.pos+docvectors+rawdocs'
+
+    # Use the correct index path.
     for cmd in run_cmds:
-        call(cmd, shell=True)
+        call(cmd.format(index_path), shell=True)
 
     expected_t1_map = extract_value_from_doc("TREC 2011 Microblog Track", 1, 1)
     expected_t2_map = extract_value_from_doc("TREC 2012 Microblog Track", 1, 1)

--- a/src/main/python/run_regression_tweets2013.py
+++ b/src/main/python/run_regression_tweets2013.py
@@ -33,7 +33,6 @@ def trec_eval_metric(metric, qrels, run):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run regression tests on Tweets2013.')
     parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
-    parser.set_defaults(index=False)
 
     args = parser.parse_args()
 

--- a/src/main/python/run_regression_wt10g.py
+++ b/src/main/python/run_regression_wt10g.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import argparse
+
 from subprocess import call
 
 index_cmd = """
@@ -9,10 +11,10 @@ nohup sh target/appassembler/bin/IndexCollection -collection WtCollection \
  -storePositions -storeDocvectors"""
 
 run_cmds = [ \
-    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.wt10g.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.451-550.txt -output run.wt10g.451-550.bm25.txt -bm25",
-    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.wt10g.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.451-550.txt -output run.wt10g.451-550.bm25+rm3.txt -bm25 -rm3",
-    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.wt10g.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.451-550.txt -output run.wt10g.451-550.ql.txt -ql",
-    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index lucene-index.wt10g.pos+docvectors -topics src/main/resources/topics-and-qrels/topics.451-550.txt -output run.wt10g.451-550.ql+rm3.txt -ql -rm3"]
+    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.451-550.txt -output run.wt10g.451-550.bm25.txt -bm25",
+    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.451-550.txt -output run.wt10g.451-550.bm25+rm3.txt -bm25 -rm3",
+    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.451-550.txt -output run.wt10g.451-550.ql.txt -ql",
+    "nohup sh target/appassembler/bin/SearchCollection -topicreader Trec -index {} -topics src/main/resources/topics-and-qrels/topics.451-550.txt -output run.wt10g.451-550.ql+rm3.txt -ql -rm3"]
 
 qrels = "src/main/resources/topics-and-qrels/qrels.451-550.txt"
 
@@ -23,9 +25,23 @@ def trec_eval_metric(metric, qrels, run):
     return float(os.popen("eval/trec_eval.9.0/trec_eval -m {} {} {}".format(metric, qrels, run)).read().split("\t")[2].strip())
 
 if __name__ == "__main__":
-    call(index_cmd, shell=True)
+    parser = argparse.ArgumentParser(description='Run regression tests on Wt10g.')
+    parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
+    parser.set_defaults(index=False)
+
+    args = parser.parse_args()
+
+    # Decide if we're going to index from scratch. If not, use pre-stored index at known location.
+    if args.index == True:
+        call(index_cmd, shell=True)
+        index_path = 'lucene-index.wt10g.pos+docvectors'
+        print(args.index)
+    else:
+        index_path = '/tuna1/indexes/lucene-index.wt10g.pos+docvectors'
+
+    # Use the correct index path.
     for cmd in run_cmds:
-        call(cmd, shell=True)
+        call(cmd.format(index_path), shell=True)
 
     expected_map = extract_value_from_doc("Wt10g: Topics 451-550", 1, 1)
     actual_map = trec_eval_metric("map", qrels, "run.wt10g.451-550.bm25.txt")

--- a/src/main/python/run_regression_wt10g.py
+++ b/src/main/python/run_regression_wt10g.py
@@ -27,7 +27,6 @@ def trec_eval_metric(metric, qrels, run):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run regression tests on Wt10g.')
     parser.add_argument('--index', dest='index', action='store_true', help='rebuild index from scratch')
-    parser.set_defaults(index=False)
 
     args = parser.parse_args()
 


### PR DESCRIPTION
By default, this doesn't rebuild index:
```
nohup python src/main/python/run_regression_disks12.py >& log.disks12 &
```
Instead, it uses indexes from `/tuna1/scratch/`

To explicitly rebuild index, do:
```
nohup python src/main/python/run_regression_disks12.py --index >& log.disks12 &
```