### PR TITLE
Add date filter to background linking reranker

### DIFF
--- a/src/main/java/io/anserini/index/generator/WapoGenerator.java
+++ b/src/main/java/io/anserini/index/generator/WapoGenerator.java
@@ -45,8 +45,7 @@ public class WapoGenerator extends LuceneDocumentGenerator<WashingtonPostCollect
   public static final String FIELD_RAW = "raw";
   public static final String FIELD_BODY = "contents";
   public static final String FIELD_ID = "id";
-  public static final String FIELD_DATE = "published_date";
-  
+
   private static final String PATTERN = "<.+>";
   public static final List<String> CONTENT_TYPE_TAG = Arrays.asList("sanitized_html", "tweet");
 
@@ -86,7 +85,7 @@ public class WapoGenerator extends LuceneDocumentGenerator<WashingtonPostCollect
     doc.add(new StringField(FIELD_ID, id, Field.Store.YES));
     // This is needed to break score ties by docid.
     doc.add(new SortedDocValuesField(FIELD_ID, new BytesRef(id)));
-    doc.add(new LongPoint(FIELD_DATE, wapoDoc.getPublishDate()));
+    doc.add(new LongPoint(WapoField.PUBLISHED_DATE.name, wapoDoc.getPublishDate()));
     doc.add(new StoredField(WapoField.PUBLISHED_DATE.name, wapoDoc.getPublishDate()));
     wapoDoc.getAuthor().ifPresent(author -> {
       doc.add(new StringField(WapoField.AUTHOR.name, author, Field.Store.NO));

--- a/src/main/java/io/anserini/index/generator/WapoGenerator.java
+++ b/src/main/java/io/anserini/index/generator/WapoGenerator.java
@@ -45,6 +45,7 @@ public class WapoGenerator extends LuceneDocumentGenerator<WashingtonPostCollect
   public static final String FIELD_RAW = "raw";
   public static final String FIELD_BODY = "contents";
   public static final String FIELD_ID = "id";
+  public static final String FIELD_DATE = "published_date";
   
   private static final String PATTERN = "<.+>";
   public static final List<String> CONTENT_TYPE_TAG = Arrays.asList("sanitized_html", "tweet");
@@ -85,7 +86,8 @@ public class WapoGenerator extends LuceneDocumentGenerator<WashingtonPostCollect
     doc.add(new StringField(FIELD_ID, id, Field.Store.YES));
     // This is needed to break score ties by docid.
     doc.add(new SortedDocValuesField(FIELD_ID, new BytesRef(id)));
-    doc.add(new LongPoint(WapoField.PUBLISHED_DATE.name, wapoDoc.getPublishDate()));
+    doc.add(new LongPoint(FIELD_DATE, wapoDoc.getPublishDate()));
+    doc.add(new StoredField(WapoField.PUBLISHED_DATE.name, wapoDoc.getPublishDate()));
     wapoDoc.getAuthor().ifPresent(author -> {
       doc.add(new StringField(WapoField.AUTHOR.name, author, Field.Store.NO));
     });

--- a/src/main/java/io/anserini/rerank/lib/NewsBackgroundLinkingReranker.java
+++ b/src/main/java/io/anserini/rerank/lib/NewsBackgroundLinkingReranker.java
@@ -70,12 +70,13 @@ public class NewsBackgroundLinkingReranker implements Reranker {
     }
 
     if(context.getSearchArgs().backgroundlinking_datefilter){
-      try{
-        Document queryDoc = reader.document(NewsBackgroundLinkingTopicReader.convertDocidToLuceneDocid(reader, queryDocId));
+      try {
+        int luceneId = NewsBackgroundLinkingTopicReader.convertDocidToLuceneDocid(reader, queryDocId);
+        Document queryDoc = reader.document(luceneId);
         long queryDocDate = Long.parseLong(queryDoc.getField(PUBLISHED_DATE.name).stringValue());
         for (int i = 0; i < docs.documents.length; i++) {
           long date = Long.parseLong(docs.documents[i].getField(PUBLISHED_DATE.name).stringValue());
-          if(date > queryDocDate){
+          if (date > queryDocDate){
             toRemove.add(i);
           }
         }

--- a/src/main/java/io/anserini/rerank/lib/NewsBackgroundLinkingReranker.java
+++ b/src/main/java/io/anserini/rerank/lib/NewsBackgroundLinkingReranker.java
@@ -69,14 +69,14 @@ public class NewsBackgroundLinkingReranker implements Reranker {
       }
     }
 
-    if(context.getSearchArgs().backgroundlinking_datefilter){
+    if (context.getSearchArgs().backgroundlinking_datefilter) {
       try {
         int luceneId = NewsBackgroundLinkingTopicReader.convertDocidToLuceneDocid(reader, queryDocId);
         Document queryDoc = reader.document(luceneId);
         long queryDocDate = Long.parseLong(queryDoc.getField(PUBLISHED_DATE.name).stringValue());
         for (int i = 0; i < docs.documents.length; i++) {
           long date = Long.parseLong(docs.documents[i].getField(PUBLISHED_DATE.name).stringValue());
-          if (date > queryDocDate){
+          if (date > queryDocDate) {
             toRemove.add(i);
           }
         }

--- a/src/main/java/io/anserini/rerank/lib/NewsBackgroundLinkingReranker.java
+++ b/src/main/java/io/anserini/rerank/lib/NewsBackgroundLinkingReranker.java
@@ -34,7 +34,7 @@ import java.util.Set;
 
 import static io.anserini.index.generator.LuceneDocumentGenerator.FIELD_BODY;
 import static io.anserini.index.generator.LuceneDocumentGenerator.FIELD_ID;
-import static io.anserini.index.generator.WapoGenerator.FIELD_DATE;
+import static io.anserini.index.generator.WapoGenerator.WapoField.PUBLISHED_DATE;
 
 /*
 * TREC News Track Background Linking task postprocessing.
@@ -73,9 +73,9 @@ public class NewsBackgroundLinkingReranker implements Reranker {
     if(context.getSearchArgs().backgroundlinking_datefilter){
       try{
         Document query_doc = reader.document(NewsBackgroundLinkingTopicReader.convertDocidToLuceneDocid(reader, queryDocId));
-        long query_doc_date = Long.parseLong(query_doc.getField(FIELD_DATE).stringValue());
+        long query_doc_date = Long.parseLong(query_doc.getField(PUBLISHED_DATE.name).stringValue());
         for (int i = 0; i < docs.documents.length; i++) {
-          long date = Long.parseLong(docs.documents[i].getField(FIELD_DATE).stringValue());
+          long date = Long.parseLong(docs.documents[i].getField(PUBLISHED_DATE.name).stringValue());
           if(date > query_doc_date){
             to_remove.add(i);
           }

--- a/src/main/java/io/anserini/search/SearchArgs.java
+++ b/src/main/java/io/anserini/search/SearchArgs.java
@@ -66,7 +66,11 @@ public class SearchArgs {
   @Option(name = "-backgroundlinking.weighted", usage = "Boolean switch to construct boosted query for TREC News Track Background " +
       "Linking task. The terms scores are their tf-idf score from the query document")
   public boolean backgroundlinking_weighted = false;
-  
+
+  @Option(name = "-backgroundlinking.datefilter", usage = "Boolean switch to filter out articles published after topic article " +
+      "for the TREC News Track Background Linking task.")
+  public boolean backgroundlinking_datefilter = false;
+
   @Option(name = "-stemmer", usage = "Stemmer: one of the following porter,krovetz,none. Default porter")
   public String stemmer = "porter";
   


### PR DESCRIPTION
Date is saved as an additional field
Date filter can be toggled using command line argument

Without datefilter (BM25 + RM3)
```
target/appassembler/bin/SearchCollection -searchnewsbackground -index lucene-index.core18.pos+docvectors+rawdocs -topicreader NewsBackgroundLinking -topics ~/topics/newsir18-topics.txt -bm25 -rm3 -hits 100 -backgroundlinking.k 100 -runtag bm25_rm3 -output test/bm25-rm3.txt
```
will result in `NDCG@5 = 0.3526`  

With datefilter (BM25 + RM3)
```
target/appassembler/bin/SearchCollection -searchnewsbackground -index lucene-index.core18.pos+docvectors+rawdocs -topicreader NewsBackgroundLinking -topics ~/topics/newsir18-topics.txt -bm25 -rm3 -hits 100 -backgroundlinking.k 100 -backgroundlinking.datefilter -runtag bm25_rm3_df -output outputs/bm25-rm3-df.txt
```
will result in `NDCG@5 = 0.4171`
