### PR TITLE
SourceDocument refactor for separate raw field

### DIFF
--- a/src/main/java/io/anserini/collection/AclAnthology.java
+++ b/src/main/java/io/anserini/collection/AclAnthology.java
@@ -105,7 +105,7 @@ public class AclAnthology extends DocumentCollection<AclAnthology.Document> {
   /**
    * A document in a JSON collection.
    */
-  public class Document implements SourceDocument {
+  public class Document extends SourceDocument {
     private String id;
     private String contents;
     private JsonNode paper;

--- a/src/main/java/io/anserini/collection/BibtexCollection.java
+++ b/src/main/java/io/anserini/collection/BibtexCollection.java
@@ -95,7 +95,7 @@ public class BibtexCollection extends DocumentCollection<BibtexCollection.Docume
   /**
    * A document in a Bibtex collection.
    */
-  public static class Document implements SourceDocument {
+  public static class Document extends SourceDocument {
     private String id;
     private String contents;
     private String type;

--- a/src/main/java/io/anserini/collection/CarCollection.java
+++ b/src/main/java/io/anserini/collection/CarCollection.java
@@ -76,7 +76,7 @@ public class CarCollection extends DocumentCollection<CarCollection.Document> {
    * The paraID serves as the id.
    * See <a href="http://trec-car.cs.unh.edu/datareleases/">this reference</a> for details.
    */
-  public static class Document implements SourceDocument {
+  public static class Document extends SourceDocument {
     private final String paraID;
     private final String paragraph;
 

--- a/src/main/java/io/anserini/collection/ClueWeb09Collection.java
+++ b/src/main/java/io/anserini/collection/ClueWeb09Collection.java
@@ -345,7 +345,7 @@ public class ClueWeb09Collection extends DocumentCollection<ClueWeb09Collection.
    * A document from the <a href="https://www.lemurproject.org/clueweb09.php/">ClueWeb09 collection</a>.
    * This class derives from tools provided by CMU for reading the ClueWeb09 collection.
    */
-  public static class Document implements SourceDocument {
+  public static class Document extends SourceDocument {
     public static final String WARC_VERSION = "WARC/0.18";
     protected final static String NEWLINE = "\n";
 

--- a/src/main/java/io/anserini/collection/CoreCollection.java
+++ b/src/main/java/io/anserini/collection/CoreCollection.java
@@ -113,7 +113,7 @@ public class CoreCollection extends DocumentCollection<CoreCollection.Document> 
   /**
    * A document in a Core collection.
    */
-  public static class Document implements SourceDocument {
+  public static class Document extends SourceDocument {
     private String id;
     private String contents;
     private JsonNode jsonNode;

--- a/src/main/java/io/anserini/collection/CovidCollectionDocument.java
+++ b/src/main/java/io/anserini/collection/CovidCollectionDocument.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-public abstract class CovidCollectionDocument implements SourceDocument {
+public abstract class CovidCollectionDocument extends SourceDocument {
   private static final Logger LOG = LogManager.getLogger(CovidCollectionDocument.class);
   protected String id;
   protected String content;
@@ -76,6 +76,7 @@ public abstract class CovidCollectionDocument implements SourceDocument {
     return true;
   }
 
+  @Override
   public String raw() {
     return raw;
   }

--- a/src/main/java/io/anserini/collection/HtmlCollection.java
+++ b/src/main/java/io/anserini/collection/HtmlCollection.java
@@ -100,7 +100,7 @@ public class HtmlCollection extends DocumentCollection<HtmlCollection.Document> 
   /**
    * A generic document in {@code HtmlCollection}.
    */
-  public static class Document implements SourceDocument {
+  public static class Document extends SourceDocument {
     private String id;
     private String contents;
 

--- a/src/main/java/io/anserini/collection/JsonCollection.java
+++ b/src/main/java/io/anserini/collection/JsonCollection.java
@@ -127,7 +127,7 @@ public class JsonCollection extends DocumentCollection<JsonCollection.Document> 
   /**
    * A document in a JSON collection.
    */
-  public static class Document implements MultifieldSourceDocument {
+  public static class Document extends MultifieldSourceDocument {
     private String id;
     private String contents;
     private Map<String, String> fields;

--- a/src/main/java/io/anserini/collection/MultifieldSourceDocument.java
+++ b/src/main/java/io/anserini/collection/MultifieldSourceDocument.java
@@ -18,11 +18,11 @@ package io.anserini.collection;
 
 import java.util.Map;
 
-public interface MultifieldSourceDocument extends SourceDocument {
+public abstract class MultifieldSourceDocument extends SourceDocument {
   /**
    * Returns a map of fields associated with this document.
    *
    * @return a map of fields associated with this document
    */
-  Map<String, String> fields();
+  public abstract Map<String, String> fields();
 }

--- a/src/main/java/io/anserini/collection/NewYorkTimesCollection.java
+++ b/src/main/java/io/anserini/collection/NewYorkTimesCollection.java
@@ -128,7 +128,7 @@ public class NewYorkTimesCollection extends DocumentCollection<NewYorkTimesColle
    * A document from the <a href="https://catalog.ldc.upenn.edu/products/LDC2008T19">New York Times
    * Annotated Corpus</a>.
    */
-  public static class Document implements SourceDocument {
+  public static class Document extends SourceDocument {
     private final RawDocument raw;
     private String id;
     private String contents;

--- a/src/main/java/io/anserini/collection/SourceDocument.java
+++ b/src/main/java/io/anserini/collection/SourceDocument.java
@@ -21,20 +21,29 @@ package io.anserini.collection;
  * Lucene {@link org.apache.lucene.document.Document}, which is the Lucene representation that
  * can be directly inserted into an index.
  */
-public interface SourceDocument {
+public abstract class SourceDocument {
   /**
    * Returns the unique identifier of the document.
    *
    * @return the unique identifier of the document
    */
-  String id();
+  public abstract String id();
+
+  /**
+   * Returns the content of the document to be searched.
+   *
+   * @return the content of the document to be searched
+   */
+  public abstract String content();
 
   /**
    * Returns the raw content of the document.
    *
    * @return the raw content of the document
    */
-  String content();
+  public String raw() {
+    return content();
+  };
 
   /**
    * Returns whether this document is meant to be indexed. Certain collections (e.g., ClueWeb)
@@ -42,5 +51,5 @@ public interface SourceDocument {
    *
    * @return <code>true</code> if this document is meant to be indexed
    */
-  boolean indexable();
+  public abstract boolean indexable();
 }

--- a/src/main/java/io/anserini/collection/TrecCollection.java
+++ b/src/main/java/io/anserini/collection/TrecCollection.java
@@ -190,7 +190,7 @@ public class TrecCollection extends DocumentCollection<TrecCollection.Document> 
   /**
    * A document in a classic TREC <i>ad hoc</i> document collection.
    */
-  public static class Document implements SourceDocument {
+  public static class Document extends SourceDocument {
 
     protected static final String DOCNO = "<DOCNO>";
     protected static final String TERMINATING_DOCNO = "</DOCNO>";

--- a/src/main/java/io/anserini/collection/TweetCollection.java
+++ b/src/main/java/io/anserini/collection/TweetCollection.java
@@ -202,7 +202,7 @@ public class TweetCollection extends DocumentCollection<TweetCollection.Document
   /**
    * A tweet (i.e., status).
    */
-  public static class Document implements SourceDocument {
+  public static class Document extends SourceDocument {
     // Required fields
     protected String screenName;
     protected int followersCount;

--- a/src/main/java/io/anserini/collection/WashingtonPostCollection.java
+++ b/src/main/java/io/anserini/collection/WashingtonPostCollection.java
@@ -110,7 +110,7 @@ public class WashingtonPostCollection extends DocumentCollection<WashingtonPostC
   /**
    * A document from the <a href="https://trec.nist.gov/data/wapost/">TREC Washington Post Corpus</a>.
    */
-  public static class Document implements SourceDocument {
+  public static class Document extends SourceDocument {
     private static final Logger LOG = LogManager.getLogger(Document.class);
 
     // Required fields

--- a/src/main/java/io/anserini/collection/WikipediaCollection.java
+++ b/src/main/java/io/anserini/collection/WikipediaCollection.java
@@ -90,7 +90,7 @@ public class WikipediaCollection extends DocumentCollection<WikipediaCollection.
   /**
    * A Wikipedia article. The article title serves as the id.
    */
-  public static class Document implements SourceDocument {
+  public static class Document extends SourceDocument {
     private final String title;
     private final String contents;
 

--- a/src/test/java/io/anserini/collection/AclAnthologyTest.java
+++ b/src/test/java/io/anserini/collection/AclAnthologyTest.java
@@ -118,6 +118,7 @@ public class AclAnthologyTest extends DocumentCollectionTest<AclAnthology.Docume
         assertEquals(expectedValue, aclDoc.id());
       } else if (expectedKey.equals("contents")) {
         assertEquals(expectedValue, aclDoc.content());
+        assertEquals(expectedValue, doc.raw());
       } else if (expectedKey.equals("authors")) {
         assertEquals(expectedValue, String.join(" ", aclDoc.authors()));
       } else if (expectedKey.equals("sigs")) {

--- a/src/test/java/io/anserini/collection/BibtexCollectionTest.java
+++ b/src/test/java/io/anserini/collection/BibtexCollectionTest.java
@@ -100,6 +100,7 @@ public class BibtexCollectionTest extends DocumentCollectionTest<BibtexCollectio
         assertEquals(expectedValue, ((BibtexCollection.Document) doc).type());
       } else if (expectedKey.equals("contents")) {
         assertEquals(expectedValue, doc.content());
+        assertEquals(expectedValue, doc.raw());
       } else {
         Value parsedValue = parsedFields.get(new Key(expectedKey));
         assertNotNull(parsedValue);

--- a/src/test/java/io/anserini/collection/ClueWeb09CollectionTest.java
+++ b/src/test/java/io/anserini/collection/ClueWeb09CollectionTest.java
@@ -62,5 +62,6 @@ public class ClueWeb09CollectionTest extends DocumentCollectionTest<ClueWeb09Col
       assertEquals(expected.get("id"), doc.id());
     }
     assertEquals(expected.get("content"), doc.content());
+    assertEquals(expected.get("content"), doc.raw());
   }
 }

--- a/src/test/java/io/anserini/collection/ClueWeb12CollectionTest.java
+++ b/src/test/java/io/anserini/collection/ClueWeb12CollectionTest.java
@@ -62,5 +62,6 @@ public class ClueWeb12CollectionTest extends DocumentCollectionTest<ClueWeb12Col
       assertEquals(expected.get("id"), doc.id());
     }
     assertEquals(expected.get("content"), doc.content());
+    assertEquals(expected.get("content"), doc.raw());
   }
 }

--- a/src/test/java/io/anserini/collection/CoreCollectionTest.java
+++ b/src/test/java/io/anserini/collection/CoreCollectionTest.java
@@ -95,6 +95,7 @@ public class CoreCollectionTest extends DocumentCollectionTest<CoreCollection.Do
         assertEquals(expectedValue, coreDoc.id());
       } else if (expectedKey.equals("contents")) {
         assertEquals(expected.get("title") + " " + expected.get("abstract"), coreDoc.content());
+        assertEquals(expected.get("title") + " " + expected.get("abstract"), coreDoc.raw());
       } else {
         assert(coreDoc.jsonNode().has(expectedKey));
       }

--- a/src/test/java/io/anserini/collection/JsonCollectionLineObjectTest.java
+++ b/src/test/java/io/anserini/collection/JsonCollectionLineObjectTest.java
@@ -62,6 +62,7 @@ public class JsonCollectionLineObjectTest extends JsonCollectionTest {
     assertTrue(doc.indexable());
     assertEquals(expected.get("id"), doc.id());
     assertEquals(expected.get("content"), doc.content());
+    assertEquals(expected.get("content"), doc.raw());
     assertEquals(expected.get("field1"), ((JsonCollection.Document) doc).fields().get("field1"));
     assertEquals(expected.get("field2"), ((JsonCollection.Document) doc).fields().get("field2"));
   }

--- a/src/test/java/io/anserini/collection/JsonCollectionTest.java
+++ b/src/test/java/io/anserini/collection/JsonCollectionTest.java
@@ -24,5 +24,6 @@ public abstract class JsonCollectionTest extends DocumentCollectionTest<JsonColl
     assertTrue(doc.indexable());
     assertEquals(expected.get("id"), doc.id());
     assertEquals(expected.get("content"), doc.content());
+    assertEquals(expected.get("content"), doc.raw());
   }
 }

--- a/src/test/java/io/anserini/collection/NewYorkTimesCollectionTest.java
+++ b/src/test/java/io/anserini/collection/NewYorkTimesCollectionTest.java
@@ -53,6 +53,7 @@ public class NewYorkTimesCollectionTest extends DocumentCollectionTest<NewYorkTi
     assertTrue(doc.indexable());
     assertEquals(expected.get("id"), nyt.id());
     assertEquals(expected.get("content"), nyt.content());
+    assertEquals(expected.get("content"), nyt.raw());
     assertEquals(expected.get("headline"), nyt.getRawDocument().getHeadline());
     assertEquals(expected.get("abstract"), nyt.getRawDocument().getArticleAbstract());
     assertEquals(expected.get("body"), nyt.getRawDocument().getBody());

--- a/src/test/java/io/anserini/collection/TrecCollectionTest.java
+++ b/src/test/java/io/anserini/collection/TrecCollectionTest.java
@@ -59,5 +59,6 @@ public class TrecCollectionTest extends DocumentCollectionTest<TrecCollection.Do
     assertTrue(doc.indexable());
     assertEquals(expected.get("id"), doc.id());
     assertEquals(expected.get("content"), doc.content());
+    assertEquals(expected.get("content"), doc.raw());
   }
 }

--- a/src/test/java/io/anserini/collection/TrecwebCollectionTest.java
+++ b/src/test/java/io/anserini/collection/TrecwebCollectionTest.java
@@ -55,5 +55,6 @@ public class TrecwebCollectionTest extends DocumentCollectionTest<TrecwebCollect
     assertTrue(doc.indexable());
     assertEquals(expected.get("id"), doc.id());
     assertEquals(expected.get("content"), doc.content());
+    assertEquals(expected.get("content"), doc.raw());
   }
 }

--- a/src/test/java/io/anserini/collection/TweetCollectionTest.java
+++ b/src/test/java/io/anserini/collection/TweetCollectionTest.java
@@ -57,6 +57,7 @@ public class TweetCollectionTest extends DocumentCollectionTest<TweetCollection.
     assertTrue(doc.indexable());
     assertEquals(expected.get("id"), doc.id());
     assertEquals(expected.get("content"), doc.content());
+    assertEquals(expected.get("content"), doc.raw());
     assertEquals(expected.get("screen_name"), ((TweetCollection.Document) doc).getScreenName());
     assertEquals((long) Long.valueOf(expected.get("timestamp_ms")),
         ((TweetCollection.Document) doc).getTimestampMs().getAsLong());

--- a/src/test/java/io/anserini/collection/WikipediaCollectionTest.java
+++ b/src/test/java/io/anserini/collection/WikipediaCollectionTest.java
@@ -48,5 +48,6 @@ public class WikipediaCollectionTest extends DocumentCollectionTest<WikipediaCol
     assertTrue(doc.indexable());
     assertEquals(expected.get("id"), doc.id());
     assertEquals(expected.get("content"), doc.content());
+    assertEquals(expected.get("content"), doc.raw());
   }
 }


### PR DESCRIPTION
Addresses #1048

Made the `SourceDocument` an abstract class so that we can have a separate `raw()` function that returns `content()` by default. I also added the respective tests and updated relevant collections.