### PR TITLE
Fixed broken MB13 regression

### DIFF
--- a/src/main/resources/regression/mb13.yaml
+++ b/src/main/resources/regression/mb13.yaml
@@ -21,8 +21,6 @@ index_options:
   - -tweet.stemming
 index_stats:
   documents: 203145916
-  documents (non-empty): 203143269
-  total terms: 2099082414
 topic_reader: Microblog
 topics:
   - name: "[TREC 2013 Microblog Track](http://trec.nist.gov/data/microblog2013.html)"

--- a/src/main/resources/regression/mb13.yaml
+++ b/src/main/resources/regression/mb13.yaml
@@ -21,8 +21,8 @@ index_options:
   - -tweet.stemming
 index_stats:
   documents: 203145916
-  documents (non-empty): 203143249
-  total terms: 2099082204
+  documents (non-empty): 203143269
+  total terms: 2099082414
 topic_reader: Microblog
 topics:
   - name: "[TREC 2013 Microblog Track](http://trec.nist.gov/data/microblog2013.html)"

--- a/src/main/resources/regression/mb13.yaml
+++ b/src/main/resources/regression/mb13.yaml
@@ -17,10 +17,13 @@ index_options:
   - -storeDocvectors
   - -storeRawDocs
   - -uniqueDocid
+  - -optimize
   - -tweet.keepUrls
   - -tweet.stemming
 index_stats:
   documents: 203145916
+  documents (non-empty): 203143249
+  total terms: 2099082204
 topic_reader: Microblog
 topics:
   - name: "[TREC 2013 Microblog Track](http://trec.nist.gov/data/microblog2013.html)"


### PR DESCRIPTION
See issue #409 documenting MB13 regression failure. Source can be traced back to
6b19d373634d510e8ac5f5b26b1a3d5c321926e4

In MB13 there are duplicate documents: optimize flag forces segment merge to clean this up,
yielding different index stats.

Rerunning regression now as final confirmation.