### PR TITLE
Explicit line endings and encoding for MSMARCO passage on Windows

### DIFF
--- a/src/main/python/msmarco/convert_collection_to_jsonl.py
+++ b/src/main/python/msmarco/convert_collection_to_jsonl.py
@@ -22,7 +22,7 @@ import argparse
 def convert_collection(args):
     print('Converting collection...')
     file_index = 0
-    with open(args.collection_path) as f:
+    with open(args.collection_path, encoding='utf-8') as f:
         for i, line in enumerate(f):
             doc_id, doc_text = line.rstrip().split('\t')
 
@@ -30,7 +30,7 @@ def convert_collection(args):
                 if i > 0:
                     output_jsonl_file.close()
                 output_path = os.path.join(args.output_folder, 'docs{:02d}.json'.format(file_index))
-                output_jsonl_file = open(output_path, 'w')
+                output_jsonl_file = open(output_path, 'w', encoding='utf-8', newline='\n')
                 file_index += 1
             output_dict = {'id': doc_id, 'contents': doc_text}
             output_jsonl_file.write(json.dumps(output_dict) + '\n')

--- a/src/main/python/msmarco/filter_queries.py
+++ b/src/main/python/msmarco/filter_queries.py
@@ -31,8 +31,8 @@ if __name__ == '__main__':
             query_id, _, _, _ = line.rstrip().split('\t')
             qrels.add(query_id)
 
-    with open(args.output_queries, 'w') as fout:
-        with open(args.queries) as f:
+    with open(args.output_queries, 'w', encoding='utf-8', newline='\n') as fout:
+        with open(args.queries, encoding='utf-8') as f:
             for line in f:
                 query_id, _ = line.rstrip().split('\t')
                 if query_id in qrels:


### PR DESCRIPTION
Line endings + encoding errors in Python prevented the MSMARCO passage experiments from being replicated on Windows so this should fix it. I also re-ran the experiment again on Linux and it still worked.

Will wait for @LuKuuu to also confirm that it works for him on Windows