### PR TITLE
Convert array fields for CORE dataset collection to string

### DIFF
--- a/src/main/java/io/anserini/collection/CoreCollection.java
+++ b/src/main/java/io/anserini/collection/CoreCollection.java
@@ -125,9 +125,9 @@ public class CoreCollection extends DocumentCollection<CoreCollection.Document> 
                   "doi:" + json.get("doi").asText();
         } else if ("abstract".equals(e.getKey())) {
           this.contents = json.get("title").asText() + "\n" + json.get("abstract").asText();
-        } else if ("topics".equals(e.getKey())) {
+        } else if (e.getValue() instanceof ArrayNode) {
           ArrayNode arrayField = (ArrayNode) e.getValue();
-          StringJoiner sj = new StringJoiner(" ");
+          StringJoiner sj = new StringJoiner("::");
           arrayField.elements().forEachRemaining( arrayElement -> {
             sj.add(arrayElement.asText());
           });

--- a/src/main/java/io/anserini/collection/CoreCollection.java
+++ b/src/main/java/io/anserini/collection/CoreCollection.java
@@ -19,6 +19,7 @@ package io.anserini.collection;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.tukaani.xz.XZInputStream;
@@ -34,6 +35,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.StringJoiner;
 
 /**
  * A document collection in the
@@ -43,8 +45,8 @@ import java.util.NoSuchElementException;
  * Inside each file should be a bunch of JSON objects, each per line:
  *
  * <pre>
- * {"id": "doc1", "contents": "this is the contents 1."}
- * {"id": "doc2", "contents": "this is the contents 2."}
+ * {"id": "doc1", "contents": "this is the contents 1.", "year": 2019, "topics": ["topic 1"]}
+ * {"id": "doc2", "contents": "this is the contents 2.", "year": 2020, "topics": ["topic 2"]}
  * </pre>
  */
 public class CoreCollection extends DocumentCollection<CoreCollection.Document> {
@@ -123,6 +125,13 @@ public class CoreCollection extends DocumentCollection<CoreCollection.Document> 
                   "doi:" + json.get("doi").asText();
         } else if ("abstract".equals(e.getKey())) {
           this.contents = json.get("title").asText() + "\n" + json.get("abstract").asText();
+        } else if ("topics".equals(e.getKey())) {
+          ArrayNode arrayField = (ArrayNode) e.getValue();
+          StringJoiner sj = new StringJoiner(" ");
+          arrayField.elements().forEachRemaining( arrayElement -> {
+            sj.add(arrayElement.asText());
+          });
+          this.fields.put(e.getKey(), sj.toString());
         } else {
           this.fields.put(e.getKey(), e.getValue().asText());
         }

--- a/src/test/java/io/anserini/collection/CoreDocumentTest.java
+++ b/src/test/java/io/anserini/collection/CoreDocumentTest.java
@@ -67,7 +67,7 @@ public class CoreDocumentTest extends DocumentTest {
     doc1.put("doi", "null");
     doc1.put("title", "this is the title 1");
     doc1.put("abstract", "this is the abstract 1");
-    doc1.put("topics", "Topic 1 Other");
+    doc1.put("topics", "Topic 1::Other");
     doc1.put("year", "2020");
     doc1.put("field1", "doc1 field1 content");
     doc1.put("field2", "doc1 field2 content");
@@ -77,7 +77,7 @@ public class CoreDocumentTest extends DocumentTest {
     doc2.put("doi", "doi2");
     doc2.put("title", "this is the title 2");
     doc2.put("abstract", "this is the abstract 2");
-    doc2.put("topics", "Topic 2 Other");
+    doc2.put("topics", "Topic 2::Other");
     doc2.put("year", "2010");
     doc2.put("field1", "doc2 field1 content");
     doc2.put("field2", "doc2 field2 content");

--- a/src/test/java/io/anserini/collection/CoreDocumentTest.java
+++ b/src/test/java/io/anserini/collection/CoreDocumentTest.java
@@ -44,6 +44,8 @@ public class CoreDocumentTest extends DocumentTest {
       "  \"doi\": null," +
       "  \"title\": \"this is the title 1\"," +
       "  \"abstract\": \"this is the abstract 1\"," +
+      "  \"topics\": [\"Topic 1\", \"Other\"]," +
+      "  \"year\": 2020," +
       "  \"field1\": \"doc1 field1 content\"," +
       "  \"field2\": \"doc1 field2 content\"" +
       "}\n" +
@@ -52,6 +54,8 @@ public class CoreDocumentTest extends DocumentTest {
       "  \"doi\": \"doi2\"," +
       "  \"title\": \"this is the title 2\"," +
       "  \"abstract\": \"this is the abstract 2\"," +
+      "  \"topics\": [\"Topic 2\", \"Other\"]," +
+      "  \"year\": 2010," +
       "  \"field1\": \"doc2 field1 content\"," +
       "  \"field2\": \"doc2 field2 content\"" +
       "}";
@@ -63,6 +67,8 @@ public class CoreDocumentTest extends DocumentTest {
     doc1.put("doi", "null");
     doc1.put("title", "this is the title 1");
     doc1.put("abstract", "this is the abstract 1");
+    doc1.put("topics", "Topic 1 Other");
+    doc1.put("year", "2020");
     doc1.put("field1", "doc1 field1 content");
     doc1.put("field2", "doc1 field2 content");
     expected.add(doc1);
@@ -71,6 +77,8 @@ public class CoreDocumentTest extends DocumentTest {
     doc2.put("doi", "doi2");
     doc2.put("title", "this is the title 2");
     doc2.put("abstract", "this is the abstract 2");
+    doc2.put("topics", "Topic 2 Other");
+    doc2.put("year", "2010");
     doc2.put("field1", "doc2 field1 content");
     doc2.put("field2", "doc2 field2 content");
     expected.add(doc2);


### PR DESCRIPTION
Addresses CORE issue https://github.com/castorini/anserini/issues/889.
## Changes
The `CoreCollection` generates a `MultifieldSourceDocument` that is indexed into Lucene for the CORE dataset. Right now we perform `e.getValue().asText()` for all document fields, which for `ArrayNode` JSON types (such as the "topics" field), this [defaults to the empty string](https://fasterxml.github.io/jackson-databind/javadoc/2.10/com/fasterxml/jackson/databind/node/ContainerNode.html#asText--), not the actual text value of the field. This change will convert any array fields into a single string separated by `::`, which can then be indexed by Lucene.

To get the "topics" and "year" fields indexed as "stored" fields in Lucene, we can pass the `-storeTransformedDocs` flag to the indexer, instead of creating a new Generator class. I don't think creating a new generator would be necessary since I'm able to search on the `topic` and `year` fields successfully using the Lucene index. Just FYI I'm using https://github.com/DmitryKey/luke to verify the fields in the index.
