### PR TITLE
Adding the capability to adding fields other than `id` and `contents`

### DIFF
--- a/docs/experiments-trec2018.md
+++ b/docs/experiments-trec2018.md
@@ -104,6 +104,22 @@ The above commands generate _ALL_ results we have put in the notebook paper. To 
 TBD
 ```
 
+### Task 3: Web Track 2014
+
+Steps to deterministically reproduce the results:
+
+#### Get code and data:
+```
+git clone https://github.com/castorini/Anserini.git && cd Anserini && mvn clean package appassembler:assemble
+```
+#### Build the indexes:
+  - index of ClueWeb12 Full with additional fields (url, title, anchor_text, html_body):
+      ```
+      nohup sh Anserini/target/appassembler/bin/IndexCollection -collection ClueWeb12Collection \
+      -generator JsoupGenerator -threads 44 -input /path/to/cw12 -index lucene-index.cw12.pos+docvectors+rawdocs \
+      -storePositions -storeDocvectors -storeRawDocs -fields url title anchor_text html_body \
+      >& log.cw12.pos+docvectors+rawdocs+fields &
+      ```
 
 ## Core Track
 

--- a/src/main/java/io/anserini/collection/CarCollection.java
+++ b/src/main/java/io/anserini/collection/CarCollection.java
@@ -18,6 +18,7 @@ package io.anserini.collection;
 
 import edu.unh.cs.treccar_v2.Data;
 import edu.unh.cs.treccar_v2.read_data.DeserializeData;
+import org.apache.lucene.document.Field;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -95,5 +96,8 @@ public class CarCollection extends DocumentCollection
     public boolean indexable() {
       return true;
     }
+  
+    @Override
+    public List<Field> getAdditionalFields(List<String> fieldNames) { return null; }
   }
 }

--- a/src/main/java/io/anserini/collection/ClueWeb12Collection.java
+++ b/src/main/java/io/anserini/collection/ClueWeb12Collection.java
@@ -54,7 +54,10 @@ package io.anserini.collection;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.TextField;
 import org.apache.tools.ant.filters.StringInputStream;
+import org.jsoup.Jsoup;
 
 import java.io.DataInput;
 import java.io.DataInputStream;
@@ -191,7 +194,6 @@ public class ClueWeb12Collection extends DocumentCollection
     public boolean indexable() {
       return "response".equals(getWARCType());
     }
-
     /**
      * WARC header class.
      */

--- a/src/main/java/io/anserini/collection/HtmlCollection.java
+++ b/src/main/java/io/anserini/collection/HtmlCollection.java
@@ -21,6 +21,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.document.Field;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
@@ -30,6 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 /**
@@ -157,5 +159,8 @@ public class HtmlCollection extends DocumentCollection
     public boolean indexable() {
       return true;
     }
+  
+    @Override
+    public List<Field> getAdditionalFields(List<String> fieldNames) { return null; }
   }
 }

--- a/src/main/java/io/anserini/collection/JsonCollection.java
+++ b/src/main/java/io/anserini/collection/JsonCollection.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.document.Field;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -162,5 +163,8 @@ public class JsonCollection extends DocumentCollection
     public boolean indexable() {
       return true;
     }
+  
+    @Override
+    public List<Field> getAdditionalFields(List<String> fieldNames) { return null; }
   }
 }

--- a/src/main/java/io/anserini/collection/NewYorkTimesCollection.java
+++ b/src/main/java/io/anserini/collection/NewYorkTimesCollection.java
@@ -21,6 +21,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.document.Field;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -44,13 +45,7 @@ import java.nio.file.Path;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Set;
+import java.util.*;
 
 /**
  * An instance of the <a href="https://catalog.ldc.upenn.edu/products/LDC2008T19">New York Times
@@ -178,6 +173,9 @@ public class NewYorkTimesCollection extends DocumentCollection
     public boolean indexable() {
       return true;
     }
+  
+    @Override
+    public List<Field> getAdditionalFields(List<String> fieldNames) { return null; }
 
     public RawDocument getRawDocument() {
       return raw;

--- a/src/main/java/io/anserini/collection/SourceDocument.java
+++ b/src/main/java/io/anserini/collection/SourceDocument.java
@@ -16,6 +16,11 @@
 
 package io.anserini.collection;
 
+import org.apache.lucene.document.Field;
+
+import java.util.List;
+import java.util.Map;
+
 /**
  * A raw document from a collection. A source document is explicitly distinguish a from a Lucene
  * {@link org.apache.lucene.document.Document}, which is the Lucene representation that can be
@@ -43,4 +48,11 @@ public interface SourceDocument {
    * @return <code>true</code> if this document is meant to be indexed
    */
   boolean indexable();
+  
+  /**
+   * Returns the additional Lucene Fields from the document.
+   * It is up to the concrete collection to choose and implement this method.
+   * For example, for Web collection, we may index the Url of the web page as well.
+   */
+  List<Field> getAdditionalFields(List<String> fieldNames);
 }

--- a/src/main/java/io/anserini/collection/TrecCollection.java
+++ b/src/main/java/io/anserini/collection/TrecCollection.java
@@ -19,6 +19,7 @@ package io.anserini.collection;
 import org.apache.commons.compress.compressors.z.ZCompressorInputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.document.Field;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -31,10 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -196,5 +194,8 @@ public class TrecCollection extends DocumentCollection
     public boolean indexable() {
       return true;
     }
+  
+    @Override
+    public List<Field> getAdditionalFields(List<String> fieldNames) { return null; }
   }
 }

--- a/src/main/java/io/anserini/collection/TweetCollection.java
+++ b/src/main/java/io/anserini/collection/TweetCollection.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.anserini.util.JsonParser;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.document.Field;
 
 import javax.json.JsonException;
 import java.io.BufferedReader;
@@ -255,6 +256,9 @@ public class TweetCollection extends DocumentCollection
     public boolean indexable() {
       return true;
     }
+  
+    @Override
+    public List<Field> getAdditionalFields(List<String> fieldNames) { return null; }
 
     public long getIdLong() {
       return idLong;

--- a/src/main/java/io/anserini/collection/WashingtonPostCollection.java
+++ b/src/main/java/io/anserini/collection/WashingtonPostCollection.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.anserini.util.JsonParser;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.document.Field;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -128,6 +129,9 @@ public class WashingtonPostCollection extends DocumentCollection
     public boolean indexable() {
       return true;
     }
+  
+    @Override
+    public List<Field> getAdditionalFields(List<String> fieldNames) { return null; }
   
     public Optional<String> getArticleUrl() {
       return articleUrl;

--- a/src/main/java/io/anserini/collection/WikipediaCollection.java
+++ b/src/main/java/io/anserini/collection/WikipediaCollection.java
@@ -18,6 +18,7 @@ package io.anserini.collection;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.document.Field;
 import org.wikiclean.WikiClean;
 import org.wikiclean.WikiClean.WikiLanguage;
 import org.wikiclean.WikiCleanBuilder;
@@ -114,5 +115,8 @@ public class WikipediaCollection extends DocumentCollection
     public boolean indexable() {
       return true;
     }
+  
+    @Override
+    public List<Field> getAdditionalFields(List<String> fieldNames) { return null; }
   }
 }

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -43,12 +43,14 @@ import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.OptionHandlerFilter;
 import org.kohsuke.args4j.ParserProperties;
 import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.spi.StringArrayOptionHandler;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -75,6 +77,13 @@ public final class IndexCollection {
 
     @Option(name = "-collection", required = true, usage = "collection class in io.anserini.collection")
     public String collectionClass;
+  
+    @Option(name = "-fields", handler = StringArrayOptionHandler.class, usage = "The additional indexing fields other "
+        +"than id and contents. It is up to the specific collection to implement the details. "
+        +"Valid options for ClueWeb09|12: url,title,html_body,anchor_text,spam_score,pagerank_scoreinlink_counts,outlink_counts.")
+    public String[] fields = new String[] {
+        "url", "title", "html_body", "anchor_text", "spam_score", "pagerank_score", "inlink_counts", "outlink_counts"
+    };
 
     @Option(name = "-generator", required = true, usage = "document generator in io.anserini.index.generator")
     public String generatorClass;
@@ -207,7 +216,7 @@ public final class IndexCollection {
           }
 
           @SuppressWarnings("unchecked") // Yes, we know what we're doing here.
-          Document doc = generator.createDocument(d);
+          Document doc = generator.createDocument(d, d.getAdditionalFields(Arrays.asList(args.fields)));
           if (doc == null) {
             counters.unindexed.incrementAndGet();
             continue;
@@ -254,6 +263,7 @@ public final class IndexCollection {
     LOG.info("DocumentCollection path: " + args.input);
     LOG.info("Index path: " + args.index);
     LOG.info("CollectionClass: " + args.collectionClass);
+    LOG.info("Additional Fields: " + String.join(" ", args.fields));
     LOG.info("Generator: " + args.generatorClass);
     LOG.info("Threads: " + args.threads);
     LOG.info("Keep stopwords? " + args.keepStopwords);

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -81,9 +81,7 @@ public final class IndexCollection {
     @Option(name = "-fields", handler = StringArrayOptionHandler.class, usage = "The additional indexing fields other "
         +"than id and contents. It is up to the specific collection to implement the details. "
         +"Valid options for ClueWeb09|12: url,title,html_body,anchor_text,spam_score,pagerank_scoreinlink_counts,outlink_counts.")
-    public String[] fields = new String[] {
-        "url", "title", "html_body", "anchor_text", "spam_score", "pagerank_score", "inlink_counts", "outlink_counts"
-    };
+    public String[] fields = new String[]{};
 
     @Option(name = "-generator", required = true, usage = "document generator in io.anserini.index.generator")
     public String generatorClass;

--- a/src/main/java/io/anserini/index/IndexUtils.java
+++ b/src/main/java/io/anserini/index/IndexUtils.java
@@ -77,6 +77,9 @@ public class IndexUtils {
 
     @Option(name = "-printTermInfo", metaVar = "term", usage = "prints term info (stemmed, total counts, doc counts, etc.)")
     String term;
+  
+    @Option(name = "-search", usage = "point search for a document")
+    String searchDocid;
 
     @Option(name = "-dumpDocVector", metaVar = "docid", usage = "prints the document vector of a document")
     String docvectorDocid;
@@ -165,6 +168,11 @@ public class IndexUtils {
       System.out.println("  " + fd + " (" + "indexOption: " + fi.getIndexOptions() +
           ", hasVectors: " + fi.hasVectors() + ")");
     }
+  }
+  
+  public void pointSearch(String extenalDocid) throws IOException, ParseException {
+    Document d = reader.document(convertDocidToLuceneDocid(extenalDocid));
+    System.out.println(d);
   }
 
   public void printTermCounts(String termStr) throws IOException, ParseException {
@@ -478,6 +486,10 @@ public class IndexUtils {
 
     if (args.stats) {
       util.printIndexStats();
+    }
+  
+    if (args.searchDocid != null) {
+      util.pointSearch(args.searchDocid);
     }
 
     if (args.term != null) {

--- a/src/main/java/io/anserini/index/generator/LuceneDocumentGenerator.java
+++ b/src/main/java/io/anserini/index/generator/LuceneDocumentGenerator.java
@@ -30,6 +30,9 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.util.BytesRef;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * Converts a {@link SourceDocument} into a Lucene {@link Document}, ready to be indexed.
  * Prior to the creation of the Lucene document, this class will apply an optional
@@ -76,6 +79,14 @@ public class LuceneDocumentGenerator<T extends SourceDocument> {
     config(args);
     setCounters(counters);
   }
+  
+  protected void addSelfDefinedFields(Document document, List<Field> additionalFields) {
+    if (additionalFields != null) {
+      for (Field field : additionalFields) {
+        document.add(field);
+      }
+    }
+  }
 
   /**
    * Constructor with config and counters
@@ -99,7 +110,7 @@ public class LuceneDocumentGenerator<T extends SourceDocument> {
     this.counters = counters;
   }
 
-  public Document createDocument(T src) {
+  public Document createDocument(T src, List<Field> additionalFields) {
     String id = src.id();
     String contents;
 
@@ -146,6 +157,8 @@ public class LuceneDocumentGenerator<T extends SourceDocument> {
     }
 
     document.add(new Field(FIELD_BODY, contents, fieldType));
+    
+    addSelfDefinedFields(document, additionalFields);
 
     return document;
   }

--- a/src/main/java/io/anserini/index/generator/TweetGenerator.java
+++ b/src/main/java/io/anserini/index/generator/TweetGenerator.java
@@ -41,6 +41,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Converts a {@link TweetCollection.Document} into a Lucene {@link Document}, ready to be indexed.
@@ -107,7 +108,7 @@ public class TweetGenerator extends LuceneDocumentGenerator<TweetCollection.Docu
   }
 
   @Override
-  public Document createDocument(TweetCollection.Document tweetDoc) {
+  public Document createDocument(TweetCollection.Document tweetDoc, List<Field> additionalFields) {
     String id = tweetDoc.id();
 
     if (tweetDoc.content().trim().isEmpty()) {

--- a/src/main/java/io/anserini/index/generator/WapoGenerator.java
+++ b/src/main/java/io/anserini/index/generator/WapoGenerator.java
@@ -28,6 +28,7 @@ import org.apache.lucene.util.BytesRef;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Converts a {@link WashingtonPostCollection.Document} into a Lucene {@link Document}, ready to be indexed.
@@ -67,7 +68,7 @@ public class WapoGenerator extends LuceneDocumentGenerator<WashingtonPostCollect
   }
 
   @Override
-  public Document createDocument(WashingtonPostCollection.Document wapoDoc) {
+  public Document createDocument(WashingtonPostCollection.Document wapoDoc, List<Field> additionalFields) {
     String id = wapoDoc.id();
 
     if (wapoDoc.content().trim().isEmpty()) {

--- a/src/test/java/io/anserini/collection/ClueWeb12DocumentTest.java
+++ b/src/test/java/io/anserini/collection/ClueWeb12DocumentTest.java
@@ -54,7 +54,7 @@ public class ClueWeb12DocumentTest extends DocumentTest {
         "WARC-TREC-ID: clueweb09-az0000-00-00000\n" +
         "Content-Type: application/http;msgtype=response\n" +
         "WARC-Identified-Payload-Type: \n" +
-        "Content-Length: 345\n" + // The Content-Length MUST match the length of the record!!!
+        "Content-Length: 448\n" + // The Content-Length MUST match the length of the record!!!
         "\n" +
         "HTTP/1.1 200 OK\n" +
         "Content-Type: text/html\n" +
@@ -66,10 +66,14 @@ public class ClueWeb12DocumentTest extends DocumentTest {
         "Connection: close\n" +
         "Last-Modified: Tue, 13 Jan 2009 18:05:10 GMT\n" +
         "Expires: Mon, 20 Dec 1998 01:00:00 GMT\n" +
-        "Content-Length: 49\n" +
+        "Content-Length: 149\n" +
         "\n" +
         "<html>\n" +
-        "whatever here will be included\n" +
+        "<head></head>\n" +
+        "<body>\n" +
+        "whatever here will be included <title>fox river</title>\n" +
+        "<a href=\"http://www.link.com\">anchor text 1</a>\n" +
+        "</body>\n" +
         "</html>\n");
 
     HashMap<String, String> doc1 = new HashMap<>();
@@ -84,7 +88,11 @@ public class ClueWeb12DocumentTest extends DocumentTest {
     HashMap<String, String> doc2 = new HashMap<>();
     doc2.put("id", "clueweb09-az0000-00-00000");
     doc2.put("content", "<html>\n" +
-        "whatever here will be included\n" +
+        "<head></head>\n" +
+        "<body>\n" +
+        "whatever here will be included <title>fox river</title>\n" +
+        "<a href=\"http://www.link.com\">anchor text 1</a>\n" +
+        "</body>\n" +
         "</html>");
     expected.add(doc2);
   }

--- a/src/test/java/io/anserini/index/GeneratorTest.java
+++ b/src/test/java/io/anserini/index/GeneratorTest.java
@@ -1,0 +1,185 @@
+/**
+ * Anserini: An information retrieval toolkit built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.index;
+
+import io.anserini.collection.BaseFileSegment;
+import io.anserini.collection.ClueWeb12Collection;
+import io.anserini.index.generator.JsoupGenerator;
+import org.apache.commons.io.FileUtils;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.*;
+import org.apache.lucene.queryparser.flexible.standard.StandardQueryParser;
+import org.apache.lucene.search.*;
+import org.apache.lucene.search.similarities.BM25Similarity;
+import org.apache.lucene.search.similarities.Similarity;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LuceneTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.*;
+
+public class GeneratorTest extends LuceneTestCase {
+
+  private Path tempDir;
+  private String testingDocPath = "src/test/resources/sample_docs/clueweb/clueweb12-1";
+  private List<String> fields = Arrays.asList(new String[]{"url", "title", "anchor_text", "html_body"});
+  private IndexReader reader;
+  
+  private void buildTestIndex() throws IOException {
+    Directory dir = FSDirectory.open(tempDir);
+    
+    IndexWriterConfig config = new IndexWriterConfig();
+    config.setOpenMode(IndexWriterConfig.OpenMode.CREATE);
+    config.setSimilarity(new BM25Similarity());
+    config.setOpenMode(IndexWriterConfig.OpenMode.CREATE);
+    config.setRAMBufferSizeMB(8);
+    config.setUseCompoundFile(false);
+    config.setMergeScheduler(new ConcurrentMergeScheduler());
+    
+    IndexWriter writer = new IndexWriter(dir, config);
+
+    FieldType textOptions = new FieldType();
+    textOptions.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+    textOptions.setStored(true);
+    textOptions.setTokenized(true);
+    textOptions.setStoreTermVectors(true);
+    textOptions.setStoreTermVectorPositions(true);
+    
+    ClueWeb12Collection collection = new ClueWeb12Collection();
+    JsoupGenerator generator = new JsoupGenerator();
+    String rawDoc = FileUtils.readFileToString(new File(testingDocPath), StandardCharsets.UTF_8);
+    BaseFileSegment<ClueWeb12Collection.Document> iter = collection.createFileSegment(rawDoc);
+    while (iter.hasNext()) {
+      ClueWeb12Collection.Document parsed = iter.next();
+      Document d = generator.createDocument(parsed,
+          parsed.getAdditionalFields(fields));
+      writer.addDocument(d);
+    }
+    writer.commit();
+    writer.forceMerge(1);
+    writer.close();
+    
+    reader = DirectoryReader.open(FSDirectory.open(tempDir));
+  }
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    tempDir = createTempDir();
+    buildTestIndex();
+  }
+
+  @After
+  @Override
+  public void tearDown() throws Exception {
+    reader.close();
+    super.tearDown();
+  }
+  
+  @Test
+  public void testIndexIncludesFields() throws Exception {
+    Directory dir = FSDirectory.open(tempDir);
+    IndexReader reader = DirectoryReader.open(dir);
+    FieldInfos fieldInfos = MultiFields.getMergedFieldInfos(reader);
+    Fields indexedFields = MultiFields.getFields(reader);
+    Set<String> indexedFieldsSet = new HashSet<>();
+    int i = 0;
+    for (String fd : indexedFields) {
+      if (fields.contains(fd)) {
+        indexedFieldsSet.add(fd);
+      }
+    }
+    assertEquals(new HashSet<String>(fields), indexedFieldsSet);
+  
+    Document d = reader.document(0);
+    assertEquals(d.getField("url").stringValue(), "http://clueweb09.test.com/");
+    assertEquals(d.getField("title").stringValue(), "fox fox river");
+    assertEquals(d.getField("anchor_text").stringValue(), " anchor text fox");
+    // HTML BODY is NOT stored!!!!
+  }
+
+  @Test
+  public void testSearchFields() throws Exception {
+    class TFSimilarity extends Similarity {
+      class TFSimWeight extends SimWeight {
+        @Override
+        public float getValueForNormalization() {
+          // we return a TF-IDF like normalization to be nice, but we don't actually normalize ourselves.
+          return 1;
+        }
+        @Override
+        public void normalize(float queryNorm, float boost) {}
+      }
+      @Override
+      public final SimWeight computeWeight(CollectionStatistics collectionStats, TermStatistics... termStats) {
+        return new TFSimWeight();
+      }
+      @Override
+      public final SimScorer simScorer(SimWeight stats, LeafReaderContext context) throws IOException {
+        class TFDocScorer extends SimScorer {
+          @Override
+          public float score(int doc, float freq) {
+            return freq;
+          }
+    
+          @Override
+          public Explanation explain(int doc, Explanation freq) {
+            return null;
+          }
+    
+          @Override
+          public float computeSlopFactor(int distance) {
+            return 1.0f / (distance + 1);
+          }
+    
+          @Override
+          public float computePayloadFactor(int doc, int start, int end, BytesRef payload) {
+            return 1;
+          }
+        }
+        return new TFDocScorer();
+      }
+      @Override
+      public final long computeNorm(FieldInvertState state) {
+        return 1;
+      }
+    }
+    IndexSearcher searcher = new IndexSearcher(reader);
+    searcher.setSimilarity(new TFSimilarity());
+    StandardQueryParser p = new StandardQueryParser();
+    TopDocs rs;
+    rs = searcher.search( p.parse("fox", "html_body"), 1);
+    assertEquals(rs.scoreDocs.length, 1);
+    assertEquals(rs.scoreDocs[0].score, 4, 1e-8);
+    rs = searcher.search( p.parse("fox", "anchor_text"), 1);
+    assertEquals(rs.scoreDocs.length, 1);
+    assertEquals(rs.scoreDocs[0].score, 1, 1e-8);
+    rs = searcher.search( p.parse("fox", "title"), 1);
+    assertEquals(rs.scoreDocs.length, 1);
+    assertEquals(rs.scoreDocs[0].score, 2, 1e-8);
+  }
+}

--- a/src/test/java/io/anserini/index/IndexerTest.java
+++ b/src/test/java/io/anserini/index/IndexerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.anserini.integration;
+package io.anserini.index;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;

--- a/src/test/java/io/anserini/integration/EndToEndTest.java
+++ b/src/test/java/io/anserini/integration/EndToEndTest.java
@@ -153,6 +153,7 @@ public abstract class EndToEndTest extends LuceneTestCase {
       checkIndex();
     } catch (Exception e) {
       System.out.println("Test Indexing failed");
+      e.printStackTrace();
       fail();
     }
   }

--- a/src/test/resources/sample_docs/clueweb/clueweb12-1
+++ b/src/test/resources/sample_docs/clueweb/clueweb12-1
@@ -1,0 +1,30 @@
+WARC/1.0
+WARC-Type: response
+WARC-Target-URI: http://clueweb09.test.com/
+WARC-Warcinfo-ID: 993d3969-9643-4934-b1c6-68d4dbe55b83
+WARC-Date: 2009-03-65T08:43:19-0800
+WARC-Record-ID: <urn:uuid:6f12f095-18a8-4415-8f04-ec2477be81d5>
+WARC-TREC-ID: clueweb09-az0000-00-00000
+Content-Type: application/http;msgtype=response
+WARC-Identified-Payload-Type:
+Content-Length: 458
+
+HTTP/1.1 200 OK
+Content-Type: text/html
+Date: Tue, 13 Jan 2009 18:05:10 GMT
+Pragma: no-cache
+Cache-Control: no-cache, must-revalidate
+X-Powered-By: PHP/4.4.8
+Server: WebServerX
+Connection: close
+Last-Modified: Tue, 13 Jan 2009 18:05:10 GMT
+Expires: Mon, 20 Dec 1998 01:00:00 GMT
+Content-Length: 159
+
+<html>
+<head></head>
+<body>
+whatever here will be included fox <title>fox fox river</title>
+<a href="http://www.link.com">anchor text fox</a>
+</body>
+</html>


### PR DESCRIPTION
In this PR, I create the framework to add fields other than `id` and `contents`.
The implementation leaves the specific fields to the collections, i.e., what fields are supported should be decided by each collection and the type of the fields are also finalized in the collection.
Then the additional list of fields are passed to the generator to be added into Lucene Documents. 

Also, as the part of this PR I've added 4 fields `url`, `title`, `anchor_text` and `html_body` to ClueWeb collections.