### PR TITLE
Remove datePublished from CoreGenerator to prevent errors on Solr

### DIFF
--- a/src/main/java/io/anserini/index/generator/CoreGenerator.java
+++ b/src/main/java/io/anserini/index/generator/CoreGenerator.java
@@ -84,7 +84,6 @@ public class CoreGenerator extends LuceneDocumentGenerator<CoreCollection.Docume
     CoreField.DOI.name,
     CoreField.OAI.name,
     CoreField.IDENTIFIERS.name,
-    CoreField.DATE_PUBLISHED.name,
     CoreField.DOWNLOAD_URL.name,
     CoreField.RELATIONS.name,
     CoreField.FULL_TEXT_IDENTIFIER.name));
@@ -142,6 +141,13 @@ public class CoreGenerator extends LuceneDocumentGenerator<CoreCollection.Docume
 
     coreDoc.jsonFields().forEach((k, v) -> {
       String fieldString = jsonNodeToString(v);
+      
+      // causes indexing to fail on Solr due to inconsistent formatting
+      // because Solr infers the field type to be Long instead of String
+      // not worth trying to parse/normalize all dates at the moment
+      if (k == CoreField.DATE_PUBLISHED.name) {
+        return;
+      }
 
       if (STRING_FIELD_NAMES.contains(k)) {
         // index field as single token


### PR DESCRIPTION
When we index the CORE hydrology abstracts, Solr reads many of the fields as `Long` values and assigns the the `Long` type to the `datePublished` field. Occasionally there is a `String` that cannot be parsed, breaking the whole indexing pipeline.

Thought it'd be easier to just remove this field entirely since it gives the same value as "year", but occasionally contains month/day. The alternative is to hard-code `datePublished` in the Solr schema.xml file which I'm not a fan of