### PR TITLE
Improved integration testing

### DIFF
--- a/src/test/java/io/anserini/integration/BibtexEndToEndTest.java
+++ b/src/test/java/io/anserini/integration/BibtexEndToEndTest.java
@@ -17,18 +17,21 @@
 package io.anserini.integration;
 
 import io.anserini.collection.BibtexCollection;
+import io.anserini.index.IndexArgs;
 import io.anserini.index.generator.BibtexGenerator;
 
 import java.util.Map;
 
 public class BibtexEndToEndTest extends EndToEndTest {
   @Override
-  protected void setIndexingArgs() {
-    dataDirPath = "bib/acl";
-    collectionClass = BibtexCollection.class.getSimpleName();
-    generator = BibtexGenerator.class.getSimpleName();
-    topicReader = "TsvInt";
-    topicFile = "src/test/resources/sample_topics/bibtex_topics.tsv";
+  protected IndexArgs getIndexArgs() {
+    IndexArgs indexArgs = createDefaultIndexArgs();
+
+    indexArgs.input = "src/test/resources/sample_docs/bib/acl";
+    indexArgs.collectionClass = BibtexCollection.class.getSimpleName();
+    indexArgs.generatorClass = BibtexGenerator.class.getSimpleName();
+
+    return indexArgs;
   }
 
   @Override
@@ -55,6 +58,9 @@ public class BibtexEndToEndTest extends EndToEndTest {
 
   @Override
   protected void setSearchGroundTruth() {
+    topicReader = "TsvInt";
+    topicFile = "src/test/resources/sample_topics/bibtex_topics.tsv";
+
     testQueries.put("bm25", createDefaultSearchArgs().bm25());
     referenceRunOutput.put("bm25", new String[]{
         "1 Q0 article-id 1 0.073800 Anserini",

--- a/src/test/java/io/anserini/integration/BibtexEndToEndTest.java
+++ b/src/test/java/io/anserini/integration/BibtexEndToEndTest.java
@@ -1,0 +1,65 @@
+/*
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.integration;
+
+import io.anserini.collection.BibtexCollection;
+import io.anserini.index.generator.BibtexGenerator;
+
+import java.util.Map;
+
+public class BibtexEndToEndTest extends EndToEndTest {
+  @Override
+  protected void setIndexingArgs() {
+    dataDirPath = "bib/acl";
+    collectionClass = BibtexCollection.class.getSimpleName();
+    generator = BibtexGenerator.class.getSimpleName();
+    topicReader = "TsvInt";
+    topicFile = "src/test/resources/sample_topics/bibtex_topics.tsv";
+  }
+
+  @Override
+  protected void setCheckIndexGroundTruth() {
+    documentContents.put(0, Map.of("id", "article-id",
+        "contents", "this is the title. ",
+        "raw", "this is the title. "));
+    documentContents.put(1, Map.of("id", "inproceedings-id",
+        "contents", "this is the title. this is the abstract",
+        "raw", "this is the title. this is the abstract"));
+    documentContents.put(2, Map.of("id", "proceedings-id",
+        "contents", "this is the title. ",
+        "raw", "this is the title. "));
+
+    docCount = 3;
+
+    fieldNormStatusTotalFields = 12;
+    termIndexStatusTermCount = 42;
+    termIndexStatusTotFreq = 54;
+    storedFieldStatusTotalDocCounts = 3;
+    termIndexStatusTotPos = 54;
+    storedFieldStatusTotFields = 37;
+  }
+
+  @Override
+  protected void setSearchGroundTruth() {
+    testQueries.put("bm25", createDefaultSearchArgs().bm25());
+    referenceRunOutput.put("bm25", new String[]{
+        "1 Q0 article-id 1 0.073800 Anserini",
+        "1 Q0 proceedings-id 2 0.073799 Anserini",
+        "1 Q0 inproceedings-id 3 0.064200 Anserini",
+        "2 Q0 inproceedings-id 1 0.471600 Anserini"});
+  }
+}

--- a/src/test/java/io/anserini/integration/EndToEndTest.java
+++ b/src/test/java/io/anserini/integration/EndToEndTest.java
@@ -56,19 +56,6 @@ public abstract class EndToEndTest extends LuceneTestCase {
   protected Map<String, SearchArgs> testQueries = new HashMap<>();
 
   protected String indexPath;
-  protected String dataDirPath;
-  protected String dataDirPrefix = "src/test/resources/sample_docs/";
-  protected String collectionClass;
-  protected String generator;
-  protected String whitelist = null;
-  protected long tweetMaxId = -1;
-
-  protected boolean storePositions = true;
-  protected boolean storeDocvectors = true;
-  protected boolean storeTransformedDocs = true;
-  protected boolean storeRawDocs = true;
-  protected boolean optimize = true;
-  protected boolean quiet = true;
 
   protected String topicReader;
   protected String topicFile;
@@ -97,47 +84,48 @@ public abstract class EndToEndTest extends LuceneTestCase {
 
     cleanup.clear();
 
-    // Set the indexing args. Subclasses will override this method and change their own settings.
-    setIndexingArgs();
+    // Subclasses will override this method and change their own settings.
+    IndexArgs indexArgs = getIndexArgs();
 
+    // Note, since we want to test end-to-end, we're going to generate command-line parameters to feed back into main.
     List<String> args = new ArrayList<>(List.of(
-        "-index", this.indexPath,
-        "-input", this.dataDirPrefix + this.dataDirPath,
+        "-index", indexPath,
+        "-input", indexArgs.input,
         "-threads", "2",
-        "-collection", this.collectionClass,
-        "-generator", this.generator));
+        "-collection", indexArgs.collectionClass,
+        "-generator", indexArgs.generatorClass));
 
-    if (this.tweetMaxId != -1) {
+    if (indexArgs.tweetMaxId != Long.MAX_VALUE) {
       args.add("-tweet.maxId");
-      args.add(this.tweetMaxId + "");
+      args.add(indexArgs.tweetMaxId + "");
     }
 
-    if (this.whitelist != null) {
+    if (indexArgs.whitelist != null) {
       args.add("-whitelist");
-      args.add(this.whitelist);
+      args.add(indexArgs.whitelist);
     }
 
-    if (this.storePositions) {
+    if (indexArgs.storePositions) {
       args.add("-storePositions");
     }
 
-    if (this.storeDocvectors) {
+    if (indexArgs.storeDocvectors) {
       args.add("-storeDocvectors");
     }
 
-    if (this.storeTransformedDocs) {
+    if (indexArgs.storeTransformedDocs) {
       args.add("-storeTransformedDocs");
     }
 
-    if (this.storeRawDocs) {
+    if (indexArgs.storeRawDocs) {
       args.add("-storeRawDocs");
     }
 
-    if (this.optimize) {
+    if (indexArgs.optimize) {
       args.add("-optimize");
     }
 
-    if (this.quiet) {
+    if (indexArgs.quiet) {
       args.add("-quiet");
     }
 
@@ -145,7 +133,20 @@ public abstract class EndToEndTest extends LuceneTestCase {
   }
 
   // Set the indexing args. Subclasses will override this method and change their own settings.
-  abstract void setIndexingArgs();
+  abstract IndexArgs getIndexArgs();
+
+  protected IndexArgs createDefaultIndexArgs() {
+    IndexArgs args = new IndexArgs();
+
+    args.storePositions = true;
+    args.storeDocvectors = true;
+    args.storeTransformedDocs = true;
+    args.storeRawDocs = true;
+    args.optimize = true;
+    args.quiet = true;
+
+    return args;
+  }
 
   @After
   @Override

--- a/src/test/java/io/anserini/integration/EndToEndTest.java
+++ b/src/test/java/io/anserini/integration/EndToEndTest.java
@@ -18,6 +18,7 @@ package io.anserini.integration;
 
 import io.anserini.index.IndexArgs;
 import io.anserini.index.IndexCollection;
+import io.anserini.index.IndexReaderUtils;
 import io.anserini.search.SearchArgs;
 import io.anserini.search.SearchCollection;
 import org.apache.commons.io.FileUtils;
@@ -44,23 +45,36 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 // This automatically tests indexing, retrieval, and evaluation from end to end.
 // Subclasses inherit and special to different collections.
 @TestRuleLimitSysouts.Limit(bytes = 20000)
 public abstract class EndToEndTest extends LuceneTestCase {
-  protected IndexArgs indexCollectionArgs = new IndexArgs();
+  private static final Random RANDOM = new Random();
+
   protected Map<String, SearchArgs> testQueries = new HashMap<>();
 
+  protected String indexPath;
   protected String dataDirPath;
   protected String dataDirPrefix = "src/test/resources/sample_docs/";
-  protected String indexOutputPrefix = "e2eTestIndex";
   protected String collectionClass;
   protected String generator;
-  protected String topicDirPrefix = "src/test/resources/sample_topics/";
+  protected String whitelist = null;
+  protected long tweetMaxId = -1;
+
+  protected boolean storePositions = true;
+  protected boolean storeDocvectors = true;
+  protected boolean storeTransformedDocs = true;
+  protected boolean storeRawDocs = true;
+  protected boolean optimize = true;
+  protected boolean quiet = true;
+
   protected String topicReader;
+  protected String topicFile;
   protected String searchOutputPrefix = "e2eTestSearch";
   protected Map<String, String[]> referenceRunOutput = new HashMap<>();
+  protected Map<Integer, Map<String, String>> documentContents = new HashMap<>();
 
   // These are the sources of truth
   protected int fieldNormStatusTotalFields;
@@ -71,45 +85,98 @@ public abstract class EndToEndTest extends LuceneTestCase {
   protected int storedFieldStatusTotFields;
   protected int docCount;
 
-  protected int counterIndexed;
-  protected int counterEmpty;
-  protected int counterUnindexable;
-  protected int counterSkipped;
-  protected int counterErrors;
-
-  // init the class variables here
-  protected abstract void init() throws Exception;
+  // List of files for cleanup in @After.
+  protected List<File> cleanup = new ArrayList<>();
 
   @Override
   @Before
   public void setUp() throws Exception {
+    // We're going to build an index for every test.
     super.setUp();
-    init();
-    testIndexing();
+    indexPath = "test-index" + RANDOM.nextInt(100000);
+
+    cleanup.clear();
+
+    // Set the indexing args. Subclasses will override this method and change their own settings.
+    setIndexingArgs();
+
+    List<String> args = new ArrayList<>(List.of(
+        "-index", this.indexPath,
+        "-input", this.dataDirPrefix + this.dataDirPath,
+        "-threads", "2",
+        "-collection", this.collectionClass,
+        "-generator", this.generator));
+
+    if (this.tweetMaxId != -1) {
+      args.add("-tweet.maxId");
+      args.add(this.tweetMaxId + "");
+    }
+
+    if (this.whitelist != null) {
+      args.add("-whitelist");
+      args.add(this.whitelist);
+    }
+
+    if (this.storePositions) {
+      args.add("-storePositions");
+    }
+
+    if (this.storeDocvectors) {
+      args.add("-storeDocvectors");
+    }
+
+    if (this.storeTransformedDocs) {
+      args.add("-storeTransformedDocs");
+    }
+
+    if (this.storeRawDocs) {
+      args.add("-storeRawDocs");
+    }
+
+    if (this.optimize) {
+      args.add("-optimize");
+    }
+
+    if (this.quiet) {
+      args.add("-quiet");
+    }
+
+    IndexCollection.main(args.toArray(new String[args.size()]));
   }
+
+  // Set the indexing args. Subclasses will override this method and change their own settings.
+  abstract void setIndexingArgs();
 
   @After
   @Override
   public void tearDown() throws Exception {
-    FileUtils.deleteDirectory(new File(this.indexOutputPrefix + this.collectionClass));
-    new File(this.searchOutputPrefix + this.topicReader).delete();
+    // Clean up the index.
+    FileUtils.deleteDirectory(new File(indexPath));
+
+    // Clean up other files we've created along the way.
+    for (File file : cleanup) {
+      file.delete();
+    }
     super.tearDown();
   }
 
-  protected void checkCounters(IndexCollection.Counters counters) {
-    assertEquals(counterIndexed, counters.indexed.get());
-    assertEquals(counterEmpty, counters.empty.get());
-    assertEquals(counterUnindexable, counters.unindexable.get());
-    assertEquals(counterSkipped, counters.skipped.get());
-    assertEquals(counterErrors, counters.errors.get());
-  }
+  @Test
+  public void checkIndex() throws IOException {
+    // Subclasses will override this method and provide the ground truth.
+    setCheckIndexGroundTruth();
 
-  protected void checkIndex() throws IOException {
     ByteArrayOutputStream bos = new ByteArrayOutputStream(1024);
-    Directory dir = FSDirectory.open(Paths.get(this.indexOutputPrefix + this.collectionClass));
+    Directory dir = FSDirectory.open(Paths.get(this.indexPath));
 
     IndexReader reader = DirectoryReader.open(dir);
     assertEquals(docCount, reader.maxDoc());
+
+    for (Map.Entry<Integer, Map<String, String>> entry : documentContents.entrySet()) {
+      String collectionDocid = IndexReaderUtils.convertLuceneDocidToDocid(reader, entry.getKey());
+      assertEquals(entry.getValue().get("id"), collectionDocid);
+      assertEquals(entry.getValue().get("raw"), IndexReaderUtils.getRawContents(reader, collectionDocid));
+      assertEquals(entry.getValue().get("contents"), IndexReaderUtils.getIndexedContents(reader, collectionDocid));
+    }
     reader.close();
 
     CheckIndex checker = new CheckIndex(dir);
@@ -150,42 +217,16 @@ public abstract class EndToEndTest extends LuceneTestCase {
     checker.close();
   }
 
-  protected void setIndexingArgs() {
-    // required
-    indexCollectionArgs.collectionClass = this.collectionClass + "Collection";
-    indexCollectionArgs.generatorClass = this.generator + "Generator";
-    indexCollectionArgs.threads = 2;
-    indexCollectionArgs.input = this.dataDirPrefix + this.dataDirPath;
-    indexCollectionArgs.index = this.indexOutputPrefix + this.collectionClass;
-
-    //optional
-    indexCollectionArgs.storePositions = true;
-    indexCollectionArgs.storeDocvectors = true;
-    indexCollectionArgs.storeTransformedDocs = true;
-    indexCollectionArgs.storeRawDocs = true;
-    indexCollectionArgs.optimize = true;
-    indexCollectionArgs.quiet = true;
-  }
-
-  protected void testIndexing() {
-    setIndexingArgs();
-    try {
-      IndexCollection.Counters counters = new IndexCollection(indexCollectionArgs).run();
-      checkCounters(counters);
-      checkIndex();
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail();
-    }
-  }
+  // Subclasses will override this method and provide the ground truth.
+  protected abstract void setCheckIndexGroundTruth();
 
   protected SearchArgs createDefaultSearchArgs() {
     SearchArgs searchArgs = new SearchArgs();
     // required
-    searchArgs.index = this.indexOutputPrefix + this.collectionClass;
-    searchArgs.topics = new String[]{this.topicDirPrefix + this.topicReader};
+    searchArgs.index = this.indexPath;
     searchArgs.output = this.searchOutputPrefix + this.topicReader;
     searchArgs.topicReader = this.topicReader;
+    searchArgs.topics = new String[]{this.topicFile};
     searchArgs.bm25 = true;
 
     // optional
@@ -199,12 +240,17 @@ public abstract class EndToEndTest extends LuceneTestCase {
 
   @Test
   public void testSearching() {
+    // Subclasses will override this method and provide the ground truth.
+    setSearchGroundTruth();
+
     try {
       for (Map.Entry<String, SearchArgs> entry : testQueries.entrySet()) {
         SearchCollection searcher = new SearchCollection(entry.getValue());
         searcher.runTopics();
         searcher.close();
         checkRankingResults(entry.getKey(), entry.getValue().output);
+        // Remember to cleanup run files.
+        cleanup.add(new File(entry.getValue().output));
       }
     } catch (Exception e) {
       System.out.println("Test Searching failed: ");
@@ -226,4 +272,7 @@ public abstract class EndToEndTest extends LuceneTestCase {
 
     assertEquals(cnt, ref.length);
   }
+
+  // Subclasses will override this method and provide the ground truth.
+  protected abstract void setSearchGroundTruth();
 }

--- a/src/test/java/io/anserini/integration/MultiThreadingSearchTest.java
+++ b/src/test/java/io/anserini/integration/MultiThreadingSearchTest.java
@@ -17,6 +17,7 @@
 package io.anserini.integration;
 
 import io.anserini.collection.TrecCollection;
+import io.anserini.index.IndexArgs;
 import io.anserini.index.generator.JsoupGenerator;
 import io.anserini.search.SearchArgs;
 import org.junit.After;
@@ -36,12 +37,14 @@ public class MultiThreadingSearchTest extends EndToEndTest {
   private Map<String, String[]> groundTruthRuns = new HashMap<>();
 
   @Override
-  protected void setIndexingArgs() {
-    dataDirPath = "trec/collection2";
-    collectionClass = TrecCollection.class.getSimpleName();
-    generator = JsoupGenerator.class.getSimpleName();
-    topicReader = "Trec";
-    topicFile = "src/test/resources/sample_topics/Trec";
+  protected IndexArgs getIndexArgs() {
+    IndexArgs indexArgs = createDefaultIndexArgs();
+
+    indexArgs.input = "src/test/resources/sample_docs/trec/collection2";
+    indexArgs.collectionClass = TrecCollection.class.getSimpleName();
+    indexArgs.generatorClass = JsoupGenerator.class.getSimpleName();
+
+    return indexArgs;
   }
 
   @Override
@@ -60,6 +63,9 @@ public class MultiThreadingSearchTest extends EndToEndTest {
 
   @Override
   protected void setSearchGroundTruth() {
+    topicReader = "Trec";
+    topicFile = "src/test/resources/sample_topics/Trec";
+
     SearchArgs searchArgs;
 
     searchArgs = createDefaultSearchArgs().bm25();

--- a/src/test/java/io/anserini/integration/MultiThreadingSearchTest.java
+++ b/src/test/java/io/anserini/integration/MultiThreadingSearchTest.java
@@ -52,8 +52,7 @@ public class MultiThreadingSearchTest extends EndToEndTest {
     docCount = 3;
 
     fieldNormStatusTotalFields = 1; // text
-    termIndexStatusTermCount = 12; // Please note that standard analyzer ignores stopwords.
-    // Also, this includes docids
+    termIndexStatusTermCount = 12; // default analyzer ignores stopwords; this includes docids
     termIndexStatusTotFreq = 17;  //
     storedFieldStatusTotalDocCounts = 3;
     // 16 positions for text fields, plus 1 for each document because of id

--- a/src/test/java/io/anserini/integration/MultiThreadingSearchTest.java
+++ b/src/test/java/io/anserini/integration/MultiThreadingSearchTest.java
@@ -20,15 +20,12 @@ import io.anserini.collection.TrecCollection;
 import io.anserini.index.IndexArgs;
 import io.anserini.index.generator.JsoupGenerator;
 import io.anserini.search.SearchArgs;
-import org.junit.After;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 

--- a/src/test/java/io/anserini/integration/MultiThreadingSearchTest.java
+++ b/src/test/java/io/anserini/integration/MultiThreadingSearchTest.java
@@ -16,6 +16,8 @@
 
 package io.anserini.integration;
 
+import io.anserini.collection.TrecCollection;
+import io.anserini.index.generator.JsoupGenerator;
 import io.anserini.search.SearchArgs;
 import org.junit.After;
 
@@ -30,34 +32,34 @@ import java.util.Map;
 import java.util.Set;
 
 public class MultiThreadingSearchTest extends EndToEndTest {
-  private List<File> cleanup = new ArrayList<>();
   private Map<String, Set<String>> runsForQuery = new HashMap<>();
   private Map<String, String[]> groundTruthRuns = new HashMap<>();
 
   @Override
-  protected void init() {
+  protected void setIndexingArgs() {
     dataDirPath = "trec/collection2";
-    collectionClass = "Trec";
-    generator = "Jsoup";
+    collectionClass = TrecCollection.class.getSimpleName();
+    generator = JsoupGenerator.class.getSimpleName();
     topicReader = "Trec";
+    topicFile = "src/test/resources/sample_topics/Trec";
+  }
 
+  @Override
+  protected void setCheckIndexGroundTruth() {
     docCount = 3;
-
-    counterIndexed = 3;
-    counterEmpty = 0;
-    counterUnindexable = 0;
-    counterSkipped = 0;
-    counterErrors = 0;
 
     fieldNormStatusTotalFields = 1; // text
     termIndexStatusTermCount = 12; // Please note that standard analyzer ignores stopwords.
-                                   // Also, this includes docids
+    // Also, this includes docids
     termIndexStatusTotFreq = 17;  //
     storedFieldStatusTotalDocCounts = 3;
     // 16 positions for text fields, plus 1 for each document because of id
     termIndexStatusTotPos = 16 + storedFieldStatusTotalDocCounts;
     storedFieldStatusTotFields = 9;  // 3 docs * (1 id + 1 text + 1 raw)
+  }
 
+  @Override
+  protected void setSearchGroundTruth() {
     SearchArgs searchArgs;
 
     searchArgs = createDefaultSearchArgs().bm25();
@@ -158,14 +160,5 @@ public class MultiThreadingSearchTest extends EndToEndTest {
       // Add the file to the cleanup list.
       cleanup.add(runfile);
     }
-  }
-
-  @After
-  @Override
-  public void tearDown() throws Exception {
-    for (File file : cleanup) {
-      file.delete();
-    }
-    super.tearDown();
   }
 }

--- a/src/test/java/io/anserini/integration/TrecEndToEndTest.java
+++ b/src/test/java/io/anserini/integration/TrecEndToEndTest.java
@@ -17,16 +17,19 @@
 package io.anserini.integration;
 
 import io.anserini.collection.TrecCollection;
+import io.anserini.index.IndexArgs;
 import io.anserini.index.generator.JsoupGenerator;
 
 public class TrecEndToEndTest extends EndToEndTest {
   @Override
-  protected void setIndexingArgs() {
-    dataDirPath = "trec/collection2";
-    collectionClass = TrecCollection.class.getSimpleName();
-    generator = JsoupGenerator.class.getSimpleName();
-    topicReader = "Trec";
-    topicFile = "src/test/resources/sample_topics/Trec";
+  protected IndexArgs getIndexArgs() {
+    IndexArgs indexArgs = createDefaultIndexArgs();
+
+    indexArgs.input = "src/test/resources/sample_docs/trec/collection2";
+    indexArgs.collectionClass = TrecCollection.class.getSimpleName();
+    indexArgs.generatorClass = JsoupGenerator.class.getSimpleName();
+
+    return indexArgs;
   }
 
   @Override
@@ -44,6 +47,9 @@ public class TrecEndToEndTest extends EndToEndTest {
 
   @Override
   protected void setSearchGroundTruth() {
+    topicReader = "Trec";
+    topicFile = "src/test/resources/sample_topics/Trec";
+
     testQueries.put("bm25", createDefaultSearchArgs().bm25());
     referenceRunOutput.put("bm25", new String[]{
         "1 Q0 DOC222 1 0.343200 Anserini",

--- a/src/test/java/io/anserini/integration/TrecEndToEndTest.java
+++ b/src/test/java/io/anserini/integration/TrecEndToEndTest.java
@@ -16,22 +16,22 @@
 
 package io.anserini.integration;
 
+import io.anserini.collection.TrecCollection;
+import io.anserini.index.generator.JsoupGenerator;
+
 public class TrecEndToEndTest extends EndToEndTest {
+  @Override
+  protected void setIndexingArgs() {
+    dataDirPath = "trec/collection2";
+    collectionClass = TrecCollection.class.getSimpleName();
+    generator = JsoupGenerator.class.getSimpleName();
+    topicReader = "Trec";
+    topicFile = "src/test/resources/sample_topics/Trec";
+  }
 
   @Override
-  protected void init() {
-    dataDirPath = "trec/collection2";
-    collectionClass = "Trec";
-    generator = "Jsoup";
-    topicReader = "Trec";
-
+  protected void setCheckIndexGroundTruth() {
     docCount = 3;
-
-    counterIndexed = 3;
-    counterEmpty = 0;
-    counterUnindexable = 0;
-    counterSkipped = 0;
-    counterErrors = 0;
 
     fieldNormStatusTotalFields = 1;  // text
     termIndexStatusTermCount = 12;   // Note that standard analyzer ignores stopwords; includes docids.
@@ -40,7 +40,10 @@ public class TrecEndToEndTest extends EndToEndTest {
     // 16 positions for text fields, plus 1 for each document because of id
     termIndexStatusTotPos = 16 + storedFieldStatusTotalDocCounts;
     storedFieldStatusTotFields = 9;  // 3 docs * (1 id + 1 text + 1 raw)
+  }
 
+  @Override
+  protected void setSearchGroundTruth() {
     testQueries.put("bm25", createDefaultSearchArgs().bm25());
     referenceRunOutput.put("bm25", new String[]{
         "1 Q0 DOC222 1 0.343200 Anserini",

--- a/src/test/java/io/anserini/integration/TrecEndToEndWhitelistTest.java
+++ b/src/test/java/io/anserini/integration/TrecEndToEndWhitelistTest.java
@@ -17,19 +17,21 @@
 package io.anserini.integration;
 
 import io.anserini.collection.TrecCollection;
+import io.anserini.index.IndexArgs;
 import io.anserini.index.generator.JsoupGenerator;
 
 public class TrecEndToEndWhitelistTest extends EndToEndTest {
   @Override
-  protected void setIndexingArgs() {
-    dataDirPath = "trec/collection2";
-    collectionClass = TrecCollection.class.getSimpleName();
-    generator = JsoupGenerator.class.getSimpleName();
-    topicReader = "Trec";
-    topicFile = "src/test/resources/sample_topics/Trec";
+  protected IndexArgs getIndexArgs() {
+    IndexArgs indexArgs = createDefaultIndexArgs();
 
-    whitelist = "src/test/resources/sample_docs/trec/collection2/whitelist.txt";
+    indexArgs.input = "src/test/resources/sample_docs/trec/collection2";
+    indexArgs.collectionClass = TrecCollection.class.getSimpleName();
+    indexArgs.generatorClass = JsoupGenerator.class.getSimpleName();
+    indexArgs.whitelist = "src/test/resources/sample_docs/trec/collection2/whitelist.txt";
     // With a whitelist, we're only indexing DOC222
+
+    return indexArgs;
   }
 
   @Override
@@ -46,6 +48,9 @@ public class TrecEndToEndWhitelistTest extends EndToEndTest {
 
   @Override
   protected void setSearchGroundTruth() {
+    topicReader = "Trec";
+    topicFile = "src/test/resources/sample_topics/Trec";
+
     testQueries.put("bm25", createDefaultSearchArgs().bm25());
     referenceRunOutput.put("bm25", new String[]{
         "1 Q0 DOC222 1 0.372700 Anserini"

--- a/src/test/java/io/anserini/integration/TrecEndToEndWhitelistTest.java
+++ b/src/test/java/io/anserini/integration/TrecEndToEndWhitelistTest.java
@@ -16,22 +16,25 @@
 
 package io.anserini.integration;
 
+import io.anserini.collection.TrecCollection;
+import io.anserini.index.generator.JsoupGenerator;
+
 public class TrecEndToEndWhitelistTest extends EndToEndTest {
+  @Override
+  protected void setIndexingArgs() {
+    dataDirPath = "trec/collection2";
+    collectionClass = TrecCollection.class.getSimpleName();
+    generator = JsoupGenerator.class.getSimpleName();
+    topicReader = "Trec";
+    topicFile = "src/test/resources/sample_topics/Trec";
+
+    whitelist = "src/test/resources/sample_docs/trec/collection2/whitelist.txt";
+    // With a whitelist, we're only indexing DOC222
+  }
 
   @Override
-  protected void init() {
-    dataDirPath = "trec/collection2";
-    collectionClass = "Trec";
-    generator = "Jsoup";
-    topicReader = "Trec";
-
+  protected void setCheckIndexGroundTruth() {
     docCount = 1;
-
-    counterIndexed = 1;
-    counterEmpty = 0;
-    counterUnindexable = 0;
-    counterSkipped = 2;
-    counterErrors = 0;
 
     fieldNormStatusTotalFields = 1;  // text
     termIndexStatusTermCount = 5;   // Note that standard analyzer ignores stopwords; includes docids.
@@ -39,17 +42,13 @@ public class TrecEndToEndWhitelistTest extends EndToEndTest {
     storedFieldStatusTotalDocCounts = 1;
     termIndexStatusTotPos = 7;
     storedFieldStatusTotFields = 3;
+  }
 
+  @Override
+  protected void setSearchGroundTruth() {
     testQueries.put("bm25", createDefaultSearchArgs().bm25());
     referenceRunOutput.put("bm25", new String[]{
         "1 Q0 DOC222 1 0.372700 Anserini"
     });
-  }
-
-  @Override
-  protected void setIndexingArgs() {
-    super.setIndexingArgs();
-    indexCollectionArgs.whitelist = "src/test/resources/sample_docs/trec/collection2/whitelist.txt";
-    // With a whitelist, we're only indexing DOC222
   }
 }

--- a/src/test/java/io/anserini/integration/TweetEndToEndTest.java
+++ b/src/test/java/io/anserini/integration/TweetEndToEndTest.java
@@ -16,43 +16,10 @@
 
 package io.anserini.integration;
 
-import io.anserini.search.SearchArgs;
-
-import java.util.Map;
+import io.anserini.collection.TweetCollection;
+import io.anserini.index.generator.TweetGenerator;
 
 public class TweetEndToEndTest extends EndToEndTest {
-
-  @Override
-  protected void init() {
-    dataDirPath = "tweets/collection1";
-    collectionClass = "Tweet";
-    generator = "Tweet";
-    topicReader = "Microblog";
-
-    docCount = 4;
-
-    counterIndexed = 4;
-    counterEmpty = 0;
-    counterUnindexable = 0;
-    counterSkipped = 5;
-    counterErrors = 0;
-
-    fieldNormStatusTotalFields = 1; // text
-
-    // We set that retweets and the tweets with ids larger than tweetMaxId will NOT be indexed!
-    termIndexStatusTermCount = 32; // other indexable fields: 4 doc ids + 4 "lang" fields + 4 "screen_name" fields
-    termIndexStatusTotFreq = 36;
-    storedFieldStatusTotalDocCounts = 4;
-    // 24 positions for text fields, plus 3 for each document because of id, screen_name and lang
-    termIndexStatusTotPos = 24 + 3 * storedFieldStatusTotalDocCounts;
-    storedFieldStatusTotFields = 12;  // 4 tweets * (1 id + 1 text + 1 raw)
-
-    testQueries.put("bm25", createDefaultSearchArgs().bm25().searchTweets());
-    referenceRunOutput.put("bm25", new String[] {
-        "1 Q0 5 1 0.614300 Anserini",
-        "1 Q0 3 2 0.364800 Anserini" });
-  }
-
   // Note that in the test cases, we have:
   // {... "id":1,"id_str":"1","text":"RT This is a Retweet and will NOT NOT be indexed!" ... }
   // {... "id":10,"id_str":"10","text":"This tweet won't be indexed since the maxId is 9" ... }
@@ -63,7 +30,34 @@ public class TweetEndToEndTest extends EndToEndTest {
   // Thus, there should be a total of 4 documents indexed: 9 objects - 5 skipped
   @Override
   protected void setIndexingArgs() {
-    super.setIndexingArgs();
-    indexCollectionArgs.tweetMaxId = 9L;
+    dataDirPath = "tweets/collection1";
+    collectionClass = TweetCollection.class.getSimpleName();
+    generator = TweetGenerator.class.getSimpleName();
+    topicReader = "Microblog";
+    topicFile = "src/test/resources/sample_topics/Microblog";
+    tweetMaxId = 9L;
+  }
+
+  @Override
+  protected void setCheckIndexGroundTruth() {
+    docCount = 4;
+
+    fieldNormStatusTotalFields = 1; // text
+
+    // We set that retweets and the tweets with ids larger than tweetMaxId will NOT be indexed!
+    termIndexStatusTermCount = 32; // other indexable fields: 4 doc ids + 4 "lang" fields + 4 "screen_name" fields
+    termIndexStatusTotFreq = 36;
+    storedFieldStatusTotalDocCounts = 4;
+    // 24 positions for text fields, plus 3 for each document because of id, screen_name and lang
+    termIndexStatusTotPos = 24 + 3 * storedFieldStatusTotalDocCounts;
+    storedFieldStatusTotFields = 12;  // 4 tweets * (1 id + 1 text + 1 raw)
+  }
+
+  @Override
+  protected void setSearchGroundTruth() {
+    testQueries.put("bm25", createDefaultSearchArgs().bm25().searchTweets());
+    referenceRunOutput.put("bm25", new String[] {
+        "1 Q0 5 1 0.614300 Anserini",
+        "1 Q0 3 2 0.364800 Anserini" });
   }
 }

--- a/src/test/java/io/anserini/integration/TweetEndToEndTest.java
+++ b/src/test/java/io/anserini/integration/TweetEndToEndTest.java
@@ -17,6 +17,7 @@
 package io.anserini.integration;
 
 import io.anserini.collection.TweetCollection;
+import io.anserini.index.IndexArgs;
 import io.anserini.index.generator.TweetGenerator;
 
 public class TweetEndToEndTest extends EndToEndTest {
@@ -29,13 +30,15 @@ public class TweetEndToEndTest extends EndToEndTest {
   //
   // Thus, there should be a total of 4 documents indexed: 9 objects - 5 skipped
   @Override
-  protected void setIndexingArgs() {
-    dataDirPath = "tweets/collection1";
-    collectionClass = TweetCollection.class.getSimpleName();
-    generator = TweetGenerator.class.getSimpleName();
-    topicReader = "Microblog";
-    topicFile = "src/test/resources/sample_topics/Microblog";
-    tweetMaxId = 9L;
+  protected IndexArgs getIndexArgs() {
+    IndexArgs indexArgs = createDefaultIndexArgs();
+
+    indexArgs.input = "src/test/resources/sample_docs/tweets/collection1";
+    indexArgs.collectionClass = TweetCollection.class.getSimpleName();
+    indexArgs.generatorClass = TweetGenerator.class.getSimpleName();
+    indexArgs.tweetMaxId = 9L;
+
+    return indexArgs;
   }
 
   @Override
@@ -55,6 +58,9 @@ public class TweetEndToEndTest extends EndToEndTest {
 
   @Override
   protected void setSearchGroundTruth() {
+    topicReader = "Microblog";
+    topicFile = "src/test/resources/sample_topics/Microblog";
+
     testQueries.put("bm25", createDefaultSearchArgs().bm25().searchTweets());
     referenceRunOutput.put("bm25", new String[] {
         "1 Q0 5 1 0.614300 Anserini",

--- a/src/test/resources/sample_topics/bibtex_topics.tsv
+++ b/src/test/resources/sample_topics/bibtex_topics.tsv
@@ -1,0 +1,2 @@
+1	title
+2	abstract


### PR DESCRIPTION
Clearly separates different phases of the testing: building the index, checking the built index, and performing retrieval runs. Provides abstract methods for subclasses to override and supply ground truth and custom parameters.

Indexing calls `main` of `IndexCollection`. Since we're doing end-to-end testing, might as well test command-line parsing.

Added initial implementation of `BibtexEndToEndTest`.