### PR TITLE
Bug fig MS MARCO bug: b1 and k transposed

### DIFF
--- a/docs/experiments-msmarco.md
+++ b/docs/experiments-msmarco.md
@@ -108,7 +108,7 @@ Average precision and recall@1000 are the two metrics we care about the most.
 
 ## BM25 Tuning
 
-Note that this figure differs slightly from the value reported in [Document Expansion by Query Prediction](https://arxiv.org/abs/1904.08375) (see section on tuning BM25 parameters below), which uses the Anserini default of `k1=0.9`, `b=0.4`.
+Note that this figure differs slightly from the value reported in [Document Expansion by Query Prediction](https://arxiv.org/abs/1904.08375), which uses the Anserini default of `k1=0.9`, `b=0.4`.
 
 Tuning was accomplished with the `tune_bm25.py` script, using the queries found [here](https://github.com/castorini/Anserini-data/tree/master/MSMARCO).
 There are five different sets of 10k samples (from the `shuf` command).
@@ -116,7 +116,9 @@ We tune on each individual set and then average parameter values across all five
 Note that we are currently optimizing recall@1000 since Anserini output will serve as input to later stage rerankers (e.g., based on BERT), and we want to maximize the number of relevant documents the rerankers have to work with.
 The tuned parameters using this method are `k1=0.82`, `b=0.72`.
 
-Setting                              | MRR@10 | MAP    | Recall@1000 |
-:------------------------------------|-------:|-------:|------------:|
-Default Anserini (`k1=0.9`, `b=0.4`) | 0.1839 | 0.1925 | 0.8526
-Tuned (`k1=0.82`, `b=0.72`)          | 0.1875 | 0.1956 | 0.8578
+Here's the comparison between the Anserini default and tuned parameters:
+
+Setting                     | MRR@10 | MAP    | Recall@1000 |
+:---------------------------|-------:|-------:|------------:|
+Default (`k1=0.9`, `b=0.4`) | 0.1839 | 0.1925 | 0.8526
+Tuned (`k1=0.82`, `b=0.72`) | 0.1875 | 0.1956 | 0.8578

--- a/docs/experiments-msmarco.md
+++ b/docs/experiments-msmarco.md
@@ -108,10 +108,15 @@ Average precision and recall@1000 are the two metrics we care about the most.
 
 ## BM25 Tuning
 
-Note that this figure differs slightly from the value reported in [Document Expansion by Query Prediction](https://arxiv.org/abs/1904.08375) (see section on tuning BM25 parameters below), which uses the Anserini default of `b1=0.9`, `k=0.4`.
+Note that this figure differs slightly from the value reported in [Document Expansion by Query Prediction](https://arxiv.org/abs/1904.08375) (see section on tuning BM25 parameters below), which uses the Anserini default of `k1=0.9`, `b=0.4`.
 
 Tuning was accomplished with the `tune_bm25.py` script, using the queries found [here](https://github.com/castorini/Anserini-data/tree/master/MSMARCO).
 There are five different sets of 10k samples (from the `shuf` command).
 We tune on each individual set and then average parameter values across all five sets (this has the effect of regularization).
 Note that we are currently optimizing recall@1000 since Anserini output will serve as input to later stage rerankers (e.g., based on BERT), and we want to maximize the number of relevant documents the rerankers have to work with.
-The tuned parameters using this method are `b1=0.82`, `k=0.72`.
+The tuned parameters using this method are `k1=0.82`, `b=0.72`.
+
+Setting                              | MRR@10 | MAP    | Recall@1000 |
+:------------------------------------|-------:|-------:|------------:|
+Default Anserini (`k1=0.9`, `b=0.4`) | 0.1839 | 0.1925 | 0.8526
+Tuned (`k1=0.82`, `b=0.72`)          | 0.1875 | 0.1956 | 0.8578

--- a/src/main/python/msmarco/retrieve.py
+++ b/src/main/python/msmarco/retrieve.py
@@ -31,8 +31,8 @@ if __name__ == '__main__':
     parser.add_argument('--output', required=True, default='', help='output filee')
     parser.add_argument('--index', required=True, default='', help='index path')
     parser.add_argument('--hits', default=10, help='number of hits to retrieve')
-    parser.add_argument('--b1', default=0.82, help='BM25 b1 parameter')
-    parser.add_argument('--k', default=0.72, help='BM25 k parameter')
+    parser.add_argument('--k1', default=0.82, help='BM25 k1 parameter')
+    parser.add_argument('--b', default=0.72, help='BM25 b parameter')
     # See our MS MARCO documentation to understand how these parameter values were tuned.
     parser.add_argument('--rm3', action='store_true', default=False, help='use RM3')
     parser.add_argument('--fbTerms', default=10, type=int, help='RM3 parameter: number of expansion terms')
@@ -42,8 +42,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     searcher = JSearcher(JString(args.index))
-    searcher.setBM25Similarity(float(args.b1), float(args.k))
-    print('Initializing BM25, setting b1={} and k={}'.format(args.b1, args.k))
+    searcher.setBM25Similarity(float(args.k1), float(args.b))
+    print('Initializing BM25, setting k1={} and b={}'.format(args.k1, args.b))
     if args.rm3:
         searcher.setRM3Reranker(args.fbTerms, args.fbDocs, args.originalQueryWeight)
         print('Initializing RM3, setting fbTerms={}, fbDocs={} and originalQueryWeight={}'.format(args.fbTerms, args.fbDocs, args.originalQueryWeight))

--- a/src/main/python/msmarco/tune_bm25.py
+++ b/src/main/python/msmarco/tune_bm25.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 Anserini: A Lucene toolkit for replicable information retrieval research
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,21 +13,16 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-"""
+'''
 
 # Simple script for tuning BM25 parameters (k1 and b) for MS MARCO
-#
-# The output of the script should be (on dev set):
-#   Best parameters: run.bm25.b1_0.6.k_0.8.txt: MRR@10 = 0.1906588552326375
-#
-# Compared to default Anserini parameters of b1=0.9, k=0.4, MRR@10 = 0.18388092964024202
 
 import argparse
 import os
 import re
 import subprocess
 
-parser = argparse.ArgumentParser(description='Retrieve MS MARCO Passages')
+parser = argparse.ArgumentParser(description='Tunes BM25 parameters for MS MARCO Passages')
 parser.add_argument('--base_directory', required=True, help='base directory for storing runs')
 parser.add_argument('--index', required=True, help='index to use')
 parser.add_argument('--queries', required=True, help='queries for evaluation')
@@ -50,16 +45,16 @@ print('queries: {}'.format(queries))
 print('qrels: {}'.format(qrels))
 print('\n')
 
-for b1 in [0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2]:
-    for k in [0.5, 0.6, 0.7, 0.8, 0.9]:
-        print('Trying... b1 = {}, k = {}'.format(b1, k))
-        filename = 'run.bm25.b1_{}.k_{}.txt'.format(b1, k)
+for k1 in [0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2]:
+    for b in [0.5, 0.6, 0.7, 0.8, 0.9]:
+        print('Trying... k1 = {}, b = {}'.format(k1, b))
+        filename = 'run.bm25.k1_{}.b_{}.txt'.format(k1, b)
         if os.path.isfile('{}/{}'.format(base_directory, filename)):
            print('Run already exists, skipping!')
         else:
            subprocess.call('python src/main/python/msmarco/retrieve.py \
                --index {} --qid_queries {} --output {}/{} \
-               --b1 {} --k {} --hits 1000'.format(index, queries, base_directory, filename, b1, k), shell=True)
+               --k1 {} --b {} --hits 1000'.format(index, queries, base_directory, filename, k1, b), shell=True)
 
 print('\n\nStarting evaluation...')
 


### PR DESCRIPTION
This PR fixes #632

As it turns out, two bugs cancel each other out. I transposed the variables in two different places, so the result of the tuning remains the same.

Added effectiveness numbers from default and tuned parameters for future reference.
