### PR TITLE
Support field search and batched field search for MS MARCO

### DIFF
--- a/src/main/java/io/anserini/search/SearchMsmarco.java
+++ b/src/main/java/io/anserini/search/SearchMsmarco.java
@@ -22,12 +22,15 @@ import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.OptionHandlerFilter;
 import org.kohsuke.args4j.ParserProperties;
+import org.kohsuke.args4j.spi.MapOptionHandler;
 
 import java.io.File;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -73,6 +76,10 @@ public class SearchMsmarco {
 
     @Option(name = "-originalQueryWeight", metaVar = "[value]", usage = "RM3 parameter: weight to assign to the original query")
     public float originalQueryWeight = 0.5f;
+
+    @Option(name = "-fields", metaVar = "[key=value]", handler = MapOptionHandler.class,
+            usage = "Fields to search with assigned float weight")
+    public Map<String, String> fields = new HashMap<>();
   }
 
   public static void main(String[] args) throws Exception {
@@ -88,6 +95,11 @@ public class SearchMsmarco {
       return;
     }
 
+    Map<String, Float> fields = new HashMap<>();
+    retrieveArgs.fields.forEach((key, value) -> {
+      fields.put(key, Float.valueOf(value));
+    });
+
     long totalStartTime = System.nanoTime();
 
     SimpleSearcher searcher = new SimpleSearcher(retrieveArgs.index);
@@ -98,6 +110,10 @@ public class SearchMsmarco {
       searcher.setRM3Reranker(retrieveArgs.fbTerms, retrieveArgs.fbDocs, retrieveArgs.originalQueryWeight);
       System.out.println("Initializing RM3, setting fbTerms=" + retrieveArgs.fbTerms + ", fbDocs=" + retrieveArgs.fbDocs
               + " and originalQueryWeight=" + retrieveArgs.originalQueryWeight);
+    }
+
+    if (retrieveArgs.fields.size() > 0) {
+      System.out.println("Performing weighted field search with fields=" + retrieveArgs.fields);
     }
 
     PrintWriter out = new PrintWriter(Files.newBufferedWriter(Paths.get(retrieveArgs.output), StandardCharsets.US_ASCII));
@@ -113,7 +129,12 @@ public class SearchMsmarco {
         String qid = split[0];
         String query = split[1];
 
-        SimpleSearcher.Result[] hits = searcher.search(query, retrieveArgs.hits);
+        SimpleSearcher.Result[] hits;
+        if (retrieveArgs.fields.size() > 0) {
+          hits = searcher.searchFields(query, fields, retrieveArgs.hits);
+        } else {
+          hits = searcher.search(query, retrieveArgs.hits);
+        }
 
         if (lineNumber % 100 == 0) {
           double timePerQuery = (double) (System.nanoTime() - startTime) / (lineNumber + 1) / 1e9;
@@ -131,7 +152,12 @@ public class SearchMsmarco {
       List<String> queries = lines.stream().map(x -> x.trim().split("\t")[1]).collect(Collectors.toList());
       List<String> qids = lines.stream().map(x -> x.trim().split("\t")[0]).collect(Collectors.toList());
 
-      Map<String, SimpleSearcher.Result[]> results = searcher.batchSearch(queries, qids, retrieveArgs.hits, -1, retrieveArgs.threads);
+      Map<String, SimpleSearcher.Result[]> results;
+      if (retrieveArgs.fields.size() > 0) {
+        results = searcher.batchSearchFields(queries, qids, retrieveArgs.hits, retrieveArgs.threads, fields);
+      } else {
+        results = searcher.batchSearch(queries, qids, retrieveArgs.hits, retrieveArgs.threads);
+      }
 
       for (String qid : qids) {
         SimpleSearcher.Result[] hits = results.get(qid);

--- a/src/test/java/io/anserini/IndexerTestBase.java
+++ b/src/test/java/io/anserini/IndexerTestBase.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 public class IndexerTestBase extends LuceneTestCase {
-  protected static Path tempDir1;
+  protected Path tempDir1;
 
   // A very simple example of how to build an index.
   private void buildTestIndex() throws IOException {


### PR DESCRIPTION
- Added support for weighted field search with support for multiple threads on MS MARCO Passage
- Fields can be specified with command line arguments
  - ex) `-fields contents=1.0f -fields predictions=2.0f` (key is the field name and value is the weight)
- I also added a couple of of extra texts for fielded search and batch search in the `SimpleSearcherTest`
- This is so we can replicate some of the fielded docTTTTTquery results later