### PR TITLE
Patch for #383: Fix document unit tests

### DIFF
--- a/src/main/java/io/anserini/collection/WashingtonPostCollection.java
+++ b/src/main/java/io/anserini/collection/WashingtonPostCollection.java
@@ -125,7 +125,7 @@ public class WashingtonPostCollection extends DocumentCollection
                   && JsonParser.isFieldAvailable(contentObj.getContent())
                   && Document.CONTENT_TYPE_TAG.contains(contentObj.getType().get())) {
             String content = contentObj.getContent().get();
-            builder.append(removeTags(content));
+            builder.append(removeTags(content.trim())).append("\n");
           }
         }
       }

--- a/src/test/java/io/anserini/collection/ClueWeb09DocumentTest.java
+++ b/src/test/java/io/anserini/collection/ClueWeb09DocumentTest.java
@@ -95,13 +95,20 @@ public class ClueWeb09DocumentTest extends DocumentTest {
     for (int i = 0; i < rawDocs.size(); i++) {
       BaseFileSegment<ClueWeb09Collection.Document> iter = collection.createFileSegment(rawDocs.get(i));
       while (true) {
+        boolean hasNext;
         try {
-          ClueWeb09Collection.Document parsed = iter.next();
-          assertEquals(parsed.id(), expected.get(i).get("id"));
-          assertEquals(parsed.content(), expected.get(i).get("content"));
+          hasNext = iter.hasNext();
         } catch (NoSuchElementException e) {
           break;
         }
+
+        if (!hasNext) {
+          break;
+        }
+
+        ClueWeb09Collection.Document parsed = iter.next();
+        assertEquals(parsed.id(), expected.get(i).get("id"));
+        assertEquals(parsed.content(), expected.get(i).get("content"));
       }
     }
   }

--- a/src/test/java/io/anserini/collection/ClueWeb12DocumentTest.java
+++ b/src/test/java/io/anserini/collection/ClueWeb12DocumentTest.java
@@ -95,13 +95,20 @@ public class ClueWeb12DocumentTest extends DocumentTest {
     for (int i = 0; i < rawDocs.size(); i++) {
       BaseFileSegment<ClueWeb12Collection.Document> iter = collection.createFileSegment(rawDocs.get(i));
       while (true) {
+        boolean hasNext;
         try {
-          ClueWeb12Collection.Document parsed = iter.next();
-          assertEquals(parsed.id(), expected.get(i).get("id"));
-          assertEquals(parsed.content(), expected.get(i).get("content"));
+          hasNext = iter.hasNext();
         } catch (NoSuchElementException e) {
           break;
         }
+
+        if (!hasNext) {
+          break;
+        }
+
+        ClueWeb12Collection.Document parsed = iter.next();
+        assertEquals(parsed.id(), expected.get(i).get("id"));
+        assertEquals(parsed.content(), expected.get(i).get("content"));
       }
     }
   }

--- a/src/test/java/io/anserini/collection/DocumentTest.java
+++ b/src/test/java/io/anserini/collection/DocumentTest.java
@@ -48,6 +48,7 @@ public class DocumentTest extends LuceneTestCase {
       Writer writer = new BufferedWriter(new OutputStreamWriter(
               new FileOutputStream(tmpPath.toFile()), "utf-8"));
       writer.write(doc);
+      writer.close();
     } catch (IOException e) {}
 
     return tmpPath;

--- a/src/test/java/io/anserini/collection/JsonDocumentArrayTest.java
+++ b/src/test/java/io/anserini/collection/JsonDocumentArrayTest.java
@@ -61,14 +61,21 @@ public class JsonDocumentArrayTest extends DocumentTest {
     for (int i = 0; i < rawFiles.size(); i++) {
       BaseFileSegment<JsonCollection.Document> iter = collection.createFileSegment(rawFiles.get(i));
       while (true) {
+        boolean hasNext;
         try {
-          JsonCollection.Document parsed = iter.next();
-          assertEquals(parsed.id(), expected.get(j).get("id"));
-          assertEquals(parsed.content(), expected.get(j).get("content"));
-          j++;
+          hasNext = iter.hasNext();
         } catch (NoSuchElementException e) {
           break;
         }
+
+        if (!hasNext) {
+          break;
+        }
+
+        JsonCollection.Document parsed = iter.next();
+        assertEquals(parsed.id(), expected.get(j).get("id"));
+        assertEquals(parsed.content(), expected.get(j).get("content"));
+        j++;
       }
     }
   }

--- a/src/test/java/io/anserini/collection/JsonDocumentObjectTest.java
+++ b/src/test/java/io/anserini/collection/JsonDocumentObjectTest.java
@@ -50,13 +50,20 @@ public class JsonDocumentObjectTest extends DocumentTest {
     for (int i = 0; i < rawFiles.size(); i++) {
       BaseFileSegment<JsonCollection.Document> iter = collection.createFileSegment(rawFiles.get(i));
       while (true) {
+        boolean hasNext;
         try {
-          JsonCollection.Document parsed = iter.next();
-          assertEquals(parsed.id(), expected.get(i).get("id"));
-          assertEquals(parsed.content(), expected.get(i).get("content"));
+          hasNext = iter.hasNext();
         } catch (NoSuchElementException e) {
           break;
         }
+
+        if (!hasNext) {
+          break;
+        }
+
+        JsonCollection.Document parsed = iter.next();
+        assertEquals(parsed.id(), expected.get(i).get("id"));
+        assertEquals(parsed.content(), expected.get(i).get("content"));
       }
     }
   }

--- a/src/test/java/io/anserini/collection/JsonLineObjectTest.java
+++ b/src/test/java/io/anserini/collection/JsonLineObjectTest.java
@@ -59,14 +59,20 @@ public class JsonLineObjectTest extends DocumentTest {
     for (int i = 0; i < rawFiles.size(); i++) {
       BaseFileSegment<JsonCollection.Document> iter = collection.createFileSegment(rawFiles.get(i));
       while (true) {
+        boolean hasNext;
         try {
-          JsonCollection.Document parsed = iter.next();
-          assertEquals(parsed.id(), expected.get(j).get("id"));
-          assertEquals(parsed.content(), expected.get(j).get("content"));
-          j++;
+          hasNext = iter.hasNext();
         } catch (NoSuchElementException e) {
           break;
         }
+
+        if (!hasNext) {
+          break;
+        }
+
+        JsonCollection.Document parsed = iter.next();
+        assertEquals(parsed.id(), expected.get(i).get("id"));
+        assertEquals(parsed.content(), expected.get(i).get("content"));
       }
     }
   }

--- a/src/test/java/io/anserini/collection/TrecDocumentTest.java
+++ b/src/test/java/io/anserini/collection/TrecDocumentTest.java
@@ -66,13 +66,20 @@ public class TrecDocumentTest extends DocumentTest {
     for (int i = 0; i < rawFiles.size(); i++) {
       BaseFileSegment<TrecCollection.Document> iter = collection.createFileSegment(rawFiles.get(i));
       while (true) {
+        boolean hasNext;
         try {
-          TrecCollection.Document parsed = iter.next();
-          assertEquals(parsed.id(), expected.get(i).get("id"));
-          assertEquals(parsed.content(), expected.get(i).get("content"));
+          hasNext = iter.hasNext();
         } catch (NoSuchElementException e) {
           break;
         }
+
+        if (!hasNext) {
+          break;
+        }
+
+        TrecCollection.Document parsed = iter.next();
+        assertEquals(parsed.id(), expected.get(i).get("id"));
+        assertEquals(parsed.content(), expected.get(i).get("content"));
       }
     }
   }

--- a/src/test/java/io/anserini/collection/TrecwebDocumentTest.java
+++ b/src/test/java/io/anserini/collection/TrecwebDocumentTest.java
@@ -55,13 +55,20 @@ public class TrecwebDocumentTest extends DocumentTest {
     for (int i = 0; i < rawFiles.size(); i++) {
       BaseFileSegment<TrecwebCollection.Document> iter = collection.createFileSegment(rawFiles.get(i));
       while (true) {
+        boolean hasNext;
         try {
-          TrecCollection.Document parsed = iter.next();
-          assertEquals(parsed.id(), expected.get(i).get("id"));
-          assertEquals(parsed.content(), expected.get(i).get("content"));
+          hasNext = iter.hasNext();
         } catch (NoSuchElementException e) {
           break;
         }
+
+        if (!hasNext) {
+          break;
+        }
+
+        TrecCollection.Document parsed = iter.next();
+        assertEquals(parsed.id(), expected.get(i).get("id"));
+        assertEquals(parsed.content(), expected.get(i).get("content"));
       }
     }
   }

--- a/src/test/java/io/anserini/collection/TweetDocumentTest.java
+++ b/src/test/java/io/anserini/collection/TweetDocumentTest.java
@@ -50,15 +50,22 @@ public class TweetDocumentTest extends DocumentTest {
     for (int i = 0; i < rawFiles.size(); i++) {
       BaseFileSegment<TweetCollection.Document> iter = collection.createFileSegment(rawFiles.get(i));
       while (true) {
+        boolean hasNext;
         try {
-          TweetCollection.Document parsed = iter.next();
-          assertEquals(parsed.id(), expected.get(i).get("id"));
-          assertEquals(parsed.content(), expected.get(i).get("content"));
-          assert(parsed.getTimestampMs().isPresent());
-          assertEquals(parsed.getTimestampMs().getAsLong(), Long.parseLong(expected.get(i).get("timestamp_ms")));
+          hasNext = iter.hasNext();
         } catch (NoSuchElementException e) {
           break;
         }
+
+        if (!hasNext) {
+          break;
+        }
+
+        TweetCollection.Document parsed = iter.next();
+        assertEquals(parsed.id(), expected.get(i).get("id"));
+        assertEquals(parsed.content(), expected.get(i).get("content"));
+        assert(parsed.getTimestampMs().isPresent());
+        assertEquals(parsed.getTimestampMs().getAsLong(), Long.parseLong(expected.get(i).get("timestamp_ms")));
       }
     }
   }

--- a/src/test/java/io/anserini/collection/WashingtonPostDocumentTest.java
+++ b/src/test/java/io/anserini/collection/WashingtonPostDocumentTest.java
@@ -77,14 +77,21 @@ public class WashingtonPostDocumentTest extends DocumentTest {
     for (int i = 0; i < rawFiles.size(); i++) {
       BaseFileSegment<WashingtonPostCollection.Document> iter = collection.createFileSegment(rawFiles.get(i));
       while (true) {
+        boolean hasNext;
         try {
-          WashingtonPostCollection.Document parsed = iter.next();
-          assertEquals(parsed.id(), expected.get(i).get("id"));
-          assertEquals(parsed.content(), expected.get(i).get("content"));
-          assertEquals(parsed.getPublishedDate(), Long.parseLong(expected.get(i).get("published_date")));
+          hasNext = iter.hasNext();
         } catch (NoSuchElementException e) {
           break;
         }
+
+        if (!hasNext) {
+          break;
+        }
+
+        WashingtonPostCollection.Document parsed = iter.next();
+        assertEquals(parsed.id(), expected.get(i).get("id"));
+        assertEquals(parsed.content(), expected.get(i).get("content"));
+        assertEquals(parsed.getPublishedDate(), Long.parseLong(expected.get(i).get("published_date")));
       }
     }
   }

--- a/src/test/java/io/anserini/collection/WikipediaArticleTest.java
+++ b/src/test/java/io/anserini/collection/WikipediaArticleTest.java
@@ -99,13 +99,20 @@ public class WikipediaArticleTest extends DocumentTest {
     WikipediaCollection collection = new WikipediaCollection();
     BaseFileSegment<WikipediaCollection.Document> iter = collection.createFileSegment(tmpPath);
     while (true) {
+      boolean hasNext;
       try {
-        WikipediaCollection.Document parsed = iter.next();
-        assertEquals(parsed.id(), "Wiktionary:Welcome, newcomers");
-        assertEquals(parsed.content(), "Wiktionary:Welcome, newcomers.\nthis is the   real content");
+        hasNext = iter.hasNext();
       } catch (NoSuchElementException e) {
         break;
       }
+
+      if (!hasNext) {
+        break;
+      }
+
+      WikipediaCollection.Document parsed = iter.next();
+      assertEquals(parsed.id(), "Wiktionary:Welcome, newcomers");
+      assertEquals(parsed.content(), "Wiktionary:Welcome, newcomers.\nthis is the   real content");
     }
   }
 }


### PR DESCRIPTION
There are 3 bugs found:

1) In helper function `createFile()` in `DocumentTest`, the buffered writer is never closed, resulting in `bufferedReader.ready()` is always `false`. Therefore all document unit tests will throw an exception and get caught silently.

2) In #352, I used the iterator in the wrong way in unit tests. Should have used the same way as our `IndexCollection` did...

3) WashingtonPostDocumentTest is broken due to some string manipulation removed from #380.

This PR has fixed these 3 bugs.

The iterator used in document unit tests needs further improvement and refactoring after #381 is addressed.