### PR TITLE
Matches the same filtering steps from Bhagavatula et al. (2018)

### DIFF
--- a/src/main/python/openresearch/convert_openresearch_to_anserini_format.py
+++ b/src/main/python/openresearch/convert_openresearch_to_anserini_format.py
@@ -1,11 +1,8 @@
 import argparse
 import gzip
 import json
-import numpy as np
 import os
 import time
-from os import listdir
-from os.path import isfile, join
 
 
 def clean(text):
@@ -20,21 +17,14 @@ def get_id_years(file_paths, train_fraction):
       for line_num, line in enumerate(f):
         obj = json.loads(line.strip())
         doc_id = obj['id']
-        in_citations = obj['inCitations']
-        out_citations = obj['outCitations']
+        if 'year' not in obj:
+          continue
+        year = int(obj['year'])
 
-        # Following Bhagavatula et al. (2018, "Content-Based Citation 
-        # Recommendation") we do not use papers with no citations and papers 
-        # that cite less than 2 times.
-        if len(in_citations) > 0 and len(out_citations) >= 2:
-          if 'year' not in obj:
-            continue
-          year = int(obj['year'])
-
-          id_years.append((doc_id, year))
+        id_years.append((doc_id, year))
         if line_num % 100000 == 0:
           print('Processed {} lines. Collected {} docs.'.format(
-              line_num, len(id_years)))
+              line_num + 1, len(id_years)))
 
   print('Sorting papers by year...')
   id_years.sort(key = lambda x: x[1])
@@ -45,14 +35,16 @@ def get_id_years(file_paths, train_fraction):
   dev_ids = id_years[num_train:num_train + num_dev]
   test_ids = id_years[num_train + num_dev:]
 
-  train_ids = set(doc_id for doc_id, _ in train_ids)
-  dev_ids = set(doc_id for doc_id, _ in dev_ids)
-  test_ids = set(doc_id for doc_id, _ in test_ids)
-
+  train_ids = set(id for id, _ in train_ids)
+  dev_ids = set(id for id, _ in dev_ids)
+  test_ids = set(id for id, _ in test_ids)
+  
   print('Collected {}, {}, {} papers for training, dev, and test sets.'.format(
       len(train_ids), len(dev_ids), len(test_ids)))
 
-  return train_ids, dev_ids, test_ids
+  id_years = {id: year for id, year in id_years}
+
+  return train_ids, dev_ids, test_ids, id_years
 
 
 def create_dataset(args):
@@ -68,11 +60,11 @@ def create_dataset(args):
     queries_files[set_name] = open(queries_filepath, 'w')
     qrels_files[set_name] = open(qrels_filepath, 'w')
   
-  file_names = listdir(args.collection_path)
+  file_names = os.listdir(args.collection_path)
   file_paths = []
   for file_name in file_names:
-    file_path = join(args.collection_path, file_name)
-    if not isfile(file_path):
+    file_path = os.path.join(args.collection_path, file_name)
+    if not os.path.isfile(file_path):
       continue
     if not file_path.endswith('.gz'):
       continue
@@ -82,12 +74,12 @@ def create_dataset(args):
 
   # We first need to collect papers by year, sort them, and split between 
   # training, dev, and test sets.
-  train_ids, dev_ids, test_ids = get_id_years(
+  train_ids, dev_ids, test_ids, id_years = get_id_years(
       file_paths=file_paths, train_fraction=args.train_fraction)
 
-  number_citations_all = []
+  doc_ids = train_ids | dev_ids | test_ids
+
   n_docs = 0
-  n_docs_used = 0
   file_index = 0
   num_train = 0
   num_dev = 0
@@ -98,12 +90,9 @@ def create_dataset(args):
       for line in f:
         obj = json.loads(line.strip())
         doc_id = obj['id']
-        doc_text = '[Title]: {} [Abstract]: {}'.format(
-            obj['title'], obj['paperAbstract'])
-        out_citations = obj['outCitations']
-        in_citations = obj['inCitations']
 
-        doc_text = clean(doc_text)
+        if doc_id not in doc_ids:
+          continue
 
         if n_docs % args.max_docs_per_file == 0:
           if n_docs > 0:
@@ -112,12 +101,41 @@ def create_dataset(args):
               args.output_folder, 'corpus/docs{:02d}.json'.format(file_index))
           output_jsonl_file = open(output_path, 'w')
           file_index += 1
-
+        
+        doc_text = '[Title]: {} [Abstract]: {}'.format(
+            obj['title'], obj['paperAbstract'])
+        doc_text = clean(doc_text)
         output_dict = {'id': doc_id, 'contents': doc_text}
         output_jsonl_file.write(json.dumps(output_dict) + '\n')
         n_docs += 1
-        number_citations_all.append(len(in_citations))
-        
+
+        out_citations = obj['outCitations']
+
+        # Remove citations not in the corpus.
+        out_citations = [
+            out_citation for out_citation in out_citations 
+            if out_citation in doc_ids
+        ]
+
+        # Remove self citations.
+        out_citations = [
+            out_citation for out_citation in out_citations 
+            if out_citation != doc_id
+        ]
+
+        # Use only citations that have an older publication year than the citing
+        # paper's or do not have an year.
+        out_citations2 = []
+        for out_citation in out_citations: 
+          if out_citation in id_years:
+            if id_years[out_citation] <= obj['year']:
+              out_citations2.append(out_citation)
+        out_citations = out_citations2
+
+        # Skip papers with no out citations.
+        if len(out_citations) == 0:
+          continue
+
         if doc_id in train_ids:
           set_name = 'train'
           num_train += 1  
@@ -127,8 +145,6 @@ def create_dataset(args):
         elif doc_id in test_ids:
           set_name = 'test'
           num_test += 1
-        else:
-          continue
 
         queries_file = queries_files[set_name]
         qrels_file = qrels_files[set_name]
@@ -137,21 +153,19 @@ def create_dataset(args):
         doc_title = clean(doc_title)
         if args.use_abstract_in_query:
           doc_abstract = clean(obj['paperAbstract'])
-          query = doc_title + ' [SEP] ' + doc_abstract
+          query = '[Title]: ' + doc_title + ' [Abstract]: ' + doc_abstract
         else:
           query = doc_title
         queries_file.write('{}\t{}\n'.format(doc_id, query))
         for out_citation in out_citations:
           qrels_file.write('{} 0 {} 1\n'.format(doc_id, out_citation))
 
-        n_docs_used += 1
-
         if n_docs % 100000 == 0:
-          print('Read {}/{} files. {} lines converted in {} files in {} secs.'.format(
+          print('Read {}/{} files. {} docs written in {} files in {} secs.'.format(
               file_num, len(file_paths), n_docs, file_index, 
               int(time.time() - start_time)))
-          print('Total examples: {} ({} train, {} valid, {} test)'.format(
-              n_docs_used, num_train, num_dev, num_test))
+          print('Examples: {} train, {} valid, {} test'.format(
+              num_train, num_dev, num_test))
 
   # Close queries and qrels files.
   for queries_file in queries_files.values():
@@ -161,12 +175,22 @@ def create_dataset(args):
 
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(description='''Converts Open Research Corpus jsonl collection to Anserini's jsonl files.''')
-  parser.add_argument('--collection_path', required=True, help='Open Research jsonl collection file')
+  parser = argparse.ArgumentParser(
+      description='Converts Open Research Corpus jsonl collection to '
+                  'Anserini\'s jsonl files.')
+  parser.add_argument('--collection_path', required=True, 
+                      help='Open Research jsonl collection file')
   parser.add_argument('--output_folder', required=True, help='output file')
-  parser.add_argument('--max_docs_per_file', default=1000000, type=int, help='maximum number of documents in each jsonl file.')
-  parser.add_argument('--train_fraction', default=0.8, type=float, help='Fraction of the whole dataset that will be used for training. Data is sorted by year in the first train_fraction is used for training, the remaining is evenly split between dev and test sets.')
-  parser.add_argument('--use_abstract_in_query', action='store_true', help='If given, use title and a abstract as query. Otherwise, use only title.')
+  parser.add_argument('--max_docs_per_file', default=1000000, type=int, 
+                      help='maximum number of documents in each jsonl file.')
+  parser.add_argument(
+      '--train_fraction', default=0.8, type=float, 
+      help='Fraction of the whole dataset that will be used for training. Data '
+           'is sorted by year in the first train_fraction is used for '
+           'training, the remaining is evenly split between dev and test sets.')
+  parser.add_argument('--use_abstract_in_query', action='store_true',
+                      help='If True use title and a abstract as query. If '
+                           'False, use only title.')
 
   args = parser.parse_args()
 


### PR DESCRIPTION
The filtering steps are:
1. Remove all papers without a year of publication. The corpus will be created from the output from this step.
2. Sort papers by year and use the oldest 80% for training, the middle 10% for dev, and the more recent 10% for test.
3. For training, dev, and test splits remove all self-citations, citations whose publication year is later than that of the citing paper, and cited papers that are not in the corpus.
4. From the output of step 3, remove all papers that do not cite any other paper.