### PR TITLE
Fix CovidGenerator and add Trialstreamer collection

### DIFF
--- a/docs/experiments-covid.md
+++ b/docs/experiments-covid.md
@@ -179,7 +179,7 @@ DATA_DIR=./covid-"${DATE}"
 sh target/appassembler/bin/IndexCollection -collection CovidCollection -generator CovidGenerator \
    -threads 8 -input "${DATA_DIR}" \
    -solr -solr.index covid -solr.zkUrl localhost:9983 \
-   -storePositions -storeDocvectors -storeTransformedDocs
+   -storePositions -storeDocvectors -storeContents -storeRaw
 ```
 
 Once indexing is complete, you can query in Solr at [`http://localhost:8983/solr/#/covid/query`](http://localhost:8983/solr/#/covid/query).

--- a/src/main/java/io/anserini/collection/CovidTrialstreamerCollection.java
+++ b/src/main/java/io/anserini/collection/CovidTrialstreamerCollection.java
@@ -1,0 +1,137 @@
+/*
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.collection;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/**
+ * A document collection for the Trialstreamer dataset modelled after CORD-19.
+ */
+public class CovidTrialstreamerCollection extends DocumentCollection<CovidTrialstreamerCollection.Document> {
+  private static final Logger LOG = LogManager.getLogger(CovidTrialstreamerCollection.class);
+
+  public CovidTrialstreamerCollection(Path path){
+    this.path = path;
+    this.allowedFileSuffix = Set.of(".csv");
+  }
+
+  @Override
+  public FileSegment<CovidTrialstreamerCollection.Document> createFileSegment(Path p) throws IOException {
+    return new Segment(p);
+  }
+
+  /**
+   * A file containing a single CSV document.
+   */
+  public class Segment extends FileSegment<CovidTrialstreamerCollection.Document> {
+    CSVParser csvParser = null;
+    private CSVRecord record = null;
+    private Iterator<CSVRecord> iterator = null; // iterator for CSV records
+
+    public Segment(Path path) throws IOException {
+      super(path);
+      bufferedReader = new BufferedReader(new InputStreamReader(
+          new FileInputStream(path.toString())));
+
+      csvParser = new CSVParser(bufferedReader, CSVFormat.DEFAULT
+        .withFirstRecordAsHeader()
+        .withIgnoreHeaderCase()
+        .withTrim());
+
+      iterator = csvParser.iterator();
+      if (iterator.hasNext()) {
+        record = iterator.next();
+      }
+    }
+
+    @Override
+    public void readNext() throws NoSuchElementException {
+      if (record == null) {
+        throw new NoSuchElementException("Record is empty");
+      } else {
+        bufferedRecord = new CovidTrialstreamerCollection.Document(record);
+        if (iterator.hasNext()) { // if CSV contains more lines, we parse the next record
+          record = iterator.next();
+        } else {
+          atEOF = true; // there is no more JSON object in the bufferedReader
+        }
+      }
+    }
+
+    @Override
+    public void close() {
+      super.close();
+      if (csvParser != null) {
+        try {
+          csvParser.close();
+        } catch (IOException e) {
+          // do nothing
+        }
+      }
+    }
+  }
+
+  /**
+   * A document in a CORD-19 collection.
+   */
+  public class Document extends CovidCollectionDocument {
+    private JsonNode facets;
+
+    public Document(CSVRecord record) {
+      id = record.get("cord_uid");
+      content = record.get("title").replace("\n", " ");
+      content += record.get("abstract").isEmpty() ? "" : "\n" + record.get("abstract");
+      this.record = record;
+
+      String fullTextJson = getFullTextJson(CovidTrialstreamerCollection.this.path.toString());
+      if (fullTextJson != null) {
+        raw = fullTextJson;
+        StringReader fullTextReader = new StringReader(fullTextJson);
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+          JsonNode recordJsonNode = mapper.readerFor(JsonNode.class).readTree(fullTextReader);
+          facets = recordJsonNode.get("facets");
+        } catch (IOException e) {
+          LOG.error("Could not read JSON string");
+        }
+      } else {
+        String recordJson = getRecordJson();
+        raw = recordJson == null ? "" : recordJson;
+      }
+    }
+
+    public JsonNode facets() {
+      return facets;
+    }
+  }
+}

--- a/src/main/resources/solr/schemas/covid.json
+++ b/src/main/resources/solr/schemas/covid.json
@@ -64,5 +64,23 @@
     "type":"pint",
     "stored":true,
     "docValues":true
+  },
+  "add-field": {
+    "name":"outcomes_vocab",
+    "type":"string",
+    "stored":true,
+    "multiValued":true
+  },
+  "add-field": {
+    "name":"population_vocab",
+    "type":"string",
+    "stored":true,
+    "multiValued":true
+  },
+  "add-field": {
+    "name":"interventions_vocab",
+    "type":"string",
+    "stored":true,
+    "multiValued":true
   }
 }


### PR DESCRIPTION
* Updated the CovidGenerator according to the SourceDocument refactor and also fixed documentation
* Added support for facet fields in the Trialstreamer data
* Will add tests for all of the Covid related collections and generators in a follow up PR so we know things don't break