### PR TITLE
add Jelinek-Mercer (Dirichlet) QL scoring

### DIFF
--- a/src/main/java/io/anserini/search/SearchArgs.java
+++ b/src/main/java/io/anserini/search/SearchArgs.java
@@ -103,6 +103,15 @@ public class SearchArgs {
    * setting seems reasonable and does not contradict Zhai and Lafferty.
    */
 
+  @Option(name = "-qld", usage = "use query likelihood Dirichlet scoring model")
+  public boolean qld = false;
+
+  @Option(name = "-qljm", usage = "use query likelihood Jelinek Mercer scoring model")
+  public boolean qljm = false;
+
+  @Option(name = "-qljm.lambda", handler = StringArrayOptionHandler.class, usage = "Jelinek Mercer smoothing parameter")
+  public String[] qljm_lambda = new String[] {"0.1"};
+
   @Option(name = "-bm25", usage = "use BM25 scoring model")
   public boolean bm25 = false;
 

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -215,9 +215,13 @@ public final class SearchCollection implements Closeable {
   public List<TaggedSimilarity> constructSimiliries() {
     // Figure out which scoring model to use.
     List<TaggedSimilarity> similarities = new ArrayList<>();
-    if (args.ql) {
+    if (args.ql || args.qld) {
       for (String mu : args.mu) {
         similarities.add(new TaggedSimilarity(new LMDirichletSimilarity(Float.valueOf(mu)), "mu:"+mu));
+      }
+    } else if (args.qljm) {
+      for (String lambda : args.qljm_lambda) {
+        similarities.add(new TaggedSimilarity(new LMJelinekMercerSimilarity(Float.valueOf(lambda)), "lambda:" + lambda));
       }
     } else if (args.bm25) {
       for (String k1 : args.k1) {


### PR DESCRIPTION
As discussed in #465 I've re introduced the option to use Jelinek Mercer QL scoring (`qljm`) and added the redundant QL Dirichlet option (`qld`) rebased against master.