### PR TITLE
SimpleSearcher refactoring, clarifies 'contents' vs. 'raw' field

### DIFF
--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -332,6 +332,7 @@ public class IndexReaderUtils {
 
   /**
    * Returns the document vector for a particular document as a map of terms to term frequencies.
+   *
    * @param reader index reader
    * @param docid collection docid
    * @return the document vector for a particular document as a map of terms to term frequencies
@@ -357,12 +358,13 @@ public class IndexReaderUtils {
   }
 
   /**
-   * Returns the raw document given its collection docid.
+   * Returns the raw contents of a document based on an internal Lucene docid.
+   *
    * @param reader index reader
    * @param docid collection docid
-   * @return the raw document given its collection docid, or <code>null</code> if not found.
+   * @return raw contents of a document
    */
-  public static String getRawDocument(IndexReader reader, String docid) {
+  public static String getRawContents(IndexReader reader, String docid) {
     try {
       Document rawDoc = reader.document(convertDocidToLuceneDocid(reader, docid));
 
@@ -376,7 +378,28 @@ public class IndexReaderUtils {
   }
 
   /**
+   * Returns the indexed contents of a document based on a collection docid.
+   *
+   * @param reader index reader
+   * @param docid collection docid
+   * @return indexed contents of a document
+   */
+  public static String getIndexedContents(IndexReader reader, String docid) {
+    try {
+      Document rawDoc = reader.document(convertDocidToLuceneDocid(reader, docid));
+
+      if (rawDoc == null) {
+        return null;
+      }
+      return rawDoc.get(IndexArgs.CONTENTS);
+    } catch (IOException e) {
+      return null;
+    }
+  }
+
+  /**
    * Computes the BM25 weight of a term (prior to analysis) in a particular document.
+   *
    * @param reader index reader
    * @param docid collection docid
    * @param term term (prior to analysis)
@@ -498,6 +521,7 @@ public class IndexReaderUtils {
 
   /**
    * Converts a collection docid to a Lucene internal docid
+   *
    * @param reader index reader
    * @param docid collection docid
    * @return corresponding Lucene internal docid, or -1 if docid not found
@@ -523,6 +547,7 @@ public class IndexReaderUtils {
 
   /**
    * Converts a Lucene internal docid to a collection docid
+   *
    * @param reader index reader
    * @param docid Lucene internal docid
    * @return corresponding collection docid, or <code>null</code> if not found.

--- a/src/test/java/io/anserini/IndexerTestBase.java
+++ b/src/test/java/io/anserini/IndexerTestBase.java
@@ -63,7 +63,8 @@ public class IndexerTestBase extends LuceneTestCase {
     doc1.add(new StringField(IndexArgs.ID, "doc1", Field.Store.YES));
     doc1.add(new SortedDocValuesField(IndexArgs.ID, new BytesRef("doc1".getBytes())));
     doc1.add(new Field(IndexArgs.CONTENTS, doc1Text , textOptions));
-    doc1.add(new StoredField(IndexArgs.RAW, doc1Text));
+    // specifically demonstrate how "contents" and "raw" might diverge:
+    doc1.add(new StoredField(IndexArgs.RAW, String.format("{\"contents\": \"%s\"}", doc1Text)));
     writer.addDocument(doc1);
 
     Document doc2 = new Document();
@@ -71,7 +72,8 @@ public class IndexerTestBase extends LuceneTestCase {
     doc2.add(new StringField(IndexArgs.ID, "doc2", Field.Store.YES));
     doc2.add(new SortedDocValuesField(IndexArgs.ID, new BytesRef("doc2".getBytes())));
     doc2.add(new Field(IndexArgs.CONTENTS, doc2Text, textOptions));  // Note plural, to test stemming
-    doc2.add(new StoredField(IndexArgs.RAW, doc2Text));
+    // specifically demonstrate how "contents" and "raw" might diverge:
+    doc2.add(new StoredField(IndexArgs.RAW, String.format("{\"contents\": \"%s\"}", doc2Text)));
     writer.addDocument(doc2);
 
     Document doc3 = new Document();
@@ -79,7 +81,8 @@ public class IndexerTestBase extends LuceneTestCase {
     doc3.add(new StringField(IndexArgs.ID, "doc3", Field.Store.YES));
     doc3.add(new SortedDocValuesField(IndexArgs.ID, new BytesRef("doc3".getBytes())));
     doc3.add(new Field(IndexArgs.CONTENTS, doc3Text, textOptions));
-    doc3.add(new StoredField(IndexArgs.RAW, doc3Text));
+    // specifically demonstrate how "contents" and "raw" might diverge:
+    doc3.add(new StoredField(IndexArgs.RAW, String.format("{\"contents\": \"%s\"}", doc3Text)));
     writer.addDocument(doc3);
 
     writer.commit();

--- a/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
+++ b/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
@@ -320,13 +320,23 @@ public class IndexReaderUtilsTest extends IndexerTestBase {
   }
 
   @Test
-  public void testRawDoc() throws Exception {
+  public void testRawContents() throws Exception {
     Directory dir = FSDirectory.open(tempDir1);
     IndexReader reader = DirectoryReader.open(dir);
 
-    assertEquals("here is some text here is some more text. city.", IndexReaderUtils.getRawDocument(reader, "doc1"));
-    assertEquals("more texts", IndexReaderUtils.getRawDocument(reader, "doc2"));
-    assertEquals("here is a test", IndexReaderUtils.getRawDocument(reader, "doc3"));
+    assertEquals("{\"contents\": \"here is some text here is some more text. city.\"}", IndexReaderUtils.getRawContents(reader, "doc1"));
+    assertEquals("{\"contents\": \"more texts\"}", IndexReaderUtils.getRawContents(reader, "doc2"));
+    assertEquals("{\"contents\": \"here is a test\"}", IndexReaderUtils.getRawContents(reader, "doc3"));
+  }
+
+  @Test
+  public void testIndexedContents() throws Exception {
+    Directory dir = FSDirectory.open(tempDir1);
+    IndexReader reader = DirectoryReader.open(dir);
+
+    assertEquals("here is some text here is some more text. city.", IndexReaderUtils.getIndexedContents(reader, "doc1"));
+    assertEquals("more texts", IndexReaderUtils.getIndexedContents(reader, "doc2"));
+    assertEquals("here is a test", IndexReaderUtils.getIndexedContents(reader, "doc3"));
   }
 
   @Test


### PR DESCRIPTION
Fixes confusion between `contents` and `raw` fields. The `contents` field holds the contents as indexed; the `raw` field holds the raw docs.

These may be different. For example, in the COVID collection, "raw" comprises the metadata record CSV and the raw JSON of the full text. The "contents" field comprises elements that we might have pulled out of the JSON. We search against "contents", _but_ downstream applications might want to use the "raw".

Fixed `SimpleSearcher` so that this confusion is reduced from the Python end.

Note that this is a Pyserini breaking change. We will need to publish new artifact and make adjustments on the Pyserini end.