### PR TITLE
Buffer Documents for ConcurrentUpdateSolrClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,5 +304,10 @@
       <artifactId>trec-car-tools-java</artifactId>
       <version>13</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-pool2</artifactId>
+      <version>2.6.0</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -153,14 +153,14 @@ public final class IndexCollection {
     /**
      * The number of {@link SolrClient#add(Collection) add} calls to buffer before draining pending update queue.
      */
-    @Option(name = "-solr.client.queue.size", usage = "the number of update requests to buffer before draining")
+    @Option(name = "-solr.clientQueueSize", usage = "the number of update requests to buffer before draining")
     public int solrClientQueueSize = 16;
 
     /**
      * The number threads used to drain the ConcurrentUpdateSolrClient queue
      */
-    @Option(name = "-solr.client.thread.count", metaVar = "[NUMBER]", usage = "the number of threads used to drain the ConcurrentUpdateSolrClient queue")
-    public int solrClientThreadCount = 1;
+    @Option(name = "-solr.clientThreads", metaVar = "[NUMBER]", usage = "the number of threads used to drain the ConcurrentUpdateSolrClient queue")
+    public int solrClientThreads = 1;
 
     /**
      * The number of SolrClients to keep in the object pool.
@@ -431,7 +431,7 @@ public final class IndexCollection {
       LOG.info("Solr commitWithin: " + args.solrCommitWithin);
       LOG.info("Solr index: " + args.solrIndex);
       LOG.info("Solr URL: " + args.solrUrl);
-      LOG.info("SolrClient thread count: " + args.solrClientThreadCount);
+      LOG.info("SolrClient thread count: " + args.solrClientThreads);
       LOG.info("SolrClient queue size: " + args.solrClientQueueSize);
       LOG.info("SolrClient pool size: " + args.solrPoolSize);
     }
@@ -487,10 +487,9 @@ public final class IndexCollection {
 
       ConcurrentUpdateSolrClient.Builder builder = new ConcurrentUpdateSolrClient.Builder(args.solrUrl)
           .withQueueSize(args.solrClientQueueSize)
-          .withThreadCount(args.solrClientThreadCount);
+          .withThreadCount(args.solrClientThreads);
 
       return new ExceptionHandlingSolrClient(builder);
-
     }
 
     @Override

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -165,7 +165,7 @@ public final class IndexCollection {
     /**
      * The number of SolrClients to keep in the object pool.
      */
-    @Option(name = "-solr.pool.size", metaVar = "[NUMBER]", usage = "the number of clients to keep in the pool")
+    @Option(name = "-solr.poolSize", metaVar = "[NUMBER]", usage = "the number of clients to keep in the pool")
     public int solrPoolSize = 16;
 
     @Option(name = "-shard.count", usage = "the number of shards for the index")

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -385,13 +385,21 @@ public final class IndexCollection {
 
     private void flush() {
       if (!buffer.isEmpty()) {
+        SolrClient solrClient = null;
         try {
-          SolrClient solrClient = solrPool.borrowObject();
+          solrClient = solrPool.borrowObject();
           solrClient.add(args.solrIndex, buffer, args.solrCommitWithin * 1000);
-          solrPool.returnObject(solrClient);
           buffer.clear();
         } catch (Exception e) {
           LOG.error("Error flushing documents to Solr", e);
+        } finally {
+          if (solrClient != null) {
+            try {
+              solrPool.returnObject(solrClient);
+            } catch (Exception e) {
+              LOG.error("Error returning SolrClient to pool", e);
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
(Re-)add object pooling for SolrClients... it helped throughput quite a bit for `CloudSolrClient` even though it's thread-safe.

Also, buffer docs for the `ConcurrentUpdateSolrClient` as it's queue is for update requests (i.e., it buffers `add(SolrInputDocument)` calls until the queue size is reached then drains the queue concurrently).