### PR TITLE
Change .travis.yml in order to pass Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ jdk:
   - oraclejdk8
 script:
   - mvn clean package appassembler:assemble
+  - sed 's/-Xmx.*G/-Xmx2G/g' target/appassembler/bin/IndexCollection
   - git clone https://github.com/castorini/Anserini-data.git
   - cd eval && tar xvfz trec_eval.9.0.tar.gz && cd trec_eval.9.0 && make && cd .. && cd ..
   - python src/main/python/run_regression.py --collection cacm --index --fail_eval

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jdk:
   - oraclejdk8
 script:
   - mvn clean package appassembler:assemble
-  - sed 's/-Xmx.*G/-Xmx2G/g' target/appassembler/bin/IndexCollection
+  - sed -i 's/-Xmx.*G/-Xmx2G/g' target/appassembler/bin/IndexCollection
   - git clone https://github.com/castorini/Anserini-data.git
   - cd eval && tar xvfz trec_eval.9.0.tar.gz && cd trec_eval.9.0 && make && cd .. && cd ..
   - python src/main/python/run_regression.py --collection cacm --index --fail_eval

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jdk:
   - oraclejdk8
 script:
   - mvn clean package appassembler:assemble
-  - sed -i 's/-Xmx.*G/-Xmx2G/g' target/appassembler/bin/IndexCollection
+  - find target/appassembler/bin/ -type f -exec sed -i 's/-Xmx.*G/-Xmx2G/g' {} \;
   - git clone https://github.com/castorini/Anserini-data.git
   - cd eval && tar xvfz trec_eval.9.0.tar.gz && cd trec_eval.9.0 && make && cd .. && cd ..
   - python src/main/python/run_regression.py --collection cacm --index --fail_eval

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <artifactId>appassembler-maven-plugin</artifactId>
         <version>2.0.0</version>
         <configuration>
-          <extraJvmArguments>-Xms512M -Xmx16G</extraJvmArguments>
+          <extraJvmArguments>-Xms512M -Xmx256G</extraJvmArguments>
           <programs>
             <program>
               <mainClass>io.anserini.index.IndexCollection</mainClass>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <artifactId>appassembler-maven-plugin</artifactId>
         <version>2.0.0</version>
         <configuration>
-          <extraJvmArguments>-Xms512M -Xmx256G</extraJvmArguments>
+          <extraJvmArguments>-Xms512M -Xmx4G</extraJvmArguments>
           <programs>
             <program>
               <mainClass>io.anserini.index.IndexCollection</mainClass>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <artifactId>appassembler-maven-plugin</artifactId>
         <version>2.0.0</version>
         <configuration>
-          <extraJvmArguments>-Xms512M -Xmx4G</extraJvmArguments>
+          <extraJvmArguments>-Xms512M -Xmx8G</extraJvmArguments>
           <programs>
             <program>
               <mainClass>io.anserini.index.IndexCollection</mainClass>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <artifactId>appassembler-maven-plugin</artifactId>
         <version>2.0.0</version>
         <configuration>
-          <extraJvmArguments>-Xms512M -Xmx8G</extraJvmArguments>
+          <extraJvmArguments>-Xms512M -Xmx16G</extraJvmArguments>
           <programs>
             <program>
               <mainClass>io.anserini.index.IndexCollection</mainClass>


### PR DESCRIPTION
Based on https://docs.travis-ci.com/user/common-build-problems/#my-build-script-is-killed-without-any-error Travis CI has memory limit of 3GB...
Dunno why we did not encounter this before.