### PR TITLE
Add unit tests to vector analyzers, fixed Anserini headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
             </program>
             <program>
               <mainClass>io.anserini.analysis.vectors.ApproximateNearestNeighborSearch</mainClass>
-              <id>NearestVector</id>
+              <id>ApproximateNearestNeighborSearch</id>
             </program>
           </programs>
         </configuration>

--- a/src/main/java/io/anserini/analysis/vectors/ApproximateNearestNeighborSearch.java
+++ b/src/main/java/io/anserini/analysis/vectors/ApproximateNearestNeighborSearch.java
@@ -1,3 +1,18 @@
+/**
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.anserini.analysis.vectors;
 
 import io.anserini.analysis.vectors.fw.FakeWordsEncoderAnalyzer;

--- a/src/main/java/io/anserini/analysis/vectors/IndexVectors.java
+++ b/src/main/java/io/anserini/analysis/vectors/IndexVectors.java
@@ -1,3 +1,18 @@
+/**
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.anserini.analysis.vectors;
 
 import io.anserini.analysis.vectors.fw.FakeWordsEncoderAnalyzer;

--- a/src/main/java/io/anserini/analysis/vectors/lexlsh/LexicalLshAnalyzer.java
+++ b/src/main/java/io/anserini/analysis/vectors/lexlsh/LexicalLshAnalyzer.java
@@ -1,3 +1,18 @@
+/**
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.anserini.analysis.vectors.lexlsh;
 
 import io.anserini.analysis.vectors.FeatureVectorsTokenizer;

--- a/src/main/java/io/anserini/analysis/vectors/lexlsh/LexicalLshFeaturePositionTokenFilter.java
+++ b/src/main/java/io/anserini/analysis/vectors/lexlsh/LexicalLshFeaturePositionTokenFilter.java
@@ -1,3 +1,18 @@
+/**
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.anserini.analysis.vectors.lexlsh;
 
 import org.apache.lucene.analysis.TokenFilter;

--- a/src/main/java/io/anserini/analysis/vectors/lexlsh/LexicalLshTruncateTokenFilter.java
+++ b/src/main/java/io/anserini/analysis/vectors/lexlsh/LexicalLshTruncateTokenFilter.java
@@ -1,3 +1,18 @@
+/**
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.anserini.analysis.vectors.lexlsh;
 
 import org.apache.lucene.analysis.TokenFilter;

--- a/src/test/java/io/anserini/analysis/vectors/FeatureVectorTokenizerTest.java
+++ b/src/test/java/io/anserini/analysis/vectors/FeatureVectorTokenizerTest.java
@@ -32,65 +32,65 @@ public class FeatureVectorTokenizerTest {
 
   @Test
   public void testTokenizeWithSpaces() throws Exception {
-      StringReader reader = new StringReader("0.10 0.20 0.30 0.40");
-      Tokenizer stream = new FeatureVectorsTokenizer();
-      stream.setReader(reader);
-      stream.reset();
-      List<String> expectedTokens = new LinkedList<>();
-      expectedTokens.add("0.10");
-      expectedTokens.add("0.20");
-      expectedTokens.add("0.30");
-      expectedTokens.add("0.40");
-      int i = 0;
-      while (stream.incrementToken()) {
-          CharTermAttribute charTermAttribute = stream.getAttribute(CharTermAttribute.class);
-          String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
-          assertEquals(expectedTokens.get(i), token);
-          i++;
-      }
-      stream.close();
+    StringReader reader = new StringReader("0.10 0.20 0.30 0.40");
+    Tokenizer stream = new FeatureVectorsTokenizer();
+    stream.setReader(reader);
+    stream.reset();
+    List<String> expectedTokens = new LinkedList<>();
+    expectedTokens.add("0.10");
+    expectedTokens.add("0.20");
+    expectedTokens.add("0.30");
+    expectedTokens.add("0.40");
+    int i = 0;
+    while (stream.incrementToken()) {
+      CharTermAttribute charTermAttribute = stream.getAttribute(CharTermAttribute.class);
+      String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
+      assertEquals(expectedTokens.get(i), token);
+      i++;
+    }
+    stream.close();
   }
 
   @Test
   public void testTokenizeWithCommas() throws Exception {
-      StringReader reader = new StringReader("0.10,-0.20,0.30,0.40");
-      Tokenizer stream = new FeatureVectorsTokenizer();
-      stream.setReader(reader);
-      stream.reset();
-      List<String> expectedTokens = new LinkedList<>();
-      expectedTokens.add("0.10");
-      expectedTokens.add("-0.20");
-      expectedTokens.add("0.30");
-      expectedTokens.add("0.40");
-      int i = 0;
-      while (stream.incrementToken()) {
-          CharTermAttribute charTermAttribute = stream.getAttribute(CharTermAttribute.class);
-          String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
-          assertEquals(expectedTokens.get(i), token);
-          i++;
-      }
-      stream.close();
+    StringReader reader = new StringReader("0.10,-0.20,0.30,0.40");
+    Tokenizer stream = new FeatureVectorsTokenizer();
+    stream.setReader(reader);
+    stream.reset();
+    List<String> expectedTokens = new LinkedList<>();
+    expectedTokens.add("0.10");
+    expectedTokens.add("-0.20");
+    expectedTokens.add("0.30");
+    expectedTokens.add("0.40");
+    int i = 0;
+    while (stream.incrementToken()) {
+      CharTermAttribute charTermAttribute = stream.getAttribute(CharTermAttribute.class);
+      String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
+      assertEquals(expectedTokens.get(i), token);
+      i++;
+    }
+    stream.close();
   }
 
   @Test
   public void testTokenizeWithCommasAndSpaces() throws Exception {
-      StringReader reader = new StringReader("0.10, -0.20, 0.30, 0.40");
-      Tokenizer stream = new FeatureVectorsTokenizer();
-      stream.setReader(reader);
-      stream.reset();
-      List<String> expectedTokens = new LinkedList<>();
-      expectedTokens.add("0.10");
-      expectedTokens.add("-0.20");
-      expectedTokens.add("0.30");
-      expectedTokens.add("0.40");
-      int i = 0;
-      while (stream.incrementToken()) {
-          CharTermAttribute charTermAttribute = stream.getAttribute(CharTermAttribute.class);
-          String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
-          assertEquals(expectedTokens.get(i), token);
-          i++;
-      }
-      stream.close();
+    StringReader reader = new StringReader("0.10, -0.20, 0.30, 0.40");
+    Tokenizer stream = new FeatureVectorsTokenizer();
+    stream.setReader(reader);
+    stream.reset();
+    List<String> expectedTokens = new LinkedList<>();
+    expectedTokens.add("0.10");
+    expectedTokens.add("-0.20");
+    expectedTokens.add("0.30");
+    expectedTokens.add("0.40");
+    int i = 0;
+    while (stream.incrementToken()) {
+      CharTermAttribute charTermAttribute = stream.getAttribute(CharTermAttribute.class);
+      String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
+      assertEquals(expectedTokens.get(i), token);
+      i++;
+    }
+    stream.close();
   }
 
 }

--- a/src/test/java/io/anserini/analysis/vectors/FeatureVectorTokenizerTest.java
+++ b/src/test/java/io/anserini/analysis/vectors/FeatureVectorTokenizerTest.java
@@ -1,0 +1,96 @@
+/**
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.anserini.analysis.vectors;
+
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.Test;
+
+import java.io.StringReader;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link FeatureVectorsTokenizer}
+ */
+public class FeatureVectorTokenizerTest {
+
+  @Test
+  public void testTokenizeWithSpaces() throws Exception {
+      StringReader reader = new StringReader("0.10 0.20 0.30 0.40");
+      Tokenizer stream = new FeatureVectorsTokenizer();
+      stream.setReader(reader);
+      stream.reset();
+      List<String> expectedTokens = new LinkedList<>();
+      expectedTokens.add("0.10");
+      expectedTokens.add("0.20");
+      expectedTokens.add("0.30");
+      expectedTokens.add("0.40");
+      int i = 0;
+      while (stream.incrementToken()) {
+          CharTermAttribute charTermAttribute = stream.getAttribute(CharTermAttribute.class);
+          String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
+          assertEquals(expectedTokens.get(i), token);
+          i++;
+      }
+      stream.close();
+  }
+
+  @Test
+  public void testTokenizeWithCommas() throws Exception {
+      StringReader reader = new StringReader("0.10,-0.20,0.30,0.40");
+      Tokenizer stream = new FeatureVectorsTokenizer();
+      stream.setReader(reader);
+      stream.reset();
+      List<String> expectedTokens = new LinkedList<>();
+      expectedTokens.add("0.10");
+      expectedTokens.add("-0.20");
+      expectedTokens.add("0.30");
+      expectedTokens.add("0.40");
+      int i = 0;
+      while (stream.incrementToken()) {
+          CharTermAttribute charTermAttribute = stream.getAttribute(CharTermAttribute.class);
+          String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
+          assertEquals(expectedTokens.get(i), token);
+          i++;
+      }
+      stream.close();
+  }
+
+  @Test
+  public void testTokenizeWithCommasAndSpaces() throws Exception {
+      StringReader reader = new StringReader("0.10, -0.20, 0.30, 0.40");
+      Tokenizer stream = new FeatureVectorsTokenizer();
+      stream.setReader(reader);
+      stream.reset();
+      List<String> expectedTokens = new LinkedList<>();
+      expectedTokens.add("0.10");
+      expectedTokens.add("-0.20");
+      expectedTokens.add("0.30");
+      expectedTokens.add("0.40");
+      int i = 0;
+      while (stream.incrementToken()) {
+          CharTermAttribute charTermAttribute = stream.getAttribute(CharTermAttribute.class);
+          String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
+          assertEquals(expectedTokens.get(i), token);
+          i++;
+      }
+      stream.close();
+  }
+
+}

--- a/src/test/java/io/anserini/analysis/vectors/fw/FakeWordsEncodeAndQuantizeFilterTest.java
+++ b/src/test/java/io/anserini/analysis/vectors/fw/FakeWordsEncodeAndQuantizeFilterTest.java
@@ -1,0 +1,78 @@
+/**
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.anserini.analysis.vectors.fw;
+
+import io.anserini.analysis.vectors.FeatureVectorsTokenizer;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.Test;
+
+import java.io.StringReader;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link io.anserini.analysis.vectors.fw.FakeWordsEncodeAndQuantizeFilter}
+ */
+public class FakeWordsEncodeAndQuantizeFilterTest {
+
+  @Test
+  public void testFiltering() throws Exception {
+    StringReader reader = new StringReader("-0.10 0.20 0.30 0.40");
+    Tokenizer stream = new FeatureVectorsTokenizer();
+    stream.setReader(reader);
+    FakeWordsEncodeAndQuantizeFilter filter = new FakeWordsEncodeAndQuantizeFilter(stream, 20);
+    filter.reset();
+    List<String> expectedTokens = new LinkedList<>();
+    expectedTokens.add("_"); // quantization leads to zero
+    expectedTokens.add("f2"); // quantization leads to 4 tokens
+    expectedTokens.add("f2");
+    expectedTokens.add("f2");
+    expectedTokens.add("f2");
+    expectedTokens.add("f3"); // quantization leads to 6 tokens
+    expectedTokens.add("f3");
+    expectedTokens.add("f3");
+    expectedTokens.add("f3");
+    expectedTokens.add("f3");
+    expectedTokens.add("f3");
+    expectedTokens.add("f4"); // quantization leads to 16 tokens
+    expectedTokens.add("f4");
+    expectedTokens.add("f4");
+    expectedTokens.add("f4");
+    expectedTokens.add("f4");
+    expectedTokens.add("f4");
+    expectedTokens.add("f4");
+    expectedTokens.add("f4");
+    expectedTokens.add("f4");
+    expectedTokens.add("f4");
+    expectedTokens.add("f4");
+    expectedTokens.add("f4");
+    expectedTokens.add("f4");
+    expectedTokens.add("f4");
+    expectedTokens.add("f4");
+    int i = 0;
+    while (filter.incrementToken()) {
+      CharTermAttribute charTermAttribute = filter.getAttribute(CharTermAttribute.class);
+      String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
+      assertEquals(expectedTokens.get(i), token);
+      i++;
+    }
+    filter.close();
+  }
+
+}

--- a/src/test/java/io/anserini/analysis/vectors/fw/FakeWordsEncoderAnalyzerTest.java
+++ b/src/test/java/io/anserini/analysis/vectors/fw/FakeWordsEncoderAnalyzerTest.java
@@ -1,0 +1,126 @@
+/**
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.anserini.analysis.vectors.fw;
+
+import io.anserini.util.AnalyzerUtils;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.CommonTermsQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.RAMDirectory;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.apache.lucene.search.BooleanClause.Occur.SHOULD;
+import static org.junit.Assert.assertEquals;
+
+public class FakeWordsEncoderAnalyzerTest {
+
+  @Test
+  public void testBinaryFVIndexAndSearch() throws Exception {
+    FakeWordsEncoderAnalyzer analyzer = new FakeWordsEncoderAnalyzer(30);
+    Directory directory = new RAMDirectory();
+    IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(analyzer));
+    DirectoryReader reader = null;
+    try {
+      List<Double> values = new LinkedList<>();
+      values.add(0.1d);
+      values.add(0.3d);
+      values.add(0.5d);
+      values.add(0.7d);
+      values.add(0.11d);
+      values.add(0.13d);
+      values.add(0.17d);
+      values.add(0.19d);
+      values.add(0.23d);
+      values.add(0.29d);
+
+      byte[] bytes = toByteArray(values);
+      String fvString = toDoubleString(bytes);
+
+      String fieldName = "fvs";
+      Document document = new Document();
+      document.add(new TextField(fieldName, fvString, Field.Store.YES));
+      writer.addDocument(document);
+      writer.commit();
+
+      reader = DirectoryReader.open(writer);
+      assertSimQuery(analyzer, fieldName, fvString, reader);
+    } finally {
+      if (reader != null) {
+        reader.close();
+      }
+      writer.close();
+      directory.close();
+    }
+  }
+
+  private void assertSimQuery(Analyzer analyzer, String fieldName, String text, DirectoryReader reader) throws IOException {
+    IndexSearcher searcher = new IndexSearcher(reader);
+    CommonTermsQuery simQuery = new CommonTermsQuery(SHOULD, SHOULD, 1);
+    for (String token : AnalyzerUtils.tokenize(analyzer, text)) {
+      simQuery.add(new Term(fieldName, token));
+    }
+    TopDocs topDocs = searcher.search(simQuery, 1);
+    assertEquals(1, topDocs.totalHits.value);
+  }
+
+  private byte[] toByteArray(List<Double> values) {
+    int blockSize = Double.SIZE / Byte.SIZE;
+    byte[] bytes = new byte[values.size() * blockSize];
+    for (int i = 0, j = 0; i < values.size(); i++, j += blockSize) {
+      ByteBuffer.wrap(bytes, j, blockSize).putDouble(values.get(i));
+    }
+    return bytes;
+  }
+
+  private String toDoubleString(byte[] bytes) {
+    double[] a = toDoubleArray(bytes);
+    StringBuilder builder = new StringBuilder();
+    for (Double d : a) {
+      if (builder.length() > 0) {
+        builder.append(' ');
+      }
+      builder.append(d);
+    }
+    return builder.toString();
+  }
+
+  private double[] toDoubleArray(byte[] array) {
+    int blockSize = Double.SIZE / Byte.SIZE;
+    ByteBuffer wrap = ByteBuffer.wrap(array);
+    int capacity = array.length / blockSize;
+    double[] doubles = new double[capacity];
+    for (int i = 0; i < capacity; i++) {
+      double e = wrap.getDouble(i * blockSize);
+      doubles[i] = e;
+    }
+    return doubles;
+  }
+
+}

--- a/src/test/java/io/anserini/analysis/vectors/lexlsh/LexicalLshAnalyzerTest.java
+++ b/src/test/java/io/anserini/analysis/vectors/lexlsh/LexicalLshAnalyzerTest.java
@@ -1,3 +1,18 @@
+/**
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.anserini.analysis.vectors.lexlsh;
 
 import io.anserini.util.AnalyzerUtils;

--- a/src/test/java/io/anserini/analysis/vectors/lexlsh/LexicalLshAnalyzerTest.java
+++ b/src/test/java/io/anserini/analysis/vectors/lexlsh/LexicalLshAnalyzerTest.java
@@ -1,0 +1,144 @@
+package io.anserini.analysis.vectors.lexlsh;
+
+import io.anserini.util.AnalyzerUtils;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.CommonTermsQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.RAMDirectory;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.apache.lucene.search.BooleanClause.Occur.SHOULD;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link LexicalLshAnalyzer}
+ */
+public class LexicalLshAnalyzerTest {
+
+  @Test
+  public void testTextIndexAndSearch() throws Exception {
+    String fieldName = "text";
+    String[] texts = new String[]{
+        "0.1,0.3,0.5,0.7,0.11,0.13,0.17,0.19,0.23,0.29",
+        "0.111 0.3333 0.4445 0.5755 0.1551131 0.12131233 0.155557 0.1123219 0.6623 0.429"
+    };
+
+    for (String text : texts) {
+      LexicalLshAnalyzer analyzer = new LexicalLshAnalyzer();
+      Directory directory = new RAMDirectory();
+      IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(analyzer));
+      DirectoryReader reader = null;
+      try {
+        Document document = new Document();
+        document.add(new TextField(fieldName, text, Field.Store.YES));
+        writer.addDocument(document);
+        writer.commit();
+
+        reader = DirectoryReader.open(writer);
+        assertSimQuery(analyzer, fieldName, text, reader);
+      } finally {
+        if (reader != null) {
+          reader.close();
+        }
+        writer.close();
+        directory.close();
+      }
+    }
+  }
+
+  @Test
+  public void testBinaryIndexAndSearch() throws Exception {
+    LexicalLshAnalyzer analyzer = new LexicalLshAnalyzer();
+    Directory directory = new RAMDirectory();
+    IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(analyzer));
+    DirectoryReader reader = null;
+    try {
+      List<Double> values = new LinkedList<>();
+      values.add(0.1d);
+      values.add(0.3d);
+      values.add(0.5d);
+      values.add(0.7d);
+      values.add(0.11d);
+      values.add(0.13d);
+      values.add(0.17d);
+      values.add(0.19d);
+      values.add(0.23d);
+      values.add(0.29d);
+
+      byte[] bytes = toByteArray(values);
+      String fvString = toDoubleString(bytes);
+
+      String fieldName = "fvs";
+      Document document = new Document();
+      document.add(new TextField(fieldName, fvString, Field.Store.YES));
+      writer.addDocument(document);
+      writer.commit();
+
+      reader = DirectoryReader.open(writer);
+      assertSimQuery(analyzer, fieldName, fvString, reader);
+    } finally {
+      if (reader != null) {
+        reader.close();
+      }
+      writer.close();
+      directory.close();
+    }
+  }
+
+  private void assertSimQuery(LexicalLshAnalyzer analyzer, String fieldName, String text, DirectoryReader reader) throws IOException {
+    IndexSearcher searcher = new IndexSearcher(reader);
+    CommonTermsQuery simQuery = new CommonTermsQuery(SHOULD, SHOULD, 1);
+    for (String token : AnalyzerUtils.tokenize(analyzer, text)) {
+      simQuery.add(new Term(fieldName, token));
+    }
+    TopDocs topDocs = searcher.search(simQuery, 1);
+    assertEquals(1, topDocs.totalHits.value);
+  }
+
+  private byte[] toByteArray(List<Double> values) {
+    int blockSize = Double.SIZE / Byte.SIZE;
+    byte[] bytes = new byte[values.size() * blockSize];
+    for (int i = 0, j = 0; i < values.size(); i++, j += blockSize) {
+      ByteBuffer.wrap(bytes, j, blockSize).putDouble(values.get(i));
+    }
+    return bytes;
+  }
+
+  private String toDoubleString(byte[] bytes) {
+    double[] a = toDoubleArray(bytes);
+    StringBuilder builder = new StringBuilder();
+    for (Double d : a) {
+      if (builder.length() > 0) {
+        builder.append(' ');
+      }
+      builder.append(d);
+    }
+    return builder.toString();
+  }
+
+  private double[] toDoubleArray(byte[] array) {
+    int blockSize = Double.SIZE / Byte.SIZE;
+    ByteBuffer wrap = ByteBuffer.wrap(array);
+    int capacity = array.length / blockSize;
+    double[] doubles = new double[capacity];
+    for (int i = 0; i < capacity; i++) {
+      double e = wrap.getDouble(i * blockSize);
+      doubles[i] = e;
+    }
+    return doubles;
+  }
+
+}

--- a/src/test/java/io/anserini/analysis/vectors/lexlsh/LexicalLshFeaturePositionTokenFilterTest.java
+++ b/src/test/java/io/anserini/analysis/vectors/lexlsh/LexicalLshFeaturePositionTokenFilterTest.java
@@ -31,48 +31,48 @@ import static org.junit.Assert.assertEquals;
  */
 public class LexicalLshFeaturePositionTokenFilterTest {
 
-    @Test
-    public void testFiltering() throws Exception {
-        StringReader reader = new StringReader("-0.10 0.20 0.30 0.40");
-        Tokenizer stream = new FeatureVectorsTokenizer();
-        stream.setReader(reader);
-        LexicalLshFeaturePositionTokenFilter filter = new LexicalLshFeaturePositionTokenFilter(stream);
-        filter.reset();
-        List<String> expectedTokens = new LinkedList<>();
-        expectedTokens.add("1_-0.10");
-        expectedTokens.add("2_0.20");
-        expectedTokens.add("3_0.30");
-        expectedTokens.add("4_0.40");
-        int i = 0;
-        while (filter.incrementToken()) {
-          CharTermAttribute charTermAttribute = filter.getAttribute(CharTermAttribute.class);
-          String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
-          assertEquals(expectedTokens.get(i), token);
-          i++;
-        }
-        filter.close();
+  @Test
+  public void testFiltering() throws Exception {
+    StringReader reader = new StringReader("-0.10 0.20 0.30 0.40");
+    Tokenizer stream = new FeatureVectorsTokenizer();
+    stream.setReader(reader);
+    LexicalLshFeaturePositionTokenFilter filter = new LexicalLshFeaturePositionTokenFilter(stream);
+    filter.reset();
+    List<String> expectedTokens = new LinkedList<>();
+    expectedTokens.add("1_-0.10");
+    expectedTokens.add("2_0.20");
+    expectedTokens.add("3_0.30");
+    expectedTokens.add("4_0.40");
+    int i = 0;
+    while (filter.incrementToken()) {
+      CharTermAttribute charTermAttribute = filter.getAttribute(CharTermAttribute.class);
+      String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
+      assertEquals(expectedTokens.get(i), token);
+      i++;
     }
+    filter.close();
+  }
 
-    @Test
-    public void testFilteringWithOffset() throws Exception {
-        StringReader reader = new StringReader("-0.104123 0.20435 0.3042366 0.41243241");
-        Tokenizer stream = new FeatureVectorsTokenizer();
-        stream.setReader(reader);
-        LexicalLshFeaturePositionTokenFilter filter = new LexicalLshFeaturePositionTokenFilter(stream, 2);
-        filter.reset();
-        List<String> expectedTokens = new LinkedList<>();
-        expectedTokens.add("1_-104123");
-        expectedTokens.add("2_20435");
-        expectedTokens.add("3_3042366");
-        expectedTokens.add("4_41243241");
-        int i = 0;
-        while (filter.incrementToken()) {
-            CharTermAttribute charTermAttribute = filter.getAttribute(CharTermAttribute.class);
-            String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
-            assertEquals(expectedTokens.get(i), token);
-            i++;
-        }
-        filter.close();
+  @Test
+  public void testFilteringWithOffset() throws Exception {
+    StringReader reader = new StringReader("-0.104123 0.20435 0.3042366 0.41243241");
+    Tokenizer stream = new FeatureVectorsTokenizer();
+    stream.setReader(reader);
+    LexicalLshFeaturePositionTokenFilter filter = new LexicalLshFeaturePositionTokenFilter(stream, 2);
+    filter.reset();
+    List<String> expectedTokens = new LinkedList<>();
+    expectedTokens.add("1_-104123");
+    expectedTokens.add("2_20435");
+    expectedTokens.add("3_3042366");
+    expectedTokens.add("4_41243241");
+    int i = 0;
+    while (filter.incrementToken()) {
+      CharTermAttribute charTermAttribute = filter.getAttribute(CharTermAttribute.class);
+      String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
+      assertEquals(expectedTokens.get(i), token);
+      i++;
     }
+    filter.close();
+  }
 
 }

--- a/src/test/java/io/anserini/analysis/vectors/lexlsh/LexicalLshFeaturePositionTokenFilterTest.java
+++ b/src/test/java/io/anserini/analysis/vectors/lexlsh/LexicalLshFeaturePositionTokenFilterTest.java
@@ -1,0 +1,78 @@
+/**
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.anserini.analysis.vectors.lexlsh;
+
+import io.anserini.analysis.vectors.FeatureVectorsTokenizer;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.Test;
+
+import java.io.StringReader;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link LexicalLshFeaturePositionTokenFilter}
+ */
+public class LexicalLshFeaturePositionTokenFilterTest {
+
+    @Test
+    public void testFiltering() throws Exception {
+        StringReader reader = new StringReader("-0.10 0.20 0.30 0.40");
+        Tokenizer stream = new FeatureVectorsTokenizer();
+        stream.setReader(reader);
+        LexicalLshFeaturePositionTokenFilter filter = new LexicalLshFeaturePositionTokenFilter(stream);
+        filter.reset();
+        List<String> expectedTokens = new LinkedList<>();
+        expectedTokens.add("1_-0.10");
+        expectedTokens.add("2_0.20");
+        expectedTokens.add("3_0.30");
+        expectedTokens.add("4_0.40");
+        int i = 0;
+        while (filter.incrementToken()) {
+          CharTermAttribute charTermAttribute = filter.getAttribute(CharTermAttribute.class);
+          String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
+          assertEquals(expectedTokens.get(i), token);
+          i++;
+        }
+        filter.close();
+    }
+
+    @Test
+    public void testFilteringWithOffset() throws Exception {
+        StringReader reader = new StringReader("-0.104123 0.20435 0.3042366 0.41243241");
+        Tokenizer stream = new FeatureVectorsTokenizer();
+        stream.setReader(reader);
+        LexicalLshFeaturePositionTokenFilter filter = new LexicalLshFeaturePositionTokenFilter(stream, 2);
+        filter.reset();
+        List<String> expectedTokens = new LinkedList<>();
+        expectedTokens.add("1_-104123");
+        expectedTokens.add("2_20435");
+        expectedTokens.add("3_3042366");
+        expectedTokens.add("4_41243241");
+        int i = 0;
+        while (filter.incrementToken()) {
+            CharTermAttribute charTermAttribute = filter.getAttribute(CharTermAttribute.class);
+            String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
+            assertEquals(expectedTokens.get(i), token);
+            i++;
+        }
+        filter.close();
+    }
+
+}

--- a/src/test/java/io/anserini/analysis/vectors/lexlsh/LexicalLshTruncateTokenFilterTest.java
+++ b/src/test/java/io/anserini/analysis/vectors/lexlsh/LexicalLshTruncateTokenFilterTest.java
@@ -31,26 +31,26 @@ import static org.junit.Assert.assertEquals;
  */
 public class LexicalLshTruncateTokenFilterTest {
 
-    @Test
-    public void testFiltering() throws Exception {
-        StringReader reader = new StringReader("0.10123 0.20412412 -0.3042141 0.4123123");
-        Tokenizer stream = new WhitespaceTokenizer();
-        stream.setReader(reader);
-        LexicalLshTruncateTokenFilter filter = new LexicalLshTruncateTokenFilter(stream, 3);
-        filter.reset();
-        List<String> expectedTokens = new LinkedList<>();
-        expectedTokens.add("0.101");
-        expectedTokens.add("0.204");
-        expectedTokens.add("-0.304");
-        expectedTokens.add("0.412");
-        int i = 0;
-        while (filter.incrementToken()) {
-            CharTermAttribute charTermAttribute = filter.getAttribute(CharTermAttribute.class);
-            String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
-            assertEquals(expectedTokens.get(i), token);
-            i++;
-        }
-        filter.close();
+  @Test
+  public void testFiltering() throws Exception {
+    StringReader reader = new StringReader("0.10123 0.20412412 -0.3042141 0.4123123");
+    Tokenizer stream = new WhitespaceTokenizer();
+    stream.setReader(reader);
+    LexicalLshTruncateTokenFilter filter = new LexicalLshTruncateTokenFilter(stream, 3);
+    filter.reset();
+    List<String> expectedTokens = new LinkedList<>();
+    expectedTokens.add("0.101");
+    expectedTokens.add("0.204");
+    expectedTokens.add("-0.304");
+    expectedTokens.add("0.412");
+    int i = 0;
+    while (filter.incrementToken()) {
+      CharTermAttribute charTermAttribute = filter.getAttribute(CharTermAttribute.class);
+      String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
+      assertEquals(expectedTokens.get(i), token);
+      i++;
     }
+    filter.close();
+  }
 
 }

--- a/src/test/java/io/anserini/analysis/vectors/lexlsh/LexicalLshTruncateTokenFilterTest.java
+++ b/src/test/java/io/anserini/analysis/vectors/lexlsh/LexicalLshTruncateTokenFilterTest.java
@@ -1,0 +1,56 @@
+/**
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.anserini.analysis.vectors.lexlsh;
+
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.core.WhitespaceTokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.Test;
+
+import java.io.StringReader;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link LexicalLshTruncateTokenFilter}
+ */
+public class LexicalLshTruncateTokenFilterTest {
+
+    @Test
+    public void testFiltering() throws Exception {
+        StringReader reader = new StringReader("0.10123 0.20412412 -0.3042141 0.4123123");
+        Tokenizer stream = new WhitespaceTokenizer();
+        stream.setReader(reader);
+        LexicalLshTruncateTokenFilter filter = new LexicalLshTruncateTokenFilter(stream, 3);
+        filter.reset();
+        List<String> expectedTokens = new LinkedList<>();
+        expectedTokens.add("0.101");
+        expectedTokens.add("0.204");
+        expectedTokens.add("-0.304");
+        expectedTokens.add("0.412");
+        int i = 0;
+        while (filter.incrementToken()) {
+            CharTermAttribute charTermAttribute = filter.getAttribute(CharTermAttribute.class);
+            String token = new String(charTermAttribute.buffer(), 0, charTermAttribute.length());
+            assertEquals(expectedTokens.get(i), token);
+            i++;
+        }
+        filter.close();
+    }
+
+}


### PR DESCRIPTION
this PR adds some unit tests for vector analyzers and some missing Anserini license headers.