### PR TITLE
Updated MS MARC documentation + regressions (BM25 Tuning for doc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Each collection is associated with [regression tests](docs/regressions.md) for r
 Note that these regressions capture the "out of the box" experience, based on [_default_ parameter settings](https://github.com/castorini/Anserini/blob/master/src/main/java/io/anserini/search/SearchArgs.java).
 
 + [Regressions for Disks 1 &amp; 2](docs/regressions-disk12.md)
-+ [Regressions for Disks 4 &amp; 5 (Robust04)](docs/regressions-robust04.md)
++ [Regressions for Disks 4 &amp; 5 (Robust04)](docs/regressions-robust04.md) [[Colab demo](https://colab.research.google.com/drive/1s44ylhEkXDzqNgkJSyXDYetGIxO9TWZn)]
 + [Regressions for AQUAINT (Robust05)](docs/regressions-robust05.md)
 + [Regressions for the New York Times (Core17)](docs/regressions-core17.md)
 + [Regressions for the Washington Post (Core18)](docs/regressions-core18.md)

--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ Note that these regressions capture the "out of the box" experience, based on [_
 
 Other experiments:
 
-+ [Guide to running experiments on the MS MARCO Passage Task](docs/experiments-msmarco-passage.md)
-+ [Guide to running experiments on the MS MARCO Document Task](docs/experiments-msmarco-doc.md)
-+ [Guide to running Experiments on the AI2 Open Research Corpus](docs/experiments-openresearch.md)
++ [Guide to running BM25 baselines on the MS MARCO Passage Task](docs/experiments-msmarco-passage.md)
++ [Guide to running BM25 baselines on the MS MARCO Document Task](docs/experiments-msmarco-doc.md)
++ [Guide to replicating document expansion by query prediction (Doc2query) results](docs/experiments-doc2query.md)
++ [Guide to running experiments on the AI2 Open Research Corpus](docs/experiments-openresearch.md)
 + [Experiments from Yang et al. (JDIQ 2018)](docs/experiments-jdiq2018.md)
 + [Experiments from Lin (SIGIR Forum 2018)](docs/experiments-forum2018.md)
 + Runbooks for TREC 2018: [[Anserini group](docs/runbook-trec2018-anserini.md)] [[h2oloo group](docs/runbook-trec2018-h2oloo.md)]

--- a/docs/experiments-doc2query.md
+++ b/docs/experiments-doc2query.md
@@ -1,0 +1,91 @@
+# Anserini: Doc2query Experiments
+
+This section describes how to replicate the document expansion experiments in following paper:
+
++ Rodrigo Nogueira, Wei Yang, Jimmy Lin, Kyunghyun Cho. [Document Expansion by Query Prediction.](https://arxiv.org/abs/1904.08375) _arxiv:1904.08375_
+
+For a complete "from scratch" replication (in particularly, training the seq2seq model), see [this code repo](https://github.com/nyu-dl/dl4ir-doc2query).
+Here, we run through how to replicate the BM25+Doc2query condition with our copy of the predicted queries.
+
+## MS MARCO Passage Ranking
+
+To replicate our Doc2query results on the [MS MARCO Passage Ranking Task](https://github.com/microsoft/MSMARCO-Passage-Ranking), follow these instructions.
+Before going through this guide, it might make sense to [replicate our BM25 baselines](experiments-msmarco-passage.md) first.
+
+To start, grab the predicted queries (i.e., document expansions):
+
+```
+wget https://www.dropbox.com/s/709q495d9hohcmh/pred-test_topk10.tar.gz -P msmarco-passage
+tar -xzvf msmarco-passage/pred-test_topk10.tar.gz -C msmarco-passage
+```
+
+To confirm, `pred-test_topk10.tar.gz` should have an MD5 checksum of `241608d4d12a0bc595bed2aff0f56ea3`.
+
+Check out the file:
+
+```
+$ wc msmarco-passage/pred-test_topk10.txt
+ 8841823 536446170 2962345659 msmarco-passage/pred-test_topk10.txt
+```
+
+These are the predicted queries based on our seq2seq model, based on top _k_ sampling with a beam size of 10.
+There are as many lines in the above file as there are documents; all 10 predicted queries are concatenated on a single line.
+
+Now let's create a new document collection by concatenating the predicted queries to the original documents:
+
+```
+python src/main/python/msmarco/augment_collection_with_predictions.py \
+  --collection_path msmarco-passage/collection.tsv --output_folder msmarco-passage/collection_jsonl_expanded_topk10 \
+  --predictions msmarco-passage/pred-test_topk10.txt --stride 1
+```
+
+We can then reindex the collection:
+
+```
+sh ./target/appassembler/bin/IndexCollection -collection JsonCollection \
+ -generator LuceneDocumentGenerator -threads 9 -input msmarco-passage/collection_jsonl_expanded_topk10 \
+ -index msmarco-passage/lucene-index-msmarco-expanded-topk10 -storePositions -storeDocvectors -storeRawDocs
+```
+
+And run retrieval (same as above):
+
+```
+python ./src/main/python/msmarco/retrieve.py --hits 1000 --index msmarco-passage/lucene-index-msmarco-expanded-topk10 \
+ --qid_queries msmarco-passage/queries.dev.small.tsv --output msmarco-passage/run.dev.small.expanded-topk10.tsv
+```
+
+Finally, to evaluate:
+
+```
+python ./src/main/python/msmarco/msmarco_eval.py \
+ msmarco-passage/qrels.dev.small.tsv msmarco-passage/run.dev.small.expanded-topk10.tsv
+```
+
+The output should be:
+
+```
+#####################
+MRR @10: 0.2213412471005586
+QueriesRanked: 6980
+#####################
+```
+
+Note that these figures are slightly higher than the values reported in our arXiv paper (0.218) due to BM25 parameter tuning (see above) and an upgrade from Lucene 7.6 to Lucene 8.0 (experiments in the paper were run with Lucene 7.6).
+
+One additional trick not explored in our arXiv paper is to weight the original document and predicted queries differently.
+The `augment_collection_with_predictions.py` script provides an option `--original_copies` that duplicates the original text _n_ times, which is an easy way to weight the original document by _n_.
+For example `--original_copies 2` would yield the following results:
+
+```
+#####################
+MRR @10: 0.2287041774685029
+QueriesRanked: 6980
+#####################
+```
+
+So, this simple trick improves MRR by a bit over baseline Doc2query.
+
+## TREC CAR
+
+Instructions coming soon!
+

--- a/docs/experiments-doc2query.md
+++ b/docs/experiments-doc2query.md
@@ -1,6 +1,6 @@
 # Anserini: Doc2query Experiments
 
-This section describes how to replicate the document expansion experiments in following paper:
+This page describes how to replicate the document expansion experiments in following paper:
 
 + Rodrigo Nogueira, Wei Yang, Jimmy Lin, Kyunghyun Cho. [Document Expansion by Query Prediction.](https://arxiv.org/abs/1904.08375) _arxiv:1904.08375_
 

--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -109,8 +109,8 @@ It is well known that BM25 parameter tuning is important.
 The above instructions use the Anserini (system-wide) default of `k1=0.9`, `b=0.4`.
 
 Let's try to do better!
-BM25 tuning was accomplished using the queries found [here](https://github.com/castorini/Anserini-data/tree/master/MSMARCO): these are five different sets of 10k samples (from the `shuf` command).
-We tuned on each individual set (grid search, in tenth increments) and then averaged parameter values across all five sets (this has the effect of regularization).
+We tuned BM25 using the queries found [here](https://github.com/castorini/Anserini-data/tree/master/MSMARCO): these are five different sets of 10k samples from the training queries (using the `shuf` command).
+Tuning was performed on each individual set (grid search, in tenth increments) and then we averaged parameter values across all five sets (this has the effect of regularization).
 Here, we optimized for average precision (AP).
 The tuned parameters using this approach are `k1=3.44`, `b=0.87`.
 

--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -108,6 +108,7 @@ We see that "out of the box" Anserini is already better!
 It is well known that BM25 parameter tuning is important.
 The above instructions use the Anserini (system-wide) default of `k1=0.9`, `b=0.4`.
 
+Let's try to do better!
 BM25 tuning was accomplished using the queries found [here](https://github.com/castorini/Anserini-data/tree/master/MSMARCO): these are five different sets of 10k samples (from the `shuf` command).
 We tuned on each individual set (grid search, in tenth increments) and then averaged parameter values across all five sets (this has the effect of regularization).
 Here, we optimized for average precision (AP).

--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -1,6 +1,6 @@
-# Anserini: Experiments on [MS MARCO (Document)](https://github.com/microsoft/TREC-2019-Deep-Learning)
+# Anserini: BM25 Baselines on [MS MARCO (Document)](https://github.com/microsoft/TREC-2019-Deep-Learning)
 
-This page contains basic instructions for getting started on the MS MARCO *document* ranking task.
+This page contains instructions for running BM25 baselines on the MS MARCO *document* ranking task.
 Note that there is a separate [MS MARCO *passage* ranking task](experiments-msmarco-passage.md).
 
 ## Data Prep

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -1,7 +1,8 @@
-# Anserini: Experiments on [MS MARCO (Passage)](https://github.com/microsoft/MSMARCO-Passage-Ranking)
+# Anserini: BM25 Baselines on [MS MARCO (Passage)](https://github.com/microsoft/MSMARCO-Passage-Ranking)
 
-This page contains basic instructions for getting started on the MS MARCO *passage* ranking task.
+This page contains instructions for running BM25 baselines on the MS MARCO *passage* ranking task.
 Note that there is a separate [MS MARCO *document* ranking task](experiments-msmarco-doc.md).
+We also have a [separate page](experiments-doc2query.md) describing document expansion experiments (Doc2query) for this task.
 
 ## Data Prep
 
@@ -137,86 +138,3 @@ Setting                     | MRR@10 | MAP    | Recall@1000 |
 :---------------------------|-------:|-------:|------------:|
 Default (`k1=0.9`, `b=0.4`) | 0.1839 | 0.1925 | 0.8526
 Tuned (`k1=0.82`, `b=0.72`) | 0.1875 | 0.1956 | 0.8578
-
-
-## Document Expansion by Query Prediction: Doc2query
-
-This section describes how to replicate the document expansion experiments in following paper:
-
-+ Rodrigo Nogueira, Wei Yang, Jimmy Lin, Kyunghyun Cho. [Document Expansion by Query Prediction.](https://arxiv.org/abs/1904.08375) _arxiv:1904.08375_
-
-For a complete "from scratch" replication (in particularly, training the seq2seq model), see [this code repo](https://github.com/nyu-dl/dl4ir-doc2query).
-Here, we run through how to replicate the BM25+Doc2query condition with our copy of the predicted queries.
-
-First, grab the predicted queries (i.e., document expansions):
-
-```
-wget https://www.dropbox.com/s/709q495d9hohcmh/pred-test_topk10.tar.gz -P msmarco-passage
-tar -xzvf msmarco-passage/pred-test_topk10.tar.gz -C msmarco-passage
-```
-
-To confirm, `pred-test_topk10.tar.gz` should have an MD5 checksum of `241608d4d12a0bc595bed2aff0f56ea3`.
-
-Check out the file:
-
-```
-$ wc msmarco-passage/pred-test_topk10.txt
- 8841823 536446170 2962345659 msmarco-passage/pred-test_topk10.txt
-```
-
-These are the predicted queries based on our seq2seq model, based on top _k_ sampling with a beam size of 10.
-There are as many lines in the above file as there are documents; all 10 predicted queries are concatenated on a single line.
-
-Now let's create a new document collection by concatenating the predicted queries to the original documents:
-
-```
-python src/main/python/msmarco/augment_collection_with_predictions.py \
-  --collection_path msmarco-passage/collection.tsv --output_folder msmarco-passage/collection_jsonl_expanded_topk10 \
-  --predictions msmarco-passage/pred-test_topk10.txt --stride 1
-```
-
-We can then reindex the collection:
-
-```
-sh ./target/appassembler/bin/IndexCollection -collection JsonCollection \
- -generator LuceneDocumentGenerator -threads 9 -input msmarco-passage/collection_jsonl_expanded_topk10 \
- -index msmarco-passage/lucene-index-msmarco-expanded-topk10 -storePositions -storeDocvectors -storeRawDocs
-```
-
-And run retrieval (same as above):
-
-```
-python ./src/main/python/msmarco/retrieve.py --hits 1000 --index msmarco-passage/lucene-index-msmarco-expanded-topk10 \
- --qid_queries msmarco-passage/queries.dev.small.tsv --output msmarco-passage/run.dev.small.expanded-topk10.tsv
-```
-
-Finally, to evaluate:
-
-```
-python ./src/main/python/msmarco/msmarco_eval.py \
- msmarco-passage/qrels.dev.small.tsv msmarco-passage/run.dev.small.expanded-topk10.tsv
-```
-
-The output should be:
-
-```
-#####################
-MRR @10: 0.2213412471005586
-QueriesRanked: 6980
-#####################
-```
-
-Note that these figures are slightly higher than the values reported in our arXiv paper (0.218) due to BM25 parameter tuning (see above) and an upgrade from Lucene 7.6 to Lucene 8.0 (experiments in the paper were run with Lucene 7.6).
-
-One additional trick not explored in our arXiv paper is to weight the original document and predicted queries differently.
-The `augment_collection_with_predictions.py` script provides an option `--original_copies` that duplicates the original text _n_ times, which is an easy way to weight the original document by _n_.
-For example `--original_copies 2` would yield the following results:
-
-```
-#####################
-MRR @10: 0.2287041774685029
-QueriesRanked: 6980
-#####################
-```
-
-So, this simple trick improves MRR by a bit over baseline Doc2query.

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -117,7 +117,7 @@ Average precision and recall@1000 are the two metrics we care about the most.
 Note that this figure differs slightly from the value reported in [Document Expansion by Query Prediction](https://arxiv.org/abs/1904.08375), which uses the Anserini (system-wide) default of `k1=0.9`, `b=0.4`.
 
 Tuning was accomplished with the `tune_bm25.py` script, using the queries found [here](https://github.com/castorini/Anserini-data/tree/master/MSMARCO).
-There are five different sets of 10k samples (from the `shuf` command).
+There are five different sets of 10k samples (using the `shuf` command).
 We tuned on each individual set and then averaged parameter values across all five sets (this has the effect of regularization).
 Note that we optimized recall@1000 since Anserini output serves as input to later stage rerankers (e.g., based on BERT), and we want to maximize the number of relevant documents the rerankers have to work with.
 The tuned parameters using this method are `k1=0.82`, `b=0.68`.

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -118,8 +118,8 @@ Note that this figure differs slightly from the value reported in [Document Expa
 
 Tuning was accomplished with the `tune_bm25.py` script, using the queries found [here](https://github.com/castorini/Anserini-data/tree/master/MSMARCO).
 There are five different sets of 10k samples (from the `shuf` command).
-We tune on each individual set and then average parameter values across all five sets (this has the effect of regularization).
-Note that we are currently optimizing recall@1000 since Anserini output will serve as input to later stage rerankers (e.g., based on BERT), and we want to maximize the number of relevant documents the rerankers have to work with.
+We tuned on each individual set and then averaged parameter values across all five sets (this has the effect of regularization).
+Note that we optimized recall@1000 since Anserini output serves as input to later stage rerankers (e.g., based on BERT), and we want to maximize the number of relevant documents the rerankers have to work with.
 The tuned parameters using this method are `k1=0.82`, `b=0.68`.
 
 Here's the comparison between the Anserini default and tuned parameters:

--- a/docs/regressions-msmarco-doc.md
+++ b/docs/regressions-msmarco-doc.md
@@ -63,3 +63,7 @@ R@1000                                  | BM25 (Default)| +RM3      | BM25 (Tune
 [MS MARCO Document Ranking: Dev Queries](https://github.com/microsoft/TREC-2019-Deep-Learning)| 0.8856    | 0.8785    | 0.9326    | 0.9320    |
 
 
+
+The setting "default" refers the default BM25 settings of `k1=0.9`, `b=0.4`, while "tuned" refers to the tuned setting of `k1=3.44`, `b=0.87`.
+See [this page](experiments-msmarco-doc.md) for more details.
+Note that here we are using `trec_eval` to evaluate the top 1000 hits for each query; beware, the runs provided by MS MARCO organizers for reranking have only 100 hits per query.

--- a/docs/regressions-msmarco-doc.md
+++ b/docs/regressions-msmarco-doc.md
@@ -26,18 +26,26 @@ The regression experiments here evaluate on the 5193 dev set questions; see [thi
 After indexing has completed, you should be able to perform retrieval as follows:
 
 ```
-nohup target/appassembler/bin/SearchCollection -topicreader Tsv -index lucene-index.msmarco-doc.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -output run.msmarco-doc.bm25.topics.msmarco-doc.dev.txt -bm25 &
+nohup target/appassembler/bin/SearchCollection -topicreader Tsv -index lucene-index.msmarco-doc.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -output run.msmarco-doc.bm25-default.topics.msmarco-doc.dev.txt -bm25 &
 
-nohup target/appassembler/bin/SearchCollection -topicreader Tsv -index lucene-index.msmarco-doc.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -output run.msmarco-doc.bm25+rm3.topics.msmarco-doc.dev.txt -bm25 -rm3 &
+nohup target/appassembler/bin/SearchCollection -topicreader Tsv -index lucene-index.msmarco-doc.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -output run.msmarco-doc.bm25-default+rm3.topics.msmarco-doc.dev.txt -bm25 -rm3 &
+
+nohup target/appassembler/bin/SearchCollection -topicreader Tsv -index lucene-index.msmarco-doc.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -output run.msmarco-doc.bm25-tuned.topics.msmarco-doc.dev.txt -bm25 -k1 3.44 -b 0.87 &
+
+nohup target/appassembler/bin/SearchCollection -topicreader Tsv -index lucene-index.msmarco-doc.pos+docvectors+rawdocs -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -output run.msmarco-doc.bm25-tuned+rm3.topics.msmarco-doc.dev.txt -bm25 -k1 3.44 -b 0.87 -rm3 &
 
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```
-eval/trec_eval.9.0.4/trec_eval -m map -c -m recall.1000 -c src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt run.msmarco-doc.bm25.topics.msmarco-doc.dev.txt
+eval/trec_eval.9.0.4/trec_eval -m map -c -m recall.1000 -c src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt run.msmarco-doc.bm25-default.topics.msmarco-doc.dev.txt
 
-eval/trec_eval.9.0.4/trec_eval -m map -c -m recall.1000 -c src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt run.msmarco-doc.bm25+rm3.topics.msmarco-doc.dev.txt
+eval/trec_eval.9.0.4/trec_eval -m map -c -m recall.1000 -c src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt run.msmarco-doc.bm25-default+rm3.topics.msmarco-doc.dev.txt
+
+eval/trec_eval.9.0.4/trec_eval -m map -c -m recall.1000 -c src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt run.msmarco-doc.bm25-tuned.topics.msmarco-doc.dev.txt
+
+eval/trec_eval.9.0.4/trec_eval -m map -c -m recall.1000 -c src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt run.msmarco-doc.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
 
 ```
 
@@ -45,13 +53,13 @@ eval/trec_eval.9.0.4/trec_eval -m map -c -m recall.1000 -c src/main/resources/to
 
 With the above commands, you should be able to replicate the following results:
 
-MAP                                     | BM25      | +RM3      |
-:---------------------------------------|-----------|-----------|
-[MS MARCO Document Ranking: Dev Queries](https://github.com/microsoft/TREC-2019-Deep-Learning)| 0.2310    | 0.1632    |
+MAP                                     | BM25 (Default)| +RM3      | BM25 (Tuned)| +RM3      |
+:---------------------------------------|-----------|-----------|-----------|-----------|
+[MS MARCO Document Ranking: Dev Queries](https://github.com/microsoft/TREC-2019-Deep-Learning)| 0.2310    | 0.1632    | 0.2788    | 0.2289    |
 
 
-R@1000                                  | BM25      | +RM3      |
-:---------------------------------------|-----------|-----------|
-[MS MARCO Document Ranking: Dev Queries](https://github.com/microsoft/TREC-2019-Deep-Learning)| 0.8856    | 0.8785    |
+R@1000                                  | BM25 (Default)| +RM3      | BM25 (Tuned)| +RM3      |
+:---------------------------------------|-----------|-----------|-----------|-----------|
+[MS MARCO Document Ranking: Dev Queries](https://github.com/microsoft/TREC-2019-Deep-Learning)| 0.8856    | 0.8785    | 0.9326    | 0.9320    |
 
 

--- a/docs/regressions-msmarco-passage-doc2query.md
+++ b/docs/regressions-msmarco-passage-doc2query.md
@@ -1,7 +1,11 @@
 # Anserini: Regressions for [MS MARCO](https://github.com/microsoft/MSMARCO-Passage-Ranking) (Passage Expansion)
 
-This page documents regression experiments for the MS MARCO Passage Ranking Task (with Doc2query expansions), which is integrated into Anserini's regression testing framework.
-For more complete instructions on how to run end-to-end experiments, refer to [this page](experiments-msmarco-passage.md).
+This page documents regression experiments for the MS MARCO Passage Ranking Task with Doc2query expansions, as proposed in the following paper:
+
++ Rodrigo Nogueira, Wei Yang, Jimmy Lin, Kyunghyun Cho. [Document Expansion by Query Prediction.](https://arxiv.org/abs/1904.08375) _arxiv:1904.08375_
+
+These experiments are integrated into Anserini's regression testing framework.
+For more complete instructions on how to run end-to-end experiments, refer to [this page](experiments-doc2query.md).
 
 ## Indexing
 

--- a/src/main/resources/docgen/templates/msmarco-doc.template
+++ b/src/main/resources/docgen/templates/msmarco-doc.template
@@ -37,3 +37,7 @@ ${eval_cmds}
 With the above commands, you should be able to replicate the following results:
 
 ${effectiveness}
+
+The setting "default" refers the default BM25 settings of `k1=0.9`, `b=0.4`, while "tuned" refers to the tuned setting of `k1=3.44`, `b=0.87`.
+See [this page](experiments-msmarco-doc.md) for more details.
+Note that here we are using `trec_eval` to evaluate the top 1000 hits for each query; beware, the runs provided by MS MARCO organizers for reranking have only 100 hits per query.

--- a/src/main/resources/docgen/templates/msmarco-passage-doc2query.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-doc2query.template
@@ -1,7 +1,11 @@
 # Anserini: Regressions for [MS MARCO](https://github.com/microsoft/MSMARCO-Passage-Ranking) (Passage Expansion)
 
-This page documents regression experiments for the MS MARCO Passage Ranking Task (with Doc2query expansions), which is integrated into Anserini's regression testing framework.
-For more complete instructions on how to run end-to-end experiments, refer to [this page](experiments-msmarco-passage.md).
+This page documents regression experiments for the MS MARCO Passage Ranking Task with Doc2query expansions, as proposed in the following paper:
+
++ Rodrigo Nogueira, Wei Yang, Jimmy Lin, Kyunghyun Cho. [Document Expansion by Query Prediction.](https://arxiv.org/abs/1904.08375) _arxiv:1904.08375_
+
+These experiments are integrated into Anserini's regression testing framework.
+For more complete instructions on how to run end-to-end experiments, refer to [this page](experiments-doc2query.md).
 
 ## Indexing
 

--- a/src/main/resources/regression/msmarco-doc.yaml
+++ b/src/main/resources/regression/msmarco-doc.yaml
@@ -48,8 +48,8 @@ topics:
     path: topics.msmarco-doc.dev.txt
     qrel: qrels.msmarco-doc.dev.txt
 models:
-  - name: bm25
-    display: BM25
+  - name: bm25-default
+    display: BM25 (Default)
     params:
       - -bm25
     results:
@@ -57,7 +57,7 @@ models:
         - 0.2310
       R@1000:
         - 0.8856
-  - name: bm25+rm3
+  - name: bm25-default+rm3
     display: +RM3
     params:
       - -bm25
@@ -67,3 +67,26 @@ models:
         - 0.1632
       R@1000:
         - 0.8785
+  - name: bm25-tuned
+    display: BM25 (Tuned)
+    params:
+      - -bm25
+      - -k1 3.44
+      - -b 0.87
+    results:
+      map:
+        - 0.2788
+      R@1000:
+        - 0.9326
+  - name: bm25-tuned+rm3
+    display: +RM3
+    params:
+      - -bm25
+      - -k1 3.44
+      - -b 0.87
+      - -rm3
+    results:
+      map:
+        - 0.2289
+      R@1000:
+        - 0.9320


### PR DESCRIPTION
+ Moved Doc2query documentation (on passages) into its own dedicated page.
+ Added documentation and regression on BM25 tuning for the MS MARCO document ranking task.