### PR TITLE
Fixed appassembler for Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,8 @@
         <version>2.0.0</version>
         <configuration>
           <extraJvmArguments>-Xms512M -Xmx31G</extraJvmArguments>
+          <repositoryLayout>flat</repositoryLayout>
+          <useWildcardClassPath>true</useWildcardClassPath>
           <programs>
             <program>
               <mainClass>io.anserini.ltr.FeatureExtractorCli</mainClass>


### PR DESCRIPTION
Addressing #943:
For Windows, appassembler generated invalid batch files with too long classpaths.
To fix it, we can use wildcards (available from Java 6) along with a flat directory structure.