### PR TITLE
Add alternative faster script implemented in Java and Add Replication Log for doc2query

### DIFF
--- a/docs/experiments-doc2query.md
+++ b/docs/experiments-doc2query.md
@@ -161,3 +161,4 @@ TREC CAR corpus v2.0 in this experiment instead of corpus v1.5 used in the paper
 ## Replication Log
 
 + Results replicated by [@justram](https://github.com/justram) on 2019-08-09 (commit [`5f098f`](https://github.com/justram/Anserini/commit/5f098f23527611bca1224149bc2d155adce1e48))
++ Results replicated by [@ronakice](https://github.com/ronakice) on 2019-08-13 (commit [`5b29d16`](https://github.com/castorini/anserini/commit/5b29d1654abc5e8a014c2230da990ab2f91fb340))

--- a/docs/experiments-doc2query.md
+++ b/docs/experiments-doc2query.md
@@ -54,6 +54,14 @@ python ./src/main/python/msmarco/retrieve.py --hits 1000 --index msmarco-passage
  --qid_queries msmarco-passage/queries.dev.small.tsv --output msmarco-passage/run.dev.small.expanded-topk10.tsv
 ```
 
+Alternatively, we can run the same script implemented in Java, which is a bit faster:
+
+```
+./target/appassembler/bin/SearchMsmarco  -hits 1000 -threads 1 \
+ -index msmarco-passage/lucene-index-msmarco-expanded-topk10 -qid_queries msmarco-passage/queries.dev.small.tsv \
+ -output msmarco-passage/run.dev.small.expanded-topk10.tsv
+```
+
 Finally, to evaluate:
 
 ```


### PR DESCRIPTION
Added faster retrieval script mentioned in [docs/experiments-msmarco-passage.md](https://github.com/castorini/anserini/blob/5b29d1654abc5e8a014c2230da990ab2f91fb340/docs/experiments-msmarco-passage.md).

Also, successfully replicated on:
OS: Ubuntu 18.04.3 LTS
JAVA: openjdk 11.0.4 2019-07-16
Python: 3.6.8