### PR TITLE
Added multithreaded indexing through Elasticsearch (with ES 7.0.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,31 @@
       <version>${lucene.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>4.4.11</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-high-level-client</artifactId>
+      <version>7.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client</artifactId>
+      <version>7.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <version>7.0.0</version>
+    </dependency>
+    <dependency>
       <groupId>edu.umass.ciir</groupId>
       <artifactId>RankLib</artifactId>
       <version>2.1</version>


### PR DESCRIPTION
This is part of the effort of integrating Elasticsearch into Anserini. It's based off the `lucene8` branch to avoid class path errors.

The current approach in this PR is to have bulks of indexing requests (of a specified batch size) sent to Elasticsearch high level REST clients taken from a pool; this is very similar to the approach of the Solr integration.

Here, we set up the ELK stack using [docker-elk](https://github.com/deviantony/docker-elk).

When testing, adjust the `es` parameters as you see fit. Depending on the documents you are indexing, you probably also have to increase the ELK stack's heap size (adjust the corresponding `JAVA_OPTS` in `docker-compose.yml` in `docker-elk`).

Note: As of May 19, 2019, this PR is not meant for an immediate merge; instead, it's a source for continued suggestions, improvements, and collaborations.