### PR TITLE
Reverted code cleanup changes for inferring class types

### DIFF
--- a/src/main/java/io/anserini/collection/DocumentCollection.java
+++ b/src/main/java/io/anserini/collection/DocumentCollection.java
@@ -110,7 +110,7 @@ public abstract class DocumentCollection<T extends SourceDocument> implements It
     List<Path> paths = discover(this.path);
     Iterator<Path> pathsIterator = paths.iterator();
 
-    return new Iterator<>(){
+    return new Iterator<FileSegment<T>>(){
       Path segmentPath;
       FileSegment<T> segment;
 
@@ -159,7 +159,7 @@ public abstract class DocumentCollection<T extends SourceDocument> implements It
   public final List<Path> discover(Path p) {
     final List<Path> paths = new ArrayList<>();
 
-    FileVisitor<Path> fv = new SimpleFileVisitor<>() {
+    FileVisitor<Path> fv = new SimpleFileVisitor<Path>() {
       @Override
       public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
         Path name = file.getFileName();

--- a/src/main/java/io/anserini/collection/FileSegment.java
+++ b/src/main/java/io/anserini/collection/FileSegment.java
@@ -102,7 +102,7 @@ public abstract class FileSegment<T extends SourceDocument> implements Iterable<
    */
   @Override
   public final Iterator<T> iterator(){
-    return new Iterator<>(){
+    return new Iterator<T>(){
       @Override
       public T next() throws NoSuchElementException {
         if (error) {


### PR DESCRIPTION
Reverting a few lines from #756 - just found out that it breaks Java 8 build even though travis passes for Java 11, and we probably want to keep some backwards compatibility? 

```
ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project anserini: Compilation failure: Compilation failure:
[ERROR] anserini/src/main/java/io/anserini/collection/DocumentCollection.java:[113,24] cannot infer type arguments for java.util.Iterator<E>
[ERROR]   reason: cannot use '<>' with anonymous inner classes
[ERROR] anserini/src/main/java/io/anserini/collection/DocumentCollection.java:[162,49] cannot infer type arguments for java.nio.file.SimpleFileVisitor<T>
[ERROR]   reason: cannot use '<>' with anonymous inner classes
[ERROR] anserini/src/main/java/io/anserini/collection/FileSegment.java:[105,24] cannot infer type arguments for java.util.Iterator<E>
[ERROR]   reason: cannot use '<>' with anonymous inner classes
```