### PR TITLE
ExtractDocumentLengths: prints out sum of doclengths, both lossy and lossless

### DIFF
--- a/src/main/java/io/anserini/util/ExtractDocumentLengths.java
+++ b/src/main/java/io/anserini/util/ExtractDocumentLengths.java
@@ -66,6 +66,9 @@ public class ExtractDocumentLengths {
     PrintStream out = new PrintStream(new FileOutputStream(new File(myArgs.output)));
 
     int numDocs = reader.numDocs();
+    long lossyTotalTerms = 0;
+    long exactTotalTerms = 0;
+
     out.println("docid\tdoc_length\tunique_term_count\tlossy_doc_length\tlossy_unique_term_count");
     for (int i = 0; i < numDocs; i++) {
       Terms terms = reader.getTermVector(i, "contents");
@@ -80,7 +83,14 @@ public class ExtractDocumentLengths {
       int lossyDoclength = SmallFloat.byte4ToInt(SmallFloat.intToByte4((int) exactDoclength));
       int lossyTermCount = SmallFloat.byte4ToInt(SmallFloat.intToByte4((int) exactTermCount));
       out.println(String.format("%d\t%d\t%d\t%d\t%d", i, exactDoclength, exactTermCount, lossyDoclength, lossyTermCount));
+      lossyTotalTerms += lossyDoclength;
+      exactTotalTerms += exactDoclength;
     }
+
+    System.out.println("Total number of terms in collection (sum of doclengths):");
+    System.out.println("Lossy: " + lossyTotalTerms);
+    System.out.println("Exact: " + exactTotalTerms);
+
     out.flush();
     out.close();
     reader.close();

--- a/src/test/java/io/anserini/IndexerWithEmptyDocumentTestBase.java
+++ b/src/test/java/io/anserini/IndexerWithEmptyDocumentTestBase.java
@@ -38,10 +38,11 @@ import org.junit.Before;
 import java.io.IOException;
 import java.nio.file.Path;
 
-public class IndexerTestBase extends LuceneTestCase {
+public class IndexerWithEmptyDocumentTestBase extends LuceneTestCase {
   protected Path tempDir1;
 
   // A very simple example of how to build an index.
+  // Creates an index similar to IndexerTestBase, but adds an empty document to test error handling.
   private void buildTestIndex() throws IOException {
     Directory dir = FSDirectory.open(tempDir1);
 
@@ -81,6 +82,14 @@ public class IndexerTestBase extends LuceneTestCase {
     doc3.add(new Field(IndexArgs.CONTENTS, doc3Text, textOptions));
     doc3.add(new StoredField(IndexArgs.RAW, doc3Text));
     writer.addDocument(doc3);
+
+    Document doc4 = new Document();
+    String doc4Text = "";
+    doc4.add(new StringField(IndexArgs.ID, "doc4", Field.Store.YES));
+    doc4.add(new SortedDocValuesField(IndexArgs.ID, new BytesRef("doc4".getBytes())));
+    doc4.add(new Field(IndexArgs.CONTENTS, doc4Text, textOptions));
+    doc4.add(new StoredField(IndexArgs.RAW, doc4Text));
+    writer.addDocument(doc4);
 
     writer.commit();
     writer.forceMerge(1);

--- a/src/test/java/io/anserini/integration/EndToEndTest.java
+++ b/src/test/java/io/anserini/integration/EndToEndTest.java
@@ -85,6 +85,7 @@ public abstract class EndToEndTest extends LuceneTestCase {
   public void setUp() throws Exception {
     super.setUp();
     init();
+    testIndexing();
   }
 
   @After
@@ -196,7 +197,8 @@ public abstract class EndToEndTest extends LuceneTestCase {
     return searchArgs;
   }
 
-  protected void testSearching() {
+  @Test
+  public void testSearching() {
     try {
       for (Map.Entry<String, SearchArgs> entry : testQueries.entrySet()) {
         SearchCollection searcher = new SearchCollection(entry.getValue());
@@ -223,11 +225,5 @@ public abstract class EndToEndTest extends LuceneTestCase {
     }
 
     assertEquals(cnt, ref.length);
-  }
-
-  @Test
-  public void testAll() {
-    testIndexing();
-    testSearching();
   }
 }

--- a/src/test/java/io/anserini/integration/MultiThreadingSearchTest.java
+++ b/src/test/java/io/anserini/integration/MultiThreadingSearchTest.java
@@ -153,6 +153,7 @@ public class MultiThreadingSearchTest extends EndToEndTest {
         assertEquals(groundTruthRuns.get(run)[cnt], s);
         cnt++;
       }
+      assertEquals(cnt, groundTruthRuns.get(run).length);
 
       // Add the file to the cleanup list.
       cleanup.add(runfile);

--- a/src/test/java/io/anserini/search/SearchCollectionTest.java
+++ b/src/test/java/io/anserini/search/SearchCollectionTest.java
@@ -1,12 +1,10 @@
 package io.anserini.search;
 
-import org.junit.After;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class SearchCollectionTest {

--- a/src/test/java/io/anserini/util/ExtractDocumentLengthsTest.java
+++ b/src/test/java/io/anserini/util/ExtractDocumentLengthsTest.java
@@ -21,6 +21,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
@@ -30,6 +32,19 @@ import java.util.Random;
 public class ExtractDocumentLengthsTest extends IndexerTestBase {
   private static final Random rand = new Random();
   private String randomFileName;
+
+  private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+  private PrintStream save;
+
+  private void redirectStdout() {
+    save = System.out;
+    out.reset();
+    System.setOut(new PrintStream(out));
+  }
+
+  private void restoreStdout() {
+    System.setOut(save);
+  }
 
   @Before
   @Override
@@ -49,7 +64,12 @@ public class ExtractDocumentLengthsTest extends IndexerTestBase {
   public void test() throws Exception {
     // See: https://github.com/castorini/anserini/issues/903
     Locale.setDefault(Locale.US);
+    redirectStdout();
     ExtractDocumentLengths.main(new String[] {"-index", tempDir1.toString(), "-output", randomFileName});
+    restoreStdout();
+
+    assertEquals("Total number of terms in collection (sum of doclengths):\nLossy: 12\nExact: 12\n",
+        out.toString());
 
     List<String> lines = Files.readAllLines(Paths.get(randomFileName));
     assertEquals(4, lines.size());

--- a/src/test/java/io/anserini/util/ExtractDocumentLengthsTest.java
+++ b/src/test/java/io/anserini/util/ExtractDocumentLengthsTest.java
@@ -17,6 +17,7 @@
 package io.anserini.util;
 
 import io.anserini.IndexerTestBase;
+import io.anserini.IndexerWithEmptyDocumentTestBase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 
-public class ExtractDocumentLengthsTest extends IndexerTestBase {
+public class ExtractDocumentLengthsTest extends IndexerWithEmptyDocumentTestBase {
   private static final Random rand = new Random();
   private String randomFileName;
 
@@ -72,9 +73,10 @@ public class ExtractDocumentLengthsTest extends IndexerTestBase {
         out.toString());
 
     List<String> lines = Files.readAllLines(Paths.get(randomFileName));
-    assertEquals(4, lines.size());
+    assertEquals(5, lines.size());
     assertEquals("0\t8\t5\t8\t5", lines.get(1));
     assertEquals("1\t2\t2\t2\t2", lines.get(2));
     assertEquals("2\t2\t2\t2\t2", lines.get(3));
+    assertEquals("3\t0\t0\t0\t0", lines.get(4));
   }
 }

--- a/src/test/java/io/anserini/util/ExtractNormsTest.java
+++ b/src/test/java/io/anserini/util/ExtractNormsTest.java
@@ -17,6 +17,7 @@
 package io.anserini.util;
 
 import io.anserini.IndexerTestBase;
+import io.anserini.IndexerWithEmptyDocumentTestBase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,7 +28,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 
-public class ExtractNormsTest extends IndexerTestBase {
+public class ExtractNormsTest extends IndexerWithEmptyDocumentTestBase {
   private static final Random rand = new Random();
   private String randomFileName;
 
@@ -52,9 +53,10 @@ public class ExtractNormsTest extends IndexerTestBase {
     ExtractNorms.main(new String[] {"-index", tempDir1.toString(), "-output", randomFileName});
 
     List<String> lines = Files.readAllLines(Paths.get(randomFileName));
-    assertEquals(4, lines.size());
+    assertEquals(5, lines.size());
     assertEquals("0\t8", lines.get(1));
     assertEquals("1\t2", lines.get(2));
     assertEquals("2\t2", lines.get(3));
+    assertEquals("3\t0", lines.get(4));
   }
 }


### PR DESCRIPTION
Ref: https://github.com/osirrc/ciff/issues/21

Adds check in ExtractDocumentLengths per above issue.
