### PR TITLE
Force SolrCloud and remove ConcurrentUpdateSolrClient.

### DIFF
--- a/docs/solrini.md
+++ b/docs/solrini.md
@@ -30,7 +30,7 @@ We'll index [robust04](https://github.com/castorini/Anserini/blob/master/docs/ex
 ```
 sh target/appassembler/bin/IndexCollection -collection TrecCollection -generator JsoupGenerator \
   -threads 8 -input /path/to/robust04 \
-  -solr -solr.cloud -solr.index robust04 -solr.url localhost:9983 \
+  -solr -solr.index robust04 -solr.zkUrl localhost:9983 \
   -storePositions -storeDocvectors -storeRawDocs
 ```
 Make sure `/path/to/robust04` is updated with the appropriate path.

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -41,7 +41,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
-import org.apache.solr.client.solrj.impl.ConcurrentUpdateSolrClient;
 import org.apache.solr.common.SolrInputDocument;
 import org.kohsuke.args4j.*;
 
@@ -135,36 +134,18 @@ public final class IndexCollection {
     @Option(name = "-solr.batch", usage = "the batch size for submitting documents to Solr")
     public int solrBatch = 1000;
 
-    @Option(name = "-solr.cloud", usage = "boolean switch to determine if we're running in SolrCloud mode")
-    public boolean solrCloud = false;
-
     @Option(name = "-solr.commitWithin", usage = "the number of seconds to commitWithin")
     public int solrCommitWithin = 60;
 
     @Option(name = "-solr.index", usage = "the name of the index")
     public String solrIndex = null;
 
-    @Option(name = "-solr.url", usage = "the URL of Solr (standalone) or ZooKeeper (cloud, possibly comma-separated) servers")
-    public String solrUrl = null;
+    @Option(name = "-solr.zkUrl", usage = "the URL of Solr's ZooKeeper (comma separated list of using ensemble)")
+    public String zkUrl = null;
 
-    @Option(name = "-solr.zkChroot", usage = "the ZooKeeper chroot if using SolrCloud")
-    public String solrZkChroot = "/";
+    @Option(name = "-solr.zkChroot", usage = "the ZooKeeper chroot")
+    public String zkChroot = "/";
 
-    /**
-     * The number of {@link SolrClient#add(Collection) add} calls to buffer before draining pending update queue.
-     */
-    @Option(name = "-solr.clientQueueSize", usage = "the number of update requests to buffer before draining")
-    public int solrClientQueueSize = 16;
-
-    /**
-     * The number threads used to drain the ConcurrentUpdateSolrClient queue
-     */
-    @Option(name = "-solr.clientThreads", metaVar = "[NUMBER]", usage = "the number of threads used to drain the ConcurrentUpdateSolrClient queue")
-    public int solrClientThreads = 1;
-
-    /**
-     * The number of SolrClients to keep in the object pool.
-     */
     @Option(name = "-solr.poolSize", metaVar = "[NUMBER]", usage = "the number of clients to keep in the pool")
     public int solrPoolSize = 16;
 
@@ -444,12 +425,9 @@ public final class IndexCollection {
     LOG.info("Solr? " + args.solr);
     if (args.solr) {
       LOG.info("Solr batch size: " + args.solrBatch);
-      LOG.info("SolrCloud? " + args.solrCloud + " (zkChroot = " + args.solrZkChroot + ")");
       LOG.info("Solr commitWithin: " + args.solrCommitWithin);
       LOG.info("Solr index: " + args.solrIndex);
-      LOG.info("Solr URL: " + args.solrUrl);
-      LOG.info("SolrClient thread count: " + args.solrClientThreads);
-      LOG.info("SolrClient queue size: " + args.solrClientQueueSize);
+      LOG.info("Solr ZooKeeper URL: " + args.zkUrl);
       LOG.info("SolrClient pool size: " + args.solrPoolSize);
     }
     LOG.info("Dry run (no index created)? " + args.dryRun);
@@ -497,17 +475,7 @@ public final class IndexCollection {
 
     @Override
     public SolrClient create() {
-
-      if (args.solrCloud) {
-        List<String> urls = Splitter.on(',').splitToList(args.solrUrl);
-        return new CloudSolrClient.Builder(urls, Optional.of(args.solrZkChroot)).build();
-      }
-
-      ConcurrentUpdateSolrClient.Builder builder = new ConcurrentUpdateSolrClient.Builder(args.solrUrl)
-          .withQueueSize(args.solrClientQueueSize)
-          .withThreadCount(args.solrClientThreads);
-
-      return new ExceptionHandlingSolrClient(builder);
+      return new CloudSolrClient.Builder(Splitter.on(',').splitToList(args.zkUrl), Optional.of(args.zkChroot)).build();
     }
 
     @Override
@@ -520,17 +488,6 @@ public final class IndexCollection {
       pooled.getObject().close();
     }
 
-  }
-
-  private class ExceptionHandlingSolrClient extends ConcurrentUpdateSolrClient {
-    ExceptionHandlingSolrClient(ConcurrentUpdateSolrClient.Builder builder) {
-      super(builder);
-    }
-
-    @Override
-    public void handleError(Throwable ex) {
-      LOG.warn("Solr: Exception delivering documents", ex);
-    }
   }
 
   public void run() throws IOException {

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -147,7 +147,7 @@ public final class IndexCollection {
     public String zkChroot = "/";
 
     @Option(name = "-solr.poolSize", metaVar = "[NUMBER]", usage = "the number of clients to keep in the pool")
-    public int solrPoolSize = 16;
+    public int solrPoolSize = 8;
 
     @Option(name = "-shard.count", usage = "the number of shards for the index")
     public int shardCount = -1;


### PR DESCRIPTION
https://github.com/castorini/anserini/pull/600 added a script that setup a single-node SolrCloud instance for Solr indexing - this PR removes support for the non-cloud version in favor a simpler code path.

I originally thought it may hurt performance, but initial tests on `core17` and `gov2` show equal or slightly better performance than the old, more complex `ConcurrentUpdateSolrClient` code.