### PR TITLE
Minor doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Click "Open in Playground" and you'll be able to replicate our baselines from th
 
 Main dependencies:
 
-+ Anserini was recently upgraded to Java 11 at commit [`17b702d`](https://github.com/castorini/anserini/commit/17b702d9c3c0971e04eb8386ab83bf2fb2630714) (7/11/2019) from Java 8.
++ Anserini was upgraded to Java 11 at commit [`17b702d`](https://github.com/castorini/anserini/commit/17b702d9c3c0971e04eb8386ab83bf2fb2630714) (7/11/2019) from Java 8.
 Maven 3.3+ is also required.
 + Anserini was upgraded to Lucene 8.0 as of commit [`75e36f9`](https://github.com/castorini/anserini/commit/75e36f97f7037d1ceb20fa9c91582eac5e974131) (6/12/2019); prior to that, the toolkit uses Lucene 7.6.
 Based on [preliminary experiments](docs/lucene7-vs-lucene8.md), query evaluation latency has been much improved in Lucene 8.

--- a/docs/regressions-log.md
+++ b/docs/regressions-log.md
@@ -3,19 +3,23 @@
 The following change log details commits to regression tests that alter effectiveness and the addition of new regression tests.
 This documentation is useful for figuring why results may have changed over time.
 
+### October 11, 2019
+
++ commit [`445bb45`](https://github.com/castorini/anserini/commit/445bb458da825c9919d7a4e92de5ce87c929af7d) (10/11/2019)
+
+Add regressions for NTCIR-8 ACLIA (IR4QA subtask, Chinese monolingual).
+
 ### September 5, 2019
 
 + commit [`e88b931`](https://github.com/castorini/anserini/commit/e88b931d9fdb0a2b285ed5ef666889ce0965e5e0) (9/5/2019)
 
 As it turns out, we were incorrect in entry below (commit [`2f1b665`](https://github.com/castorini/anserini/commit/2f1b66586073f1fc4e8913d1119fbbf478745013)). Regressions numbers after BM25prf fix _did_ change slightly.
 
-
 ### August 14, 2019
 
 + commit [`2f1b665`](https://github.com/castorini/anserini/commit/2f1b66586073f1fc4e8913d1119fbbf478745013) (8/14/2019)
 
 Resolves inconsistent tie-breaking for BM25prf that leads to non-deterministic results, per [#774](https://github.com/castorini/anserini/issues/774). Note that regression numbers did not change.
-
 
 ### August 9, 2019
 

--- a/docs/regressions.md
+++ b/docs/regressions.md
@@ -9,16 +9,6 @@ The regression script `src/main/python/run_regression.py` runs end-to-end regres
 
 We keep a [change log](regressions-log.md) whenever effectiveness changes or when new regressions are added.
 
-## Requirements
-
-Python>=2.6 or Python>=3.5
-
-```
-pip install -r src/main/python/requirements.txt
-```
-
-Note that Oracle JVM is necessary to replicate our regression results; there are known issues with OpenJDK (see [this](https://github.com/castorini/Anserini/pull/590) and [this](https://github.com/castorini/Anserini/issues/592)).
-
 ## Invocations
 
 tl;dr - Copy and paste the following lines into console on `tuna` to run the regressions without building indexes from scratch:


### PR DESCRIPTION
+ Updated regression log re: NTCIR
+ Removed comment about Oracle vs. OpenJDK, which doesn't appear to be true anymore.
+ Upgrade to Java 11 isn't "recent" anymore.