### PR TITLE
Encode MSMARCO text properly in UTF-8 and update MSMARCO benchmarks

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -85,7 +85,7 @@ And the output should be like this:
 
 ```
 #####################
-MRR @10: 0.18741227770955546
+MRR @10: 0.18810410697230137
 QueriesRanked: 6980
 #####################
 ```
@@ -111,8 +111,8 @@ And run the `trec_eval` tool:
 The output should be:
 
 ```
-map                   	all	0.1957
-recall_1000           	all	0.8573
+map                   	all	0.1965
+recall_1000           	all	0.8614
 ```
 
 Average precision and recall@1000 are the two metrics we care about the most.
@@ -131,11 +131,19 @@ Here's the comparison between the Anserini default and tuned parameters:
 
 Setting                     | MRR@10 | MAP    | Recall@1000 |
 :---------------------------|-------:|-------:|------------:|
+Default (`k1=0.9`, `b=0.4`) | 0.1854 | 0.1942 | 0.8575
+Tuned (`k1=0.82`, `b=0.68`) | 0.1881 | 0.1965 | 0.8614
+
+Anserini experienced an issue with character encodings when indexing MSMARCO text that was fixed after commit [`3a2203e`](https://github.com/castorini/anserini/commit/3a2203e2c287b5714af6b9cac303c9c5dc7d5d60) (1/13/2020); slightly improving effectiveness.
+
+Effectiveness numbers with Lucene 8.0 (v0.6.0 to v0.7.1) with improper character encodings are below.
+
+Setting                     | MRR@10 | MAP    | Recall@1000 |
+:---------------------------|-------:|-------:|------------:|
 Default (`k1=0.9`, `b=0.4`) | 0.1840 | 0.1926 | 0.8526
 Tuned (`k1=0.82`, `b=0.68`) | 0.1874 | 0.1957 | 0.8573
 
-Anserini was upgraded to Lucene 8.0 as of commit [`75e36f9`](https://github.com/castorini/anserini/commit/75e36f97f7037d1ceb20fa9c91582eac5e974131) (6/12/2019); prior to that, the toolkit uses Lucene 7.6.
-The above results are based on Lucene 8.0, but Lucene 7.6 results can be replicated with [v0.5.1](https://github.com/castorini/anserini/releases);
+Lucene 7.6 results can be replicated with [v0.5.1](https://github.com/castorini/anserini/releases);
 the effectiveness differences are very small.
 For convenience, here are the effectiveness numbers with Lucene 7.6 (v0.5.1):
 
@@ -143,7 +151,6 @@ Setting                     | MRR@10 | MAP    | Recall@1000 |
 :---------------------------|-------:|-------:|------------:|
 Default (`k1=0.9`, `b=0.4`) | 0.1839 | 0.1925 | 0.8526
 Tuned (`k1=0.82`, `b=0.72`) | 0.1875 | 0.1956 | 0.8578
-
 
 
 ## Replication Log

--- a/src/main/python/msmarco/convert_collection_to_jsonl.py
+++ b/src/main/python/msmarco/convert_collection_to_jsonl.py
@@ -22,18 +22,32 @@ import argparse
 def convert_collection(args):
     print('Converting collection...')
     file_index = 0
-    with open(args.collection_path) as f:
-        for i, line in enumerate(f):
+
+    # open as bytes to decode from UTF-8 and apply proper encodings
+    with open(args.collection_path, 'rb') as f:
+        for i, line in enumerate(l.decode('utf-8') for l in f):
             doc_id, doc_text = line.rstrip().split('\t')
+
+            # it seems like MSMARCO data was originally encoded as latin-1 and then
+            # wrongly encoded as UTF-8 although there is no mention of this anywhere
+            try:
+                doc_text = doc_text.encode("latin-1").decode('utf-8')
+            # skip documents with encodings that cause errors when decoding back to utf-8
+            # this was a very small number for MSMARCO passage (~45 documents)
+            except:
+                pass
 
             if i % args.max_docs_per_file == 0:
                 if i > 0:
                     output_jsonl_file.close()
                 output_path = os.path.join(args.output_folder, 'docs{:02d}.json'.format(file_index))
-                output_jsonl_file = open(output_path, 'w')
+                output_jsonl_file = open(output_path, 'w', encoding='utf-8')
                 file_index += 1
             output_dict = {'id': doc_id, 'contents': doc_text}
-            output_jsonl_file.write(json.dumps(output_dict) + '\n')
+
+            # set ensure_ascii=False to ensure unicode characters are directly stored
+            output_str = json.dumps(output_dict, ensure_ascii=False)
+            output_jsonl_file.write(output_str)
 
             if i % 100000 == 0:
                 print('Converted {} docs in {} files'.format(i, file_index))


### PR DESCRIPTION
Preliminary PR to address https://github.com/castorini/anserini/issues/945.

Effectiveness for MSMARCO passage was improved slightly by changing how we decode text when creating the JSON files used for indexing. New results were added into the MSMARCO Passage README.

If this change is good, I can re-run experiments for anything using MSMARCO passage and update those benchmarks as well (doc2query, elastirini etc). The MSMARCO Document ranking experiments also need to have the encoding fixed, I was thinking of doing this in a separate PR but I can also throw it in here.

I also haven't re-tuned the `k1` and `b` parameters yet. Not sure if this would be necessary @lintool.

@nikhilro is going to run the experiments on his machine as well to make sure things are replicable.