### PR TITLE
Add test cases for both Solr/ES with {Core18, Robust04, and MS MARCO passage}

### DIFF
--- a/src/main/java/io/anserini/search/SearchSolr.java
+++ b/src/main/java/io/anserini/search/SearchSolr.java
@@ -201,8 +201,8 @@ public final class SearchSolr implements Closeable {
     SolrQuery solrq = new SolrQuery();
     solrq.set("df", "contents");
     solrq.set("fl", "* score");
-    // Remove double quotes in query since they are special syntax in Solr query parser
-    solrq.setQuery(queryString.replace("\"", ""));
+    // Remove some characters in query which are special syntax in Solr query parser
+    solrq.setQuery(queryString.replaceAll("[+=&|<>!(){}~*?:/\"\\^\\-\\[\\]\\\\]", " "));
     solrq.setRows(args.hits);
     solrq.setSort(SortClause.desc("score"));
     solrq.addSort(SortClause.asc(FIELD_ID));

--- a/src/main/python/run_es_regression.py
+++ b/src/main/python/run_es_regression.py
@@ -119,7 +119,7 @@ class ElasticsearchClient:
         elif collection == 'msmarco-passage':
             command = 'sh target/appassembler/bin/SearchElastic -topicreader TsvString -es.index msmarco-passage ' + \
                       '-topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt ' + \
-                      '-output run.es.msmacro-passage.txt'
+                      '-output run.es.msmarco-passage.txt'
         else:
             raise Exception('Unknown collection: {}'.format(collection))
 
@@ -132,7 +132,7 @@ class ElasticsearchClient:
                       'src/main/resources/topics-and-qrels/qrels.robust04.txt run.es.robust04.bm25.topics.robust04.txt'
         elif collection == 'msmarco-passage':
             command = 'eval/trec_eval.9.0.4/trec_eval -c -mrecall.1000 -mmap ' + \
-                      'src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt run.es.msmacro-passage.txt'
+                      'src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt run.es.msmarco-passage.txt'
         else:
             raise Exception('Unknown collection: {}'.format(collection))
 

--- a/src/main/python/run_solr_regression.py
+++ b/src/main/python/run_solr_regression.py
@@ -83,6 +83,14 @@ class SolrClient:
             command = 'sh target/appassembler/bin/IndexCollection -collection WashingtonPostCollection ' + \
                       '-generator WapoGenerator -solr -solr.index core18 -solr.zkUrl localhost:9983 ' + \
                       '-threads 8 -input ' + path + ' -storePositions -storeDocvectors -storeTransformedDocs'
+        elif collection == 'robust04':
+            command = 'sh target/appassembler/bin/IndexCollection -collection TrecCollection ' + \
+                      '-generator JsoupGenerator -solr -solr.index robust04 -solr.zkUrl localhost:9983 ' + \
+                      '-threads 8 -input ' + path + ' -storePositions -storeDocvectors -storeRawDocs'
+        elif collection == 'msmarco-passage':
+            command = 'sh target/appassembler/bin/IndexCollection -collection JsonCollection ' + \
+                      '-generator JsoupGenerator -solr -solr.index msmarco-passage -solr.zkUrl localhost:9983 ' + \
+                      '-threads 8 -input ' + path + ' -storePositions -storeDocvectors -storeRawDocs'
         else:
             raise Exception('Unknown collection: {}'.format(collection))
         logger.info('Running indexing command: ' + command)
@@ -107,6 +115,14 @@ class SolrClient:
             command = 'sh target/appassembler/bin/SearchSolr -topicreader Trec -solr.index core18 ' + \
                       '-solr.zkUrl localhost:9983 -topics src/main/resources/topics-and-qrels/topics.core18.txt ' + \
                       '-output run.solr.core18.bm25.topics.core18.txt'
+        elif collection == 'robust04':
+            command = 'sh target/appassembler/bin/SearchSolr -topicreader Trec -solr.index robust04 ' + \
+                      '-solr.zkUrl localhost:9983 -topics src/main/resources/topics-and-qrels/topics.robust04.txt ' + \
+                      '-output run.solr.robust04.bm25.topics.robust04.txt'
+        elif collection == 'msmarco-passage':
+            command = 'sh target/appassembler/bin/SearchSolr -topicreader TsvString -solr.index msmarco-passage ' + \
+                      '-solr.zkUrl localhost:9983 -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt ' + \
+                      '-output run.solr.msmarco-passage.txt'
         else:
             raise Exception('Unknown collection: {}'.format(collection))
 
@@ -117,6 +133,12 @@ class SolrClient:
         if collection == 'core18':
             command = 'eval/trec_eval.9.0.4/trec_eval -m map -m P.30 ' + \
                       'src/main/resources/topics-and-qrels/qrels.core18.txt run.solr.core18.bm25.topics.core18.txt'
+        elif collection == 'robust04':
+            command = 'eval/trec_eval.9.0.4/trec_eval -m map -m P.30 ' + \
+                      'src/main/resources/topics-and-qrels/qrels.robust04.txt run.solr.robust04.bm25.topics.robust04.txt'
+        elif collection == 'msmarco-passage':
+            command = 'eval/trec_eval.9.0.4/trec_eval  -c -mrecall.1000 -mmap ' + \
+                      'src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt run.solr.msmarco-passage.txt'
         else:
             raise Exception('Unknown collection: {}'.format(collection))
 
@@ -126,6 +148,8 @@ class SolrClient:
 
         expected = 0
         if collection == 'core18': expected = 0.2495
+        elif collection == 'robust04': expected = 0.2531
+        elif collection == 'msmarco-passage': expected = 0.1926
         else: raise Exception('Unknown collection: {}'.format(collection))
 
         if math.isclose(ap, expected): logger.info('[SUCESS] {} MAP verified as expected!'.format(ap))

--- a/src/main/resources/elasticsearch/index-config.core18.json
+++ b/src/main/resources/elasticsearch/index-config.core18.json
@@ -1,0 +1,32 @@
+{
+  "mappings": {
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "contents": {
+        "type": "text",
+        "store": false,
+        "index": true,
+        "analyzer": "english"
+      },
+      "raw": {
+        "type": "text",
+        "store": true,
+        "index": false
+      }
+    }
+  },
+  "settings": {
+    "index": {
+      "refresh_interval": "60s",
+      "similarity": {
+        "default": {
+          "type": "BM25",
+          "k1": "0.9",
+          "b": "0.4"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Ref: Issue #927

Note that the current AP values of Solr with MS MARCO passage and ES with Core18 do not match their expected values. All other cases should work well.

Specifically: 
- Solr with MS MARCO passage produces `[FAILED] 0.187 MAP, expected 0.1956 MAP!`
- ES with Core18 produces `[FAILED] 0.2401 MAP, expected 0.2495 MAP!`



