### PR TITLE
Close searcher for SearchMsmarco class

### DIFF
--- a/src/main/java/io/anserini/search/SearchMsmarco.java
+++ b/src/main/java/io/anserini/search/SearchMsmarco.java
@@ -141,6 +141,8 @@ public class SearchMsmarco {
         }
       }
     }
+
+    searcher.close();
     out.flush();
     out.close();
 


### PR DESCRIPTION
Current class does not close the searcher after a run is complete which seems to cause some sort of I/O bottleneck/speed degradation. For instance, if I run consecutive experiments (with the exact same parameters), the latency for retrieving queries will increase linearly with each new experiment.

The searcher is closed properly for the other classes so I'd assume we want the same here