### PR TITLE
Trimmed from fatjar dependencies that are only needed for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,25 +238,22 @@
       <artifactId>lucene-core</artifactId>
       <version>${lucene.version}</version>
     </dependency>
-    <dependency> <!-- needed only for org.apache.lucene.search.CheckHits: candidate for cleanup -->
+    <dependency> <!-- only needed for testing -->
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-test-framework</artifactId>
       <version>${lucene.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency> <!-- only needed for testing -->
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-solrj</artifactId>
       <version>${lucene.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-      <version>4.4.11</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.8</version>
     </dependency>
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
@@ -279,11 +276,6 @@
       <version>2.1</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.10.0.pr1</version>
@@ -303,14 +295,12 @@
       <artifactId>jsoup</artifactId>
       <version>1.8.3</version>
       <type>jar</type>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
       <version>2.32</version>
       <type>jar</type>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Fatjar is down from 88M to 80M.

Note, `<scope>compile</scope>` isn't needed because `compile` scope is default.