### PR TITLE
doc2query reproduction test

### DIFF
--- a/docs/experiments-doc2query.md
+++ b/docs/experiments-doc2query.md
@@ -149,3 +149,7 @@ recip_rank            	all	0.2750
 
 Note that this MAP is sligtly higher than the arXiv paper (0.178) because we used
 TREC CAR corpus v2.0 in this experiment instead of corpus v1.5 used in the paper.
+
+## Replication Log
+
++ Results replicated by [@justram](https://github.com/justram) on 2019-08-09 (commit [`5f098f`](https://github.com/justram/Anserini/commit/5f098f23527611bca1224149bc2d155adce1e48))


### PR DESCRIPTION
Successfully reproduce doc2query experiments on MSMARCO and TREC-CAR.
OS:  Ubuntu 18.04.2 LTS
JAVA: openjdk version "11.0.4" 2019-07-1
Python: 3.6.7