### PR TITLE
Fix the deterministic axiomatic reranking 

### DIFF
--- a/src/main/java/io/anserini/rerank/lib/AxiomReranker.java
+++ b/src/main/java/io/anserini/rerank/lib/AxiomReranker.java
@@ -397,7 +397,12 @@ public class AxiomReranker<T> implements Reranker<T> {
     Map<String, Set<Integer>> termInvertedList, RerankerContext<T> context) throws IOException {
     class ScoreComparator implements Comparator<Pair<String, Double>> {
       public int compare(Pair<String, Double> a, Pair<String, Double> b) {
-        return Double.compare(b.getRight(), a.getRight());
+        int cmp = Double.compare(b.getRight(), a.getRight());
+        if (cmp == 0) {
+          return a.getLeft().compareToIgnoreCase(b.getLeft());
+        } else {
+          return cmp;
+        }
       }
     }
 


### PR DESCRIPTION
Fix the deterministic axiomatic reranking by deterministically deciding the expansion terms; This is accomplished by first looking at the expansion scores and if there are multiple terms with the same reranking score we will sort them by the case-sensitive term string.