### PR TITLE
A bug in axiomatic reranking 

### DIFF
--- a/src/main/java/io/anserini/rerank/lib/AxiomReranker.java
+++ b/src/main/java/io/anserini/rerank/lib/AxiomReranker.java
@@ -17,6 +17,7 @@
 package io.anserini.rerank.lib;
 
 import io.anserini.index.generator.LuceneDocumentGenerator;
+import io.anserini.index.generator.TweetGenerator;
 import io.anserini.rerank.Reranker;
 import io.anserini.rerank.RerankerContext;
 import io.anserini.rerank.ScoredDocuments;
@@ -226,8 +227,12 @@ public class AxiomReranker<T> implements Reranker<T> {
     }
     IndexReader reader = DirectoryReader.open(FSDirectory.open(indexPath));
     IndexSearcher searcher = new IndexSearcher(reader);
+    if (args.searchtweets) {
+      return searcher.search(new FieldValueQuery(TweetGenerator.StatusField.ID_LONG.name), reader.maxDoc(),
+          BREAK_SCORE_TIES_BY_TWEETID).scoreDocs;
+    }
     return searcher.search(new FieldValueQuery(LuceneDocumentGenerator.FIELD_ID), reader.maxDoc(),
-        args.searchtweets ? BREAK_SCORE_TIES_BY_TWEETID : BREAK_SCORE_TIES_BY_DOCID, true, true).scoreDocs;
+        BREAK_SCORE_TIES_BY_DOCID).scoreDocs;
   }
 
   /**


### PR DESCRIPTION
Fix the deterministic axiomatic reranking by building the docids cache using ID_LONG instead of ID_String for tweets collection 