### PR TITLE
Runbook for ECIR 2019 ax

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Additional regressions:
 Runbooks:
 
 + Runbooks for TREC 2018: [[Anserini group](docs/runbook-trec2018-anserini.md)] [[h2oloo group](docs/runbook-trec2018-h2oloo.md)]
-+ Runbook for ECIR 2019 [paper on axiomatic semantic term matching](docs/runbook-ecir2019-axiomatic.md)
++ Runbook for [ECIR 2019 paper on axiomatic semantic term matching](docs/runbook-ecir2019-axiomatic.md)
 
 ## Additional Documentation
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Additional regressions:
 Runbooks:
 
 + Runbooks for TREC 2018: [[Anserini group](docs/runbook-trec2018-anserini.md)] [[h2oloo group](docs/runbook-trec2018-h2oloo.md)]
++ Runbook for ECIR 2019 [paper on axiomatic semantic term matching](docs/runbook-ecir2019-axiomatic.md)
 
 ## Additional Documentation
 

--- a/docs/runbook-ecir2019-axiomatic.md
+++ b/docs/runbook-ecir2019-axiomatic.md
@@ -1,13 +1,17 @@
-### Requirements
+# Anserini: ECIR 2019 Axiomatic Semantic Term Matching
 
-Python>=2.6 or Python>=3.5
-`pip install -r src/main/python/requirements.txt`
+This page documents code for replicating results from the following paper:
 
-### Run the Parameter Sensitivity (Fig 1,2,3 in the paper)
++ Peilin Yang and Jimmy Lin. Reproducing and Generalizing Semantic Term Matching in Axiomatic Information Retrieval. Proceedings of the 41th European Conference on Information Retrieval (ECIR 2019), April 2019, Cologne, Germany.
 
-*** Users will need to change the index path at `src/main/resources/fine_tuning/collections.yaml`
-(the program will go through the `index_roots` and concatenate with collection's `index_path`. the first match will be the index path)
+**Requirements**: Python>=2.6 or Python>=3.5 `pip install -r src/main/python/requirements.txt`
 
+## Parameter Sensitivity Plots
+
+These are plots in Figures 1, 2, and 3 of the paper.
+
+First, change the index path at `src/main/resources/ecir2019_axiomatic/collections.yaml`
+The script will go through the `index_roots` and concatenate with the collection's `index_path` and take the first match as the index path.
 
 ```
 python src/main/python/ecir2019_axiomatic/run_batch.py --collection disk12 --models bm25 ql f2exp --n 32 --run --plot


### PR DESCRIPTION
Moved runbook into main `docs/` directory, following same organization as other documentation.