### PR TITLE
Index numeric values in Solr

### DIFF
--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -359,6 +359,8 @@ public final class IndexCollection {
           for (IndexableField field : document.getFields()) {
             if (field.stringValue() != null) { // For some reason, id is multi-valued with null as one of the values
               solrDocument.addField(field.name(), field.stringValue());
+            } else if (field.numericValue() != null) {
+              solrDocument.addField(field.name(), field.numericValue());
             }
           }
 


### PR DESCRIPTION
Some fields that were present in Lucene docs, such as `published_date` for WaPo, weren't being indexed since it's a `long` instead of a `String` - this change includes those fields in the Solr index.