### PR TITLE
Added Solrini search functionality over collections

### DIFF
--- a/docs/solrini.md
+++ b/docs/solrini.md
@@ -60,4 +60,13 @@ Make sure `/path/to/robust04` is updated with the appropriate path.
 
 Once indexing has completed, you should be able to query `robust04` from the Solr [query interface](http://localhost:8983/solr/#/robust04/query).
 
+You can also run the following command to replicate Anserini BM25 retrieval:
+
+```
+sh target/appassembler/bin/SearchSolrCollection -topicreader Trec \
+  -solr.index robust04 -solr.zkUrl localhost:9983 \
+  -topics src/main/resources/topics-and-qrels/topics.robust04.301-450.601-700.txt \
+  -output run.solr.robust04.bm25.topics.robust04.301-450.601-700.txt
+```
+
 Other collections can be indexed by substituting the appropriate parameters; see each collection's [experiment docs](https://github.com/castorini/anserini/tree/master/docs).

--- a/docs/solrini.md
+++ b/docs/solrini.md
@@ -69,4 +69,10 @@ sh target/appassembler/bin/SearchSolrCollection -topicreader Trec \
   -output run.solr.robust04.bm25.topics.robust04.301-450.601-700.txt
 ```
 
+Evaluation can be performed using `trec_eval`:
+
+```
+eval/trec_eval.9.0.4/trec_eval -m map -m P.30 src/main/resources/topics-and-qrels/qrels.robust2004.txt run.solr.robust04.bm25.topics.robust04.301-450.601-700.txt
+```
+
 Other collections can be indexed by substituting the appropriate parameters; see each collection's [experiment docs](https://github.com/castorini/anserini/tree/master/docs).

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,10 @@
               <id>SearchCollection</id>
             </program>
             <program>
+              <mainClass>io.anserini.search.SearchSolrCollection</mainClass>
+              <id>SearchSolrCollection</id>
+            </program>
+            <program>
               <mainClass>io.anserini.search.SearchMsmarco</mainClass>
               <id>SearchMsmarco</id>
             </program>

--- a/src/main/java/io/anserini/rerank/ScoredDocuments.java
+++ b/src/main/java/io/anserini/rerank/ScoredDocuments.java
@@ -17,10 +17,17 @@
 package io.anserini.rerank;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.util.BytesRef;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
 
 import java.io.IOException;
+import static io.anserini.index.generator.LuceneDocumentGenerator.FIELD_ID;
 
 /**
  * ScoredDocuments object that converts TopDocs from the searcher into an Anserini format
@@ -48,6 +55,38 @@ public class ScoredDocuments {
       }
       scoredDocs.scores[i] = rs.scoreDocs[i].score;
       scoredDocs.ids[i] = rs.scoreDocs[i].doc;
+    }
+
+    return scoredDocs;
+  }
+
+  public static ScoredDocuments fromSolrDocs(SolrDocumentList rs) {
+
+    ScoredDocuments scoredDocs = new ScoredDocuments();
+
+    int length = rs.size();
+    scoredDocs.documents = new Document[length];
+    scoredDocs.ids = new int[length];
+    scoredDocs.scores = new float[length];
+
+    for (int i = 0; i < length; i++) {
+
+      SolrDocument d = rs.get(i);
+
+      // Create placeholder copies of Lucene Documents
+      // Intention is for compatibility with ScoreTiesAdjusterReranker without disturbing other aspects of reranker code
+
+      Document document = new Document();
+      String id = d.getFieldValue("id").toString();
+      float score = (float) d.getFieldValue("score");
+
+      // Store the collection docid.
+      document.add(new StringField(FIELD_ID, id, Field.Store.YES));
+      // This is needed to break score ties by docid.
+      document.add(new SortedDocValuesField(FIELD_ID, new BytesRef(id)));
+      scoredDocs.documents[i] = document;
+      scoredDocs.scores[i] = score;
+      scoredDocs.ids[i] = i; // no internal Lucene ID available, use index as placeholder
     }
 
     return scoredDocs;

--- a/src/main/java/io/anserini/search/SearchSolrCollection.java
+++ b/src/main/java/io/anserini/search/SearchSolrCollection.java
@@ -1,0 +1,337 @@
+/**
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.search;
+
+import com.google.common.base.Splitter;
+import io.anserini.rerank.ScoredDocuments;
+import io.anserini.rerank.lib.ScoreTiesAdjusterReranker;
+import io.anserini.search.topicreader.TopicReader;
+import io.anserini.index.generator.TweetGenerator;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.ObjectPool;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.document.LongPoint;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.client.solrj.SolrQuery.SortClause;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.OptionHandlerFilter;
+import org.kohsuke.args4j.ParserProperties;
+import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.spi.StringArrayOptionHandler;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static io.anserini.index.generator.LuceneDocumentGenerator.FIELD_ID;
+
+/*
+* Entry point of the Retrieval.
+ */
+public final class SearchSolrCollection implements Closeable {
+
+  private static final Logger LOG = LogManager.getLogger(SearchCollection.class);
+  private static final int TIMEOUT = 600 * 1000;
+
+  private final Args args;
+  private ObjectPool<SolrClient> solrPool;
+
+  public static final class Args {
+
+    // required arguments
+
+    @Option(name = "-topics", metaVar = "[file]", handler = StringArrayOptionHandler.class, required = true, usage = "topics file")
+    public String[] topics;
+
+    @Option(name = "-output", metaVar = "[file]", required = true, usage = "output file")
+    public String output;
+
+    @Option(name = "-topicreader", required = true, usage = "define how to read the topic(query) file: one of [Trec|Webxml]")
+    public String topicReader;
+
+    @Option(name = "-solr.index", usage = "the name of the index in Solr")
+    public String solrIndex = null;
+
+    @Option(name = "-solr.poolSize", metaVar = "[NUMBER]", usage = "the number of clients to keep in the pool")
+    public int solrPoolSize = 16;
+
+    @Option(name = "-solr.zkUrl", usage = "the URL of Solr's ZooKeeper (comma separated list of using ensemble)")
+    public String zkUrl = null;
+
+    @Option(name = "-solr.zkChroot", usage = "the ZooKeeper chroot")
+    public String zkChroot = "/";
+
+    // optional arguments
+    @Option(name = "-threads", metaVar = "[Number]", usage = "Number of Threads")
+    public int threads = 1;
+
+    @Option(name = "-topicfield", usage = "Which field of the query should be used, default \"title\"." +
+            " For TREC ad hoc topics, description or narrative can be used.")
+    public String topicfield = "title";
+
+    @Option(name = "-searchtweets", usage = "Whether the search is against a tweet " +
+            "index created by IndexCollection -collection TweetCollection")
+    public Boolean searchtweets = false;
+
+    @Option(name = "-hits", metaVar = "[number]", required = false, usage = "max number of hits to return")
+    public int hits = 1000;
+
+    @Option(name = "-runtag", metaVar = "[tag]", required = false, usage = "runtag")
+    public String runtag = null;
+
+  }
+
+  private final class SolrSearcherThread<K> extends Thread {
+
+    final private SortedMap<K, Map<String, String>> topics;
+    final private String outputPath;
+    final private String runTag;
+
+    private SolrSearcherThread(SortedMap<K, Map<String, String>> topics, String outputPath, String runTag) throws IOException {
+
+      this.topics = topics;
+      this.runTag = runTag;
+      this.outputPath = outputPath;
+      setName(outputPath);
+    }
+
+    @Override
+    public void run() {
+      try {
+        LOG.info("[Start] Retrieval with Solr collection: " + args.solrIndex);
+        final long start = System.nanoTime();
+        PrintWriter out = new PrintWriter(Files.newBufferedWriter(Paths.get(outputPath), StandardCharsets.US_ASCII));
+
+        // Solr client
+        SolrClient client = solrPool.borrowObject();
+
+        for (Map.Entry<K, Map<String, String>> entry : topics.entrySet()) {
+          K qid = entry.getKey();
+          String queryString = entry.getValue().get(args.topicfield);
+          ScoredDocuments docs;
+          if (args.searchtweets) {
+            docs = searchSolrTweets(client, qid, queryString, Long.parseLong(entry.getValue().get("time")));
+          } else {
+            docs = searchSolr(client, qid, queryString);
+          }
+
+          /**
+           * the first column is the topic number.
+           * the second column is currently unused and should always be "Q0".
+           * the third column is the official document identifier of the retrieved document.
+           * the fourth column is the rank the document is retrieved.
+           * the fifth column shows the score (integer or floating point) that generated the ranking.
+           * the sixth column is called the "run tag" and should be a unique identifier for your
+           */
+          for (int i = 0; i < docs.documents.length; i++) {
+            out.println(String.format(Locale.US, "%s Q0 %s %d %f %s", qid,
+                    docs.documents[i].getField(FIELD_ID).stringValue(), (i + 1), docs.scores[i], runTag));
+          }
+        }
+        out.flush();
+        out.close();
+
+        // Needed for orderly shutdown so the SolrClient executor does not delay main thread exit
+        try {
+          solrPool.returnObject(client);
+          solrPool.close();
+        } catch (Exception e) {
+          LOG.error("Exception in SolrClient executor: ", e);
+        }
+
+        final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+        LOG.info("[Finished] Run " + topics.size() + " topics searched in "
+                + DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss"));
+      } catch (Exception e) {
+        LOG.error(Thread.currentThread().getName() + ": Unexpected Exception:", e);
+      }
+    }
+  }
+
+  public SearchSolrCollection(Args args) throws IOException {
+    this.args = args;
+    LOG.info("Solr index: " + args.solrIndex);
+    LOG.info("Solr ZooKeeper URL: " + args.zkUrl);
+    LOG.info("SolrClient pool size: " + args.solrPoolSize);
+    GenericObjectPoolConfig<SolrClient> config = new GenericObjectPoolConfig<>();
+    config.setMaxTotal(args.solrPoolSize);
+    config.setMinIdle(args.solrPoolSize); // To guard against premature discarding of solrClients
+    this.solrPool = new GenericObjectPool(new SolrClientFactory(), config);
+  }
+
+  @SuppressWarnings("unchecked")
+  public<K> void runTopics() throws IOException {
+    TopicReader<K> tr;
+    SortedMap<K, Map<String, String>> topics = new TreeMap<>();
+    for (String singleTopicsFile : args.topics) {
+      Path topicsFilePath = Paths.get(singleTopicsFile);
+      if (!Files.exists(topicsFilePath) || !Files.isRegularFile(topicsFilePath) || !Files.isReadable(topicsFilePath)) {
+        throw new IllegalArgumentException("Topics file : " + topicsFilePath + " does not exist or is not a (readable) file.");
+      }
+      try {
+        tr = (TopicReader<K>) Class.forName("io.anserini.search.topicreader." + args.topicReader + "TopicReader")
+            .getConstructor(Path.class).newInstance(topicsFilePath);
+        topics.putAll(tr.read());
+      } catch (Exception e) {
+        throw new IllegalArgumentException("Unable to load topic reader: " + args.topicReader);
+      }
+    }
+  
+    final String runTag = args.runtag == null ? "Solrini" : args.runtag;
+    final ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(args.threads);
+
+    executor.execute(new SolrSearcherThread<K>(topics, args.output, runTag));
+
+    executor.shutdown();
+
+    try {
+      // Wait for existing tasks to terminate
+      while (!executor.awaitTermination(1, TimeUnit.MINUTES)) {}
+    } catch (InterruptedException ie) {
+      // (Re-)Cancel if current thread also interrupted
+      executor.shutdownNow();
+      // Preserve interrupt status
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private class SolrClientFactory extends BasePooledObjectFactory<SolrClient> {
+
+    @Override
+    public SolrClient create() {
+      return new CloudSolrClient.Builder(Splitter.on(',').splitToList(args.zkUrl), Optional.of(args.zkChroot))
+              .withConnectionTimeout(TIMEOUT)
+              .withSocketTimeout(TIMEOUT)
+              .build();
+    }
+
+    @Override
+    public PooledObject<SolrClient> wrap(SolrClient solrClient) {
+      return new DefaultPooledObject(solrClient);
+    }
+
+    @Override
+    public void destroyObject(PooledObject<SolrClient> pooled) throws Exception {
+      pooled.getObject().close();
+    }
+  }
+
+  public<K> ScoredDocuments searchSolr(SolrClient client, K qid, String queryString)
+          throws IOException {
+
+    SolrDocumentList results = null;
+
+    SolrQuery solrq = new SolrQuery();
+    solrq.set("df", "contents");
+    solrq.set("fl", "* score");
+    // Remove double quotes in query since they are special syntax in Solr query parser
+    solrq.setQuery(queryString.replace("\"", ""));
+    solrq.setRows(args.hits);
+    solrq.setSort(SortClause.desc("score"));
+    solrq.addSort(SortClause.asc(FIELD_ID));
+
+    try {
+      QueryResponse response = client.query(args.solrIndex, solrq);
+      results = response.getResults();
+    } catch (Exception e) {
+      LOG.error("Exception during Solr query: ", e);
+    }
+
+    ScoreTiesAdjusterReranker reranker = new ScoreTiesAdjusterReranker();
+    return reranker.rerank(ScoredDocuments.fromSolrDocs(results), null);
+  }
+
+  public<K> ScoredDocuments searchSolrTweets(SolrClient client, K qid, String queryString, long t) throws IOException {
+
+    SolrDocumentList results = null;
+
+    SolrQuery solrq = new SolrQuery();
+    solrq.set("df", "contents");
+    solrq.set("fl", "* score");
+    // Remove double quotes in query since they are special syntax in Solr query parser
+    solrq.setQuery(queryString.replace("\"", ""));
+    solrq.setRows(args.hits);
+    solrq.setSort(SortClause.desc("score"));
+    solrq.addSort(SortClause.desc(TweetGenerator.StatusField.ID_LONG.name));
+
+    // Do not consider the tweets with tweet ids that are beyond the queryTweetTime
+    // <querytweettime> tag contains the timestamp of the query in terms of the
+    // chronologically nearest tweet id within the corpus
+    Query filter = LongPoint.newRangeQuery(TweetGenerator.StatusField.ID_LONG.name, 0L, t);
+    solrq.set("fq", filter.toString());
+
+    try {
+      QueryResponse response = client.query(args.solrIndex, solrq);
+      results = response.getResults();
+    } catch (Exception e) {
+      LOG.error("Exception during Solr query: ", e);
+    }
+
+    ScoreTiesAdjusterReranker reranker = new ScoreTiesAdjusterReranker();
+    return reranker.rerank(ScoredDocuments.fromSolrDocs(results), null);
+  }
+
+  @Override
+  public void close() {
+    solrPool.close();
+  }
+
+  public static void main(String[] args) throws Exception {
+    Args searchSolrArgs = new Args();
+    CmdLineParser parser = new CmdLineParser(searchSolrArgs, ParserProperties.defaults().withUsageWidth(90));
+
+    try {
+      parser.parseArgument(args);
+    } catch (CmdLineException e) {
+      System.err.println(e.getMessage());
+      parser.printUsage(System.err);
+      System.err.println("Example: SearchSolrCollection" + parser.printExample(OptionHandlerFilter.REQUIRED));
+      return;
+    }
+
+    final long start = System.nanoTime();
+    SearchSolrCollection searcher = new SearchSolrCollection(searchSolrArgs);
+    searcher.runTopics();
+    searcher.close();
+    final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+    LOG.info("Total run time: " + DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss"));
+  }
+}

--- a/src/main/resources/solr/anserini-twitter/conf/managed-schema
+++ b/src/main/resources/solr/anserini-twitter/conf/managed-schema
@@ -532,10 +532,18 @@
 
   <!-- "tweet" field type -->
   <fieldType name="tweet" class="solr.TextField">
-    <analyzer>
+    <analyzer type="index">
       <tokenizer class="solr.WhitespaceTokenizerFactory"/>
       <filter class="io.anserini.analysis.TweetLowerCaseEntityPreservingFilterFactory" />
       <filter class="solr.PorterStemFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      <filter class="io.anserini.analysis.TweetLowerCaseEntityPreservingFilterFactory" />
+      <filter class="solr.PorterStemFilterFactory"/>
+      <!-- Filter out empty tokens resulting from TweetLowerCaseEntityPreservingFilterFactory -->
+      <!-- Max (required) chosen as maxTokenLen (256) of WhitespaceTokenizerFactory -->
+      <filter class="solr.LengthFilterFactory" min="1" max="256"/>
     </analyzer>
   </fieldType>
 

--- a/src/main/resources/solr/anserini/conf/managed-schema
+++ b/src/main/resources/solr/anserini/conf/managed-schema
@@ -509,12 +509,16 @@
   <dynamicField name="*_p" type="location" indexed="true" stored="true"/>
   
   <!-- Anserini Fields -->
+  
+  <fieldType name="text_en_anserini" class="solr.TextField">
+     <analyzer class="org.apache.lucene.analysis.en.EnglishAnalyzer"/>
+  </fieldType>
 
   <!-- "raw" is stored but not searchable. -->
   <field name="raw" type="text_general" indexed="false" stored="true" multiValued="false" />
   
   <!-- "contents" searchable but not stored. -->
-  <field name="contents" type="text_en" indexed="true" stored="false" multiValued="false" />
+  <field name="contents" type="text_en_anserini" indexed="true" stored="false" multiValued="false" />
 
   <!-- Anserini WashingtonPost Fields -->
   <field name="author" type="string" />


### PR DESCRIPTION
In this PR:
- Adapted relevant code from `SearchCollection` into `SearchSolrCollection` for Solrini BM25 retrieval
- Updated analyzers in Solr schema to reconcile score differences
- Verified that retrieval results match with Anserini BM25 regressions for `robust04` and `mb11` collections
- Updated solrini documentation

This update extends search functionality per #718, minus the abstraction/refactoring. Solrini retrieval in this setup supports a subset of `SearchCollection` functionalities, and is not yet compatible with rerankers other than the default `ScoreTiesAdjusterReranker`. The main goal here was to replicate Anserini retrieval results in Solr without breaking the current `SearchCollection`. 