### PR TITLE
Indexing Freebase update: keep only English literals

### DIFF
--- a/docs/freebase.md
+++ b/docs/freebase.md
@@ -1,15 +1,56 @@
 # Manipulating Freebase with Anserini
 
+This page describes working with final Freebase data dump from 2015, downloadable [here](https://developers.google.com/freebase/).
+For verification, the dump has MD5 checksum of `bc1be939be37c9aa9219f73923f60a3d`.
+
+Let's first see how large it is:
+
+```
+$ gunzip -c freebase-rdf-latest.gz | wc
+[after a while...]
+3130753066 15151861316 425229008315
+```
+
+Interestingly, there are 3.13 billion triples in the dump, which is different from the 1.9 billion count referenced in the Freebase page.
+
 ## Indexing Freebase
 
+There are two ways to main ways to index Freebase using Lucene.
+
+The first is to treat each Freebase entity as a Lucene document.
+In this case, property and values are stored as fields in each document.
+For this, use the following command:
+
 ```
-mvn exec:java -Dexec.mainClass="io.anserini.kg.freebase.IndexFreebase" \
- -Dexec.args="-input /tuna1/collections/freebase/freebase-rdf-latest.gz -index freebase-index" > log.freebase &
+$ mvn exec:java -Dexec.mainClass="io.anserini.kg.IndexFreebase" -Dexec.args="-input freebase-rdf-latest.gz -index freebase-index-nodes-all"
 ```
 
-The command above builds an index from the Freebase RDF dump (available as a single `.gz` file). Each document in the index corresponds to a single Freebase entity with 
-a unique URI. The fields of this document correspond to the different predicates
-and their objects. All fields are stored in the index.
+This will yield 3,130,753,066 triples and 125,144,313 documents.
+
+There's an option to keep only English literals objects (and everything else):
+
+```
+$ mvn exec:java -Dexec.mainClass="io.anserini.kg.IndexFreebase" -Dexec.args="-input freebase-rdf-latest.gz -index freebase-index-nodes-en -langEnOnly"
+```
+
+This will yield 1,922,701,053 triples and 125,144,313 documents added.
+
+In the second approach, each triple forms an individual Lucene document. Run as follows:
+
+```
+$ mvn exec:java -Dexec.mainClass="io.anserini.kg.IndexFreebase" -Dexec.args="-input freebase-rdf-latest.gz -index freebase-index-triples-all -triples"
+```
+
+The issue, though, is that there are 3.13 billion triples, larger than the max 2.1 billion documents Lucene can store.
+The program catches this exception and because of the error handling, the program does manage to successfully add 2,147,483,519 documents (the max) to the index.
+
+However, if we storing each triple as a document and keep only English literal objects, we'll be fine:
+
+```
+$ mvn exec:java -Dexec.mainClass="io.anserini.kg.IndexFreebase" -Dexec.args="-input /tuna1/collections/freebase/freebase-rdf-latest.gz -index freebase-index-triples-en -triples -langEnOnly"
+```
+
+The yields a total of 1,922,701,053 triples/documents.
 
 ## Searching Freebase
 
@@ -17,8 +58,8 @@ After indexing is done, there are two ways to search Freebase.
 The simplest is lookup by `mid`:
 
 ```
-mvn exec:java -Dexec.mainClass="io.anserini.kg.freebase.LookupFreebase" \
- -Dexec.args="-index freebase-index -mid fb:m.02mjmr"
+mvn exec:java -Dexec.mainClass="io.anserini.kg.LookupFreebase" \
+ -Dexec.args="-index freebase-index-nodes-en -mid fb:m.02mjmr"
 ```
 
 The above command looks up the entity corresponding to "Barack Obama".
@@ -26,6 +67,6 @@ The above command looks up the entity corresponding to "Barack Obama".
 It is also possible to perform a free text search over the textual labels of the nodes, as follows:
 
 ```
-mvn exec:java -Dexec.mainClass="io.anserini.kg.freebase.LookupFreebase" \
- -Dexec.args="-index freebase-index -query 'Barack Obama'"
+mvn exec:java -Dexec.mainClass="io.anserini.kg.LookupFreebase" \
+ -Dexec.args="-index freebase-index-nodes-en -query 'Barack Obama'"
 ```

--- a/src/main/java/io/anserini/kg/FreebaseNode.java
+++ b/src/main/java/io/anserini/kg/FreebaseNode.java
@@ -16,7 +16,6 @@
 
 package io.anserini.kg;
 
-import org.openrdf.model.Literal;
 import org.openrdf.model.ValueFactory;
 import org.openrdf.model.impl.SimpleValueFactory;
 import org.openrdf.rio.ntriples.NTriplesUtil;
@@ -94,7 +93,6 @@ public class FreebaseNode {
   public static final String FREEBASE_NS_SHORT = "fb:";
   public static final String FREEBASE_KEY_LONG = "^http://rdf.freebase.com/key/";
   public static final String FREEBASE_KEY_SHORT = "fbkey:";
-  public static final String LANG_EN = "Optional[en]";
 
   public static String cleanUri(String uri) {
     if (uri.charAt(0) == '<') {
@@ -121,16 +119,6 @@ public class FreebaseNode {
       } else {
         return removeEnclosingQuote(objectValue);
       }
-    } else if (type.equals(FreebaseNode.RdfObjectType.TEXT)) {
-      // Previously, we were basically throwing away all non-English text...
-      // No idea why we're doing this... just commented out.
-      //
-      //Literal parsedLiteral = NTriplesUtil.parseLiteral(objectValue, valueFactory);
-      //if (parsedLiteral.getLanguage().toString().equals(LANG_EN)) {
-      //  return parsedLiteral.stringValue();
-      //}
-      //return "";
-      return objectValue;
     } else {
       return objectValue;
     }

--- a/src/main/java/io/anserini/kg/IndexFreebase.java
+++ b/src/main/java/io/anserini/kg/IndexFreebase.java
@@ -16,6 +16,9 @@
 
 package io.anserini.kg;
 
+import org.openrdf.model.Literal;
+import org.openrdf.rio.ntriples.NTriplesUtil;
+
 import io.anserini.analysis.FreebaseAnalyzer;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.logging.log4j.LogManager;
@@ -34,6 +37,8 @@ import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.OptionHandlerFilter;
 import org.kohsuke.args4j.ParserProperties;
+import org.openrdf.model.ValueFactory;
+import org.openrdf.model.impl.SimpleValueFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -49,10 +54,13 @@ import java.util.function.Function;
  * Builds an index over a Freebase dump in N-Triples RDF format. Two types of indexes are possible:
  *
  * <ul>
+ *
  * <li>Each {@link FreebaseNode} object, which represents a group of triples that share the same
  * subject ({@code mid}), is treated as a Lucene "document". This class builds an index for lookup
  * based on {@code mid} as well a free text search over the textual labels of the nodes.</li>
+ *
  * <li>Each triple is treated as its own Lucene "document".</li>
+ *
  * </ul>
  */
 public class IndexFreebase {
@@ -60,13 +68,16 @@ public class IndexFreebase {
 
   public static final class Args {
     @Option(name = "-input", metaVar = "[file]", required = true, usage = "Freebase dump file")
-    public Path input;
+    protected Path input;
 
     @Option(name = "-index", metaVar = "[path]", required = true, usage = "index path")
-    public Path index;
+    protected Path index;
 
     @Option(name = "-triples", usage = "store each triple in its own Lucene document")
-    public boolean storeTriples = false;
+    protected boolean storeTriples = false;
+
+    @Option(name = "-langEnOnly", usage = "store only English literals")
+    protected boolean langEnOnly = false;
   }
 
   // For storing each triple in its own Lucene document
@@ -88,11 +99,13 @@ public class IndexFreebase {
   private final Path indexPath;
   private final Path inputPath;
   private final boolean storeTriples;
+  private final boolean langEnOnly;
 
-  public IndexFreebase(Path inputPath, Path indexPath, boolean storeTriples) throws Exception {
+  public IndexFreebase(Path inputPath, Path indexPath, boolean storeTriples, boolean langEnOnly) {
     this.inputPath = inputPath;
     this.indexPath = indexPath;
     this.storeTriples = storeTriples;
+    this.langEnOnly = langEnOnly;
 
     LOG.info("Input path: " + this.inputPath);
     LOG.info("Index path: " + this.indexPath);
@@ -100,6 +113,10 @@ public class IndexFreebase {
     if (!Files.exists(inputPath) || !Files.isReadable(inputPath)) {
       throw new IllegalArgumentException("Input " + inputPath.toString() +
           " does not exist or is not readable.");
+    }
+
+    if ( langEnOnly) {
+      LOG.info("Storing only English literals.");
     }
   }
 
@@ -116,7 +133,7 @@ public class IndexFreebase {
     final AtomicInteger cnt = new AtomicInteger();
 
     Function<FreebaseNode, List<Document>> generator = storeTriples ?
-        new LuceneDocumentGeneratorTriples() : new LuceneDocumentGenerator();
+        new LuceneDocumentGeneratorTriples(langEnOnly) : new LuceneDocumentGenerator(langEnOnly);
 
     try {
       new Freebase(inputPath).stream().map(generator)
@@ -171,10 +188,19 @@ public class IndexFreebase {
       return;
     }
 
-    new IndexFreebase(indexArgs.input, indexArgs.index, indexArgs.storeTriples).run();
+    new IndexFreebase(indexArgs.input, indexArgs.index, indexArgs.storeTriples, indexArgs.langEnOnly).run();
   }
 
+  private static final String LANG_EN = "Optional[en]";
+  private static ValueFactory valueFactory = SimpleValueFactory.getInstance();
+
   private static class LuceneDocumentGenerator implements Function<FreebaseNode, List<Document>> {
+    private final boolean langEnOnly;
+
+    private LuceneDocumentGenerator(boolean langEnOnly) {
+      this.langEnOnly = langEnOnly;
+    }
+
     public List<Document> apply(FreebaseNode src) {
       Document doc = new Document();
       doc.add(new StringField(FIELD_ID, FreebaseNode.cleanUri(src.uri()), Field.Store.YES));
@@ -187,8 +213,17 @@ public class IndexFreebase {
       for (Map.Entry<String, List<String>> entry : src.getPredicateValues().entrySet()) {
         final String predicate = FreebaseNode.cleanUri(entry.getKey());
         // Each predicate/value is a stored field.
-        entry.getValue().forEach(value ->
-            doc.add(new StoredField(predicate, FreebaseNode.normalizeObjectValue(value))));
+        entry.getValue().forEach(value -> {
+          String normalizeObjectValue =FreebaseNode.normalizeObjectValue(value);
+          if (langEnOnly) {
+            Literal parsedLiteral = NTriplesUtil.parseLiteral(normalizeObjectValue, valueFactory);
+            if (parsedLiteral.getLanguage().toString().equals(LANG_EN)) {
+              doc.add(new StoredField(predicate, FreebaseNode.normalizeObjectValue(value)));
+            }
+          } else {
+            doc.add(new StoredField(predicate, FreebaseNode.normalizeObjectValue(value)));
+          }
+        });
 
         List<String> objects = entry.getValue();
         for (String object : objects) {
@@ -222,6 +257,12 @@ public class IndexFreebase {
   }
 
   private static class LuceneDocumentGeneratorTriples implements Function<FreebaseNode, List<Document>> {
+    private final boolean langEnOnly;
+
+    private LuceneDocumentGeneratorTriples(boolean langEnOnly) {
+      this.langEnOnly = langEnOnly;
+    }
+
     public List<Document> apply(FreebaseNode src) {
       List<Document> docs = new ArrayList<>();
 
@@ -229,7 +270,7 @@ public class IndexFreebase {
       // Iterate over predicates and object values.
       for (Map.Entry<String, List<String>> entry : src.getPredicateValues().entrySet()) {
         final String predicate = FreebaseNode.cleanUri(entry.getKey());
-        // Each predicate/value is a stored field.
+        // Each predicate/value triple forms a separate document.
         entry.getValue().forEach(value -> {
           Document doc = new Document();
           doc.add(new StringField(FIELD_SUBJECT, subject, Field.Store.YES));
@@ -246,7 +287,20 @@ public class IndexFreebase {
             doc.add(new StringField(FIELD_OBJECT, object, Field.Store.YES));
           }
 
-          docs.add(doc);
+          if (langEnOnly) {
+            // We only want to add English literals, so check the language.
+            if (FreebaseNode.getObjectType(value).equals(FreebaseNode.RdfObjectType.TEXT)) {
+              Literal parsedLiteral = NTriplesUtil.parseLiteral(value, valueFactory);
+              if (parsedLiteral.getLanguage().toString().equals(LANG_EN)) {
+                docs.add(doc);
+              }
+            } else {
+              // But we still want to add everything else...
+              docs.add(doc);
+            }
+          } else {
+            docs.add(doc);
+          }
         });
       }
 

--- a/src/test/java/io/anserini/kg/FreebaseNodeTest.java
+++ b/src/test/java/io/anserini/kg/FreebaseNodeTest.java
@@ -23,6 +23,7 @@ import org.openrdf.model.ValueFactory;
 import org.openrdf.model.impl.SimpleValueFactory;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class FreebaseNodeTest {
   /**
@@ -94,5 +95,10 @@ public class FreebaseNodeTest {
 
     assertEquals(l1expectedVal, l1val);
     assertEquals(l2expectedVal, l2val);
+
+    // Example showing how to use the API
+    ValueFactory valueFactory = SimpleValueFactory.getInstance();
+    Literal parsedLiteral = NTriplesUtil.parseLiteral(l2, valueFactory);
+    assertTrue(parsedLiteral.getLanguage().toString().equals("Optional[en]"));
   }
 }


### PR DESCRIPTION
Complete indexer, two options:
+ node as document or triple as document
+ index everything or only English literals

Details of the four conditions updated in docs.

Demo programs for searching coming up...