### PR TITLE
Fixed security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -271,17 +271,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9</version>
+      <version>2.10.0.pr1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
-      <version>2.9.9</version>
+      <version>2.10.0.pr1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.9.9</version>
+      <version>2.10.0.pr1</version>
     </dependency>
     <dependency>
       <groupId>org.jsoup</groupId>


### PR DESCRIPTION
`com.fasterxml.jackson.core:jackson-databind`:

+ [CVE-2019-14379](https://nvd.nist.gov/vuln/detail/CVE-2019-14379)
+ [CVE-2019-14439](https://nvd.nist.gov/vuln/detail/CVE-2019-14439)
