### PR TITLE
Solr threads and exceptions

### DIFF
--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -457,10 +457,20 @@ public final class IndexCollection {
         }
       }
       // Standlone
-      return new ConcurrentUpdateSolrClient.Builder(args.solrUrl)
+      ConcurrentUpdateSolrClient.Builder builder = new ConcurrentUpdateSolrClient.Builder(args.solrUrl)
           .withQueueSize(args.solrBatch)
-          .withThreadCount(args.solrClientThreads)
-          .build();
+          .withThreadCount(args.solrClientThreads);
+      return new ExceptionHandlingSolrClient(builder);
+    }
+    private class ExceptionHandlingSolrClient extends ConcurrentUpdateSolrClient {
+      ExceptionHandlingSolrClient(ConcurrentUpdateSolrClient.Builder builder) {
+        super(builder);
+      }
+
+      @Override
+      public void handleError(Throwable ex) {
+        LOG.warn("Solr: Exception delivering documents", ex);
+      }
     }
 
     @Override

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -148,6 +148,12 @@ public final class IndexCollection {
 
     @Option(name = "-solr.zkChroot", usage = "the ZooKeeper chroot, if using a ZooKeeper URL instead of Solr")
     public String solrZkChroot = null;
+
+    // Note: This is used for ConcurrentSolrClient, where each processing thread has its own instance
+    // If the architecture is changed to share one ConcurrentSolrClient among all threads, the default should likely be increased
+    @Option(name = "-solr.client.threads", metaVar = "[Number]", required = false, usage = "Number of Threads for each SolrClient")
+    public int solrClientThreads = 1;
+
   }
 
   public final class Counters {
@@ -395,6 +401,7 @@ public final class IndexCollection {
       LOG.info("Solr commitWithin: " + args.solrCommitWithin);
       LOG.info("Solr index: " + args.solrIndex);
       LOG.info("Solr URL: " + args.solrUrl);
+      LOG.info("SolrClient Threads: " + args.solrClientThreads);
     }
 
     if (args.index == null && !args.solr) {
@@ -452,7 +459,7 @@ public final class IndexCollection {
       // Standlone
       return new ConcurrentUpdateSolrClient.Builder(args.solrUrl)
           .withQueueSize(args.solrBatch)
-          .withThreadCount(args.threads)
+          .withThreadCount(args.solrClientThreads)
           .build();
     }
 


### PR DESCRIPTION
Each `ConcurrentUpdateSolrClient` has an internal executor. When creating these clients, each client had their maximum thread count set to the overall thread count for Anserini. As each processing thread has their own `ConcurrentUpdateSolrClient`, this potentially meant `args.threads*args.threads` for the total amount of `ConcurrentUpdateSolrClient`s. Local experiments with `args.threads=40` resulted in exceptions being thrown due to this. This pull request makes the `ConcurrentUpdateSolrClient` maxThreads adjustable, with a default of 1.

Not related, exceptions from Solr document delivery using `ConcurrentUpdateSolrClient` were logged to some unknown log. This pull request redirects those to the `IndexCollection`-log, so that the pattern matches the Lucene code path.