### PR TITLE
ConcurrentUpdateSolrClient should be using multiple threads to drain document queue

### DIFF
--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -419,7 +419,8 @@ public final class IndexCollection {
           this.solrClient = new CloudSolrClient.Builder(urls).build(); // Connect to list of Solr servers
         }
       } else {
-        this.solrClient = new ConcurrentUpdateSolrClient.Builder(args.solrUrl).withQueueSize(args.solrBatch).build();
+        this.solrClient = new ConcurrentUpdateSolrClient.Builder(args.solrUrl)
+            .withQueueSize(args.solrBatch).withThreadCount(args.threads).build();
       }
     }
 


### PR DESCRIPTION
@r-clancy I think you missed this minor detail :)