### PR TITLE
Catch NPE introduced in recent commit.

### DIFF
--- a/docs/known-issues/known-issues-v0.6.0.md
+++ b/docs/known-issues/known-issues-v0.6.0.md
@@ -1,3 +1,4 @@
 # Anserini Known Issues (v0.6.0)
 
 + Solr indexing for Washington Post broke due to [417ac12](https://github.com/castorini/anserini/commit/c5ee9af442c500ec43fc28808903cfca2417ac12) and has been fixed in [#807](https://github.com/castorini/anserini/pull/807) and [#809](https://github.com/castorini/anserini/pull/809).
++ SearchSolr is broken due to [72b8052](https://github.com/castorini/anserini/commit/ca253a4794b5f5bea38749bd40e5f9f4272b8052) and has been fixed in [#816](https://github.com/castorini/anserini/pull/816).

--- a/src/main/java/io/anserini/rerank/lib/ScoreTiesAdjusterReranker.java
+++ b/src/main/java/io/anserini/rerank/lib/ScoreTiesAdjusterReranker.java
@@ -28,7 +28,7 @@ public class ScoreTiesAdjusterReranker implements Reranker {
   @Override
   public ScoredDocuments rerank(ScoredDocuments docs, RerankerContext context) {
 
-    if (context.getSearchArgs().arbitraryScoreTieBreak) {
+    if (context != null && context.getSearchArgs().arbitraryScoreTieBreak) {
       return docs;
     }
 


### PR DESCRIPTION
Fixes a NPE introduced in https://github.com/castorini/anserini/commit/ca253a4794b5f5bea38749bd40e5f9f4272b8052#diff-63a77306ff399da3f59b9af78f003161R31 that broke `SearchSolr`.