### PR TITLE
Refactor dumpRawDoc in IndexUtils

### DIFF
--- a/src/main/java/io/anserini/index/IndexUtils.java
+++ b/src/main/java/io/anserini/index/IndexUtils.java
@@ -355,17 +355,20 @@ public class IndexUtils {
       LOG.info("Create dump directory failed: "+ outputDir);
       return;
     }
+    
     final class DumpThread extends Thread {
       final private IndexReader reader;
       final private String docid;
       final private String outputDir;
       final private boolean prependDocid;
+      
       public DumpThread(IndexReader reader, String docid, String outputDir, boolean prependDocid) throws IOException {
         this.reader = reader;
         this.docid = docid;
         this.outputDir = outputDir;
         this.prependDocid = prependDocid;
       }
+      
       @Override
       public void run() {
         try {
@@ -383,6 +386,7 @@ public class IndexUtils {
         }
       }
     }
+    
     List<String> docids = new ArrayList<>();
     String docid;
     while ((docid = bRdr.readLine()) != null) {


### PR DESCRIPTION
Context: I encountered file quota issue when dumping too many docs.
The new design discards the support for dumping as archival.
Instead, we leverage multi-threading to dump docs to a directory with each thread dump one doc.
Users can then feel free to archive and/or compress by themselves.