### PR TITLE
Updated segment close handling in IndexCollection

### DIFF
--- a/src/main/java/io/anserini/collection/FileSegment.java
+++ b/src/main/java/io/anserini/collection/FileSegment.java
@@ -16,7 +16,6 @@
 
 package io.anserini.collection;
 
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/main/java/io/anserini/collection/FileSegment.java
+++ b/src/main/java/io/anserini/collection/FileSegment.java
@@ -16,8 +16,6 @@
 
 package io.anserini.collection;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -40,7 +38,6 @@ import java.io.Closeable;
  * </p>
  */
 public abstract class FileSegment<T extends SourceDocument> implements Iterable<T>, Closeable {
-  private static final Logger LOG = LogManager.getLogger(FileSegment.class);
 
   protected Path path;
   protected final int BUFFER_SIZE = 1 << 16; // 64K

--- a/src/main/java/io/anserini/collection/FileSegment.java
+++ b/src/main/java/io/anserini/collection/FileSegment.java
@@ -16,6 +16,9 @@
 
 package io.anserini.collection;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -37,6 +40,7 @@ import java.io.Closeable;
  * </p>
  */
 public abstract class FileSegment<T extends SourceDocument> implements Iterable<T>, Closeable {
+  private static final Logger LOG = LogManager.getLogger(FileSegment.class);
 
   protected Path path;
   protected final int BUFFER_SIZE = 1 << 16; // 64K

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -274,7 +274,8 @@ public final class IndexCollection {
         @SuppressWarnings("unchecked")
         FileSegment<SourceDocument> segment =
             (FileSegment) collection.createFileSegment(inputFile);
-        this.fileSegment = segment; // for calling close() and cleaning up resources in case of exception
+        // in order to call close() and clean up resources in case of exception
+        this.fileSegment = segment;
 
         for (Object document : segment) {
           SourceDocument d = (SourceDocument) document;
@@ -337,7 +338,9 @@ public final class IndexCollection {
       } finally {
         // clean up resources
         try {
-          fileSegment.close();
+          if (fileSegment != null){
+            fileSegment.close();
+          }
         } catch (IOException io) {
           LOG.error("IOException closing segment: " + io.getMessage());
         }
@@ -350,6 +353,7 @@ public final class IndexCollection {
     private final Path input;
     private final DocumentCollection collection;
     private final List<SolrInputDocument> buffer = new ArrayList<>(args.solrBatch);
+    private FileSegment fileSegment;
 
     private SolrIndexerThread(DocumentCollection collection, Path input) {
       this.input = input;
@@ -370,6 +374,8 @@ public final class IndexCollection {
         @SuppressWarnings("unchecked")
         FileSegment<SourceDocument> segment =
             (FileSegment) collection.createFileSegment(input);
+        // in order to call close() and clean up resources in case of exception
+        this.fileSegment = segment;
 
         for (Object d : segment) {
           SourceDocument sourceDocument = (SourceDocument) d;
@@ -439,11 +445,19 @@ public final class IndexCollection {
           LOG.error(input.getParent().getFileName().toString() + File.separator + input.getFileName().toString() + ": error iterating through segment.");
         }
 
-        segment.close();
         LOG.info(input.getParent().getFileName().toString() + File.separator + input.getFileName().toString() + ": " + cnt + " docs added.");
         counters.indexed.addAndGet(cnt);
       } catch (Exception e) {
         LOG.error(Thread.currentThread().getName() + ": Unexpected Exception:", e);
+      } finally {
+        // clean up resources
+        try {
+          if (fileSegment != null){
+            fileSegment.close();
+          }
+        } catch (IOException io) {
+          LOG.error("IOException closing segment: " + io.getMessage());
+        }
       }
 
     }
@@ -476,6 +490,7 @@ public final class IndexCollection {
     private final Path input;
     private final DocumentCollection collection;
     private BulkRequest bulkRequest;
+    private FileSegment fileSegment;
 
     private ESIndexerThread(DocumentCollection collection, Path input) {
       this.input = input;
@@ -496,6 +511,8 @@ public final class IndexCollection {
         @SuppressWarnings("unchecked")
         FileSegment<SourceDocument> segment =
             (FileSegment) collection.createFileSegment(input);
+        // in order to call close() and clean up resources in case of exception
+        this.fileSegment = segment;
 
         int cnt = 0;
 
@@ -581,11 +598,19 @@ public final class IndexCollection {
           LOG.error(input.getParent().getFileName().toString() + File.separator + input.getFileName().toString() + ": error iterating through segment.");
         }
 
-        segment.close();
         LOG.info(input.getParent().getFileName().toString() + File.separator + input.getFileName().toString() + ": " + cnt + " docs added.");
         counters.indexed.addAndGet(cnt);
       } catch (Exception e) {
         LOG.error(Thread.currentThread().getName() + ": Unexpected Exception:", e);
+      } finally {
+        // clean up resources
+        try {
+          if (fileSegment != null){
+            fileSegment.close();
+          }
+        } catch (IOException io) {
+          LOG.error("IOException closing segment: " + io.getMessage());
+        }
       }
     }
 


### PR DESCRIPTION
This PR modifies `IndexCollection` as followup to #750:
- Moved `segment.close()` call in each indexer thread to a `finally` clause, so that resources will be cleaned up in case of unexpected exception.
- Closes #749.

Also experimented a bit with adding safeguards within `FileSegment` code, but I think ultimately `IndexCollection` (or any future code that iterate over the collections) still should be the place to handle this call - since operations performed on the documents during iteration (but not related to the iterators) might also lead to unexpected exceptions and interruption.