### PR TITLE
Improved updating of indexer stats for collections with only one file segment

### DIFF
--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -145,7 +145,12 @@ public final class IndexCollection {
                 .getDeclaredConstructor(IndexArgs.class, Counters.class)
                 .newInstance(args, counters);
 
+        // We keep track of two separate counts: the total count of documents in this file segment (cnt),
+        // and the number of documents in this current "batch" (batch). We update the global counter every
+        // 10k documents: this is so that we get intermediate updates, which is informative if a collection
+        // has only one file segment; see https://github.com/castorini/anserini/issues/683
         int cnt = 0;
+        int batch = 0;
 
         @SuppressWarnings("unchecked")
         FileSegment<SourceDocument> segment =
@@ -190,7 +195,17 @@ public final class IndexCollection {
             }
           }
           cnt++;
+          batch++;
+
+          // And the counts from this batch, reset batch counter.
+          if (batch % 10000 == 0) {
+            counters.indexed.addAndGet(batch);
+            batch = 0;
+          }
         }
+
+        // Add the remaining documents.
+        counters.indexed.addAndGet(batch);
 
         int skipped = segment.getSkippedCount();
         if (skipped > 0) {
@@ -208,7 +223,6 @@ public final class IndexCollection {
 
         LOG.info(inputFile.getParent().getFileName().toString() + File.separator +
             inputFile.getFileName().toString() + ": " + cnt + " docs added.");
-        counters.indexed.addAndGet(cnt);
       } catch (Exception e) {
         LOG.error(Thread.currentThread().getName() + ": Unexpected Exception:", e);
       } finally {
@@ -705,7 +719,7 @@ public final class IndexCollection {
     final List segmentPaths = collection.discover(collection.getCollectionPath());
 
     final int segmentCnt = segmentPaths.size();
-    LOG.info(segmentCnt + " files found in " + collectionPath.toString());
+    LOG.info(segmentCnt + (segmentCnt == 1 ? " file" : " files" ) + " found in " + collectionPath.toString());
     for (int i = 0; i < segmentCnt; i++) {
       if (args.solr) {
         executor.execute(new SolrIndexerThread(collection, (Path) segmentPaths.get(i)));
@@ -721,8 +735,12 @@ public final class IndexCollection {
     try {
       // Wait for existing tasks to terminate
       while (!executor.awaitTermination(1, TimeUnit.MINUTES)) {
-        LOG.info(String.format("%.2f percent completed",
-            (double) executor.getCompletedTaskCount() / segmentCnt * 100.0d));
+        if (segmentCnt == 1) {
+          LOG.info(String.format("%d documents indexed", counters.indexed.get()));
+        } else {
+          LOG.info(String.format("%.2f percent of file segments completed, %d documents indexed",
+              (double) executor.getCompletedTaskCount() / segmentCnt * 100.0d, counters.indexed.get()));
+        }
       }
     } catch (InterruptedException ie) {
       // (Re-)Cancel if current thread also interrupted


### PR DESCRIPTION
Closes #683 

Does something more reasonable now, like:

```
2019-11-22 20:23:42,335 INFO  [main] index.IndexCollection (IndexCollection.java:677) - Starting indexer...
2019-11-22 20:23:42,427 INFO  [main] index.IndexCollection (IndexCollection.java:722) - 1 file found in /tuna1/collections/newswire/WashingtonPost.v2/data
2019-11-22 20:24:42,486 INFO  [main] index.IndexCollection (IndexCollection.java:739) - 60000 documents indexed
2019-11-22 20:25:42,488 INFO  [main] index.IndexCollection (IndexCollection.java:739) - 120000 documents indexed
2019-11-22 20:26:42,487 INFO  [main] index.IndexCollection (IndexCollection.java:739) - 180000 documents indexed
2019-11-22 20:27:42,487 INFO  [main] index.IndexCollection (IndexCollection.java:739) - 240000 documents indexed
2019-11-22 20:28:42,489 INFO  [main] index.IndexCollection (IndexCollection.java:739) - 320000 documents indexed
2019-11-22 20:29:42,489 INFO  [main] index.IndexCollection (IndexCollection.java:739) - 400000 documents indexed
2019-11-22 20:30:42,489 INFO  [main] index.IndexCollection (IndexCollection.java:739) - 460000 documents indexed
2019-11-22 20:31:42,490 INFO  [main] index.IndexCollection (IndexCollection.java:739) - 510000 documents indexed
2019-11-22 20:32:42,492 INFO  [main] index.IndexCollection (IndexCollection.java:739) - 570000 documents indexed
2019-11-22 20:33:09,419 INFO  [pool-2-thread-1] index.IndexCollection$LocalIndexerThread (IndexCollection.java:224) - data/TREC_Washington_Post_collection.v2.jl: 595037 docs added.
2019-11-22 20:33:38,483 INFO  [main] index.IndexCollection (IndexCollection.java:807) - # Final Counter Values
2019-11-22 20:33:38,483 INFO  [main] index.IndexCollection (IndexCollection.java:808) - indexed:          595,037
2019-11-22 20:33:38,483 INFO  [main] index.IndexCollection (IndexCollection.java:809) - empty:                  0
2019-11-22 20:33:38,484 INFO  [main] index.IndexCollection (IndexCollection.java:810) - unindexed:              0
2019-11-22 20:33:38,484 INFO  [main] index.IndexCollection (IndexCollection.java:811) - unindexable:            0
2019-11-22 20:33:38,484 INFO  [main] index.IndexCollection (IndexCollection.java:812) - skipped:                0
2019-11-22 20:33:38,484 INFO  [main] index.IndexCollection (IndexCollection.java:813) - errors:                 0
2019-11-22 20:33:38,490 INFO  [main] index.IndexCollection (IndexCollection.java:816) - Total 595,037 documents indexed in 00:09:56
```
