### PR TITLE
Add search option `-axiom.docids` to axiomatic reranking

### DIFF
--- a/src/main/java/io/anserini/rerank/lib/AxiomReranker.java
+++ b/src/main/java/io/anserini/rerank/lib/AxiomReranker.java
@@ -98,15 +98,15 @@ public class AxiomReranker<T> implements Reranker<T> {
     this.R = args.axiom_r;
     this.N = args.axiom_n;
     this.beta = args.axiom_beta;
-    this.externalIndexPath = args.axiom_external_index;
+    this.externalIndexPath = args.axiom_index;
     this.outputQuery = args.axiom_outputQuery;
 
     if (this.deterministic && this.N > 1) {
       if (args.axiom_docids != null) {
-        this.externalDocidsCache = makeExternalDocidsCache(args);
+        this.externalDocidsCache = buildExternalDocidsCache(args);
         this.internalDocidsCache = null;
       } else {
-        this.internalDocidsCache = makeInternalDocidsCache(args);
+        this.internalDocidsCache = buildInternalDocidsCache(args);
         this.externalDocidsCache = null;
       }
     } else {
@@ -211,7 +211,7 @@ public class AxiomReranker<T> implements Reranker<T> {
   /**
    * If the result is deterministic we can cache all the external docids by reading them from a file
    */
-  private List<String> makeExternalDocidsCache(SearchArgs args) throws IOException {
+  private List<String> buildExternalDocidsCache(SearchArgs args) throws IOException {
     InputStream in = getReadFileStream(args.axiom_docids);
     BufferedReader bRdr = new BufferedReader(new InputStreamReader(in));
     return IOUtils.readLines(bRdr);
@@ -221,8 +221,8 @@ public class AxiomReranker<T> implements Reranker<T> {
    * If the result is deterministic we can cache all the docids. All queries can share this
    * cache.
    */
-  private ScoreDoc[] makeInternalDocidsCache(SearchArgs args) throws IOException {
-    String index = args.axiom_external_index == null ? args.index : args.axiom_external_index;
+  private ScoreDoc[] buildInternalDocidsCache(SearchArgs args) throws IOException {
+    String index = args.axiom_index == null ? args.index : args.axiom_index;
     Path indexPath = Paths.get(index);
     if (!Files.exists(indexPath) || !Files.isDirectory(indexPath) || !Files.isReadable(indexPath)) {
       throw new IllegalArgumentException(index + " does not exist or is not a directory.");

--- a/src/main/java/io/anserini/search/SearchArgs.java
+++ b/src/main/java/io/anserini/search/SearchArgs.java
@@ -110,6 +110,10 @@ public class SearchArgs {
   @Option(name = "-axiom.seed", metaVar = "[number]", usage = "seed for the random generator in axiomatic reranking")
   public long axiom_seed = 42L;
 
+  @Option(name = "-axiom.docids", usage = "sorted docids file that for deterministic reranking. this file can be obtained " +
+          "by running CLI command `IndexUtils -index /path/to/index -dumpAllDocids GZ`")
+  public String axiom_docids = null;
+
   @Option(name = "-axiom.r", usage = "parameter R in axiomatic reranking")
   public int axiom_r = 20;
 
@@ -120,7 +124,7 @@ public class SearchArgs {
   public float axiom_beta = 0.4f;
 
   @Option(name = "-axiom.index", usage = "path to the external index for generating the reranking doucments pool")
-  public String axiom_external_index = "";
+  public String axiom_external_index = null;
 
   @Option(name = "-model", metaVar = "[file]", required = false, usage = "ranklib model file")
   public String model = "";

--- a/src/main/java/io/anserini/search/SearchArgs.java
+++ b/src/main/java/io/anserini/search/SearchArgs.java
@@ -124,7 +124,7 @@ public class SearchArgs {
   public float axiom_beta = 0.4f;
 
   @Option(name = "-axiom.index", usage = "path to the external index for generating the reranking doucments pool")
-  public String axiom_external_index = null;
+  public String axiom_index = null;
 
   @Option(name = "-model", metaVar = "[file]", required = false, usage = "ranklib model file")
   public String model = "";


### PR DESCRIPTION
Add search option `-axiom.docids` to axiomatic reranking so that the algorithm can opt to read external docids from an input file. This will eliminate the need of searching and sorting all docids if we need deterministic reranking results and thus greatly improve the efficiency. 