### PR TITLE
Tweaks for Windows compatibility

### DIFF
--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -134,7 +134,7 @@ public final class SearchCollection implements Closeable {
         LOG.info("[Start] Ranking with similarity: " + taggedSimilarity.similarity.toString());
         final long start = System.nanoTime();
         if (!cascadeTag.isEmpty()) LOG.info("ReRanking with: " + cascadeTag);
-        PrintWriter out = new PrintWriter(Files.newBufferedWriter(Paths.get(outputPath), StandardCharsets.US_ASCII));
+        PrintWriter out = new PrintWriter(Files.newBufferedWriter(Paths.get(outputPath.replace(":", "=")), StandardCharsets.US_ASCII));
         for (Map.Entry<K, Map<String, String>> entry : topics.entrySet()) {
           K qid = entry.getKey();
           String queryString = entry.getValue().get(args.topicfield);

--- a/src/test/java/io/anserini/collection/DocumentTest.java
+++ b/src/test/java/io/anserini/collection/DocumentTest.java
@@ -60,6 +60,8 @@ public class DocumentTest extends LuceneTestCase {
       File file = tmpPath.toFile();
       file.delete();
     }
+    // Call garbage collector for Windows compatibility
+    System.gc(); 
     super.tearDown();
   }
 }

--- a/src/test/java/io/anserini/integration/IndexerTest.java
+++ b/src/test/java/io/anserini/integration/IndexerTest.java
@@ -113,6 +113,8 @@ public class IndexerTest extends LuceneTestCase {
   @After
   @Override
   public void tearDown() throws Exception {
+    // Call garbage collector for Windows compatibility
+    System.gc();
     super.tearDown();
   }
 

--- a/src/test/java/io/anserini/integration/MultiThreadingSearchTest.java
+++ b/src/test/java/io/anserini/integration/MultiThreadingSearchTest.java
@@ -52,8 +52,8 @@ public class MultiThreadingSearchTest extends EndToEndTest {
     try {
       Eval.setAllMetrics(this.evalMetrics);
       for (int i = 0; i < searchArgs.b.length; i++) {
-        System.out.println(evalArgs.runPath+"_k1:"+searchArgs.k1[0]+",b:"+searchArgs.b[i]);
-        Eval.eval(evalArgs.runPath+"_k1:"+searchArgs.k1[0]+",b:"+searchArgs.b[i], evalArgs.qrelPath, evalArgs.longDocids, evalArgs.asc);
+        System.out.println(evalArgs.runPath+"_k1="+searchArgs.k1[0]+",b="+searchArgs.b[i]);
+        Eval.eval(evalArgs.runPath+"_k1="+searchArgs.k1[0]+",b="+searchArgs.b[i], evalArgs.qrelPath, evalArgs.longDocids, evalArgs.asc);
         assertEquals(Eval.getAllEvals().get(this.evalMetrics[0]).aggregated,
             res[i], 0.001);
       }
@@ -68,7 +68,7 @@ public class MultiThreadingSearchTest extends EndToEndTest {
   @Override
   public void tearDown() throws Exception {
     for (String b : searchArgs.b) {
-      new File(evalArgs.runPath+"_k1:"+searchArgs.k1[0]+",b:"+b).delete();
+      new File(evalArgs.runPath+"_k1="+searchArgs.k1[0]+",b="+b).delete();
     }
     super.tearDown();
   }


### PR DESCRIPTION
Added some changes so that all test cases can pass on Windows.

Fix [#617](https://github.com/castorini/anserini/issues/617) - replaced `:` with `=` in `SearchCollection`'s `outputPath` for filename issues. 
Fix [#619](https://github.com/castorini/anserini/issues/619) - added garbage collection calls to some test cases as a workaround to Windows file deletion issue.