### PR TITLE
add replication note on Cluweb12-B13

### DIFF
--- a/src/main/resources/docgen/templates/cw12b13.template
+++ b/src/main/resources/docgen/templates/cw12b13.template
@@ -38,3 +38,7 @@ ${eval_cmds}
 With the above commands, you should be able to replicate the following results:
 
 ${effectiveness}
+
+## Replication Log
+
+* Results replicated by [@matthew-z](https://github.com/matthew-z) on 2019-04-14 (commit [`abaa4c8`](https://github.com/castorini/Anserini/commit/abaa4c8e7cb50e8e4a3677377716f609b7859538))


### PR DESCRIPTION
Hi,

I tried to replicate the results on Cluweb12-B13 with the latest version of Anserini.
Most algorithms are OK, but I found that AX-related algorithms have a bit regression:

For example, 

QL+AX

NDCG@20| My Result  | Expected |
| ------------- | ------------- | ------------- |
201-250| 0.09833  | 0.1143  |
251-300| 0.08103  | 0.1001  |

ERR@20 | My Result  | Expected |
| ------------- | ------------- | ------------- |
201-250| 0.09833  | 0.0780  |
251-300| 0.09256  | 0.0896  |



BM25+AX

NDCG@20| My Result  | Expected |
| ------------- | ------------- | ------------- |
201-250| 0.11381  | 0.1287  |
251-300| 0.08010  | 0.0964  |

ERR@20 | My Result  | Expected |
| ------------- | ------------- | ------------- |
201-250| 0.09256  | 0.0780  |
251-300| 0.07969  | 0.0929  |


The others (QL, QL+RM3, BM25, BM25+RM3) aligned well with https://github.com/castorini/Anserini/blob/master/docs/experiments-cw12b13.md