### PR TITLE
Refactored extract doclength/norm util and test cases

### DIFF
--- a/src/main/java/io/anserini/util/ExtractDocumentLengths.java
+++ b/src/main/java/io/anserini/util/ExtractDocumentLengths.java
@@ -78,6 +78,9 @@ public class ExtractDocumentLengths {
       int lossyTermCount = SmallFloat.byte4ToInt(SmallFloat.intToByte4((int) exactTermCount));
       out.println(String.format("%d\t%d\t%d\t%d\t%d", i, exactDoclength, exactTermCount, lossyDoclength, lossyTermCount));
     }
+    out.flush();
     out.close();
+    reader.close();
+    dir.close();
   }
 }

--- a/src/main/java/io/anserini/util/ExtractNorms.java
+++ b/src/main/java/io/anserini/util/ExtractNorms.java
@@ -77,6 +77,9 @@ public class ExtractNorms {
             SmallFloat.byte4ToInt((byte) docValues.longValue())));
       }
     }
+    out.flush();
     out.close();
+    reader.close();
+    dir.close();
   }
 }

--- a/src/test/java/io/anserini/util/ExtractDocumentLengthsTest.java
+++ b/src/test/java/io/anserini/util/ExtractDocumentLengthsTest.java
@@ -21,6 +21,8 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -31,19 +33,31 @@ import java.util.List;
 import java.util.Random;
 
 public class ExtractDocumentLengthsTest extends IndexerTestBase {
+  private static final Random rand = new Random();
+  private String randomFileName;
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    randomFileName = "doclengths" + rand.nextInt();
+  }
+
+  @After
+  @Override
+  public void tearDown() throws Exception {
+    super.tearDown();
+    Files.delete(Paths.get(randomFileName));
+  }
 
   @Test
   public void test() throws Exception {
-    Random rand = new Random();
-    int r = rand.nextInt();
-    ExtractDocumentLengths.main(new String[] {"-index", tempDir1.toString(), "-output", "doclengths" + r});
+    ExtractDocumentLengths.main(new String[] {"-index", tempDir1.toString(), "-output", randomFileName});
 
-    List<String> lines = Files.readAllLines(Paths.get("doclengths" + r));
+    List<String> lines = Files.readAllLines(Paths.get(randomFileName));
     assertEquals(4, lines.size());
     assertEquals("0\t7\t4\t7\t4", lines.get(1));
     assertEquals("1\t2\t2\t2\t2", lines.get(2));
     assertEquals("2\t2\t2\t2\t2", lines.get(3));
-
-    Files.delete(Paths.get("doclengths" + r));
   }
 }

--- a/src/test/java/io/anserini/util/ExtractNormsTest.java
+++ b/src/test/java/io/anserini/util/ExtractNormsTest.java
@@ -21,6 +21,8 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -31,19 +33,31 @@ import java.util.List;
 import java.util.Random;
 
 public class ExtractNormsTest extends IndexerTestBase {
+  private static final Random rand = new Random();
+  private String randomFileName;
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    randomFileName = "norms" + rand.nextInt();
+  }
+
+  @After
+  @Override
+  public void tearDown() throws Exception {
+    super.tearDown();
+    Files.delete(Paths.get(randomFileName));
+  }
 
   @Test
   public void test() throws Exception {
-    Random rand = new Random();
-    int r = rand.nextInt();
-    ExtractNorms.main(new String[] {"-index", tempDir1.toString(), "-output", "doclengths" + r});
+    ExtractNorms.main(new String[] {"-index", tempDir1.toString(), "-output", randomFileName});
 
-    List<String> lines = Files.readAllLines(Paths.get("doclengths" + r));
+    List<String> lines = Files.readAllLines(Paths.get(randomFileName));
     assertEquals(4, lines.size());
     assertEquals("0\t7", lines.get(1));
     assertEquals("1\t2", lines.get(2));
     assertEquals("2\t2", lines.get(3));
-
-    Files.delete(Paths.get("doclengths" + r));
   }
 }


### PR DESCRIPTION
We seem to have a flaky test case that breaks non-deterministically... I've replicated intermittent breakage on Linux, but can't replicate on macOS. Here's some general cleanup... hopefully it'll help.
