### PR TITLE
Minor Improvements to Solr Indexing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <artifactId>appassembler-maven-plugin</artifactId>
         <version>2.0.0</version>
         <configuration>
-          <extraJvmArguments>-Xms512M -Xmx256G</extraJvmArguments>
+          <extraJvmArguments>-Xms512M -Xmx32G</extraJvmArguments>
           <programs>
             <program>
               <mainClass>io.anserini.index.IndexCollection</mainClass>
@@ -303,11 +303,6 @@
       <groupId>com.github.TREMA-UNH</groupId>
       <artifactId>trec-car-tools-java</artifactId>
       <version>13</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-pool2</artifactId>
-      <version>2.6.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <artifactId>appassembler-maven-plugin</artifactId>
         <version>2.0.0</version>
         <configuration>
-          <extraJvmArguments>-Xms512M -Xmx32G</extraJvmArguments>
+          <extraJvmArguments>-Xms512M -Xmx31G</extraJvmArguments>
           <programs>
             <program>
               <mainClass>io.anserini.index.IndexCollection</mainClass>

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -22,14 +22,7 @@ import io.anserini.analysis.TweetAnalyzer;
 import io.anserini.collection.*;
 import io.anserini.index.generator.LuceneDocumentGenerator;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
-import org.apache.commons.pool2.BasePooledObjectFactory;
-import org.apache.commons.pool2.ObjectPool;
-import org.apache.commons.pool2.PooledObject;
-import org.apache.commons.pool2.impl.DefaultPooledObject;
-import org.apache.commons.pool2.impl.GenericObjectPool;
-import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.CharArraySet;
@@ -146,8 +139,8 @@ public final class IndexCollection {
     @Option(name = "-solr.url", usage = "the URL of Solr (standalone) or ZooKeeper (cloud, possibly comma-separated) servers")
     public String solrUrl = null;
 
-    @Option(name = "-solr.zkChroot", usage = "the ZooKeeper chroot, if using a ZooKeeper URL instead of Solr")
-    public String solrZkChroot = null;
+    @Option(name = "-solr.zkChroot", usage = "the ZooKeeper chroot if using SolrCloud")
+    public String solrZkChroot = "/";
   }
 
   public final class Counters {
@@ -280,8 +273,6 @@ public final class IndexCollection {
         LuceneDocumentGenerator generator = (LuceneDocumentGenerator) generatorClass.getDeclaredConstructor(Args.class, Counters.class).newInstance(args, counters);
         BaseFileSegment<SourceDocument> iter = (BaseFileSegment) ((SegmentProvider) collection).createFileSegment(input);
 
-        SolrClient client = solrPool.borrowObject();
-
         int cnt = 0;
         while (iter.hasNext()) {
           SourceDocument sourceDocument;
@@ -320,10 +311,10 @@ public final class IndexCollection {
           if (args.solrCloud) {
             buffer.add(solrDocument);
             if (buffer.size() == args.solrBatch) {
-              flush(client);
+              flush();
             }
           } else {
-            client.add(args.solrIndex, solrDocument, args.solrCommitWithin * 1000); // ... and ConcurrentUpdateSolrClient does it for us
+            solrClient.add(args.solrIndex, solrDocument, args.solrCommitWithin * 1000); // ... and ConcurrentUpdateSolrClient does it for us
           }
 
           cnt++;
@@ -331,14 +322,12 @@ public final class IndexCollection {
 
         // If we're running in cloud mode and have docs in the buffer, flush them.
         if (args.solrCloud && !buffer.isEmpty()) {
-          flush(client);
+          flush();
         }
 
         if (iter.getNextRecordStatus() == BaseFileSegment.Status.ERROR) {
           counters.errors.incrementAndGet();
         }
-
-        solrPool.returnObject(client);
 
         iter.close();
         LOG.info(input.getParent().getFileName().toString() + File.separator + input.getFileName().toString() + ": " + cnt + " docs added.");
@@ -349,10 +338,10 @@ public final class IndexCollection {
 
     }
 
-    private void flush(SolrClient client) {
+    private void flush() {
       if (!buffer.isEmpty()) {
         try {
-          client.add(args.solrIndex, buffer, args.solrCommitWithin * 1000);
+          solrClient.add(args.solrIndex, buffer, args.solrCommitWithin * 1000);
           buffer.clear();
         } catch (Exception e) {
           LOG.error("Error flushing documents to Solr", e);
@@ -370,7 +359,7 @@ public final class IndexCollection {
   private final DocumentCollection collection;
   private final Counters counters;
   private Path indexPath;
-  private ObjectPool<SolrClient> solrPool;
+  private SolrClient solrClient;
 
   public IndexCollection(IndexCollection.Args args) throws Exception {
     this.args = args;
@@ -426,49 +415,19 @@ public final class IndexCollection {
       this.whitelistDocids = null;
     }
 
-      if (args.solr) {
-        GenericObjectPoolConfig<SolrClient> config = new GenericObjectPoolConfig<>();
-        config.setMaxTotal(args.threads);
-        config.setMinIdle(args.threads); // To guard against premature discarding of solrClients
-        this.solrPool = new GenericObjectPool<>(new SolrClientFactory(), config);
+    if (args.solr) {
+      if (args.solrCloud) {
+        List<String> urls = Splitter.on(',').splitToList(args.solrUrl);
+        this.solrClient = new CloudSolrClient.Builder(urls, Optional.of(args.solrZkChroot)).build();
+      } else {
+        this.solrClient = new ConcurrentUpdateSolrClient.Builder(args.solrUrl).withQueueSize(args.solrBatch).withThreadCount(args.threads).build();
       }
+    }
 
     this.counters = new Counters();
   }
 
-  private class SolrClientFactory extends BasePooledObjectFactory<SolrClient> {
-
-    @Override
-    public SolrClient create() throws Exception {
-      // SolrCloud
-      if (args.solrCloud) {
-        List<String> urls = Splitter.on(',').splitToList(args.solrUrl);
-        if (StringUtils.isNotEmpty(args.solrZkChroot)) {
-          return new CloudSolrClient.Builder(urls, Optional.of(args.solrZkChroot)).build(); // Connect to ZooKeeper
-        } else {
-          return new CloudSolrClient.Builder(urls).build(); // Connect to list of Solr servers
-        }
-      }
-      // Standlone
-      return new ConcurrentUpdateSolrClient.Builder(args.solrUrl)
-          .withQueueSize(args.solrBatch)
-          .withThreadCount(args.threads)
-          .build();
-    }
-
-    @Override
-    public PooledObject<SolrClient> wrap(SolrClient solrClient) {
-      return new DefaultPooledObject(solrClient);
-    }
-
-    @Override
-    public void destroyObject(PooledObject<SolrClient> pooled) throws Exception {
-      pooled.getObject().close();
-    }
-
-  }
-
-  public void run() throws IOException, InterruptedException {
+  public void run() throws IOException {
     final long start = System.nanoTime();
     LOG.info("Starting indexer...");
 
@@ -537,11 +496,8 @@ public final class IndexCollection {
     // Do a final commit
     if (args.solr) {
       try {
-        SolrClient client = solrPool.borrowObject();
-        client.commit(args.solrIndex);
-        // Needed for orderly shutdown so the SolrClient executor does not delay main thread exit
-        solrPool.returnObject(client);
-        solrPool.close();
+        solrClient.commit(args.solrIndex);
+        solrClient.close();
       } catch (Exception e) {
         LOG.error("Exception during final Solr commit: ", e);
       }


### PR DESCRIPTION
- Since we're dealing with a single index `CloudSolrClient` is thread-safe (and `ConcurrentUpdateSolrClient` always is), so remove the object pooling.
- When indexing `cw09b` to Solr on himrod, only about 24G of RAM was being used. 31G (so we can still take advantage of compressed pointers) should be more than enough. Will confirm on `tuna` once it's done being hammered.

@lintool