### PR TITLE
Logging upgrade and fixed ES logging warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,12 +323,17 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.4</version>
+      <version>2.12.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.4</version>
+      <version>2.12.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.29</version>
     </dependency>
     <dependency>
       <groupId>io.anserini</groupId>


### PR DESCRIPTION
Discovered that we were using a very old artifact - upgraded.

Also fixed ES logging warning:

```
$ sh target/appassembler/bin/SearchElastic -topicreader Trec -es.index robust04 -topics src/main/resources/topics-and-qrels/topics.robust04.txt -output run.es.robust04.bm25.topics.robust04.txt
2019-12-02 15:10:42,323 INFO  [main] search.SearchElastic (SearchElastic.java:183) - Elasticsearch index: robust04
2019-12-02 15:10:42,324 INFO  [main] search.SearchElastic (SearchElastic.java:184) - Elasticsearch hostname: localhost
2019-12-02 15:10:42,324 INFO  [main] search.SearchElastic (SearchElastic.java:185) - Elasticsearch host port: 9200
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
2019-12-02 15:10:42,593 INFO  [main] search.SearchElastic$ESSearcherThread (SearchElastic.java:142) - [Start] Retrieval with Elasticsearch collection: robust04
2019-12-02 15:11:14,035 INFO  [main] search.SearchElastic$ESSearcherThread (SearchElastic.java:173) - [Finished] Run 250 topics searched in 00:00:31
2019-12-02 15:11:14,040 INFO  [main] search.SearchElastic (SearchElastic.java:324) - Total run time: 00:00:31
```