### PR TITLE
Added methods to get postings lists based on analyzed and unanalyzed forms in IndexReaderUtils

### DIFF
--- a/src/main/java/io/anserini/analysis/AnalyzerUtils.java
+++ b/src/main/java/io/anserini/analysis/AnalyzerUtils.java
@@ -16,6 +16,7 @@
 
 package io.anserini.analysis;
 
+import io.anserini.index.IndexCollection;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
@@ -26,7 +27,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class AnalyzerUtils {
-  static public List<String> tokenize(Analyzer analyzer, String s) {
+
+  static public List<String> analyze(String s) {
+    return analyze(IndexCollection.DEFAULT_ANALYZER, s);
+  }
+
+  static public List<String> analyze(Analyzer analyzer, String s) {
     List<String> list = new ArrayList<>();
 
     try {

--- a/src/main/java/io/anserini/ann/ApproximateNearestNeighborEval.java
+++ b/src/main/java/io/anserini/ann/ApproximateNearestNeighborEval.java
@@ -153,7 +153,7 @@ public class ApproximateNearestNeighborEval {
     System.out.println("Evaluating at retrieval depth: " + indexArgs.depth);
     TrecTopicReader trecTopicReader = new TrecTopicReader(indexArgs.topicsPath);
     Collection<String> words = new LinkedList<>();
-    trecTopicReader.read().values().forEach(e -> words.addAll(AnalyzerUtils.tokenize(standardAnalyzer, e.get("title"))));
+    trecTopicReader.read().values().forEach(e -> words.addAll(AnalyzerUtils.analyze(standardAnalyzer, e.get("title"))));
     int queryCount = 0;
     for (String word : words) {
       if (wordVectors.containsKey(word)) {
@@ -173,7 +173,7 @@ public class ApproximateNearestNeighborEval {
           if (indexArgs.msm > 0) {
             simQuery.setLowFreqMinimumNumberShouldMatch(indexArgs.msm);
           }
-          for (String token : AnalyzerUtils.tokenize(vectorAnalyzer, fvString)) {
+          for (String token : AnalyzerUtils.analyze(vectorAnalyzer, fvString)) {
             simQuery.add(new Term(IndexVectors.FIELD_VECTOR, token));
           }
 

--- a/src/main/java/io/anserini/ann/ApproximateNearestNeighborSearch.java
+++ b/src/main/java/io/anserini/ann/ApproximateNearestNeighborSearch.java
@@ -141,7 +141,7 @@ public class ApproximateNearestNeighborSearch {
       sb.append(fv);
     }
     CommonTermsQuery simQuery = new CommonTermsQuery(SHOULD, SHOULD, indexArgs.cutoff);
-    for (String token : AnalyzerUtils.tokenize(vectorAnalyzer, sb.toString())) {
+    for (String token : AnalyzerUtils.analyze(vectorAnalyzer, sb.toString())) {
       simQuery.add(new Term(IndexVectors.FIELD_VECTOR, token));
     }
     if (indexArgs.msm > 0) {

--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -314,6 +314,20 @@ public class IndexReaderUtils {
     }
   }
 
+  // These are bindings for Pyserini to work, because Pyjnius can't seem to distinguish overloaded methods.
+  // jnius.JavaException: No methods matching your arguments
+  public static List<Posting> getPostingsListForUnanalyzedTerm(IndexReader reader, String term) {
+    return getPostingsList(reader, term, true);
+  }
+
+  public static List<Posting> getPostingsListForAnalyzedTerm(IndexReader reader, String term) {
+    return getPostingsList(reader, term, false);
+  }
+
+  public static List<Posting> getPostingsListWithAnalyzer(IndexReader reader, String term, Analyzer analyzer) {
+    return getPostingsList(reader, term, analyzer);
+  }
+
   /**
    * Returns the document vector for a particular document as a map of terms to term frequencies.
    * @param reader index reader

--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -298,9 +298,9 @@ public class IndexReaderUtils {
   }
 
   // Internal helper: takes the analyzed form in all cases.
-  private static List<Posting> _getPostingsList(IndexReader reader, String raw) {
+  private static List<Posting> _getPostingsList(IndexReader reader, String analyzedTerm) {
     try {
-      Term t = new Term(IndexArgs.CONTENTS, raw);
+      Term t = new Term(IndexArgs.CONTENTS, analyzedTerm);
       PostingsEnum postingsEnum = MultiTerms.getTermPostingsEnum(reader, IndexArgs.CONTENTS, t.bytes());
 
       List<Posting> postingsList = new ArrayList<>();

--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -204,25 +204,6 @@ public class IndexReaderUtils {
     return DirectoryReader.open(dir);
   }
 
-  /**
-   * Feeds a string through the {@link EnglishStemmingAnalyzer} and returns the list of stemmed tokens.
-   * @param text input string
-   * @return list of stemmed tokens
-   */
-  public static List<String> analyze(String text) {
-    return analyzeWithAnalyzer(text, DEFAULT_ANALYZER);
-  }
-
-  /**
-   * Feeds a string through an analyzer and returns the list of stemmed tokens.
-   * @param text input string
-   * @param analyzer analyzer to use
-   * @return list of stemmed tokens
-   */
-  public static List<String> analyzeWithAnalyzer(String text, Analyzer analyzer) {
-    return AnalyzerUtils.tokenize(analyzer, text);
-  }
-
   public static Map<String, Long> getTermCounts(IndexReader reader, String termStr) throws IOException, ParseException {
     EnglishAnalyzer ea = new EnglishAnalyzer(CharArraySet.EMPTY_SET);
     QueryParser qp = new QueryParser(IndexArgs.CONTENTS, ea);
@@ -280,21 +261,57 @@ public class IndexReaderUtils {
     };
   }
 
-  public static List<Posting> getPostingsList(IndexReader reader, String termStr)
-      throws IOException, ParseException {
-    EnglishAnalyzer ea = new EnglishAnalyzer(CharArraySet.EMPTY_SET);
-    QueryParser qp = new QueryParser(IndexArgs.CONTENTS, ea);
-    TermQuery q = (TermQuery) qp.parse(termStr);
-    Term t = q.getTerm();
+  /**
+   * Returns the postings list for an unanalyzed term. That is, the method analyzes the term before looking up its
+   * postings list.
+   *
+   * @param reader index reader
+   * @param term unanalyzed term
+   * @return the postings list for an unanalyzed term
+   */
+  public static List<Posting> getPostingsList(IndexReader reader, String term) {
+    return _getPostingsList(reader, AnalyzerUtils.analyze(term).get(0));
+  }
 
-    PostingsEnum postingsEnum = MultiTerms.getTermPostingsEnum(reader, IndexArgs.CONTENTS, t.bytes());
+  /**
+   * Returns the postings list for a term.
+   *
+   * @param reader index reader
+   * @param term term
+   * @param analyze whether or not the method should analyze the term first
+   * @return the postings list for a term
+   */
+  public static List<Posting> getPostingsList(IndexReader reader, String term, boolean analyze) {
+    return _getPostingsList(reader, analyze ? AnalyzerUtils.analyze(term).get(0) : term);
+  }
 
-    List<Posting> postingsList = new ArrayList<>();
-    while (postingsEnum.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-      postingsList.add(new Posting(postingsEnum));
+  /**
+   * Returns the postings list for a term after analysis with a specific analyzer.
+   *
+   * @param reader index reader
+   * @param term term
+   * @param analyzer analyzer
+   * @return the postings list for an unanalyzed term
+   */
+  public static List<Posting> getPostingsList(IndexReader reader, String term, Analyzer analyzer) {
+    return _getPostingsList(reader, AnalyzerUtils.analyze(analyzer, term).get(0));
+  }
+
+  // Internal helper: takes the analyzed form in all cases.
+  private static List<Posting> _getPostingsList(IndexReader reader, String raw) {
+    try {
+      Term t = new Term(IndexArgs.CONTENTS, raw);
+      PostingsEnum postingsEnum = MultiTerms.getTermPostingsEnum(reader, IndexArgs.CONTENTS, t.bytes());
+
+      List<Posting> postingsList = new ArrayList<>();
+      while (postingsEnum.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+        postingsList.add(new Posting(postingsEnum));
+      }
+
+      return postingsList;
+    } catch (Exception e) {
+      return null;
     }
-
-    return postingsList;
   }
 
   /**

--- a/src/main/java/io/anserini/ltr/BaseFeatureExtractor.java
+++ b/src/main/java/io/anserini/ltr/BaseFeatureExtractor.java
@@ -142,7 +142,7 @@ abstract public class BaseFeatureExtractor<K> {
             // We will not be checking for nulls here because the input should be correct,
             // and if not it signals other issues
             q = parseQuery(queryText);
-            List<String> queryTokens = AnalyzerUtils.tokenize(queryAnalyzer, queryText);
+            List<String> queryTokens = AnalyzerUtils.analyze(queryAnalyzer, queryText);
             // Construct the reranker context
             RerankerContext<K> context = new RerankerContext<>(searcher, (K)qid,
                     q, null, queryText,

--- a/src/main/java/io/anserini/ltr/DumpTweetsLtrData.java
+++ b/src/main/java/io/anserini/ltr/DumpTweetsLtrData.java
@@ -130,7 +130,7 @@ public class DumpTweetsLtrData {
       Query q = builder.build();
 
       TopDocs rs = searcher.search(q, args.hits);
-      List<String> queryTokens = AnalyzerUtils.tokenize(new TweetAnalyzer(), queryString);
+      List<String> queryTokens = AnalyzerUtils.analyze(new TweetAnalyzer(), queryString);
 
       RerankerContext<Integer> context = new RerankerContext<>(searcher, Integer.parseInt(queryString), query, null,
           queryString, queryTokens, filter, null);

--- a/src/main/java/io/anserini/rerank/lib/BM25PrfReranker.java
+++ b/src/main/java/io/anserini/rerank/lib/BM25PrfReranker.java
@@ -95,7 +95,7 @@ public class BM25PrfReranker implements Reranker {
     BM25Similarity originalSimilarity = (BM25Similarity) searcher.getSimilarity();
     searcher.setSimilarity(new BM25PrfSimilarity(k1, b));
     IndexReader reader = searcher.getIndexReader();
-    List<String> originalQueryTerms = AnalyzerUtils.tokenize(analyzer, context.getQueryText());
+    List<String> originalQueryTerms = AnalyzerUtils.analyze(analyzer, context.getQueryText());
 
     PrfFeatures fv = expandQuery(originalQueryTerms, docs, reader);
     Query newQuery = fv.toQuery();

--- a/src/main/java/io/anserini/rerank/lib/Rm3Reranker.java
+++ b/src/main/java/io/anserini/rerank/lib/Rm3Reranker.java
@@ -73,7 +73,7 @@ public class Rm3Reranker implements Reranker {
     IndexSearcher searcher = context.getIndexSearcher();
     IndexReader reader = searcher.getIndexReader();
 
-    FeatureVector qfv = FeatureVector.fromTerms(AnalyzerUtils.tokenize(analyzer, context.getQueryText())).scaleToUnitL1Norm();
+    FeatureVector qfv = FeatureVector.fromTerms(AnalyzerUtils.analyze(analyzer, context.getQueryText())).scaleToUnitL1Norm();
 
     FeatureVector rm = estimateRelevanceModel(docs, reader, context.getSearchArgs().searchtweets);
 

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -458,7 +458,7 @@ public final class SearchCollection implements Closeable {
       }
     }
 
-    List<String> queryTokens = AnalyzerUtils.tokenize(analyzer, queryString);
+    List<String> queryTokens = AnalyzerUtils.analyze(analyzer, queryString);
     RerankerContext context = new RerankerContext<>(searcher, qid, query, null, queryString, queryTokens, null, args);
 
     return cascade.run(ScoredDocuments.fromTopDocs(rs, searcher), context);
@@ -549,7 +549,7 @@ public final class SearchCollection implements Closeable {
     } else {
       keywordQuery = new BagOfWordsQueryGenerator().buildQuery(IndexArgs.CONTENTS, analyzer, queryString);
     }
-    List<String> queryTokens = AnalyzerUtils.tokenize(analyzer, queryString);
+    List<String> queryTokens = AnalyzerUtils.analyze(analyzer, queryString);
 
     // Do not consider the tweets with tweet ids that are beyond the queryTweetTime
     // <querytweettime> tag contains the timestamp of the query in terms of the

--- a/src/main/java/io/anserini/search/SimpleSearcher.java
+++ b/src/main/java/io/anserini/search/SimpleSearcher.java
@@ -270,7 +270,7 @@ public class SimpleSearcher implements Closeable {
 
   public Result[] search(String q, int k, long t) throws IOException {
     Query query = new BagOfWordsQueryGenerator().buildQuery(IndexArgs.CONTENTS, analyzer, q);
-    List<String> queryTokens = AnalyzerUtils.tokenize(analyzer, q);
+    List<String> queryTokens = AnalyzerUtils.analyze(analyzer, q);
 
     return search(query, queryTokens, q, k, t);
   }
@@ -345,7 +345,7 @@ public class SimpleSearcher implements Closeable {
     }
 
     BooleanQuery query = queryBuilder.build();
-    List<String> queryTokens = AnalyzerUtils.tokenize(analyzer, q);
+    List<String> queryTokens = AnalyzerUtils.analyze(analyzer, q);
 
     return search(query, queryTokens, q, k, -1);
   }

--- a/src/main/java/io/anserini/search/query/BagOfWordsQueryGenerator.java
+++ b/src/main/java/io/anserini/search/query/BagOfWordsQueryGenerator.java
@@ -32,7 +32,7 @@ import java.util.List;
 public class BagOfWordsQueryGenerator extends QueryGenerator {
   @Override
   public Query buildQuery(String field, Analyzer analyzer, String queryText) {
-    List<String> tokens = AnalyzerUtils.tokenize(analyzer, queryText);
+    List<String> tokens = AnalyzerUtils.analyze(analyzer, queryText);
   
     BooleanQuery.Builder builder = new BooleanQuery.Builder();
     for (String t : tokens) {

--- a/src/main/java/io/anserini/search/query/QueryGenerator.java
+++ b/src/main/java/io/anserini/search/query/QueryGenerator.java
@@ -16,16 +16,9 @@
 
 package io.anserini.search.query;
 
-import io.anserini.analysis.AnalyzerUtils;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 
-import java.util.List;
-
 public abstract class QueryGenerator {
-  static public List<String> tokenize(Analyzer analyzer, String s) {
-    return AnalyzerUtils.tokenize(analyzer, s);
-  }
-  
   public abstract Query buildQuery(String field, Analyzer analyzer, String queryText);
 }

--- a/src/main/java/io/anserini/search/query/SdmQueryGenerator.java
+++ b/src/main/java/io/anserini/search/query/SdmQueryGenerator.java
@@ -55,7 +55,7 @@ public class SdmQueryGenerator extends QueryGenerator {
   */
   @Override
   public Query buildQuery(String field, Analyzer analyzer, String queryText) {
-    List<String> tokens = AnalyzerUtils.tokenize(analyzer, queryText);
+    List<String> tokens = AnalyzerUtils.analyze(analyzer, queryText);
     
     BooleanQuery.Builder termsBuilder = new BooleanQuery.Builder();
     if (tokens.size() == 1) {

--- a/src/main/java/io/anserini/search/topicreader/BackgroundLinkingTopicReader.java
+++ b/src/main/java/io/anserini/search/topicreader/BackgroundLinkingTopicReader.java
@@ -141,7 +141,7 @@ public class BackgroundLinkingTopicReader extends TopicReader<Integer> {
       queryStrings.add(getRawContents(rawDocStr.stringValue()));
     }
     for (int i = 0; i < queryStrings.size(); i++) {
-      List<String> queryTokens = AnalyzerUtils.tokenize(analyzer, queryStrings.get(i));
+      List<String> queryTokens = AnalyzerUtils.analyze(analyzer, queryStrings.get(i));
       if (qc == SearchCollection.QueryConstructor.SequentialDependenceModel) {
         String queryString = String.join(" ", queryTokens.subList(0, Math.min(queryTokens.size(), k)));
         queryStrings.set(i, queryString);

--- a/src/main/java/io/anserini/util/DumpAnalyzedQueries.java
+++ b/src/main/java/io/anserini/util/DumpAnalyzedQueries.java
@@ -92,7 +92,7 @@ public class DumpAnalyzedQueries {
 
     FileOutputStream out = new FileOutputStream(args.output);
     for (Map.Entry<?, Map<String, String>> entry : topics.entrySet()) {
-      List<String> tokens = AnalyzerUtils.tokenize(IndexCollection.DEFAULT_ANALYZER, entry.getValue().get("title"));
+      List<String> tokens = AnalyzerUtils.analyze(IndexCollection.DEFAULT_ANALYZER, entry.getValue().get("title"));
       out.write((entry.getKey() + "\t" + StringUtils.join(tokens, " ") + "\n").getBytes());
     }
     out.close();

--- a/src/test/java/io/anserini/IndexerTestBase.java
+++ b/src/test/java/io/anserini/IndexerTestBase.java
@@ -58,7 +58,7 @@ public class IndexerTestBase extends LuceneTestCase {
     textOptions.setStoreTermVectorPositions(true);
 
     Document doc1 = new Document();
-    String doc1Text = "here is some text here is some more text";
+    String doc1Text = "here is some text here is some more text. city.";
     doc1.add(new StringField("id", "doc1", Field.Store.YES));
     doc1.add(new SortedDocValuesField("id", new BytesRef("doc1".getBytes())));
     doc1.add(new Field("contents", doc1Text , textOptions));

--- a/src/test/java/io/anserini/analysis/EnglishStemmingAnalyzerTest.java
+++ b/src/test/java/io/anserini/analysis/EnglishStemmingAnalyzerTest.java
@@ -28,7 +28,7 @@ public class EnglishStemmingAnalyzerTest {
   @Test
   public void test1() {
     Analyzer analyzer = new EnglishStemmingAnalyzer("porter");
-    List<String> tokens = AnalyzerUtils.tokenize(analyzer, "city buses are running on schedule");
+    List<String> tokens = AnalyzerUtils.analyze(analyzer, "city buses are running on schedule");
 
     assertEquals(4, tokens.size());
     assertEquals("citi", tokens.get(0));
@@ -40,7 +40,7 @@ public class EnglishStemmingAnalyzerTest {
   @Test
   public void test2() {
     Analyzer analyzer = new EnglishStemmingAnalyzer("krovetz");
-    List<String> tokens = AnalyzerUtils.tokenize(analyzer, "city buses are running on schedule");
+    List<String> tokens = AnalyzerUtils.analyze(analyzer, "city buses are running on schedule");
 
     assertEquals(4, tokens.size());
     assertEquals("city", tokens.get(0));
@@ -50,9 +50,21 @@ public class EnglishStemmingAnalyzerTest {
   }
 
   @Test
+  public void test3() {
+    // Default is porter
+    List<String> tokens = AnalyzerUtils.analyze("city buses are running on schedule");
+
+    assertEquals(4, tokens.size());
+    assertEquals("citi", tokens.get(0));
+    assertEquals("buse", tokens.get(1));
+    assertEquals("run", tokens.get(2));
+    assertEquals("schedul", tokens.get(3));
+  }
+
+  @Test
   public void testNoStopwordsNoStemming() {
     Analyzer analyzer = new EnglishStemmingAnalyzer(CharArraySet.EMPTY_SET);
-    List<String> tokens = AnalyzerUtils.tokenize(analyzer, "this should not do stemming and should have stopwords");
+    List<String> tokens = AnalyzerUtils.analyze(analyzer, "this should not do stemming and should have stopwords");
 
     assertEquals(9, tokens.size());
     assertEquals("this", tokens.get(0));

--- a/src/test/java/io/anserini/analysis/TokenizeOnlyAnalyzerTest.java
+++ b/src/test/java/io/anserini/analysis/TokenizeOnlyAnalyzerTest.java
@@ -11,7 +11,7 @@ public class TokenizeOnlyAnalyzerTest {
   @Test
   public void test1() {
     Analyzer analyzer = new TokenizeOnlyAnalyzer();
-    List<String> tokens = AnalyzerUtils.tokenize(analyzer, "city buses are running on schedule");
+    List<String> tokens = AnalyzerUtils.analyze(analyzer, "city buses are running on schedule");
 
     assertEquals(6, tokens.size());
     assertEquals("city", tokens.get(0));

--- a/src/test/java/io/anserini/ann/fw/FakeWordsEncoderAnalyzerTest.java
+++ b/src/test/java/io/anserini/ann/fw/FakeWordsEncoderAnalyzerTest.java
@@ -84,7 +84,7 @@ public class FakeWordsEncoderAnalyzerTest {
   private void assertSimQuery(Analyzer analyzer, String fieldName, String text, DirectoryReader reader) throws IOException {
     IndexSearcher searcher = new IndexSearcher(reader);
     CommonTermsQuery simQuery = new CommonTermsQuery(SHOULD, SHOULD, 1);
-    for (String token : AnalyzerUtils.tokenize(analyzer, text)) {
+    for (String token : AnalyzerUtils.analyze(analyzer, text)) {
       simQuery.add(new Term(fieldName, token));
     }
     TopDocs topDocs = searcher.search(simQuery, 1);

--- a/src/test/java/io/anserini/ann/lexlsh/LexicalLshAnalyzerTest.java
+++ b/src/test/java/io/anserini/ann/lexlsh/LexicalLshAnalyzerTest.java
@@ -117,7 +117,7 @@ public class LexicalLshAnalyzerTest {
   private void assertSimQuery(LexicalLshAnalyzer analyzer, String fieldName, String text, DirectoryReader reader) throws IOException {
     IndexSearcher searcher = new IndexSearcher(reader);
     CommonTermsQuery simQuery = new CommonTermsQuery(SHOULD, SHOULD, 1);
-    for (String token : AnalyzerUtils.tokenize(analyzer, text)) {
+    for (String token : AnalyzerUtils.analyze(analyzer, text)) {
       simQuery.add(new Term(fieldName, token));
     }
     TopDocs topDocs = searcher.search(simQuery, 1);

--- a/src/test/java/io/anserini/index/BasicIndexOperationsTest.java
+++ b/src/test/java/io/anserini/index/BasicIndexOperationsTest.java
@@ -91,7 +91,7 @@ public class BasicIndexOperationsTest extends IndexerTestBase {
     }
 
     assertEquals(3, norms.size());
-    assertEquals(7, (int) norms.get(0));
+    assertEquals(8, (int) norms.get(0));
     assertEquals(2, (int) norms.get(1));
     assertEquals(2, (int) norms.get(2));
   }

--- a/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
+++ b/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
@@ -114,7 +114,7 @@ public class IndexReaderUtilsTest extends IndexerTestBase {
   public void testPostingsNonExistings() throws Exception {
     Directory dir = FSDirectory.open(tempDir1);
     IndexReader reader = DirectoryReader.open(dir);
-    assertEquals(null, IndexReaderUtils.getPostingsList(reader, "asxe"));
+    assertNull(IndexReaderUtils.getPostingsList(reader, "asxe"));
   }
 
   @Test

--- a/src/test/java/io/anserini/ltr/BaseFeatureExtractorTest.java
+++ b/src/test/java/io/anserini/ltr/BaseFeatureExtractorTest.java
@@ -105,7 +105,7 @@ abstract public class BaseFeatureExtractorTest<T> extends LuceneTestCase {
         TEST_PARSER.parse(queryText),
         null,
         queryText,
-        AnalyzerUtils.tokenize(TEST_ANALYZER, queryText),
+        AnalyzerUtils.analyze(TEST_ANALYZER, queryText),
         null, null);
       return context;
     } catch (ParseException e) {

--- a/src/test/java/io/anserini/search/SimpleSearcherTest.java
+++ b/src/test/java/io/anserini/search/SimpleSearcherTest.java
@@ -36,8 +36,8 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(1, results.length);
     assertEquals("doc1", results[0].docid);
     assertEquals(0, results[0].ldocid);
-    assertEquals(0.2912999987602234f, results[0].score, 10e-6);
-    assertEquals("here is some text here is some more text", results[0].content);
+    assertEquals(0.2883000075817108f, results[0].score, 10e-6);
+    assertEquals("here is some text here is some more text. city.", results[0].content);
 
     results = searcher.search("text");
     assertEquals(2, results.length);
@@ -45,14 +45,14 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(0, results[0].ldocid);
     assertEquals("doc2", results[1].docid);
     assertEquals(1, results[1].ldocid);
-    assertEquals(0.2912999987602234f, results[0].score, 10e-6);
-    assertEquals(0.27070000767707825f, results[1].score, 10e-6);
+    assertEquals(0.2883000075817108f, results[0].score, 10e-6);
+    assertEquals(0.2732999920845032f, results[1].score, 10e-6);
 
     results = searcher.search("test");
     assertEquals(1, results.length);
     assertEquals("doc3", results[0].docid);
     assertEquals(2, results[0].ldocid);
-    assertEquals(0.5648999810218811f, results[0].score, 10e-6);
+    assertEquals(0.5702000260353088f, results[0].score, 10e-6);
 
     searcher.close();
   }
@@ -61,7 +61,7 @@ public class SimpleSearcherTest extends IndexerTestBase {
   public void test2() throws Exception {
     SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
 
-    assertEquals("here is some text here is some more text",
+    assertEquals("here is some text here is some more text. city.",
         searcher.doc(0).getField("contents").stringValue());
     assertEquals("more texts",
         searcher.doc(1).getField("contents").stringValue());
@@ -69,7 +69,7 @@ public class SimpleSearcherTest extends IndexerTestBase {
         searcher.doc(2).getField("contents").stringValue());
     assertEquals(null, searcher.doc(3));
 
-    assertEquals("here is some text here is some more text",
+    assertEquals("here is some text here is some more text. city.",
         searcher.doc("doc1").getField("contents").stringValue());
     assertEquals("more texts",
         searcher.doc("doc2").getField("contents").stringValue());
@@ -84,12 +84,12 @@ public class SimpleSearcherTest extends IndexerTestBase {
   public void test3() throws Exception {
     SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
 
-    assertEquals("here is some text here is some more text", searcher.getContents(0));
+    assertEquals("here is some text here is some more text. city.", searcher.getContents(0));
     assertEquals("more texts", searcher.getContents(1));
     assertEquals("here is a test", searcher.getContents(2));
     assertEquals(null, searcher.doc(3));
 
-    assertEquals("here is some text here is some more text", searcher.getContents("doc1"));
+    assertEquals("here is some text here is some more text. city.", searcher.getContents("doc1"));
     assertEquals("more texts", searcher.getContents("doc2"));
     assertEquals("here is a test", searcher.getContents("doc3"));
     assertEquals(null, searcher.getContents("doc42"));

--- a/src/test/java/io/anserini/search/topicreader/CarTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/CarTopicReaderTest.java
@@ -17,8 +17,7 @@
 package io.anserini.search.topicreader;
 
 import io.anserini.analysis.AnalyzerUtils;
-import io.anserini.analysis.EnglishStemmingAnalyzer;
-import org.apache.lucene.analysis.Analyzer;
+import io.anserini.index.IndexCollection;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -47,8 +46,7 @@ public class CarTopicReaderTest {
     assertEquals("Yellowstone National Park/Recreation", query);
 
     // Make sure that the slash is properly tokenized.
-    Analyzer analyzer = new EnglishStemmingAnalyzer("porter");
-    List<String> tokens =  AnalyzerUtils.tokenize(analyzer, query);
+    List<String> tokens =  AnalyzerUtils.analyze(IndexCollection.DEFAULT_ANALYZER, query);
     assertEquals(4, tokens.size());
     assertEquals("recreat", tokens.get(3));
   }

--- a/src/test/java/io/anserini/util/ExtractDocumentLengthsTest.java
+++ b/src/test/java/io/anserini/util/ExtractDocumentLengthsTest.java
@@ -53,7 +53,7 @@ public class ExtractDocumentLengthsTest extends IndexerTestBase {
 
     List<String> lines = Files.readAllLines(Paths.get(randomFileName));
     assertEquals(4, lines.size());
-    assertEquals("0\t7\t4\t7\t4", lines.get(1));
+    assertEquals("0\t8\t5\t8\t5", lines.get(1));
     assertEquals("1\t2\t2\t2\t2", lines.get(2));
     assertEquals("2\t2\t2\t2\t2", lines.get(3));
   }

--- a/src/test/java/io/anserini/util/ExtractNormsTest.java
+++ b/src/test/java/io/anserini/util/ExtractNormsTest.java
@@ -53,7 +53,7 @@ public class ExtractNormsTest extends IndexerTestBase {
 
     List<String> lines = Files.readAllLines(Paths.get(randomFileName));
     assertEquals(4, lines.size());
-    assertEquals("0\t7", lines.get(1));
+    assertEquals("0\t8", lines.get(1));
     assertEquals("1\t2", lines.get(2));
     assertEquals("2\t2", lines.get(3));
   }


### PR DESCRIPTION
Closes #990 

The primary change is that `IndexReaderUtils` now has methods to fetch postings lists given analyzed and unanalyzed forms. However, this necessitated a bunch of changes for proper testing, etc.
