### PR TITLE
Background linking naming cleanup

### DIFF
--- a/docs/regressions-backgroundlinking18.md
+++ b/docs/regressions-backgroundlinking18.md
@@ -30,16 +30,16 @@ After indexing has completed, you should be able to perform retrieval as follows
 
 ```
 nohup target/appassembler/bin/SearchCollection -index lucene-index.backgroundlinking18.pos+docvectors+rawdocs \
- -topicreader NewsBackgroundLinking -topics src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt \
- -searchnewsbackground -backgroundlinking.k 100 -bm25 -hits 100 -output run.backgroundlinking18.bm25.topics.backgroundlinking18.txt &
+ -topicreader BackgroundLinking -topics src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt \
+ -backgroundlinking -backgroundlinking.k 100 -bm25 -hits 100 -output run.backgroundlinking18.bm25.topics.backgroundlinking18.txt &
 
 nohup target/appassembler/bin/SearchCollection -index lucene-index.backgroundlinking18.pos+docvectors+rawdocs \
- -topicreader NewsBackgroundLinking -topics src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt \
- -searchnewsbackground -backgroundlinking.k 100 -bm25 -rm3 -hits 100 -output run.backgroundlinking18.bm25+rm3.topics.backgroundlinking18.txt &
+ -topicreader BackgroundLinking -topics src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt \
+ -backgroundlinking -backgroundlinking.k 100 -bm25 -rm3 -hits 100 -output run.backgroundlinking18.bm25+rm3.topics.backgroundlinking18.txt &
 
 nohup target/appassembler/bin/SearchCollection -index lucene-index.backgroundlinking18.pos+docvectors+rawdocs \
- -topicreader NewsBackgroundLinking -topics src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt \
- -searchnewsbackground -backgroundlinking.datefilter -backgroundlinking.k 100 -bm25 -rm3 -hits 100 -output run.backgroundlinking18.bm25+rm3+df.topics.backgroundlinking18.txt &
+ -topicreader BackgroundLinking -topics src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt \
+ -backgroundlinking -backgroundlinking.datefilter -backgroundlinking.k 100 -bm25 -rm3 -hits 100 -output run.backgroundlinking18.bm25+rm3+df.topics.backgroundlinking18.txt &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-backgroundlinking19.md
+++ b/docs/regressions-backgroundlinking19.md
@@ -30,16 +30,16 @@ After indexing has completed, you should be able to perform retrieval as follows
 
 ```
 nohup target/appassembler/bin/SearchCollection -index lucene-index.backgroundlinking19.pos+docvectors+rawdocs \
- -topicreader NewsBackgroundLinking -topics src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt \
- -searchnewsbackground -backgroundlinking.k 100 -bm25 -hits 100 -output run.backgroundlinking19.bm25.topics.backgroundlinking19.txt &
+ -topicreader BackgroundLinking -topics src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt \
+ -backgroundlinking -backgroundlinking.k 100 -bm25 -hits 100 -output run.backgroundlinking19.bm25.topics.backgroundlinking19.txt &
 
 nohup target/appassembler/bin/SearchCollection -index lucene-index.backgroundlinking19.pos+docvectors+rawdocs \
- -topicreader NewsBackgroundLinking -topics src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt \
- -searchnewsbackground -backgroundlinking.k 100 -bm25 -rm3 -hits 100 -output run.backgroundlinking19.bm25+rm3.topics.backgroundlinking19.txt &
+ -topicreader BackgroundLinking -topics src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt \
+ -backgroundlinking -backgroundlinking.k 100 -bm25 -rm3 -hits 100 -output run.backgroundlinking19.bm25+rm3.topics.backgroundlinking19.txt &
 
 nohup target/appassembler/bin/SearchCollection -index lucene-index.backgroundlinking19.pos+docvectors+rawdocs \
- -topicreader NewsBackgroundLinking -topics src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt \
- -searchnewsbackground -backgroundlinking.datefilter -backgroundlinking.k 100 -bm25 -rm3 -hits 100 -output run.backgroundlinking19.bm25+rm3+df.topics.backgroundlinking19.txt &
+ -topicreader BackgroundLinking -topics src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt \
+ -backgroundlinking -backgroundlinking.datefilter -backgroundlinking.k 100 -bm25 -rm3 -hits 100 -output run.backgroundlinking19.bm25+rm3+df.topics.backgroundlinking19.txt &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/src/main/java/io/anserini/rerank/lib/NewsBackgroundLinkingReranker.java
+++ b/src/main/java/io/anserini/rerank/lib/NewsBackgroundLinkingReranker.java
@@ -19,7 +19,7 @@ package io.anserini.rerank.lib;
 import io.anserini.rerank.Reranker;
 import io.anserini.rerank.RerankerContext;
 import io.anserini.rerank.ScoredDocuments;
-import io.anserini.search.topicreader.NewsBackgroundLinkingTopicReader;
+import io.anserini.search.topicreader.BackgroundLinkingTopicReader;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Terms;
@@ -71,7 +71,7 @@ public class NewsBackgroundLinkingReranker implements Reranker {
 
     if (context.getSearchArgs().backgroundlinking_datefilter) {
       try {
-        int luceneId = NewsBackgroundLinkingTopicReader.convertDocidToLuceneDocid(reader, queryDocId);
+        int luceneId = BackgroundLinkingTopicReader.convertDocidToLuceneDocid(reader, queryDocId);
         Document queryDoc = reader.document(luceneId);
         long queryDocDate = Long.parseLong(queryDoc.getField(PUBLISHED_DATE.name).stringValue());
         for (int i = 0; i < docs.documents.length; i++) {
@@ -107,7 +107,7 @@ public class NewsBackgroundLinkingReranker implements Reranker {
     Map<String, Long> m = new HashMap<>();
     try {
       Terms terms = reader.getTermVector(
-          NewsBackgroundLinkingTopicReader.convertDocidToLuceneDocid(reader, docid), CONTENTS);
+          BackgroundLinkingTopicReader.convertDocidToLuceneDocid(reader, docid), CONTENTS);
       TermsEnum it = terms.iterator();
       while (it.next() != null) {
         String term = it.term().utf8ToString();

--- a/src/main/java/io/anserini/search/SearchArgs.java
+++ b/src/main/java/io/anserini/search/SearchArgs.java
@@ -54,9 +54,8 @@ public class SearchArgs {
       "index created by IndexCollection -collection TweetCollection")
   public Boolean searchtweets = false;
   
-  @Option(name = "-searchnewsbackground", usage = "Whether the search for News Track Background Linking Task " +
-      "index created by IndexCollection -collection WashingtonPostCollection")
-  public Boolean searchnewsbackground = false;
+  @Option(name = "-backgroundlinking", usage = "performs the background linking task as part of the TREC News Track")
+  public Boolean backgroundlinking = false;
   
   @Option(name = "-backgroundlinking.paragraph", usage = "construct one query string from each paragraph of the query document. " +
       "The results will be a round-robin combination of the results from running these paragraph queries")

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -34,7 +34,7 @@ import io.anserini.search.query.BagOfWordsQueryGenerator;
 import io.anserini.search.query.SdmQueryGenerator;
 import io.anserini.search.similarity.AccurateBM25Similarity;
 import io.anserini.search.similarity.TaggedSimilarity;
-import io.anserini.search.topicreader.NewsBackgroundLinkingTopicReader;
+import io.anserini.search.topicreader.BackgroundLinkingTopicReader;
 import io.anserini.search.topicreader.TopicReader;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.logging.log4j.LogManager;
@@ -179,7 +179,7 @@ public final class SearchCollection implements Closeable {
           ScoredDocuments docs;
           if (args.searchtweets) {
             docs = searchTweets(this.searcher, qid, queryString, Long.parseLong(entry.getValue().get("time")), cascade);
-          } else if (args.searchnewsbackground) {
+          } else if (args.backgroundlinking) {
             docs = searchBackgroundLinking(this.searcher, qid, queryString, cascade);
           } else{
             docs = search(this.searcher, qid, queryString, cascade);
@@ -472,7 +472,7 @@ public final class SearchCollection implements Closeable {
       args.backgroundlinking_weighted = false;
     }
     queryDocID = queryString;
-    List<String> queryList = NewsBackgroundLinkingTopicReader.generateQueryString(reader, queryDocID,
+    List<String> queryList = BackgroundLinkingTopicReader.generateQueryString(reader, queryDocID,
         args.backgroundlinking_paragraph, args.backgroundlinking_k, args.backgroundlinking_weighted, qc, analyzer);
     List<ScoredDocuments> allRes = new ArrayList<>();
     for (String queryStr : queryList) {
@@ -484,11 +484,10 @@ public final class SearchCollection implements Closeable {
         // Because the actual query strings are extracted from tokenized document!!!
         q = new StandardQueryParser().parse(queryStr, IndexArgs.CONTENTS);
       }
-      Query filter = new TermInSetQuery(WashingtonPostGenerator.WashingtonPostField.KICKER.name, new BytesRef("Opinions"), new BytesRef("Letters to the Editor"), new BytesRef("The Post's View")
-//          new Term(WapoGenerator.WapoField.KICKER.name, "Opinions"),
-//          new Term(WapoGenerator.WapoField.KICKER.name, "Letters to the Editor"),
-//          new Term(WapoGenerator.WapoField.KICKER.name, "The Post's View")
-      );
+
+      Query filter = new TermInSetQuery(WashingtonPostGenerator.WashingtonPostField.KICKER.name,
+          new BytesRef("Opinions"), new BytesRef("Letters to the Editor"), new BytesRef("The Post's View"));
+
       BooleanQuery.Builder builder = new BooleanQuery.Builder();
       builder.add(filter, BooleanClause.Occur.MUST_NOT);
       builder.add(q, BooleanClause.Occur.MUST);

--- a/src/main/java/io/anserini/search/topicreader/BackgroundLinkingTopicReader.java
+++ b/src/main/java/io/anserini/search/topicreader/BackgroundLinkingTopicReader.java
@@ -52,8 +52,8 @@ import java.util.regex.Pattern;
 /**
  * Topic reader for TREC2018 news track background linking task
  */
-public class NewsBackgroundLinkingTopicReader extends TopicReader<Integer> {
-  public NewsBackgroundLinkingTopicReader(Path topicFile) {
+public class BackgroundLinkingTopicReader extends TopicReader<Integer> {
+  public BackgroundLinkingTopicReader(Path topicFile) {
     super(topicFile);
   }
 
@@ -61,12 +61,11 @@ public class NewsBackgroundLinkingTopicReader extends TopicReader<Integer> {
       Pattern.compile("<top(.*?)</top>", Pattern.DOTALL);
   private static final Pattern NUM_PATTERN =
       Pattern.compile("<num> Number: (\\d+) </num>", Pattern.DOTALL);
-  // TREC 2011 topics uses <title> tag
   private static final Pattern DOCID_PATTERN =
       Pattern.compile("<docid>\\s*(.*?)\\s*</docid>", Pattern.DOTALL);
-  // TREC 2012 topics use <query> tag
   private static final Pattern URL_PATTERN =
-      Pattern.compile("<url>\\s*(.*?)\\s*</url>", Pattern.DOTALL);
+      Pattern.compile("<url>\\s*(.*?)\\s*</?url>", Pattern.DOTALL);
+  // Note that some TREC 2018 topics don't properly close the </url> tags.
 
   /**
    * @return SortedMap where keys are query/topic IDs and values are title portions of the topics
@@ -96,7 +95,8 @@ public class NewsBackgroundLinkingTopicReader extends TopicReader<Integer> {
         }
         fields.put("title", m.group(1));
       }
-      if (line.startsWith("<url>") && line.endsWith("</url>")) {
+      if (line.startsWith("<url>") && (line.endsWith("</url>") || line.endsWith("<url>"))) {
+        // Note that some TREC 2018 topics don't properly close the </url> tags.
         m = URL_PATTERN.matcher(line);
         if (!m.find()) {
           throw new IOException("Error parsing " + line);

--- a/src/main/resources/regression/backgroundlinking18.yaml
+++ b/src/main/resources/regression/backgroundlinking18.yaml
@@ -12,7 +12,7 @@ index_options:
   - -storePositions
   - -storeDocvectors
   - -storeRawDocs
-topic_reader: NewsBackgroundLinking
+topic_reader: BackgroundLinking
 input_roots:
   - /tuna1/      # on tuna
   - /store/      # on orca
@@ -49,7 +49,7 @@ models:
   - name: bm25
     display: BM25
     params:
-      - -searchnewsbackground -backgroundlinking.k 100 -bm25 -hits 100
+      - -backgroundlinking -backgroundlinking.k 100 -bm25 -hits 100
     results:
       AP:
         - 0.2490
@@ -58,7 +58,7 @@ models:
   - name: bm25+rm3
     display: +RM3
     params:
-      - -searchnewsbackground -backgroundlinking.k 100 -bm25 -rm3 -hits 100
+      - -backgroundlinking -backgroundlinking.k 100 -bm25 -rm3 -hits 100
     results:
       AP:
         - 0.2642
@@ -67,7 +67,7 @@ models:
   - name: bm25+rm3+df
     display: +RM3+DF
     params:
-      - -searchnewsbackground -backgroundlinking.datefilter -backgroundlinking.k 100 -bm25 -rm3 -hits 100
+      - -backgroundlinking -backgroundlinking.datefilter -backgroundlinking.k 100 -bm25 -rm3 -hits 100
     results:
       AP:
         - 0.2692

--- a/src/main/resources/regression/backgroundlinking19.yaml
+++ b/src/main/resources/regression/backgroundlinking19.yaml
@@ -12,7 +12,7 @@ index_options:
   - -storePositions
   - -storeDocvectors
   - -storeRawDocs
-topic_reader: NewsBackgroundLinking
+topic_reader: BackgroundLinking
 input_roots:
   - /tuna1/      # on tuna
   - /store/      # on orca
@@ -49,7 +49,7 @@ models:
   - name: bm25
     display: BM25
     params:
-      - -searchnewsbackground -backgroundlinking.k 100 -bm25 -hits 100
+      - -backgroundlinking -backgroundlinking.k 100 -bm25 -hits 100
     results:
       AP:
         - 0.3027
@@ -58,7 +58,7 @@ models:
   - name: bm25+rm3
     display: +RM3
     params:
-      - -searchnewsbackground -backgroundlinking.k 100 -bm25 -rm3 -hits 100
+      - -backgroundlinking -backgroundlinking.k 100 -bm25 -rm3 -hits 100
     results:
       AP:
         - 0.3790
@@ -67,7 +67,7 @@ models:
   - name: bm25+rm3+df
     display: +RM3+DF
     params:
-      - -searchnewsbackground -backgroundlinking.datefilter -backgroundlinking.k 100 -bm25 -rm3 -hits 100
+      - -backgroundlinking -backgroundlinking.datefilter -backgroundlinking.k 100 -bm25 -rm3 -hits 100
     results:
       AP:
         - 0.3158

--- a/src/test/java/io/anserini/search/topicreader/BackgroundLinkingTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/BackgroundLinkingTopicReaderTest.java
@@ -1,0 +1,71 @@
+/*
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.search.topicreader;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.SortedMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class BackgroundLinkingTopicReaderTest {
+
+  @Test
+  public void test2018() throws IOException {
+    TopicReader<Integer> reader = new BackgroundLinkingTopicReader(
+        Paths.get("src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt"));
+
+    SortedMap<Integer, Map<String, String>> topics = reader.read();
+
+    assertEquals(50, topics.keySet().size());
+    assertEquals(321, (int) topics.firstKey());
+    assertEquals("9171debc316e5e2782e0d2404ca7d09d", topics.get(topics.firstKey()).get("title"));
+    assertEquals("https://www.washingtonpost.com/news/worldviews/wp/2016/09/01/" +
+        "women-are-half-of-the-world-but-only-22-percent-of-its-parliaments/",
+        topics.get(topics.firstKey()).get("url"));
+
+    assertEquals(825, (int) topics.lastKey());
+    assertEquals("a1c41a70-35c7-11e3-8a0e-4e2cf80831fc", topics.get(topics.lastKey()).get("title"));
+    assertEquals("https://www.washingtonpost.com/business/economy/" +
+        "cellulosic-ethanol-once-the-way-of-the-future-is-off-to-a-delayed-boisterous-start/" +
+        "2013/11/08/a1c41a70-35c7-11e3-8a0e-4e2cf80831fc_story.html", topics.get(topics.lastKey()).get("url"));
+  }
+
+  @Test
+  public void test2019() throws IOException {
+    TopicReader<Integer> reader = new BackgroundLinkingTopicReader(
+        Paths.get("src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt"));
+
+    SortedMap<Integer, Map<String, String>> topics = reader.read();
+
+    assertEquals(60, topics.keySet().size());
+    assertEquals(826, (int) topics.firstKey());
+    assertEquals("96ab542e-6a07-11e6-ba32-5a4bf5aad4fa", topics.get(topics.firstKey()).get("title"));
+    assertEquals("https://www.washingtonpost.com/sports/nationals/" +
+        "the-minor-leagues-life-in-pro-baseballs-shadowy-corner/" +
+        "2016/08/26/96ab542e-6a07-11e6-ba32-5a4bf5aad4fa_story.html", topics.get(topics.firstKey()).get("url"));
+
+    assertEquals(885, (int) topics.lastKey());
+    assertEquals("5ae44bfd66a49bcad7b55b29b55d63b6", topics.get(topics.lastKey()).get("title"));
+    assertEquals("https://www.washingtonpost.com/news/capital-weather-gang/wp/2017/07/14/" +
+        "sun-erupts-to-mark-another-bastille-day-aurora-possible-in-new-england-sunday-night/",
+        topics.get(topics.lastKey()).get("url"));
+  }
+}


### PR DESCRIPTION
Lots of inconsistencies in options, naming, etc; we have `searchnewsbackground` and `backgroundlinking` and `NewsBackgroundLinking`. I standardized all names/options around `backgroundlinking`.