### PR TITLE
Refactor WashingtonPost Collection Indexing

### DIFF
--- a/src/main/java/io/anserini/collection/WashingtonPostCollection.java
+++ b/src/main/java/io/anserini/collection/WashingtonPostCollection.java
@@ -93,12 +93,7 @@ public class WashingtonPostCollection extends DocumentCollection
       return bufferedRecord != null;
     }
 
-    private String removeTags(String content) {
-      return content.replaceAll(Document.PATTERN, " ");
-    }
-
     private void parseRecord(String record) {
-      StringBuilder builder = new StringBuilder();
       ObjectMapper mapper = new ObjectMapper();
       Document.WashingtonPostObject wapoObj = null;
       try {
@@ -115,8 +110,14 @@ public class WashingtonPostCollection extends DocumentCollection
 
       bufferedRecord = new WashingtonPostCollection.Document();
       bufferedRecord.id = wapoObj.getId();
-      bufferedRecord.publishedDate = wapoObj.getPublishedDate();
+      bufferedRecord.title = wapoObj.getTitle();
+      bufferedRecord.articleUrl = wapoObj.getArticleUrl();
+      bufferedRecord.author = wapoObj.getAuthor();
+      bufferedRecord.obj = wapoObj;
+      bufferedRecord.content = record;
 
+      /*
+      StringBuilder builder = new StringBuilder();
       builder.append(wapoObj.getTitle()).append("\n");
 
       if (JsonParser.isFieldAvailable(wapoObj.getContents())) {
@@ -136,6 +137,7 @@ public class WashingtonPostCollection extends DocumentCollection
       }
 
       bufferedRecord.content = builder.toString();
+      */
     }
   }
 
@@ -144,13 +146,15 @@ public class WashingtonPostCollection extends DocumentCollection
    */
   public static class Document implements SourceDocument {
     private static final Logger LOG = LogManager.getLogger(Document.class);
-    private static final String PATTERN = "<.+>";
-    private static final List<String> CONTENT_TYPE_TAG = Arrays.asList("sanitized_html", "tweet");
 
     // Required fields
     protected String id;
-    protected long publishedDate;
+    protected String articleUrl;
+    protected String author;
+    protected long publishDate;
+    protected String title;
     protected String content;
+    protected WashingtonPostObject obj;
 
     @Override
     public String id() {
@@ -166,17 +170,39 @@ public class WashingtonPostCollection extends DocumentCollection
     public boolean indexable() {
       return true;
     }
-
-    public long getPublishedDate() {
-      return publishedDate;
+  
+    public String getArticleUrl() {
+      return articleUrl;
     }
-
+  
+    public String getAuthor() {
+      return author;
+    }
+  
+    public long getPublishDate() {
+      return publishDate;
+    }
+  
+    public String getTitle() {
+      return title;
+    }
+  
+    public String getContent() {
+      return content;
+    }
+  
+    public WashingtonPostObject getObj() {
+      return obj;
+    }
+  
     /**
      * Used internally by Jackson for JSON parsing.
      */
     public static class WashingtonPostObject {
       // Required fields
       protected String id;
+      protected String articleUrl;
+      protected String author;
       protected long publishedDate;
       protected String title;
 
@@ -285,6 +311,16 @@ public class WashingtonPostCollection extends DocumentCollection
       public String getId() {
         return id;
       }
+  
+      @JsonGetter("article_url")
+      public String getArticleUrl() {
+        return articleUrl;
+      }
+  
+      @JsonGetter("author")
+      public String getAuthor() {
+        return author;
+      }
 
       @JsonGetter("published_date")
       public long getPublishedDate() {
@@ -302,9 +338,13 @@ public class WashingtonPostCollection extends DocumentCollection
       @JsonCreator
       public WashingtonPostObject(
               @JsonProperty(value = "id", required = true) String id,
+              @JsonProperty(value = "article_url", required = true) String articleUrl,
+              @JsonProperty(value = "author", required = true) String author,
               @JsonProperty(value = "published_date", required = true) long publishedDate,
               @JsonProperty(value = "title", required = true) String title) {
         this.id = id;
+        this.articleUrl = articleUrl;
+        this.author = author;
         this.publishedDate = publishedDate;
         this.title = title;
       }

--- a/src/main/java/io/anserini/collection/WashingtonPostCollection.java
+++ b/src/main/java/io/anserini/collection/WashingtonPostCollection.java
@@ -339,8 +339,8 @@ public class WashingtonPostCollection extends DocumentCollection
       @JsonCreator
       public WashingtonPostObject(
               @JsonProperty(value = "id", required = true) String id,
-              @JsonProperty(value = "article_url", required = true) String articleUrl,
-              @JsonProperty(value = "author", required = true) String author,
+              @JsonProperty(value = "article_url", required = false) String articleUrl,
+              @JsonProperty(value = "author", required = false) String author,
               @JsonProperty(value = "published_date", required = true) long publishedDate,
               @JsonProperty(value = "title", required = true) String title) {
         this.id = id;

--- a/src/main/java/io/anserini/collection/WashingtonPostCollection.java
+++ b/src/main/java/io/anserini/collection/WashingtonPostCollection.java
@@ -116,29 +116,6 @@ public class WashingtonPostCollection extends DocumentCollection
       bufferedRecord.author = wapoObj.getAuthor();
       bufferedRecord.obj = wapoObj;
       bufferedRecord.content = record;
-
-      /*
-      StringBuilder builder = new StringBuilder();
-      builder.append(wapoObj.getTitle()).append("\n");
-
-      if (JsonParser.isFieldAvailable(wapoObj.getContents())) {
-        for (Document.WashingtonPostObject.Content contentObj : wapoObj.getContents().get()) {
-          if (contentObj == null) continue;
-          if (JsonParser.isFieldAvailable(contentObj.getType())
-                  && JsonParser.isFieldAvailable(contentObj.getContent())
-                  && Document.CONTENT_TYPE_TAG.contains(contentObj.getType().get())) {
-            String content = contentObj.getContent().get();
-            builder.append(removeTags(content)).append("\n");
-          }
-          if (JsonParser.isFieldAvailable(contentObj.getFullCaption())) {
-            String fullCaption = contentObj.getFullCaption().get();
-            builder.append(removeTags(fullCaption)).append("\n");
-          }
-        }
-      }
-
-      bufferedRecord.content = builder.toString();
-      */
     }
   }
 

--- a/src/main/java/io/anserini/collection/WashingtonPostCollection.java
+++ b/src/main/java/io/anserini/collection/WashingtonPostCollection.java
@@ -110,6 +110,7 @@ public class WashingtonPostCollection extends DocumentCollection
 
       bufferedRecord = new WashingtonPostCollection.Document();
       bufferedRecord.id = wapoObj.getId();
+      bufferedRecord.publishDate = wapoObj.getPublishedDate();
       bufferedRecord.title = wapoObj.getTitle();
       bufferedRecord.articleUrl = wapoObj.getArticleUrl();
       bufferedRecord.author = wapoObj.getAuthor();

--- a/src/main/java/io/anserini/collection/WashingtonPostCollection.java
+++ b/src/main/java/io/anserini/collection/WashingtonPostCollection.java
@@ -150,10 +150,10 @@ public class WashingtonPostCollection extends DocumentCollection
 
     // Required fields
     protected String id;
-    protected String articleUrl;
-    protected String author;
+    protected Optional<String> articleUrl;
+    protected Optional<String> author;
     protected long publishDate;
-    protected String title;
+    protected Optional<String> title;
     protected String content;
     protected WashingtonPostObject obj;
 
@@ -172,11 +172,11 @@ public class WashingtonPostCollection extends DocumentCollection
       return true;
     }
   
-    public String getArticleUrl() {
+    public Optional<String> getArticleUrl() {
       return articleUrl;
     }
   
-    public String getAuthor() {
+    public Optional<String> getAuthor() {
       return author;
     }
   
@@ -184,7 +184,7 @@ public class WashingtonPostCollection extends DocumentCollection
       return publishDate;
     }
   
-    public String getTitle() {
+    public Optional<String> getTitle() {
       return title;
     }
   
@@ -202,10 +202,10 @@ public class WashingtonPostCollection extends DocumentCollection
     public static class WashingtonPostObject {
       // Required fields
       protected String id;
-      protected String articleUrl;
-      protected String author;
+      protected Optional<String> articleUrl;
+      protected Optional<String> author;
       protected long publishedDate;
-      protected String title;
+      protected Optional<String> title;
 
       // Optional fields
       protected Optional<List<Content>> contents;
@@ -314,12 +314,12 @@ public class WashingtonPostCollection extends DocumentCollection
       }
   
       @JsonGetter("article_url")
-      public String getArticleUrl() {
+      public Optional<String> getArticleUrl() {
         return articleUrl;
       }
   
       @JsonGetter("author")
-      public String getAuthor() {
+      public Optional<String> getAuthor() {
         return author;
       }
 
@@ -329,7 +329,7 @@ public class WashingtonPostCollection extends DocumentCollection
       }
 
       @JsonGetter("title")
-      public String getTitle() {
+      public Optional<String> getTitle() {
         return title;
       }
 
@@ -339,10 +339,10 @@ public class WashingtonPostCollection extends DocumentCollection
       @JsonCreator
       public WashingtonPostObject(
               @JsonProperty(value = "id", required = true) String id,
-              @JsonProperty(value = "article_url", required = false) String articleUrl,
-              @JsonProperty(value = "author", required = false) String author,
+              @JsonProperty(value = "article_url", required = false) Optional<String> articleUrl,
+              @JsonProperty(value = "author", required = false) Optional<String> author,
               @JsonProperty(value = "published_date", required = true) long publishedDate,
-              @JsonProperty(value = "title", required = true) String title) {
+              @JsonProperty(value = "title", required = true) Optional<String> title) {
         this.id = id;
         this.articleUrl = articleUrl;
         this.author = author;

--- a/src/main/java/io/anserini/index/generator/WapoGenerator.java
+++ b/src/main/java/io/anserini/index/generator/WapoGenerator.java
@@ -1,0 +1,135 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.index.generator;
+
+import io.anserini.collection.WashingtonPostCollection;
+import io.anserini.collection.WashingtonPostCollection.Document.WashingtonPostObject;
+import io.anserini.index.IndexCollection;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.document.*;
+import org.apache.lucene.index.IndexOptions;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Converts a {@link WashingtonPostCollection.Document} into a Lucene {@link Document}, ready to be indexed.
+ */
+public class WapoGenerator extends LuceneDocumentGenerator<WashingtonPostCollection.Document> {
+  private static final Logger LOG = LogManager.getLogger(WapoGenerator.class);
+
+  public static final String FIELD_RAW = "raw";
+  public static final String FIELD_BODY = "contents";
+  public static final String FIELD_ID = "id";
+  
+  private static final String PATTERN = "<.+>";
+  private static final List<String> CONTENT_TYPE_TAG = Arrays.asList("sanitized_html", "tweet");
+
+  public enum WapoField {
+    AUTHOR("author"),
+    ARTICLE_URL("article_url"),
+    PUBLISHED_DATE("published_date"),
+    TITLE("title"),
+    FULL_CAPTION("ful" +
+        "lCaption"),
+    KICKER("kicker");
+
+    public final String name;
+  
+    WapoField(String s) {
+      name = s;
+    }
+  }
+  
+  public WapoGenerator(IndexCollection.Args args,
+                        IndexCollection.Counters counters) throws IOException {
+    super(args, counters);
+  }
+  
+  private String removeTags(String content) {
+    return content.replaceAll(PATTERN, " ");
+  }
+
+  @Override
+  public Document createDocument(WashingtonPostCollection.Document wapoDoc) {
+    String id = wapoDoc.id();
+
+    if (wapoDoc.content().trim().isEmpty()) {
+      counters.empty.incrementAndGet();
+      return null;
+    }
+
+    Document doc = new Document();
+    doc.add(new StringField(FIELD_ID, id, Field.Store.YES));
+    doc.add(new LongPoint(WapoField.PUBLISHED_DATE.name, wapoDoc.getPublishDate()));
+    doc.add(new StringField(WapoField.AUTHOR.name, wapoDoc.getAuthor(), Field.Store.NO));
+    doc.add(new StringField(WapoField.ARTICLE_URL.name, wapoDoc.getArticleUrl(), Field.Store.NO));
+    doc.add(new StringField(WapoField.TITLE.name, wapoDoc.getTitle(), Field.Store.NO));
+
+    StringBuilder contentBuilder = new StringBuilder();
+    contentBuilder.append(wapoDoc.getTitle()).append("\n\n");
+  
+    wapoDoc.getObj().getContents().ifPresent(contents -> {
+      for (WashingtonPostObject.Content contentObj : contents) {
+        if (contentObj == null) continue;
+        if (contentObj.getType().isPresent() && contentObj.getContent().isPresent()) {
+          contentObj.getType().ifPresent(type -> {
+            contentObj.getContent().ifPresent(content -> {
+              if (CONTENT_TYPE_TAG.contains(type)) {
+                contentBuilder.append(removeTags(content)).append("\n");
+              } else if (type.compareToIgnoreCase("kicker") == 0) {
+                doc.add(new StringField(WapoField.KICKER.name, content, Field.Store.NO));
+              }
+            });
+          });
+        }
+        contentObj.getFullCaption().ifPresent(caption -> {
+          String fullCaption = contentObj.getFullCaption().get();
+          doc.add(new StringField(WapoField.FULL_CAPTION.name, fullCaption, Field.Store.NO));
+          contentBuilder.append(removeTags(fullCaption)).append("\n");
+        });
+      }
+    });
+
+    if (args.storeRawDocs) { // store the raw json string as one single field
+      doc.add(new StoredField(FIELD_RAW, wapoDoc.getContent()));
+    }
+
+    FieldType fieldType = new FieldType();
+
+    fieldType.setStored(args.storeTransformedDocs);
+
+    // Are we storing document vectors?
+    if (args.storeDocvectors) {
+      fieldType.setStoreTermVectors(true);
+      fieldType.setStoreTermVectorPositions(true);
+    }
+
+    // Are we building a "positional" or "count" index?
+    if (args.storePositions) {
+      fieldType.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
+    } else {
+      fieldType.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+    }
+
+    doc.add(new Field(FIELD_BODY, contentBuilder.toString(), fieldType));
+
+    return doc;
+  }
+}

--- a/src/main/java/io/anserini/index/generator/WapoGenerator.java
+++ b/src/main/java/io/anserini/index/generator/WapoGenerator.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.document.*;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.util.BytesRef;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -67,7 +68,6 @@ public class WapoGenerator extends LuceneDocumentGenerator<WashingtonPostCollect
 
   @Override
   public Document createDocument(WashingtonPostCollection.Document wapoDoc) {
-    System.out.println(wapoDoc.id());
     String id = wapoDoc.id();
 
     if (wapoDoc.content().trim().isEmpty()) {
@@ -77,6 +77,8 @@ public class WapoGenerator extends LuceneDocumentGenerator<WashingtonPostCollect
 
     Document doc = new Document();
     doc.add(new StringField(FIELD_ID, id, Field.Store.YES));
+    // This is needed to break score ties by docid.
+    doc.add(new SortedDocValuesField(FIELD_ID, new BytesRef(id)));
     doc.add(new LongPoint(WapoField.PUBLISHED_DATE.name, wapoDoc.getPublishDate()));
     wapoDoc.getAuthor().ifPresent(author -> {
       doc.add(new StringField(WapoField.AUTHOR.name, author, Field.Store.NO));

--- a/src/main/java/io/anserini/index/generator/WapoGenerator.java
+++ b/src/main/java/io/anserini/index/generator/WapoGenerator.java
@@ -67,6 +67,7 @@ public class WapoGenerator extends LuceneDocumentGenerator<WashingtonPostCollect
 
   @Override
   public Document createDocument(WashingtonPostCollection.Document wapoDoc) {
+    System.out.println(wapoDoc.id());
     String id = wapoDoc.id();
 
     if (wapoDoc.content().trim().isEmpty()) {
@@ -77,9 +78,15 @@ public class WapoGenerator extends LuceneDocumentGenerator<WashingtonPostCollect
     Document doc = new Document();
     doc.add(new StringField(FIELD_ID, id, Field.Store.YES));
     doc.add(new LongPoint(WapoField.PUBLISHED_DATE.name, wapoDoc.getPublishDate()));
-    doc.add(new StringField(WapoField.AUTHOR.name, wapoDoc.getAuthor(), Field.Store.NO));
-    doc.add(new StringField(WapoField.ARTICLE_URL.name, wapoDoc.getArticleUrl(), Field.Store.NO));
-    doc.add(new StringField(WapoField.TITLE.name, wapoDoc.getTitle(), Field.Store.NO));
+    wapoDoc.getAuthor().ifPresent(author -> {
+      doc.add(new StringField(WapoField.AUTHOR.name, author, Field.Store.NO));
+    });
+    wapoDoc.getArticleUrl().ifPresent(url -> {
+      doc.add(new StringField(WapoField.ARTICLE_URL.name, url, Field.Store.NO));
+    });
+    wapoDoc.getTitle().ifPresent(title -> {
+      doc.add(new StringField(WapoField.TITLE.name, title, Field.Store.NO));
+    });
 
     StringBuilder contentBuilder = new StringBuilder();
     contentBuilder.append(wapoDoc.getTitle()).append("\n\n");

--- a/src/main/java/io/anserini/index/generator/WapoGenerator.java
+++ b/src/main/java/io/anserini/index/generator/WapoGenerator.java
@@ -46,8 +46,7 @@ public class WapoGenerator extends LuceneDocumentGenerator<WashingtonPostCollect
     ARTICLE_URL("article_url"),
     PUBLISHED_DATE("published_date"),
     TITLE("title"),
-    FULL_CAPTION("ful" +
-        "lCaption"),
+    FULL_CAPTION("fullCaption"),
     KICKER("kicker");
 
     public final String name;

--- a/src/test/java/io/anserini/collection/WashingtonPostDocumentTest.java
+++ b/src/test/java/io/anserini/collection/WashingtonPostDocumentTest.java
@@ -89,9 +89,9 @@ public class WashingtonPostDocumentTest extends DocumentTest {
 
         WashingtonPostCollection.Document parsed = iter.next();
         assertEquals(parsed.id(), expected.get(i).get("id"));
-        assertEquals(parsed.getArticleUrl(), expected.get(i).get("article_url"));
-        assertEquals(parsed.getTitle(), expected.get(i).get("title"));
-        assertEquals(parsed.getAuthor(), expected.get(i).get("author"));
+        assertEquals(parsed.getArticleUrl().get(), expected.get(i).get("article_url"));
+        assertEquals(parsed.getTitle().get(), expected.get(i).get("title"));
+        assertEquals(parsed.getAuthor().get(), expected.get(i).get("author"));
         assertEquals(parsed.getPublishDate(), Long.parseLong(expected.get(i).get("published_date")));
         assertEquals(parsed.getContent(), expected.get(i).get("content"));
       }

--- a/src/test/java/io/anserini/collection/WashingtonPostDocumentTest.java
+++ b/src/test/java/io/anserini/collection/WashingtonPostDocumentTest.java
@@ -92,7 +92,7 @@ public class WashingtonPostDocumentTest extends DocumentTest {
         WashingtonPostCollection.Document parsed = iter.next();
         assertEquals(parsed.id(), expected.get(i).get("id"));
         assertEquals(parsed.content(), expected.get(i).get("content"));
-        assertEquals(parsed.getPublishedDate(), Long.parseLong(expected.get(i).get("published_date")));
+        //assertEquals(parsed.getPublishedDate(), Long.parseLong(expected.get(i).get("published_date")));
       }
     }
   }

--- a/src/test/java/io/anserini/collection/WashingtonPostDocumentTest.java
+++ b/src/test/java/io/anserini/collection/WashingtonPostDocumentTest.java
@@ -39,7 +39,7 @@ public class WashingtonPostDocumentTest extends DocumentTest {
                 "\"title\": " +
                 "\"Controlled exposure to light can ease jet lag’s effects before and after a trip\", " +
 
-                "\"author\": \"\", " +
+                "\"author\": \"Mike\", " +
 
                 "\"published_date\": 1356999181000, " +
 
@@ -60,13 +60,11 @@ public class WashingtonPostDocumentTest extends DocumentTest {
 
     HashMap<String, String> doc1 = new HashMap<>();
     doc1.put("id", "5f992bbc-4b9f-11e2-a6a6-aabac85e8036");
+    doc1.put("title", "Controlled exposure to light can ease jet lag’s effects before and after a trip");
+    doc1.put("author", "Mike");
+    doc1.put("article_url", "https://www.washingtonpost.com/national/controlled-exposure-to-light-can-ease-jet-lags-effects-before-and-after-a-trip/2012/12/24/5f992bbc-4b9f-11e2-a6a6-aabac85e8036_story.html");
     // Only "sanitized_html" and "tweet" of <type> subtag in <content> tag will be included
-    doc1.put("content", "Controlled exposure to light can ease jet lag’s effects before and after a trip\n" +
-             "Using light to help reset your body clock\n" +
-             "When traveling east:\n" +
-             "A few days before you leave, start exposing yourself to bright light in the morning.\n" +
-             "When traveling west:\n" +
-             "When you arrive, expose yourself to light during the evening hours.\n");
+    doc1.put("content", doc);
     doc1.put("published_date", "1356999181000");
 
     expected.add(doc1);
@@ -91,8 +89,11 @@ public class WashingtonPostDocumentTest extends DocumentTest {
 
         WashingtonPostCollection.Document parsed = iter.next();
         assertEquals(parsed.id(), expected.get(i).get("id"));
-        assertEquals(parsed.content(), expected.get(i).get("content"));
-        //assertEquals(parsed.getPublishedDate(), Long.parseLong(expected.get(i).get("published_date")));
+        assertEquals(parsed.getArticleUrl(), expected.get(i).get("article_url"));
+        assertEquals(parsed.getTitle(), expected.get(i).get("title"));
+        assertEquals(parsed.getAuthor(), expected.get(i).get("author"));
+        assertEquals(parsed.getPublishDate(), Long.parseLong(expected.get(i).get("published_date")));
+        assertEquals(parsed.getContent(), expected.get(i).get("content"));
       }
     }
   }


### PR DESCRIPTION
Please see #403 for details.

This PR adds the `WapoGenerator` where the actual contents are parsed.
Now the `WashingtonPostCollection` is mainly a Json adaptor and it sends the raw Json object to `WapoGenerator`.  