### PR TITLE
Segment constructors should be public

### DIFF
--- a/src/main/java/io/anserini/collection/AclAnthology.java
+++ b/src/main/java/io/anserini/collection/AclAnthology.java
@@ -70,7 +70,7 @@ public class AclAnthology extends DocumentCollection<AclAnthology.Document> {
     private Map.Entry<String, JsonNode> nodeEntry = null;
     private Iterator<Map.Entry<String, JsonNode>> iter = null; // iterator for JSON document object
 
-    protected Segment(Path path) throws IOException {
+    public Segment(Path path) throws IOException {
       super(path);
 
       // read YAML file into JsonNode format

--- a/src/main/java/io/anserini/collection/BibtexCollection.java
+++ b/src/main/java/io/anserini/collection/BibtexCollection.java
@@ -61,7 +61,7 @@ public class BibtexCollection extends DocumentCollection<BibtexCollection.Docume
     private Iterator<Map.Entry<Key, BibTeXEntry>> iterator = null; // iterator for JSON document array
     private BibTeXDatabase database;
 
-    protected Segment(Path path) throws IOException {
+    public Segment(Path path) throws IOException {
       super(path);
       bufferedReader = new BufferedReader(new FileReader(path.toString()));
       BibTeXParser bibtexParser;

--- a/src/main/java/io/anserini/collection/CarCollection.java
+++ b/src/main/java/io/anserini/collection/CarCollection.java
@@ -53,7 +53,7 @@ public class CarCollection extends DocumentCollection<CarCollection.Document> {
     private final FileInputStream stream;
     private final Iterator<Data.Paragraph> iter;
 
-    protected Segment(Path path) throws IOException {
+    public Segment(Path path) throws IOException {
       super(path);
       stream = new FileInputStream(new File(path.toString()));
       iter = DeserializeData.iterableParagraphs(stream).iterator();

--- a/src/main/java/io/anserini/collection/ClueWeb09Collection.java
+++ b/src/main/java/io/anserini/collection/ClueWeb09Collection.java
@@ -98,7 +98,7 @@ public class ClueWeb09Collection extends DocumentCollection<ClueWeb09Collection.
 
     protected DataInputStream stream;
 
-    protected Segment(Path path) throws IOException {
+    public Segment(Path path) throws IOException {
       super(path);
       this.stream = new DataInputStream(new GZIPInputStream(Files.newInputStream(path, StandardOpenOption.READ)));
     }

--- a/src/main/java/io/anserini/collection/ClueWeb12Collection.java
+++ b/src/main/java/io/anserini/collection/ClueWeb12Collection.java
@@ -90,7 +90,7 @@ public class ClueWeb12Collection extends DocumentCollection<ClueWeb12Collection.
   public static class Segment extends FileSegment<ClueWeb12Collection.Document> {
     protected DataInputStream stream;
 
-    protected Segment(Path path) throws IOException {
+    public Segment(Path path) throws IOException {
       super(path);
       this.stream = new DataInputStream(new GZIPInputStream(Files.newInputStream(path, StandardOpenOption.READ)));
     }

--- a/src/main/java/io/anserini/collection/CoreCollection.java
+++ b/src/main/java/io/anserini/collection/CoreCollection.java
@@ -65,7 +65,7 @@ public class CoreCollection extends DocumentCollection<CoreCollection.Document> 
     private Iterator<JsonNode> iter = null; // iterator for JSON document array
     private MappingIterator<JsonNode> iterator; // iterator for JSON line objects
 
-    protected Segment(Path path) throws IOException {
+    public Segment(Path path) throws IOException {
       super(path);
 
       if (path.endsWith(".xz")) {

--- a/src/main/java/io/anserini/collection/JsonCollection.java
+++ b/src/main/java/io/anserini/collection/JsonCollection.java
@@ -86,7 +86,7 @@ public class JsonCollection extends DocumentCollection<JsonCollection.Document> 
     private Iterator<JsonNode> iter = null; // iterator for JSON document array
     private MappingIterator<JsonNode> iterator; // iterator for JSON line objects
 
-    protected Segment(Path path) throws IOException {
+    public Segment(Path path) throws IOException {
       super(path);
       bufferedReader = new BufferedReader(new FileReader(path.toString()));
       ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/io/anserini/collection/NewYorkTimesCollection.java
+++ b/src/main/java/io/anserini/collection/NewYorkTimesCollection.java
@@ -83,7 +83,7 @@ public class NewYorkTimesCollection extends DocumentCollection<NewYorkTimesColle
     private TarArchiveInputStream tarInput = null;
     private ArchiveEntry nextEntry = null;
 
-    protected Segment(Path path) throws IOException {
+    public Segment(Path path) throws IOException {
       super(path);
       if (this.path.toString().endsWith(".tgz")) {
         tarInput = new TarArchiveInputStream(new GzipCompressorInputStream(new FileInputStream(path.toFile())));


### PR DESCRIPTION
@edwinzhng @nikhilro I'm going to sneak in this PR before the the next artifact release.

I've made all segment constructors public; there's not reason they shouldn't be (since the segment implementations are static classes, and thus can have existence outside ties to a collection), and in fact some of them are already public. This makes all segment constructors uniformly public.

This also increases testability as a side effect.