### PR TITLE
#358 paragraph segmentation scripts for Robust04 and Core17 collection in Python

### DIFF
--- a/src/main/python/paragraph_indexing/README.md
+++ b/src/main/python/paragraph_indexing/README.md
@@ -1,0 +1,89 @@
+# Paragraph Indexing
+
+
+
+## Segment
+
+Segment each raw document into paragraph and dump out into seperate .json file named with DOCID in json format, e.g.
+
+```
+[
+    {
+        'id':'{$DOCNO}.0001',
+        'content':'content0001'
+	},
+    {
+        'id':'{$DOCNO}.0002',
+        'content':'content0001'
+    }
+]
+```
+
+This is done by `paraseg/seg_${collection}.py`, where supported collections so far are `robust04` and `core17`
+
+### Example:
+
+Run 
+
+```
+python paraseg/seg_robust04.py \
+ --input lucene-index.robust04.pos+docvectors+rawdocs.allDocids.txt.output.tar.gz \
+ --output robust04.paragraphs/
+```
+
+All documents will be segmented into paragraph and stored in folder `robust04.paragraphs/`
+
+### Input file
+
+The input raw documents should be a `tar.gz` file containing each document in a seperate file named as DOCID. This file can be generated through following command (e.g Robust04)
+
+Suppose you're under Anserini directory. First indexing
+
+```bash
+nohup sh target/appassembler/bin/IndexCollection -collection TrecCollection \
+ -input /path/to/disk45/ -generator JsoupGenerator \
+ -index lucene-index.robust04.pos+docvectors+rawdocs -threads 16 \
+ -storePositions -storeDocvectors -storeRawDocs -optimize \
+ >& log.robust04.pos+docvectors+rawdocs &
+```
+
+and then
+
+```bash
+sh target/appassembler/bin/IndexUtils \
+ -index lucene-index.robust04.pos+docvectors+rawdocs \
+ -dumpAllDocids NONE &&
+sh target/appassembler/bin/IndexUtils \
+ -index lucene-index.robust04.pos+docvectors+rawdocs \
+ -dumpRawDocs lucene-index.robust04.pos+docvectors+rawdocs.allDocids.txt
+```
+
+and the output `tar.gz` file will be named as 
+
+```
+lucene-index.robust04.pos+docvectors+rawdocs.allDocids.txt.output.tar.gz
+```
+
+
+
+## Paragraph Indexing
+
+The json file can be indexed using `JsonCollection` in Anserini. Run
+
+```bash
+sh target/appassembler/bin/IndexCollection -collection JsonCollection \
+ -input /path/to/robust04.paragraphs -generator LuceneDocumentGenerator \
+ -index lucene-index.robust04.paragraphs.pos+docvectors+rawdocs -threads 16 \
+ -storePositions -storeDocvectors -storeRawDocs -optimize  &&
+```
+
+to index each paragraph for Robust04 collection. `-input` should be the output folder of the paragraph segmentation
+
+
+
+## TL;DR
+
+1. Download `paraseg/` and `run.sh` under Anserini directory
+2. Run `bash run.sh robust04` on Robust04 collection or `bash run.sh core17` on NYT Collection.
+3. This script will segment document into paragraph, do paragraph indexing, and do searching on `BM25`, `BM25+RM3`, `QL`, `QL+RM3`
+

--- a/src/main/python/paragraph_indexing/README.md
+++ b/src/main/python/paragraph_indexing/README.md
@@ -19,19 +19,23 @@ Segment each raw document into paragraph and dump out into seperate .json file n
 ]
 ```
 
-This is done by `paraseg/seg_${collection}.py`, where supported collections so far are `robust04` and `core17`
+This is done by calling `seg_${collection}.py`, where supported collections so far are `robust04` and `core17`
+
+
 
 ### Example:
 
 Run 
 
 ```
-python paraseg/seg_robust04.py \
+python seg_robust04.py \
  --input lucene-index.robust04.pos+docvectors+rawdocs.allDocids.txt.output.tar.gz \
  --output robust04.paragraphs/
 ```
 
-All documents will be segmented into paragraph and stored in folder `robust04.paragraphs/`
+All documents will be segmented into paragraph and stored in folder `./robust04.paragraphs/`
+
+
 
 ### Input file
 
@@ -78,12 +82,3 @@ sh target/appassembler/bin/IndexCollection -collection JsonCollection \
 ```
 
 to index each paragraph for Robust04 collection. `-input` should be the output folder of the paragraph segmentation
-
-
-
-## TL;DR
-
-1. Download `paraseg/` and `run.sh` under Anserini directory
-2. Run `bash run.sh robust04` on Robust04 collection or `bash run.sh core17` on NYT Collection.
-3. This script will segment document into paragraph, do paragraph indexing, and do searching on `BM25`, `BM25+RM3`, `QL`, `QL+RM3`
-

--- a/src/main/python/paragraph_indexing/README.md
+++ b/src/main/python/paragraph_indexing/README.md
@@ -51,7 +51,9 @@ nohup sh target/appassembler/bin/IndexCollection -collection TrecCollection \
  >& log.robust04.pos+docvectors+rawdocs &
 ```
 
-and then
+and then dump the raw documents by the following two steps:
+1. dump all docids of the collection
+2. feed the docids file to dump raw documents
 
 ```bash
 sh target/appassembler/bin/IndexUtils \

--- a/src/main/python/paragraph_indexing/paraseg.py
+++ b/src/main/python/paragraph_indexing/paraseg.py
@@ -1,0 +1,258 @@
+"""
+Anserini: An information retrieval toolkit built on Lucene
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+class _ParaSegmenter(object):
+  """ The base class for all Paragraph Segmentation class """
+  def __init__(self, bufferreader, start_pattern_list=None):
+    self._br = bufferreader
+    self._isstart = False
+    self._curline = None
+    self._paralist = []
+    self._setup(start_pattern_list)
+
+  def _setup(self, pattern_list):
+    """ Find the start of the first paragraph of input document
+    This can only be called once when initializing the object
+
+    Args:
+      pattern_list(list): an indicator of starting a paragraph
+
+    Effect:
+      self._isstart set to True if found, else remains False
+      If <code>pattern_list</code> is None, treated as started
+    """
+    if pattern_list is None:
+      self._isstart = True
+      return
+
+    while True:
+      self._curline = self._br.readline()
+      if not self._curline:
+        return
+
+      if self._curline in pattern_list:
+        self._isstart = True
+        return
+
+  def _isend(self, line):
+    """ An indicator of the a paragraph's end. The code in this base class indicates
+    the end of a documents, as the end of a document indicates the end of a paragraph as well.
+
+    Args:
+      line(str): the line to be tested on
+
+    Return:
+      (bool): if this line is a paragraph end
+    """
+    if not line or line == b'</TEXT>':
+      return True
+
+    return False
+
+  def hasnextpara(self):
+    """ Check if there is anthoer paragraph in this document
+
+    If self._isstart == False after initialization, no useful information is contained in
+    this document, then return False
+    If reach the end of the doc, return False
+
+    Return:
+      (bool) if this document has further content
+
+    """
+    if not self._isstart or not self._curline or self._curline == b'</TEXT>':
+      return False
+    return True
+
+  def nextpara(self):
+    """ Two cases here:
+
+    1. There is a pattern indicating a new paragraph followed by self._curline,
+      In this case, after calling self.hasnextpara(), len(self._paralist) == 0.
+      In this case, also, subclasses should fill self._paralist in `self.hasnextpara()`
+    2. There is only a pattern indicating the end of a paragraph,
+      so one has to readline until the end to see if it is a paragraph.
+      In this case, after calling self.hasnextpara() and return True,
+      len(self._paralist) > 0
+
+    Return:
+      str: A string contains a paragraph
+    """
+    if not self._paralist:
+      while True:
+        self._curline = self._br.readline()
+        if self._isend(self._curline):
+          break
+        self._paralist.append(self._curline.decode('utf-8').strip())
+
+    parastr = ' '.join(self._paralist)
+    del self._paralist[:]
+    return parastr
+
+
+class FBISParaSegmenter(_ParaSegmenter):
+  """ A Segmenter to segment documents in FBIS collection under Robust04.
+
+  Args:
+    bufferreader (io.BufferedReader): the buffered reader of a document.
+  """
+  def __init__(self, bufferedreader):
+    start_pattern_list = [b'\n'] # start pattern by observation
+
+    super(FBISParaSegmenter, self).__init__(bufferedreader, start_pattern_list)
+    self._linelimit = 50 # An empirical number to decide if this is end of paragraph
+
+  def _isend(self, line):
+    if super(FBISParaSegmenter, self)._isend(line):
+      return True
+
+    if line[-2:] == b'.\n' and len(line) < self._linelimit:
+      return True
+
+    return False
+
+  def hasnextpara(self):
+    if not super(FBISParaSegmenter, self).hasnextpara():
+      return False
+
+    while True:
+      self._curline = self._br.readline()
+      if self._isend(self._curline):
+        break
+      self._paralist.append(self._curline.decode('utf-8').strip())
+
+    if not self._paralist:
+      # Handle the following pattern
+      # b'\n'
+      # b'</Text>\n'
+      return False
+
+    if len(self._curline) > 1:
+      # skip if self._curline == b'\n'
+      self._paralist.append(self._curline.decode('utf-8').strip())
+
+    return True
+
+
+class FR94ParaSegmenter(_ParaSegmenter):
+  """ A Segmenter to segment documents in FR94 collection under Robust04.
+
+  Args:
+    bufferreader (io.BufferedReader): the buffered reader of a document.
+  """
+  def __init__(self, bufferreader):
+    self._start_pattern_list = [
+        b'<!-- PJG 0012 frnewline -->\n',
+        b'<!-- PJG ITAG l=11 g=1 f=1 -->\n'
+    ] # start pattern by observation
+    super(FR94ParaSegmenter, self).__init__(bufferreader, self._start_pattern_list)
+
+  def _isend(self, line):
+    if super(FR94ParaSegmenter, self)._isend(line):
+      return True
+    if line[:4] == b'<!--':
+      return True
+    return False
+
+  def hasnextpara(self):
+    if not self._isstart:
+      return False
+
+    # find start pattern
+    while self._curline:
+      if self._curline in self._start_pattern_list:
+        return True
+      self._curline = self._br.readline()
+
+    return False
+
+
+class FTParaSegmenter(_ParaSegmenter):
+  """ A Segmenter to segment documents in FT collection under Robust04.
+
+  Args:
+    bufferreader (io.BufferedReader): the buffered reader of a document.
+  """
+  def __init__(self, bufferreader):
+    start_pattern_list = [b'<TEXT>\n'] # start pattern by observation
+    super(FTParaSegmenter, self).__init__(bufferreader, start_pattern_list)
+    self._linelimit = 105 # An empirical number to decide if this is end of paragraph
+
+  def _isend(self, line):
+    if super(FTParaSegmenter, self)._isend(line):
+      return True
+    if line[-2:] == b'.\n' and len(line) < self._linelimit:
+      return True
+    return False
+
+  def hasnextpara(self):
+    if not super(FTParaSegmenter, self).hasnextpara():
+      return False
+
+    while True:
+      self._curline = self._br.readline()
+      self._paralist.append(self._curline.decode('utf-8').strip())
+      if self._isend(self._curline):
+        break
+
+    return True
+
+
+class LAParaSegmenter(_ParaSegmenter):
+  """ A Segmenter to segment documents in LA collection under Robust04.
+
+  Args:
+    bufferreader (io.BufferedReader): the buffered reader of a document.
+  """
+  def __init__(self, bufferreader):
+    self._start_pattern_list = [b'<P>\n']
+    super(LAParaSegmenter, self).__init__(bufferreader, self._start_pattern_list)
+
+  def _isend(self, line):
+    if super(LAParaSegmenter, self)._isend(line):
+      return True
+    if line == b'</P>\n':
+      return True
+    return False
+
+  def hasnextpara(self):
+    if not super(LAParaSegmenter, self).hasnextpara():
+      return False
+
+    while self._curline:
+      if self._curline in self._start_pattern_list:
+        return True
+      self._curline = self._br.readline()
+
+    return False
+
+
+
+class NYTParaSegmenter(_ParaSegmenter):
+  """ A Segmenter to segment documents in New York Times collection under Core17.
+
+  Args:
+    bufferreader (io.BufferedReader): the buffered reader of a document.
+  """
+  def __init__(self, bufferreader):
+    super(NYTParaSegmenter, self).__init__(bufferreader)
+
+  def hasnextpara(self):
+    self._curline = self._br.readline()
+    return len(self._curline) > 0
+
+  def nextpara(self):
+    return self._curline.decode('utf-8').strip()

--- a/src/main/python/paragraph_indexing/paraseg.py
+++ b/src/main/python/paragraph_indexing/paraseg.py
@@ -15,244 +15,244 @@ limitations under the License.
 """
 
 class _ParaSegmenter(object):
-  """ The base class for all Paragraph Segmentation class """
-  def __init__(self, bufferedreader, start_pattern_list=None):
-    self._br = bufferedreader
-    self._isstart = False
-    self._curline = None
-    self._paralist = []
-    self._setup(start_pattern_list)
+    """ The base class for all Paragraph Segmentation class """
+    def __init__(self, bufferedreader, start_pattern_list=None):
+        self._br = bufferedreader
+        self._isstart = False
+        self._curline = None
+        self._paralist = []
+        self._setup(start_pattern_list)
 
-  def _setup(self, pattern_list):
-    """ Find the start of the first paragraph of input document
-    This can only be called once when initializing the object
+    def _setup(self, pattern_list):
+        """ Find the start of the first paragraph of input document
+        This can only be called once when initializing the object
 
-    Args:
-      pattern_list(list): an indicator of starting a paragraph
+        Args:
+            pattern_list(list): an indicator of starting a paragraph
 
-    Effect:
-      self._isstart set to True if found, else remains False
-      If <code>pattern_list</code> is None, treated as started
-    """
-    if pattern_list is None:
-      self._isstart = True
-      return
+        Effect:
+            self._isstart set to True if found, else remains False
+            If <code>pattern_list</code> is None, treated as started
+        """
+        if pattern_list is None:
+            self._isstart = True
+            return
 
-    while True:
-      self._curline = self._br.readline()
-      if not self._curline:
-        return
+        while True:
+            self._curline = self._br.readline()
+            if not self._curline:
+                return
 
-      if self._curline in pattern_list:
-        self._isstart = True
-        return
+            if self._curline in pattern_list:
+                self._isstart = True
+                return
 
-  def _isend(self, line):
-    """ An indicator of the a paragraph's end. The code in this base class indicates
-    the end of a documents, as the end of a document indicates the end of a paragraph as well.
+    def _isend(self, line):
+        """ An indicator of the a paragraph's end. The code in this base class indicates
+        the end of a documents, as the end of a document indicates the end of a paragraph as well.
 
-    Args:
-      line(str): the line to be tested on
+        Args:
+            line(str): the line to be tested on
 
-    Return:
-      (bool): if this line is a paragraph end
-    """
-    if not line or line == b'</TEXT>':
-      return True
+        Return:
+            (bool): if this line is a paragraph end
+        """
+        if not line or line == b'</TEXT>':
+            return True
 
-    return False
+        return False
 
-  def hasnextpara(self):
-    """ Check if there is anthoer paragraph in this document
+    def hasnextpara(self):
+        """ Check if there is anthoer paragraph in this document
 
-    If self._isstart == False after initialization, no useful information is contained in
-    this document, then return False
-    If reach the end of the doc, return False
+        If self._isstart == False after initialization, no useful information is contained in
+        this document, then return False
+        If reach the end of the doc, return False
 
-    Return:
-      (bool) if this document has further content
+        Return:
+            (bool) if this document has further content
 
-    """
-    if not self._isstart or not self._curline or self._curline == b'</TEXT>':
-      return False
-    return True
+        """
+        if not self._isstart or not self._curline or self._curline == b'</TEXT>':
+            return False
+        return True
 
-  def nextpara(self):
-    """ Two cases here:
+    def nextpara(self):
+        """ Two cases here:
 
-    1. There is a pattern indicating a new paragraph followed by self._curline,
-      In this case, after calling self.hasnextpara(), len(self._paralist) == 0.
-      In this case, also, subclasses should fill self._paralist in `self.hasnextpara()`
-    2. There is only a pattern indicating the end of a paragraph,
-      so one has to readline until the end to see if it is a paragraph.
-      In this case, after calling self.hasnextpara() and return True,
-      len(self._paralist) > 0
+        1. There is a pattern indicating a new paragraph followed by self._curline,
+            In this case, after calling self.hasnextpara(), len(self._paralist) == 0.
+            In this case, also, subclasses should fill self._paralist in `self.hasnextpara()`
+        2. There is only a pattern indicating the end of a paragraph,
+            so one has to readline until the end to see if it is a paragraph.
+            In this case, after calling self.hasnextpara() and return True,
+            len(self._paralist) > 0
 
-    Return:
-      str: A string contains a paragraph
-    """
-    if not self._paralist:
-      while True:
-        self._curline = self._br.readline()
-        if self._isend(self._curline):
-          break
-        self._paralist.append(self._curline.decode('utf-8').strip())
+        Return:
+            str: A string contains a paragraph
+        """
+        if not self._paralist:
+            while True:
+                self._curline = self._br.readline()
+                if self._isend(self._curline):
+                    break
+                self._paralist.append(self._curline.decode('utf-8').strip())
 
-    parastr = ' '.join(self._paralist)
-    del self._paralist[:]
-    return parastr
+        parastr = ' '.join(self._paralist)
+        del self._paralist[:]
+        return parastr
 
 
 class FBISParaSegmenter(_ParaSegmenter):
-  """ A Segmenter to segment documents in FBIS collection under Robust04.
+    """ A Segmenter to segment documents in FBIS collection under Robust04.
 
-  Args:
-    bufferedreader (io.BufferedReader): the buffered reader of a document.
-  """
-  def __init__(self, bufferedreader):
-    start_pattern_list = [b'\n'] # start pattern by observation
+    Args:
+        bufferedreader (io.BufferedReader): the buffered reader of a document.
+    """
+    def __init__(self, bufferedreader):
+        start_pattern_list = [b'\n'] # start pattern by observation
 
-    super(FBISParaSegmenter, self).__init__(bufferedreader, start_pattern_list)
-    self._linelimit = 50 # An empirical number to decide if this is end of paragraph
+        super(FBISParaSegmenter, self).__init__(bufferedreader, start_pattern_list)
+        self._linelimit = 50 # An empirical number to decide if this is end of paragraph
 
-  def _isend(self, line):
-    if super(FBISParaSegmenter, self)._isend(line):
-      return True
+    def _isend(self, line):
+        if super(FBISParaSegmenter, self)._isend(line):
+            return True
 
-    if line[-2:] == b'.\n' and len(line) < self._linelimit:
-      return True
+        if line[-2:] == b'.\n' and len(line) < self._linelimit:
+            return True
 
-    return False
+        return False
 
-  def hasnextpara(self):
-    if not super(FBISParaSegmenter, self).hasnextpara():
-      return False
+    def hasnextpara(self):
+        if not super(FBISParaSegmenter, self).hasnextpara():
+            return False
 
-    while True:
-      self._curline = self._br.readline()
-      if self._isend(self._curline):
-        break
-      self._paralist.append(self._curline.decode('utf-8').strip())
+        while True:
+            self._curline = self._br.readline()
+            if self._isend(self._curline):
+                break
+            self._paralist.append(self._curline.decode('utf-8').strip())
 
-    if not self._paralist:
-      # Handle the following pattern
-      # b'\n'
-      # b'</Text>\n'
-      return False
+        if not self._paralist:
+            # Handle the following pattern
+            # b'\n'
+            # b'</Text>\n'
+            return False
 
-    if len(self._curline) > 1:
-      # skip if self._curline == b'\n'
-      self._paralist.append(self._curline.decode('utf-8').strip())
+        if len(self._curline) > 1:
+            # skip if self._curline == b'\n'
+            self._paralist.append(self._curline.decode('utf-8').strip())
 
-    return True
+        return True
 
 
 class FR94ParaSegmenter(_ParaSegmenter):
-  """ A Segmenter to segment documents in FR94 collection under Robust04.
+    """ A Segmenter to segment documents in FR94 collection under Robust04.
 
-  Args:
-    bufferedreader (io.BufferedReader): the buffered reader of a document.
-  """
-  def __init__(self, bufferedreader):
-    self._start_pattern_list = [
-        b'<!-- PJG 0012 frnewline -->\n',
-        b'<!-- PJG ITAG l=11 g=1 f=1 -->\n'
-    ] # start pattern by observation
-    super(FR94ParaSegmenter, self).__init__(bufferedreader, self._start_pattern_list)
+    Args:
+        bufferedreader (io.BufferedReader): the buffered reader of a document.
+    """
+    def __init__(self, bufferedreader):
+        self._start_pattern_list = [
+            b'<!-- PJG 0012 frnewline -->\n',
+            b'<!-- PJG ITAG l=11 g=1 f=1 -->\n'
+        ] # start pattern by observation
+        super(FR94ParaSegmenter, self).__init__(bufferedreader, self._start_pattern_list)
 
-  def _isend(self, line):
-    if super(FR94ParaSegmenter, self)._isend(line):
-      return True
-    if line[:4] == b'<!--':
-      return True
-    return False
+    def _isend(self, line):
+        if super(FR94ParaSegmenter, self)._isend(line):
+            return True
+        if line[:4] == b'<!--':
+            return True
+        return False
 
-  def hasnextpara(self):
-    if not self._isstart:
-      return False
+    def hasnextpara(self):
+        if not self._isstart:
+            return False
 
-    # find start pattern
-    while self._curline:
-      if self._curline in self._start_pattern_list:
-        return True
-      self._curline = self._br.readline()
+        # find start pattern
+        while self._curline:
+            if self._curline in self._start_pattern_list:
+                return True
+            self._curline = self._br.readline()
 
-    return False
+        return False
 
 
 class FTParaSegmenter(_ParaSegmenter):
-  """ A Segmenter to segment documents in FT collection under Robust04.
+    """ A Segmenter to segment documents in FT collection under Robust04.
 
-  Args:
-    bufferedreader (io.BufferedReader): the buffered reader of a document.
-  """
-  def __init__(self, bufferedreader):
-    start_pattern_list = [b'<TEXT>\n'] # start pattern by observation
-    super(FTParaSegmenter, self).__init__(bufferedreader, start_pattern_list)
-    self._linelimit = 105 # An empirical number to decide if this is end of paragraph
+    Args:
+        bufferedreader (io.BufferedReader): the buffered reader of a document.
+    """
+    def __init__(self, bufferedreader):
+        start_pattern_list = [b'<TEXT>\n'] # start pattern by observation
+        super(FTParaSegmenter, self).__init__(bufferedreader, start_pattern_list)
+        self._linelimit = 105 # An empirical number to decide if this is end of paragraph
 
-  def _isend(self, line):
-    if super(FTParaSegmenter, self)._isend(line):
-      return True
-    if line[-2:] == b'.\n' and len(line) < self._linelimit:
-      return True
-    return False
+    def _isend(self, line):
+        if super(FTParaSegmenter, self)._isend(line):
+            return True
+        if line[-2:] == b'.\n' and len(line) < self._linelimit:
+            return True
+        return False
 
-  def hasnextpara(self):
-    if not super(FTParaSegmenter, self).hasnextpara():
-      return False
+    def hasnextpara(self):
+        if not super(FTParaSegmenter, self).hasnextpara():
+            return False
 
-    while True:
-      self._curline = self._br.readline()
-      self._paralist.append(self._curline.decode('utf-8').strip())
-      if self._isend(self._curline):
-        break
+        while True:
+            self._curline = self._br.readline()
+            self._paralist.append(self._curline.decode('utf-8').strip())
+            if self._isend(self._curline):
+                break
 
-    return True
+        return True
 
 
 class LAParaSegmenter(_ParaSegmenter):
-  """ A Segmenter to segment documents in LA collection under Robust04.
+    """ A Segmenter to segment documents in LA collection under Robust04.
 
-  Args:
-    bufferedreader (io.BufferedReader): the buffered reader of a document.
-  """
-  def __init__(self, bufferedreader):
-    self._start_pattern_list = [b'<P>\n']
-    super(LAParaSegmenter, self).__init__(bufferedreader, self._start_pattern_list)
+    Args:
+        bufferedreader (io.BufferedReader): the buffered reader of a document.
+    """
+    def __init__(self, bufferedreader):
+        self._start_pattern_list = [b'<P>\n']
+        super(LAParaSegmenter, self).__init__(bufferedreader, self._start_pattern_list)
 
-  def _isend(self, line):
-    if super(LAParaSegmenter, self)._isend(line):
-      return True
-    if line == b'</P>\n':
-      return True
-    return False
+    def _isend(self, line):
+        if super(LAParaSegmenter, self)._isend(line):
+            return True
+        if line == b'</P>\n':
+            return True
+        return False
 
-  def hasnextpara(self):
-    if not super(LAParaSegmenter, self).hasnextpara():
-      return False
+    def hasnextpara(self):
+        if not super(LAParaSegmenter, self).hasnextpara():
+            return False
 
-    while self._curline:
-      if self._curline in self._start_pattern_list:
-        return True
-      self._curline = self._br.readline()
+        while self._curline:
+            if self._curline in self._start_pattern_list:
+                return True
+            self._curline = self._br.readline()
 
-    return False
+        return False
 
 
 
 class NYTParaSegmenter(_ParaSegmenter):
-  """ A Segmenter to segment documents in New York Times collection under Core17.
+    """ A Segmenter to segment documents in New York Times collection under Core17.
 
-  Args:
-    bufferedreader (io.BufferedReader): the buffered reader of a document.
-  """
-  def __init__(self, bufferedreader):
-    super(NYTParaSegmenter, self).__init__(bufferedreader)
+    Args:
+        bufferedreader (io.BufferedReader): the buffered reader of a document.
+    """
+    def __init__(self, bufferedreader):
+        super(NYTParaSegmenter, self).__init__(bufferedreader)
 
-  def hasnextpara(self):
-    self._curline = self._br.readline()
-    return len(self._curline) > 0
+    def hasnextpara(self):
+        self._curline = self._br.readline()
+        return len(self._curline) > 0
 
-  def nextpara(self):
-    return self._curline.decode('utf-8').strip()
+    def nextpara(self):
+        return self._curline.decode('utf-8').strip()

--- a/src/main/python/paragraph_indexing/paraseg.py
+++ b/src/main/python/paragraph_indexing/paraseg.py
@@ -16,8 +16,8 @@ limitations under the License.
 
 class _ParaSegmenter(object):
   """ The base class for all Paragraph Segmentation class """
-  def __init__(self, bufferreader, start_pattern_list=None):
-    self._br = bufferreader
+  def __init__(self, bufferedreader, start_pattern_list=None):
+    self._br = bufferedreader
     self._isstart = False
     self._curline = None
     self._paralist = []
@@ -107,7 +107,7 @@ class FBISParaSegmenter(_ParaSegmenter):
   """ A Segmenter to segment documents in FBIS collection under Robust04.
 
   Args:
-    bufferreader (io.BufferedReader): the buffered reader of a document.
+    bufferedreader (io.BufferedReader): the buffered reader of a document.
   """
   def __init__(self, bufferedreader):
     start_pattern_list = [b'\n'] # start pattern by observation
@@ -151,14 +151,14 @@ class FR94ParaSegmenter(_ParaSegmenter):
   """ A Segmenter to segment documents in FR94 collection under Robust04.
 
   Args:
-    bufferreader (io.BufferedReader): the buffered reader of a document.
+    bufferedreader (io.BufferedReader): the buffered reader of a document.
   """
-  def __init__(self, bufferreader):
+  def __init__(self, bufferedreader):
     self._start_pattern_list = [
         b'<!-- PJG 0012 frnewline -->\n',
         b'<!-- PJG ITAG l=11 g=1 f=1 -->\n'
     ] # start pattern by observation
-    super(FR94ParaSegmenter, self).__init__(bufferreader, self._start_pattern_list)
+    super(FR94ParaSegmenter, self).__init__(bufferedreader, self._start_pattern_list)
 
   def _isend(self, line):
     if super(FR94ParaSegmenter, self)._isend(line):
@@ -184,11 +184,11 @@ class FTParaSegmenter(_ParaSegmenter):
   """ A Segmenter to segment documents in FT collection under Robust04.
 
   Args:
-    bufferreader (io.BufferedReader): the buffered reader of a document.
+    bufferedreader (io.BufferedReader): the buffered reader of a document.
   """
-  def __init__(self, bufferreader):
+  def __init__(self, bufferedreader):
     start_pattern_list = [b'<TEXT>\n'] # start pattern by observation
-    super(FTParaSegmenter, self).__init__(bufferreader, start_pattern_list)
+    super(FTParaSegmenter, self).__init__(bufferedreader, start_pattern_list)
     self._linelimit = 105 # An empirical number to decide if this is end of paragraph
 
   def _isend(self, line):
@@ -215,11 +215,11 @@ class LAParaSegmenter(_ParaSegmenter):
   """ A Segmenter to segment documents in LA collection under Robust04.
 
   Args:
-    bufferreader (io.BufferedReader): the buffered reader of a document.
+    bufferedreader (io.BufferedReader): the buffered reader of a document.
   """
-  def __init__(self, bufferreader):
+  def __init__(self, bufferedreader):
     self._start_pattern_list = [b'<P>\n']
-    super(LAParaSegmenter, self).__init__(bufferreader, self._start_pattern_list)
+    super(LAParaSegmenter, self).__init__(bufferedreader, self._start_pattern_list)
 
   def _isend(self, line):
     if super(LAParaSegmenter, self)._isend(line):
@@ -245,10 +245,10 @@ class NYTParaSegmenter(_ParaSegmenter):
   """ A Segmenter to segment documents in New York Times collection under Core17.
 
   Args:
-    bufferreader (io.BufferedReader): the buffered reader of a document.
+    bufferedreader (io.BufferedReader): the buffered reader of a document.
   """
-  def __init__(self, bufferreader):
-    super(NYTParaSegmenter, self).__init__(bufferreader)
+  def __init__(self, bufferedreader):
+    super(NYTParaSegmenter, self).__init__(bufferedreader)
 
   def hasnextpara(self):
     self._curline = self._br.readline()

--- a/src/main/python/paragraph_indexing/paraseg.py
+++ b/src/main/python/paragraph_indexing/paraseg.py
@@ -63,7 +63,7 @@ class _ParaSegmenter(object):
         return False
 
     def hasnextpara(self):
-        """ Check if there is anthoer paragraph in this document
+        """ Check if there is a paragraph in this document
 
         If self._isstart == False after initialization, no useful information is contained in
         this document, then return False

--- a/src/main/python/paragraph_indexing/seg_core17.py
+++ b/src/main/python/paragraph_indexing/seg_core17.py
@@ -1,0 +1,80 @@
+"""
+Anserini: An information retrieval toolkit built on Lucene
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import argparse
+import json
+import logging
+import os
+
+from .paraseg import NYTParaSegmenter
+from .utils import TgzReader, safe_mkdir, form_json
+
+if __name__ == '__main__':
+  logging.basicConfig(level=logging.DEBUG,
+                      format='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S ')
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--input", '-i', type=str,
+                      help='path to input tgz file', required=True)
+  parser.add_argument("--output", '-o', type=str,
+                      help='path to output folder', required=True)
+
+  args = parser.parse_args()
+  input_path = args.input
+  output_path = args.output
+
+  # preprocessing
+  safe_mkdir(output_path)
+
+  # start to segment
+  counter = 0
+
+  logging.info('start to segment files from %s', input_path)
+  reader = TgzReader(input_path)
+  while reader.hasnext():
+    counter += 1
+    if counter % 100000 == 0:
+      logging.info('%s files have been processed', counter)
+
+    docname, content_buffer = reader.next()
+    segmenter = NYTParaSegmenter(content_buffer)
+
+    paraid = 0
+    parajsonarray = []
+    while segmenter.hasnextpara():
+      parastr = segmenter.nextpara()
+      if len(parastr) < 50: # drop paragraphs with length < 50
+        continue
+
+      paraid += 1
+      if paraid >= 10000:
+        logging.info('document %s has more than 10000 paragraphs...', docname)
+        break
+      parajsonarray.append(form_json(docname, paraid, parastr))
+
+    # This is an empty file
+    if paraid == 0:
+      paraid += 1
+      parastr = ''
+      parajsonarray.append(form_json(docname, paraid, parastr))
+
+    jsonstr = json.dumps(parajsonarray, separators=(',', ':'), indent=2)
+
+    with open(os.path.join(output_path, '{}.json'.format(docname)), 'w') as f:
+      f.write(jsonstr)
+
+  logging.info('%d files have been segmented into paragraphs stored in %s', counter, output_path)
+  reader.close()

--- a/src/main/python/paragraph_indexing/seg_robust04.py
+++ b/src/main/python/paragraph_indexing/seg_robust04.py
@@ -1,0 +1,90 @@
+"""
+Anserini: An information retrieval toolkit built on Lucene
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import argparse
+import json
+import logging
+import os
+
+from .paraseg import FBISParaSegmenter, FR94ParaSegmenter, FTParaSegmenter, LAParaSegmenter
+from .utils import TgzReader, safe_mkdir, form_json
+
+SEGMENTER = {
+    'FB': FBISParaSegmenter,
+    'FR': FR94ParaSegmenter,
+    'FT': FTParaSegmenter,
+    'LA': LAParaSegmenter
+}
+
+if __name__ == '__main__':
+  logging.basicConfig(level=logging.DEBUG,
+                      format='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S ')
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--input", '-i', type=str,
+                      help='path to input tgz file', required=True)
+  parser.add_argument("--output", '-o', type=str,
+                      help='path to output folder', required=True)
+
+  args = parser.parse_args()
+  input_path = args.input
+  output_path = args.output
+
+  # preprocessing
+  safe_mkdir(output_path)
+
+  # start to segment
+  counter = 0
+
+  logging.info('start to segment files from %s', input_path)
+  reader = TgzReader(input_path)
+  while reader.hasnext():
+    counter += 1
+    if counter % 100000 == 0:
+      logging.info('%d files have been processed', counter)
+
+    docname, content_buffer = reader.next()
+    if docname[:2] in SEGMENTER:
+      segmenter = SEGMENTER[docname[:2]](content_buffer)
+    else:
+      raise TypeError('Invalid file type')
+
+    paraid = 0
+    parajsonarray = []
+    while segmenter.hasnextpara():
+      parastr = segmenter.nextpara()
+      if len(parastr) < 50:
+        continue
+
+      paraid += 1
+      if paraid >= 10000:
+        logging.info('document %s has more than 10000 paragraphs...', docname)
+        break
+      parajsonarray.append(form_json(docname, paraid, parastr))
+
+    # This is an empty file
+    if paraid == 0:
+      paraid += 1
+      parastr = ''
+      parajsonarray.append(form_json(docname, paraid, parastr))
+
+    jsonstr = json.dumps(parajsonarray, separators=(',', ':'), indent=2)
+
+    with open(os.path.join(output_path, '{}.json'.format(docname)), 'w') as f:
+      f.write(jsonstr)
+
+  logging.info('%d files have been segmented into paragraphs stored in %s', counter, output_path)
+  reader.close()

--- a/src/main/python/paragraph_indexing/seg_robust04.py
+++ b/src/main/python/paragraph_indexing/seg_robust04.py
@@ -30,61 +30,61 @@ SEGMENTER = {
 }
 
 if __name__ == '__main__':
-  logging.basicConfig(level=logging.DEBUG,
-                      format='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S ')
+    logging.basicConfig(level=logging.DEBUG,
+                        format='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S ')
 
-  parser = argparse.ArgumentParser()
-  parser.add_argument("--input", '-i', type=str,
-                      help='path to input tgz file', required=True)
-  parser.add_argument("--output", '-o', type=str,
-                      help='path to output folder', required=True)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", '-i', type=str,
+                        help='path to input tgz file', required=True)
+    parser.add_argument("--output", '-o', type=str,
+                        help='path to output folder', required=True)
 
-  args = parser.parse_args()
-  input_path = args.input
-  output_path = args.output
+    args = parser.parse_args()
+    input_path = args.input
+    output_path = args.output
 
-  # preprocessing
-  safe_mkdir(output_path)
+    # preprocessing
+    safe_mkdir(output_path)
 
-  # start to segment
-  counter = 0
+    # start to segment
+    counter = 0
 
-  logging.info('start to segment files from %s', input_path)
-  reader = TgzReader(input_path)
-  while reader.hasnext():
-    counter += 1
-    if counter % 100000 == 0:
-      logging.info('%d files have been processed', counter)
+    logging.info('start to segment files from %s', input_path)
+    reader = TgzReader(input_path)
+    while reader.hasnext():
+        counter += 1
+        if counter % 100000 == 0:
+            logging.info('%d files have been processed', counter)
 
-    docname, content_buffer = reader.next()
-    if docname[:2] in SEGMENTER:
-      segmenter = SEGMENTER[docname[:2]](content_buffer)
-    else:
-      raise TypeError('Invalid file type')
+        docname, content_buffer = reader.next()
+        if docname[:2] in SEGMENTER:
+            segmenter = SEGMENTER[docname[:2]](content_buffer)
+        else:
+            raise TypeError('Invalid file type')
 
-    paraid = 0
-    parajsonarray = []
-    while segmenter.hasnextpara():
-      parastr = segmenter.nextpara()
-      if len(parastr) < 50:
-        continue
+        paraid = 0
+        parajsonarray = []
+        while segmenter.hasnextpara():
+            parastr = segmenter.nextpara()
+            if len(parastr) < 50:
+                continue
 
-      paraid += 1
-      if paraid >= 10000:
-        logging.info('document %s has more than 10000 paragraphs...', docname)
-        break
-      parajsonarray.append(form_json(docname, paraid, parastr))
+            paraid += 1
+            if paraid >= 10000:
+                logging.info('document %s has more than 10000 paragraphs...', docname)
+                break
+            parajsonarray.append(form_json(docname, paraid, parastr))
 
-    # This is an empty file
-    if paraid == 0:
-      paraid += 1
-      parastr = ''
-      parajsonarray.append(form_json(docname, paraid, parastr))
+        # This is an empty file
+        if paraid == 0:
+            paraid += 1
+            parastr = ''
+            parajsonarray.append(form_json(docname, paraid, parastr))
 
-    jsonstr = json.dumps(parajsonarray, separators=(',', ':'), indent=2)
+        jsonstr = json.dumps(parajsonarray, separators=(',', ':'), indent=2)
 
-    with open(os.path.join(output_path, '{}.json'.format(docname)), 'w') as f:
-      f.write(jsonstr)
+        with open(os.path.join(output_path, '{}.json'.format(docname)), 'w') as f:
+            f.write(jsonstr)
 
-  logging.info('%d files have been segmented into paragraphs stored in %s', counter, output_path)
-  reader.close()
+    logging.info('%d files have been segmented into paragraphs stored in %s', counter, output_path)
+    reader.close()

--- a/src/main/python/paragraph_indexing/utils.py
+++ b/src/main/python/paragraph_indexing/utils.py
@@ -18,63 +18,63 @@ import os
 import tarfile
 
 class TgzReader(object):
-  """ A Reader to read tar.gz with multiple raw document files efficiently.
+    """ A Reader to read tar.gz with multiple raw document files efficiently.
 
-  A tar.gz file has the following structure:
+    A tar.gz file has the following structure:
 
-    DOCID_1:
-      RAW DOCS 1
-    DOCID_2:
-      RAW DOCS 2
-    ...
+        DOCID_1:
+            RAW DOCS 1
+        DOCID_2:
+            RAW DOCS 2
+        ...
 
-  Args:
-    path(str): the path of input tar.gz file
-  """
-  def __init__(self, path):
-    self._path = path
-    self._tar = tarfile.open(path, "r:gz")
-    self._next = None
-
-  def close(self):
-    """ close the reader stream. """
-    self._tar.close()
-
-  def hasnext(self):
-    """ return whether the tar file has files or not
-
-    Returns:
-      bool: whether the tar file has files or not
+    Args:
+        path(str): the path of input tar.gz file
     """
-    self._next = self._tar.next()
-    if not self._next:
-      return False
-    if not self._next.isfile():
-      return self.hasnext()
-    return True
+    def __init__(self, path):
+        self._path = path
+        self._tar = tarfile.open(path, "r:gz")
+        self._next = None
 
-  def next(self):
-    """ get the next tf-idf files
+    def close(self):
+        """ close the reader stream. """
+        self._tar.close()
 
-    Returns:
-      (str, io.BytesIO): the file name and a bytes io stream containing doc contents.
+    def hasnext(self):
+        """ return whether the tar file has files or not
 
-    Raises:
-      ValueError: if there is not next entry in this tar file.
-    """
-    if self._next:
-      return self._next.name, self._tar.extractfile(self._next)
-    raise ValueError("No files.")
+        Returns:
+            bool: whether the tar file has files or not
+        """
+        self._next = self._tar.next()
+        if not self._next:
+            return False
+        if not self._next.isfile():
+            return self.hasnext()
+        return True
+
+    def next(self):
+        """ get the next tf-idf files
+
+        Returns:
+            (str, io.BytesIO): the file name and a bytes io stream containing doc contents.
+
+        Raises:
+            ValueError: if there is not next entry in this tar file.
+        """
+        if self._next:
+            return self._next.name, self._tar.extractfile(self._next)
+        raise ValueError("No files.")
 
 def safe_mkdir(path):
-  """ create directory if not exists """
-  if not os.path.exists(path):
-    os.mkdir(path)
+    """ create directory if not exists """
+    if not os.path.exists(path):
+        os.mkdir(path)
 
 def form_json(doc_name, para_id, content):
-  """ form a document into json format """
-  doc = {
-      'id': '{}.{:04d}'.format(doc_name, para_id),
-      'contents': content
-  }
-  return doc
+    """ form a document into json format """
+    doc = {
+        'id': '{}.{:04d}'.format(doc_name, para_id),
+        'contents': content
+    }
+    return doc

--- a/src/main/python/paragraph_indexing/utils.py
+++ b/src/main/python/paragraph_indexing/utils.py
@@ -1,0 +1,80 @@
+"""
+Anserini: An information retrieval toolkit built on Lucene
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import tarfile
+
+class TgzReader(object):
+  """ A Reader to read tar.gz with multiple raw document files efficiently.
+
+  A tar.gz file has the following structure:
+
+    DOCID_1:
+      RAW DOCS 1
+    DOCID_2:
+      RAW DOCS 2
+    ...
+
+  Args:
+    path(str): the path of input tar.gz file
+  """
+  def __init__(self, path):
+    self._path = path
+    self._tar = tarfile.open(path, "r:gz")
+    self._next = None
+
+  def close(self):
+    """ close the reader stream. """
+    self._tar.close()
+
+  def hasnext(self):
+    """ return whether the tar file has files or not
+
+    Returns:
+      bool: whether the tar file has files or not
+    """
+    self._next = self._tar.next()
+    if not self._next:
+      return False
+    if not self._next.isfile():
+      return self.hasnext()
+    return True
+
+  def next(self):
+    """ get the next tf-idf files
+
+    Returns:
+      (str, io.BytesIO): the file name and a bytes io stream containing doc contents.
+
+    Raises:
+      ValueError: if there is not next entry in this tar file.
+    """
+    if self._next:
+      return self._next.name, self._tar.extractfile(self._next)
+    raise ValueError("No files.")
+
+def safe_mkdir(path):
+  """ create directory if not exists """
+  if not os.path.exists(path):
+    os.mkdir(path)
+
+def form_json(doc_name, para_id, content):
+  """ form a document into json format """
+  doc = {
+      'id': '{}.{:04d}'.format(doc_name, para_id),
+      'contents': content
+  }
+  return doc


### PR DESCRIPTION
These codes provides paragraph segmentation on Robust04 and Core17 collections, by reading the raw documents stored in the document-level indexing files. Each document will be segmented into paragraphs and dumped in `json` format which meets the input format of [`JsonCollection`](https://github.com/Kytabyte/Anserini/blob/master/src/main/java/io/anserini/collection/JsonCollection.java). As such, one is able to build paragraph-level indexing afterwards. 

I designed a base class for all paragraph segmenter called `_ParaSegmenter` in `paraseg.py` and all concrete segmenters extends this base class.

The base class defines four basic functionalities that a segmenter should have:
1. how to identify the start of the main body (`_setup`)
2. how to identify the start of *a* paragraph (`hasnextpara`)
3. how to identify the end of a paragraph (`_isend`)
4. return the next paragraph (`nextpara`)

For different collections, the strategies may vary. 

For some collections, they are very easy to detect. for instance, NYT just split paragraphs by `\n`, with no else indicators; for LA collections in Robust04, every paragraph is wrapped around by `<P></P>`, a and each paragraph is a single line.

However, some collections are not that easy to do paragraph separation. For FT collections in Robust04, a document starts by a `<TEXT>` line. However, due to the technical issues in formatting and printing at that time, instead of one-line-one-paragraph, each paragraph is manually cut by several newlines, and the separator between paragraphs is `\n` as well. This makes the paragraphs cannot generally be segmented by a deterministic rule. For instance, the content of a raw document may look like this:

```
<TEXT>
b'He said those points will have a bearing on the future of\n'
b'Mexico and noted the EZLN is not prepared to lay down its\n'
b'weapons, since it is certain that the pacification process in\n'
b'Chiapas is not simple. The signing of a peace accord, he added,\n'
b'will not be fast or easy to attain, and many days will pass in\n'
b'order to obtain satisfactory responses to the proposals by the\n'
b'EZLN General Command.\n'
b'During a private meeting with foreign correspondents, the\n'
b'subcommander felt all the demands on the list submitted to\n'
b'Manuel Camacho Solis, commissioner for peace and reconciliation\n'
b'in Chiapas, can be resolved by the federal authorities with a\n'
b'total commitment and interest in improving the conditions in\n'
b"which Mexico's Indians live.\n"
</TEXT>
```

Without reading the content, we can "guess" that the line `EZLN General Command` and `which Mexico's Indians live` may be the end of paragraphs because they are shorter than other lines. This is not always reliable but this is the only way to separate them. So for this collection, we have to 1) determine where the main body started and where a new paragraph started separately and 2) use an empirical length of a line to determine if this is the end of a paragraph.

Generally, this is quick-and-dirty idea to build the document-level indexing, dump the raw docs, apply the paragraph segmentation, and build the paragraph-level indexing again. However, I think this process may be moved to inside the file segment part during index collection smoothly, except the fact that the document cleaning process will apparently be more delicately treated than what we currently do, as we have to detect paragraphs on the original document instead of the dumped `raw doc` which has already been processed.

