### PR TITLE
Optional analyzer in getTermCounts

### DIFF
--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -17,6 +17,7 @@
 package io.anserini.index;
 
 import io.anserini.analysis.AnalyzerUtils;
+import io.anserini.analysis.DefaultEnglishAnalyzer;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
@@ -25,8 +26,6 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.CharArraySet;
-import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexableField;
@@ -204,11 +203,11 @@ public class IndexReaderUtils {
   }
 
   public static Map<String, Long> getTermCounts(IndexReader reader, String termStr) throws IOException, ParseException {
-    EnglishAnalyzer ea = new EnglishAnalyzer(CharArraySet.EMPTY_SET);
-    return getTermCounts(reader, termStr, ea);
+    DefaultEnglishAnalyzer ea = DefaultEnglishAnalyzer.newDefaultInstance();
+    return getTermCountsWithAnalyzer(reader, termStr, ea);
   }
 
-  public static Map<String, Long> getTermCounts(IndexReader reader, String termStr, Analyzer analyzer) throws IOException, ParseException {
+  public static Map<String, Long> getTermCountsWithAnalyzer(IndexReader reader, String termStr, Analyzer analyzer) throws IOException, ParseException {
     QueryParser qp = new QueryParser(IndexArgs.CONTENTS, analyzer);
     TermQuery q = (TermQuery) qp.parse(termStr);
     Term t = q.getTerm();

--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -205,13 +205,17 @@ public class IndexReaderUtils {
 
   public static Map<String, Long> getTermCounts(IndexReader reader, String termStr) throws IOException, ParseException {
     EnglishAnalyzer ea = new EnglishAnalyzer(CharArraySet.EMPTY_SET);
-    QueryParser qp = new QueryParser(IndexArgs.CONTENTS, ea);
+    return getTermCounts(reader, termStr, ea);
+  }
+
+  public static Map<String, Long> getTermCounts(IndexReader reader, String termStr, Analyzer analyzer) throws IOException, ParseException {
+    QueryParser qp = new QueryParser(IndexArgs.CONTENTS, analyzer);
     TermQuery q = (TermQuery) qp.parse(termStr);
     Term t = q.getTerm();
 
     Map<String, Long> termInfo = Map.ofEntries(
-        Map.entry("collectionFreq", reader.totalTermFreq(t)),
-        Map.entry("docFreq", Long.valueOf(reader.docFreq(t)))
+      Map.entry("collectionFreq", reader.totalTermFreq(t)),
+      Map.entry("docFreq", Long.valueOf(reader.docFreq(t)))
     );
 
     return termInfo;

--- a/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
+++ b/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
@@ -70,6 +70,35 @@ public class IndexReaderUtilsTest extends IndexerTestBase {
   }
 
   @Test
+  public void testTermCountsWithAnalyzer() throws Exception {
+    Directory dir = FSDirectory.open(tempDir1);
+    IndexReader reader = DirectoryReader.open(dir);
+    DefaultEnglishAnalyzer analyzer = DefaultEnglishAnalyzer.newDefaultInstance();
+
+    Map<String, Long> termCountMap;
+
+    termCountMap = IndexReaderUtils.getTermCountsWithAnalyzer(reader, "here", analyzer);
+    assertEquals(Long.valueOf(3), termCountMap.get("collectionFreq"));
+    assertEquals(Long.valueOf(2), termCountMap.get("docFreq"));
+
+    termCountMap = IndexReaderUtils.getTermCountsWithAnalyzer(reader, "more", analyzer);
+    assertEquals(Long.valueOf(2), termCountMap.get("collectionFreq"));
+    assertEquals(Long.valueOf(2), termCountMap.get("docFreq"));
+
+    termCountMap = IndexReaderUtils.getTermCountsWithAnalyzer(reader, "some", analyzer);
+    assertEquals(Long.valueOf(2), termCountMap.get("collectionFreq"));
+    assertEquals(Long.valueOf(1), termCountMap.get("docFreq"));
+
+    termCountMap = IndexReaderUtils.getTermCountsWithAnalyzer(reader, "test", analyzer);
+    assertEquals(Long.valueOf(1), termCountMap.get("collectionFreq"));
+    assertEquals(Long.valueOf(1), termCountMap.get("docFreq"));
+
+    termCountMap = IndexReaderUtils.getTermCountsWithAnalyzer(reader, "text", analyzer);
+    assertEquals(Long.valueOf(3), termCountMap.get("collectionFreq"));
+    assertEquals(Long.valueOf(2), termCountMap.get("docFreq"));
+  }
+
+  @Test
   public void testIterateThroughTerms() throws Exception {
     Directory dir = FSDirectory.open(tempDir1);
     IndexReader reader = DirectoryReader.open(dir);


### PR DESCRIPTION
Make it possible to define an analyzer in the IndexReaderUtils.getTermCounts function.