### PR TITLE
Added option to use entire collection as working set in AxiomReranker

### DIFF
--- a/src/main/java/io/anserini/search/SearchArgs.java
+++ b/src/main/java/io/anserini/search/SearchArgs.java
@@ -223,6 +223,9 @@ public class SearchArgs {
   @Option(name = "-axiom", usage = "use Axiomatic query expansion model for the reranking")
   public boolean axiom = false;
 
+  @Option(name = "-axiom.collection", usage = "use Axiomatic query expansion model for the reranking, compute MI wrt entire collection")
+  public boolean axiom_collection = false;
+
   @Option(name = "-axiom.outputQuery", usage = "output original and expanded query")
   public boolean axiom_outputQuery = false;
 

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -303,7 +303,7 @@ public final class SearchCollection implements Closeable {
                 cascade.add(new AxiomReranker(args.index, args.axiom_index, FIELD_BODY,
                     args.axiom_deterministic, Integer.valueOf(seed), Integer.valueOf(r),
                     Integer.valueOf(n), Float.valueOf(beta), Integer.valueOf(top),
-                    args.axiom_docids, args.axiom_outputQuery, args.searchtweets));
+                    args.axiom_docids, args.axiom_outputQuery, args.searchtweets, args.axiom_collection));
                 cascade.add(new ScoreTiesAdjusterReranker());
                 String tag = "axiom.seed:"+seed+",axiom.r:"+r+",axiom.n:"+n+",axiom.beta:"+beta+",axiom.top:"+top;
                 cascades.put(tag, cascade);


### PR DESCRIPTION
This PR has a preliminary implementation of the `AxiomReranker` working set tweak suggested in #670. It's probably not ready for merging yet, but @lintool could you help take a look if you have some time? 

I might have missed a more efficient way to do this, but fetching overall # of documents that term(s) occur in (especially for `p(X=1, Y=1|W)`) added extra latency to the retrieval, and results tested on `robust04` also seem to be lower overall:

```
# Current:
map                     all     0.2896
P_30                    all     0.3333

# Using collection as working set:
map                     all     0.2469
P_30                    all     0.2928

# Compare runs:
base mean: 0.2896
comp mean: 0.2469
t-statistic: 6.477464, p-value: 0.000000
better (diff > 0.01):  59
worse  (diff > 0.01): 130
(mostly) unchanged  :  60
biggest gain: 0.3013 (topic 630)
biggest loss: -0.4367 (topic 450)

```
An example of expanded query difference:  

| Current axiom defaults:                 | Using collection as working set: |
|-----------------------------------|----------------------------------|
| QID: 450                          | QID: 450                         |
| Original Query: king hussein peac | Query: king hussein peac         |
| Running new query:                | Running new query:               |
| (palestin)^0.32356656             | (kuwait)^0.20778258              |
| (middl)^0.29715428                | (baghdad)^0.15543897             |
| (peac)^1.2815644                  | (peac)^0.9363058                 |
| (agreement)^0.25984994            | (hussein)^1.8835775              |
| (hussein)^2.1654453               | (king)^1.2974285                 |
| (amman)^0.37791514                | (bush)^0.091532536               |
| (egypt)^0.24848504                | (iraq)^0.28709581                |
| (king)^1.7306606                  | (war)^0.12171176                 |
| (isra)^0.5444328                  | (militari)^0.10485389            |
| (syria)^0.35093346                | (troop)^0.079224505              |
| (liber)^0.27784997                | (iraqi)^0.27525157               |
| (plo)^0.37512997                  | (saudi)^0.11765159               |
| (east)^0.34832278                 | (persian)^0.11539784             |
| (islam)^0.24752234                | (arabia)^0.111784056             |
| (israel)^0.49579915               | (jordan)^0.08369939              |
| (yassir)^0.2781821                | (gulf)^0.17836717                |
| (jordan)^0.8092843                | (invas)^0.07544765               |
| (palestinian)^0.53183997          | (saddam)^0.46273756              |
| (jordanian)^0.58591264            | (arab)^0.10895665                |
| (arab)^0.32902023                 | (presid)^0.09088026              |
