### PR TITLE
add topic reader for NTCIR format

### DIFF
--- a/src/main/java/io/anserini/search/topicreader/NtcirTopicReader.java
+++ b/src/main/java/io/anserini/search/topicreader/NtcirTopicReader.java
@@ -1,0 +1,77 @@
+/**
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.search.topicreader;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Topic reader for the XML format used in the NTCIR We Want Web (WWW) Tracks.
+ * Please cite the following papers if the NTCIR WWW test collections are used
+ * in a publication.
+ *
+ * http://research.nii.ac.jp/ntcir/workshop/OnlineProceedings13/pdf/ntcir/01-NTCIR13-OV-WWW-LuoC.pdf
+ * http://research.nii.ac.jp/ntcir/workshop/OnlineProceedings14/pdf/ntcir/01-NTCIR14-OV-WWW-MaoJ.pdf
+ */
+public class NtcirTopicReader extends TopicReader<Integer> {
+    public NtcirTopicReader(Path topicFile) {
+        super(topicFile);
+    }
+
+    @Override
+    public SortedMap<Integer, Map<String, String>> read(BufferedReader bRdr) throws IOException {
+        /**
+         * There are no narratives in NTCIR WWW topics, so this method returns
+         * a map whose keys are description and title only.
+         */
+
+        SortedMap<Integer, Map<String, String>> map = new TreeMap<>();
+        Map<String, String> fields = new HashMap<>();
+
+        String number = "";
+        String query = "";
+        String description = "";
+        String line;
+
+        while ((line = bRdr.readLine()) != null) {
+            line = line.trim();
+            if (line.startsWith("<qid")) {
+                number = line.substring(5, line.length() - 6).trim();
+            }
+            if (line.startsWith("<content>") && line.endsWith("</content>")) {
+                query = line.substring(9, line.length() - 10).trim();
+                fields.put("title", query);
+            }
+
+            if (line.startsWith("<description>") && line.endsWith("</description>")) {
+                description = line.substring(13, line.length() - 14).trim();
+                fields.put("description", description);
+            }
+
+            if (line.startsWith("</query>")) {
+                map.put(Integer.valueOf(number), fields);
+                fields = new HashMap<>();
+            }
+        }
+        return map;
+    }
+}

--- a/src/main/java/io/anserini/search/topicreader/NtcirTopicReader.java
+++ b/src/main/java/io/anserini/search/topicreader/NtcirTopicReader.java
@@ -28,50 +28,50 @@ import java.util.TreeMap;
  * Topic reader for the XML format used in the NTCIR We Want Web (WWW) Tracks.
  * Please cite the following papers if the NTCIR WWW test collections are used
  * in a publication.
- *
+ * <p>
  * http://research.nii.ac.jp/ntcir/workshop/OnlineProceedings13/pdf/ntcir/01-NTCIR13-OV-WWW-LuoC.pdf
  * http://research.nii.ac.jp/ntcir/workshop/OnlineProceedings14/pdf/ntcir/01-NTCIR14-OV-WWW-MaoJ.pdf
  */
 public class NtcirTopicReader extends TopicReader<Integer> {
-    public NtcirTopicReader(Path topicFile) {
-        super(topicFile);
+  public NtcirTopicReader(Path topicFile) {
+    super(topicFile);
+  }
+
+  @Override
+  public SortedMap<Integer, Map<String, String>> read(BufferedReader bRdr) throws IOException {
+    /**
+     * There are no narratives in NTCIR WWW topics, so this method returns
+     * a map whose keys are description and title only.
+     */
+
+    SortedMap<Integer, Map<String, String>> map = new TreeMap<>();
+    Map<String, String> fields = new HashMap<>();
+
+    String number = "";
+    String query = "";
+    String description = "";
+    String line;
+
+    while ((line = bRdr.readLine()) != null) {
+      line = line.trim();
+      if (line.startsWith("<qid")) {
+        number = line.substring(5, line.length() - 6).trim();
+      }
+      if (line.startsWith("<content>") && line.endsWith("</content>")) {
+        query = line.substring(9, line.length() - 10).trim();
+        fields.put("title", query);
+      }
+
+      if (line.startsWith("<description>") && line.endsWith("</description>")) {
+        description = line.substring(13, line.length() - 14).trim();
+        fields.put("description", description);
+      }
+
+      if (line.startsWith("</query>")) {
+        map.put(Integer.valueOf(number), fields);
+        fields = new HashMap<>();
+      }
     }
-
-    @Override
-    public SortedMap<Integer, Map<String, String>> read(BufferedReader bRdr) throws IOException {
-        /**
-         * There are no narratives in NTCIR WWW topics, so this method returns
-         * a map whose keys are description and title only.
-         */
-
-        SortedMap<Integer, Map<String, String>> map = new TreeMap<>();
-        Map<String, String> fields = new HashMap<>();
-
-        String number = "";
-        String query = "";
-        String description = "";
-        String line;
-
-        while ((line = bRdr.readLine()) != null) {
-            line = line.trim();
-            if (line.startsWith("<qid")) {
-                number = line.substring(5, line.length() - 6).trim();
-            }
-            if (line.startsWith("<content>") && line.endsWith("</content>")) {
-                query = line.substring(9, line.length() - 10).trim();
-                fields.put("title", query);
-            }
-
-            if (line.startsWith("<description>") && line.endsWith("</description>")) {
-                description = line.substring(13, line.length() - 14).trim();
-                fields.put("description", description);
-            }
-
-            if (line.startsWith("</query>")) {
-                map.put(Integer.valueOf(number), fields);
-                fields = new HashMap<>();
-            }
-        }
-        return map;
-    }
+    return map;
+  }
 }

--- a/src/main/resources/topics-and-qrels/topics.www1.english.txt
+++ b/src/main/resources/topics-and-qrels/topics.www1.english.txt
@@ -1,0 +1,402 @@
+<queries>
+	<query>
+		<qid>0001</qid>
+		<content>ascii code</content>
+	</query>
+	<query>
+		<qid>0002</qid>
+		<content>CAD</content>
+	</query>
+	<query>
+		<qid>0003</qid>
+		<content>fifa</content>
+	</query>
+	<query>
+		<qid>0004</qid>
+		<content>nike</content>
+	</query>
+	<query>
+		<qid>0005</qid>
+		<content>vmware virtual machine</content>
+	</query>
+	<query>
+		<qid>0006</qid>
+		<content>calendar</content>
+	</query>
+	<query>
+		<qid>0007</qid>
+		<content>samsung official site</content>
+	</query>
+	<query>
+		<qid>0008</qid>
+		<content>World Table Tennis Championships</content>
+	</query>
+	<query>
+		<qid>0009</qid>
+		<content>letter format</content>
+	</query>
+	<query>
+		<qid>0010</qid>
+		<content>Jurassic World</content>
+	</query>
+	<query>
+		<qid>0011</qid>
+		<content>credit card application</content>
+	</query>
+	<query>
+		<qid>0012</qid>
+		<content>child stick figures</content>
+	</query>
+	<query>
+		<qid>0013</qid>
+		<content>periodic table</content>
+	</query>
+	<query>
+		<qid>0014</qid>
+		<content>equation edior</content>
+	</query>
+	<query>
+		<qid>0015</qid>
+		<content>agricultural machinery</content>
+	</query>
+	<query>
+		<qid>0016</qid>
+		<content>migrate abroad</content>
+	</query>
+	<query>
+		<qid>0017</qid>
+		<content>gif collection</content>
+	</query>
+	<query>
+		<qid>0018</qid>
+		<content>Astrological sign</content>
+	</query>
+	<query>
+		<qid>0019</qid>
+		<content>House of Flying Daggers</content>
+	</query>
+	<query>
+		<qid>0020</qid>
+		<content>Donald Duck</content>
+	</query>
+	<query>
+		<qid>0021</qid>
+		<content>Convict Conditioning</content>
+	</query>
+	<query>
+		<qid>0022</qid>
+		<content>Sichuan University</content>
+	</query>
+	<query>
+		<qid>0023</qid>
+		<content>Battle City</content>
+	</query>
+	<query>
+		<qid>0024</qid>
+		<content>domino</content>
+	</query>
+	<query>
+		<qid>0025</qid>
+		<content>Shaolin Monastery</content>
+	</query>
+	<query>
+		<qid>0026</qid>
+		<content>Eugene</content>
+	</query>
+	<query>
+		<qid>0027</qid>
+		<content>Introduction of work report</content>
+	</query>
+	<query>
+		<qid>0028</qid>
+		<content>typing practice</content>
+	</query>
+	<query>
+		<qid>0029</qid>
+		<content>Traffic Violation</content>
+	</query>
+	<query>
+		<qid>0030</qid>
+		<content>robot</content>
+	</query>
+	<query>
+		<qid>0031</qid>
+		<content>cherry</content>
+	</query>
+	<query>
+		<qid>0032</qid>
+		<content>Chibi Maruko-chan</content>
+	</query>
+	<query>
+		<qid>0033</qid>
+		<content>UEFA Champions League final</content>
+	</query>
+	<query>
+		<qid>0034</qid>
+		<content>Euro Step</content>
+	</query>
+	<query>
+		<qid>0035</qid>
+		<content>Magnesium hydroxide</content>
+	</query>
+	<query>
+		<qid>0036</qid>
+		<content>Neptune</content>
+	</query>
+	<query>
+		<qid>0037</qid>
+		<content>hkd rmb exchange rate</content>
+	</query>
+	<query>
+		<qid>0038</qid>
+		<content>movie ranking</content>
+	</query>
+	<query>
+		<qid>0039</qid>
+		<content>router login</content>
+	</query>
+	<query>
+		<qid>0040</qid>
+		<content>merge videos</content>
+	</query>
+	<query>
+		<qid>0041</qid>
+		<content>autumn</content>
+	</query>
+	<query>
+		<qid>0042</qid>
+		<content>Alpaca</content>
+	</query>
+	<query>
+		<qid>0043</qid>
+		<content>petal</content>
+	</query>
+	<query>
+		<qid>0044</qid>
+		<content>English quotes</content>
+	</query>
+	<query>
+		<qid>0045</qid>
+		<content>commendatory term</content>
+	</query>
+	<query>
+		<qid>0046</qid>
+		<content>musical note</content>
+	</query>
+	<query>
+		<qid>0047</qid>
+		<content>rubik cube solution steps</content>
+	</query>
+	<query>
+		<qid>0048</qid>
+		<content>melbourne university world ranking</content>
+	</query>
+	<query>
+		<qid>0049</qid>
+		<content>yahoo finance</content>
+	</query>
+	<query>
+		<qid>0050</qid>
+		<content>dow jones</content>
+	</query>
+	<query>
+		<qid>0051</qid>
+		<content>Volkswagen</content>
+	</query>
+	<query>
+		<qid>0052</qid>
+		<content>1968 olympic coin value</content>
+	</query>
+	<query>
+		<qid>0053</qid>
+		<content>absolute neutrophils</content>
+	</query>
+	<query>
+		<qid>0054</qid>
+		<content>Anime pillow</content>
+	</query>
+	<query>
+		<qid>0055</qid>
+		<content>annual salary requirement</content>
+	</query>
+	<query>
+		<qid>0056</qid>
+		<content>apologetic  songs</content>
+	</query>
+	<query>
+		<qid>0057</qid>
+		<content>axle ratio</content>
+	</query>
+	<query>
+		<qid>0058</qid>
+		<content>best office software</content>
+	</query>
+	<query>
+		<qid>0059</qid>
+		<content>bios setup</content>
+	</query>
+	<query>
+		<qid>0060</qid>
+		<content>blueberry compote</content>
+	</query>
+	<query>
+		<qid>0061</qid>
+		<content>boeing history</content>
+	</query>
+	<query>
+		<qid>0062</qid>
+		<content>brady motion</content>
+	</query>
+	<query>
+		<qid>0063</qid>
+		<content>candle in window meaning</content>
+	</query>
+	<query>
+		<qid>0064</qid>
+		<content>CaSe compound</content>
+	</query>
+	<query>
+		<qid>0065</qid>
+		<content>cheap root canals</content>
+	</query>
+	<query>
+		<qid>0066</qid>
+		<content>create website</content>
+	</query>
+	<query>
+		<qid>0067</qid>
+		<content>recital themes</content>
+	</query>
+	<query>
+		<qid>0068</qid>
+		<content>dell stock</content>
+	</query>
+	<query>
+		<qid>0069</qid>
+		<content>diwali</content>
+	</query>
+	<query>
+		<qid>0070</qid>
+		<content>dna strand</content>
+	</query>
+	<query>
+		<qid>0071</qid>
+		<content>dog food for allergies</content>
+	</query>
+	<query>
+		<qid>0072</qid>
+		<content>driving school</content>
+	</query>
+	<query>
+		<qid>0073</qid>
+		<content>drum</content>
+	</query>
+	<query>
+		<qid>0074</qid>
+		<content>EARNINGS CALENDAR</content>
+	</query>
+	<query>
+		<qid>0075</qid>
+		<content>famous black leaders</content>
+	</query>
+	<query>
+		<qid>0076</qid>
+		<content>financial engines</content>
+	</query>
+	<query>
+		<qid>0077</qid>
+		<content>find part time job</content>
+	</query>
+	<query>
+		<qid>0078</qid>
+		<content>formal fallacy</content>
+	</query>
+	<query>
+		<qid>0079</qid>
+		<content>grasslands</content>
+	</query>
+	<query>
+		<qid>0080</qid>
+		<content>hp printer offline</content>
+	</query>
+	<query>
+		<qid>0081</qid>
+		<content>ibm quote</content>
+	</query>
+	<query>
+		<qid>0082</qid>
+		<content>itunes error</content>
+	</query>
+	<query>
+		<qid>0083</qid>
+		<content>jetstar airlines hong kong</content>
+	</query>
+	<query>
+		<qid>0084</qid>
+		<content>key man insurance</content>
+	</query>
+	<query>
+		<qid>0085</qid>
+		<content>largest species of eel</content>
+	</query>
+	<query>
+		<qid>0086</qid>
+		<content>low monocytes</content>
+	</query>
+	<query>
+		<qid>0087</qid>
+		<content>manila</content>
+	</query>
+	<query>
+		<qid>0088</qid>
+		<content>mexico climate</content>
+	</query>
+	<query>
+		<qid>0089</qid>
+		<content>Mineral Element</content>
+	</query>
+	<query>
+		<qid>0090</qid>
+		<content>native American Mexican</content>
+	</query>
+	<query>
+		<qid>0091</qid>
+		<content>openwrt</content>
+	</query>
+	<query>
+		<qid>0092</qid>
+		<content>pandora</content>
+	</query>
+	<query>
+		<qid>0093</qid>
+		<content>protecting embankment</content>
+	</query>
+	<query>
+		<qid>0094</qid>
+		<content>Samosa Recipes</content>
+	</query>
+	<query>
+		<qid>0095</qid>
+		<content>soda water</content>
+	</query>
+	<query>
+		<qid>0096</qid>
+		<content>Star Wars Movies</content>
+	</query>
+	<query>
+		<qid>0097</qid>
+		<content>stomach disorder</content>
+	</query>
+	<query>
+		<qid>0098</qid>
+		<content>tiffany keys</content>
+	</query>
+	<query>
+		<qid>0099</qid>
+		<content>vegetable fermentation</content>
+	</query>
+	<query>
+		<qid>0100</qid>
+		<content>weight loss</content>
+	</query>
+</queries>

--- a/src/main/resources/topics-and-qrels/topics.www2.english.txt
+++ b/src/main/resources/topics-and-qrels/topics.www2.english.txt
@@ -1,0 +1,402 @@
+<queries>
+    <query>
+        <qid>0001</qid>
+        <content>Halloween picture</content>
+        <description>Halloween is coming. You want to find some pictures about Halloween to introduce it to your children.</description>
+    </query>
+    <query>
+        <qid>0002</qid>
+        <content>calendar</content>
+        <description>You need to find a convenient online calendar.</description>
+    </query>
+    <query>
+        <qid>0003</qid>
+        <content>women's clothing winter</content>
+        <description>Winter is coming. You want to look for information on women's clothes for yourself.</description>
+    </query>
+    <query>
+        <qid>0004</qid>
+        <content>Gastrointestinal fistula</content>
+        <description>You now have a stomachache. You once heard that gastrointestinal fistula can cause a stomachache and are worried. You want to find out the symptoms, causes, and treatment of gastrointestinal fistula.</description>
+    </query>
+    <query>
+        <qid>0005</qid>
+        <content>Wall decoration</content>
+        <description>Your home needs to be decorated and you want to know more about wall decoration.</description>
+    </query>
+    <query>
+        <qid>0006</qid>
+        <content>Pet pig</content>
+        <description>Your friend has a pet pig. You want to search some information about pet pigs.</description>
+    </query>
+    <query>
+        <qid>0007</qid>
+        <content>Homemade recipes</content>
+        <description>You plan to learn to cook, so you want to find some homemade recipes.</description>
+    </query>
+    <query>
+        <qid>0008</qid>
+        <content>Which day is Halloween</content>
+        <description>You heard that Halloween is coming soon, and you want to find out which day Halloween is.</description>
+    </query>
+    <query>
+        <qid>0009</qid>
+        <content>what does Civil defense siren mean?</content>
+        <description>You suddenly heard the Civil defense siren. You want to know under what circumstances the Civil defense siren is sounded. What does it mean?</description>
+    </query>
+    <query>
+        <qid>0010</qid>
+        <content>career plan</content>
+        <description>You are an undergraduate student who is about to graduate. You want to search some information about how to plan your career.</description>
+    </query>
+    <query>
+        <qid>0011</qid>
+        <content>Branched chain amino acid</content>
+        <description>You heard the term branched chain amino acid. You want to know more about it.</description>
+    </query>
+    <query>
+        <qid>0012</qid>
+        <content>Canon</content>
+        <description>You want to know the background and stories about Canon.</description>
+    </query>
+    <query>
+        <qid>0013</qid>
+        <content>deadlift proper form</content>
+        <description>You have a fitness plan and would like to know about the proper form of deadlift.</description>
+    </query>
+    <query>
+        <qid>0014</qid>
+        <content>Derivatives of Composite Functions</content>
+        <description>You are learning about Derivatives of Composite Functions and want to search more information about it.</description>
+    </query>
+    <query>
+        <qid>0015</qid>
+        <content>Vitamin A</content>
+        <description>You want to learn some knowledge about Vitamin A.</description>
+    </query>
+    <query>
+        <qid>0016</qid>
+        <content>BMW z4 offer</content>
+        <description>You want to know the price of BMW Z4.</description>
+    </query>
+    <query>
+        <qid>0017</qid>
+        <content>Cristiano Ronaldo</content>
+        <description>Cristiano Ronaldo's performance in the World Cup is very eye-catching, so you want to know his background and stories.</description>
+    </query>
+    <query>
+        <qid>0018</qid>
+        <content>the calories of an egg</content>
+        <description>You are trying a balanced diet plan recently and want to know how many calories an egg has.</description>
+    </query>
+    <query>
+        <qid>0019</qid>
+        <content>palpitation symptoms</content>
+        <description>You have been a little uncomfortable recently. Your family said that you may have palpitation. You want to know the symptoms of palpitation.</description>
+    </query>
+    <query>
+        <qid>0020</qid>
+        <content>Birthday cake design picture</content>
+        <description>Your friend is going to have a birthday. You want to search some pictures of a creative design of birthday cake.</description>
+    </query>
+    <query>
+        <qid>0021</qid>
+        <content>International gold price</content>
+        <description>You want to find out about the international market prices of gold.</description>
+    </query>
+    <query>
+        <qid>0022</qid>
+        <content>difference between series and parallel circuits</content>
+        <description>Recently in the circuits course, you didn't understand the difference between series and parallel circuits. You want to search some information on the Internet.</description>
+    </query>
+    <query>
+        <qid>0023</qid>
+        <content>Medvedev</content>
+        <description>You want to know about the background of Medvedev.</description>
+    </query>
+    <query>
+        <qid>0024</qid>
+        <content>what does ridiculous mean</content>
+        <description>You want to find the exact interpretation of the word ridiculous.</description>
+    </query>
+    <query>
+        <qid>0025</qid>
+        <content>What is the biggest waterfall in the world?</content>
+        <description>You want to know the name of the biggest waterfall in the world.</description>
+    </query>
+    <query>
+        <qid>0026</qid>
+        <content>Canon IP1188 driver</content>
+        <description>You want to search for drivers for the Canon IP1188 printer.</description>
+    </query>
+    <query>
+        <qid>0027</qid>
+        <content>Is it okay to drink yogurt after eating persimmon?</content>
+        <description>Some people say that it is not healthy to drink yogurt after eating persimmons. You want to know whether it is true.</description>
+    </query>
+    <query>
+        <qid>0028</qid>
+        <content>nail scratches on car paint</content>
+        <description>You want to find out how to remove nail scratches on car paint.</description>
+    </query>
+    <query>
+        <qid>0029</qid>
+        <content>How to select computer monitors</content>
+        <description>You plan to buy a new computer monitor, so you want to know what criteria should be considered for selecting computer monitors.</description>
+    </query>
+    <query>
+        <qid>0030</qid>
+        <content>Red coral picture</content>
+        <description>You need to make a slide about red coral. You want to search for some pictures of red coral.</description>
+    </query>
+    <query>
+        <qid>0031</qid>
+        <content>disney</content>
+        <description>You want to find the official website of Disney.</description>
+    </query>
+    <query>
+        <qid>0032</qid>
+        <content>translation software</content>
+        <description>You are learning Chinese and you want to search for a software which can help you translate some documents.</description>
+    </query>
+    <query>
+        <qid>0033</qid>
+        <content>dictionary</content>
+        <description>You want to find a convenient online dictionary.</description>
+    </query>
+    <query>
+        <qid>0034</qid>
+        <content>southwest airline</content>
+        <description>You want to find the official website of southwest airline.</description>
+    </query>
+    <query>
+        <qid>0035</qid>
+        <content>yahoo chat</content>
+        <description>You want to find the official website of yahoo chat.</description>
+    </query>
+    <query>
+        <qid>0036</qid>
+        <content>www.chase.com</content>
+        <description>You want to find the website &quot;www.chase.com&quot;</description>
+    </query>
+    <query>
+        <qid>0037</qid>
+        <content>cheap flights</content>
+        <description>You want to book cheap flight tickets online.</description>
+    </query>
+    <query>
+        <qid>0038</qid>
+        <content>priceline.com</content>
+        <description>You want to find the website &quot;priceline.com&quot;</description>
+    </query>
+    <query>
+        <qid>0039</qid>
+        <content>song lyrics</content>
+        <description>you want to find a good lyrics website.</description>
+    </query>
+    <query>
+        <qid>0040</qid>
+        <content>Shinjuku</content>
+        <description>You are going to travel in Tokyo and you want to search for some information about Shinjuku.</description>
+    </query>
+    <query>
+        <qid>0041</qid>
+        <content>grips for M1911 pistol</content>
+        <description>You are interested in the M1911 pistol. You want to search for information about the grips of the M1911 pistol.</description>
+    </query>
+    <query>
+        <qid>0042</qid>
+        <content>angelina jolie</content>
+        <description>Angelina Jolie is your favorite star. You want to read news about her.</description>
+    </query>
+    <query>
+        <qid>0043</qid>
+        <content>jobs with a finance degree</content>
+        <description>You are a graduate with a finance degree. You want to know what jobs you are qualified for.</description>
+    </query>
+    <query>
+        <qid>0044</qid>
+        <content>louisvilleslugger.com</content>
+        <description>You want to find the website &quot;louisvilleslugger.com&quot;</description>
+    </query>
+    <query>
+        <qid>0045</qid>
+        <content>free e-mails greetting cards</content>
+        <description>You want to send an email greeting card to your friend, so you would like to find some free ones on the Internet.</description>
+    </query>
+    <query>
+        <qid>0046</qid>
+        <content>peanut</content>
+        <description>You want to find out about the nutrition of the peanut.</description>
+    </query>
+    <query>
+        <qid>0047</qid>
+        <content>deaths 1927 cleveland ohio</content>
+        <description>You are doing some statistical investigations. You need to know the deaths of Cleveland, Ohio in 1927.</description>
+    </query>
+    <query>
+        <qid>0048</qid>
+        <content>dining room chairs</content>
+        <description>You are renovating your dining room, so you want to search for some dining room chairs.</description>
+    </query>
+    <query>
+        <qid>0049</qid>
+        <content>flemish painter</content>
+        <description>You are interested in art. You want to find some Flemish painters.</description>
+    </query>
+    <query>
+        <qid>0050</qid>
+        <content>white chocolate macadamia nut cookies</content>
+        <description>You have a sweet tooth and want to find information about white chocolate macadamia nut cookies.</description>
+    </query>
+    <query>
+        <qid>0051</qid>
+        <content>prednisone</content>
+        <description>You heard a drug named prednisone. You want to know some information about it.</description>
+    </query>
+    <query>
+        <qid>0052</qid>
+        <content>movie trailer</content>
+        <description>You want to watch some movie trailers to kill time.</description>
+    </query>
+    <query>
+        <qid>0053</qid>
+        <content>wakeboard towers</content>
+        <description>Recently you are interested in wakeboarding. You want to know some information about wakeboard towers.</description>
+    </query>
+    <query>
+        <qid>0054</qid>
+        <content>the friedman test</content>
+        <description>You are learning statistics. You want to know what the Friedman Test is.</description>
+    </query>
+    <query>
+        <qid>0055</qid>
+        <content>blue note</content>
+        <description>You like Jazz. You want to find information about Blue Note Records.</description>
+    </query>
+    <query>
+        <qid>0056</qid>
+        <content>yosemite national park</content>
+        <description>You want to search for some information about yosemite national park for your trip.</description>
+    </query>
+    <query>
+        <qid>0057</qid>
+        <content>walker baskets</content>
+        <description>You want to find some information about walker baskets.</description>
+    </query>
+    <query>
+        <qid>0058</qid>
+        <content>pictures of smiles and teeth</content>
+        <description>You are looking for some pictures of smiles with teeth shown.</description>
+    </query>
+    <query>
+        <qid>0059</qid>
+        <content>boat repair</content>
+        <description>You need to repair your boat, so you want to find some boat repair shops.</description>
+    </query>
+    <query>
+        <qid>0060</qid>
+        <content>car-parts.com</content>
+        <description>You want to find the website &quot;car-parts.com&quot;</description>
+    </query>
+    <query>
+        <qid>0061</qid>
+        <content>old english fonts</content>
+        <description>You need to use old English fonts, so you want to find some ones.</description>
+    </query>
+    <query>
+        <qid>0062</qid>
+        <content>density</content>
+        <description>You want to learn the concept of density.</description>
+    </query>
+    <query>
+        <qid>0063</qid>
+        <content>www.dps.com</content>
+        <description>You want to find the website &quot;www.dps.com&quot;</description>
+    </query>
+    <query>
+        <qid>0064</qid>
+        <content>liver disease</content>
+        <description>Your friend has a liver disease. You would like to know about the symptoms, causes and treatment of liver diseases.</description>
+    </query>
+    <query>
+        <qid>0065</qid>
+        <content>avril lavigne lyrics</content>
+        <description>You love Avril Lavigne. You want to find some lyrics of her songs.</description>
+    </query>
+    <query>
+        <qid>0066</qid>
+        <content>carribean cruises</content>
+        <description>Your friend invites you to take a Caribbean cruise. You want to search for some information about it.</description>
+    </query>
+    <query>
+        <qid>0067</qid>
+        <content>tiki artist</content>
+        <description>You saw a tiki art painting in an exhibition. You want to find some tiki artists.</description>
+    </query>
+    <query>
+        <qid>0068</qid>
+        <content>hp service</content>
+        <description>There is something wrong with your HP products, so you want to find HP customer services.</description>
+    </query>
+    <query>
+        <qid>0069</qid>
+        <content>snow crab legs</content>
+        <description>You heard that the snow crab legs are delicious. You want to find some information about them.</description>
+    </query>
+    <query>
+        <qid>0070</qid>
+        <content>maps of costa rica</content>
+        <description>You are going to travel to Costa Rica, so you need to search for maps of Costa Rica.</description>
+    </query>
+    <query>
+        <qid>0071</qid>
+        <content>floor tile</content>
+        <description>Your home needs to be decorated and you want to know more about the floor tile.</description>
+    </query>
+    <query>
+        <qid>0072</qid>
+        <content>american tourister luggage</content>
+        <description>You plan to go out on holiday, so you want to buy an American Tourister suitcase.</description>
+    </query>
+    <query>
+        <qid>0073</qid>
+        <content>lululemon</content>
+        <description>You like yoga and want to buy some Lululemon clothes.</description>
+    </query>
+    <query>
+        <qid>0074</qid>
+        <content>www.mbusa.com</content>
+        <description>You want to find the website &quot;www.mbusa.com&quot;</description>
+    </query>
+    <query>
+        <qid>0075</qid>
+        <content>things to do &amp; see in croatia</content>
+        <description>You are going to travel to Croatia, so you want to know what things to do and see in Croatia.</description>
+    </query>
+    <query>
+        <qid>0076</qid>
+        <content>pogo mah jong</content>
+        <description>You heard Pogo is a great place to play free online games. You want to find mahjong games on it.</description>
+    </query>
+    <query>
+        <qid>0077</qid>
+        <content>snow white costume</content>
+        <description>Your daughter loves Snow White. You want to search for some Snow White costumes.</description>
+    </query>
+    <query>
+        <qid>0078</qid>
+        <content>movies for kids</content>
+        <description>You plan to watch movies with your children, and you want a few suggestions.</description>
+    </query>
+    <query>
+        <qid>0079</qid>
+        <content>alcohol and its negative effects on society</content>
+        <description>Some people say that alcohol has negative effects on society. You want to know something about it.</description>
+    </query>
+    <query>
+        <qid>0080</qid>
+        <content>www.gardenburger.com</content>
+        <description>You want to find the website &quot;www.gardenburger.com&quot;</description>
+    </query>
+</queries>

--- a/src/test/java/io/anserini/search/topicreader/NtcirTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/NtcirTopicReaderTest.java
@@ -1,0 +1,54 @@
+package io.anserini.search.topicreader;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.SortedMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class NtcirTopicReaderTest {
+
+  @Test
+  public void test_www1_en() throws IOException {
+
+    Path path1 = Paths.get("src/main/resources/topics-and-qrels/topics.www1.english.txt");
+    TopicReader<Integer> reader1 = new NtcirTopicReader(path1);
+
+    SortedMap<Integer, Map<String, String>> topics1 = reader1.read();
+
+    assertEquals(100, topics1.keySet().size());
+    assertEquals(1, (int) topics1.firstKey());
+    assertEquals("ascii code", topics1.get(topics1.firstKey()).get("title"));
+
+    assertEquals(100, (int) topics1.lastKey());
+    assertEquals("weight loss", topics1.get(topics1.lastKey()).get("title"));
+
+  }
+
+  @Test
+  public void test_www2_en() throws IOException {
+    Path path = Paths.get("src/main/resources/topics-and-qrels/topics.www2.english.txt");
+    TopicReader<Integer> reader = new NtcirTopicReader(path);
+
+    SortedMap<Integer, Map<String, String>> topics = reader.read();
+
+    assertEquals(80, topics.keySet().size());
+    assertEquals(1, (int) topics.firstKey());
+    assertEquals("Halloween picture", topics.get(topics.firstKey()).get("title"));
+    assertEquals("Halloween is coming. You want to find some pictures about" +
+            " Halloween to introduce it to your children.",
+        topics.get(topics.firstKey()).get("description"));
+
+
+    assertEquals(80, (int) topics.lastKey());
+    assertEquals("www.gardenburger.com", topics.get(topics.lastKey()).get("title"));
+    assertEquals("You want to find the website &quot;www.gardenburger.com&quot;",
+        topics.get(topics.lastKey()).get("description"));
+
+  }
+}
+


### PR DESCRIPTION
This is the TopicReader for topics in NTCIR format.

Regarding the evaluation tools, NTCIR evaluation tools only accept runs in NTCIR format. As Anserini generates runs in the TREC format, should I convert the NTCIR qrels into TREC format and put them in the `resources` folder, so that users can simply use the TREC eval?  

