### PR TITLE
Patch to fix issue #300 - errors building fatjar for pyjnius

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Anserini
 Build using Maven:
 
 ```
-mvn clean package
+mvn clean package appassembler:assemble
 ```
 
 The `eval/` directory contains evaluation tools and scripts, including `trec_eval`. Before using `trec_eval`, unpack and compile it, as follows:
@@ -42,17 +42,11 @@ Anserini is designed to support experiments on various standard TREC collections
 
 ## Python Interface
 
-Anserini was designed with Python integration in mind, for connecting with popular deep learning toolkits such as PyTorch. This is accomplished via [pyjnius](https://github.com/kivy/pyjnius). To make this work, tell Maven to explicitly build the fat jar, as follows:
-
-```
-mvn clean package shade:shade
-```
-
-The `SimpleSearcher` class provides a simple Python/Java bridge, shown below:
+Anserini was designed with Python integration in mind, for connecting with popular deep learning toolkits such as PyTorch. This is accomplished via [pyjnius](https://github.com/kivy/pyjnius). The `SimpleSearcher` class provides a simple Python/Java bridge, shown below:
 
 ```
 import jnius_config
-jnius_config.set_classpath("target/anserini-0.0.1-SNAPSHOT-fatjar.jar")
+jnius_config.set_classpath("target/anserini-0.1.1-SNAPSHOT-fatjar.jar")
 
 from jnius import autoclass
 JString = autoclass('java.lang.String')

--- a/pom.xml
+++ b/pom.xml
@@ -90,35 +90,27 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>appassembler-maven-plugin</artifactId>
         <version>2.0.0</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>assemble</goal>
-	    </goals>
-            <configuration>
-              <extraJvmArguments>-Xms512M -Xmx24576M</extraJvmArguments>
-              <programs>
-                <program>
-                  <mainClass>io.anserini.index.IndexCollection</mainClass>
-                  <id>IndexCollection</id>
-                </program>
-                <program>
-                  <mainClass>io.anserini.search.SearchCollection</mainClass>
-                  <id>SearchCollection</id>
-                </program>
-                <program>
-                  <mainClass>io.anserini.eval.Eval</mainClass>
-                  <id>Eval</id>
-                </program>
-                <program>
-                  <mainClass>io.anserini.index.IndexUtils</mainClass>
-                  <id>IndexUtils</id>
-                </program>
-              </programs>
-            </configuration>
-	  </execution>
-	</executions>
+        <configuration>
+          <extraJvmArguments>-Xms512M -Xmx24576M</extraJvmArguments>
+          <programs>
+            <program>
+              <mainClass>io.anserini.index.IndexCollection</mainClass>
+              <id>IndexCollection</id>
+            </program>
+            <program>
+              <mainClass>io.anserini.search.SearchCollection</mainClass>
+              <id>SearchCollection</id>
+            </program>
+            <program>
+              <mainClass>io.anserini.eval.Eval</mainClass>
+              <id>Eval</id>
+            </program>
+            <program>
+              <mainClass>io.anserini.index.IndexUtils</mainClass>
+              <id>IndexUtils</id>
+            </program>
+          </programs>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -144,7 +136,7 @@
           <execution>
             <!-- default is to bind to package phase: we override and not create fatjar unless explicitly
                  specified on command line - this speeds up the build greatly -->
-            <phase>none</phase>
+            <phase>package</phase>
             <goals>
               <goal>shade</goal>
             </goals>


### PR DESCRIPTION
This patch basically reverts commit 2c76f3c51ed57aaac24589e6b5ec19ad9c528e9c which breaks fatjar generation for pyjnius. 

Maven now by default builds the fatjar, but appassembler needs to be explicitly triggered. So the full Maven command is now back to: mvn clean package appassembler:assemble