### PR TITLE
Aligning methods for fetching doc in IndexReaderUtils and SimpleSearcher

### DIFF
--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -394,7 +394,7 @@ public class IndexReaderUtils {
       ScoreDoc[] hits = rs.scoreDocs;
 
       if (hits == null || hits.length == 0) {
-        // Silently eat the error and return -1
+        // Either the id doesn't exist or there are multiple documents with the same id. In both cases, return null.
         return null;
       }
 

--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -358,7 +358,7 @@ public class IndexReaderUtils {
   }
 
   /**
-   * Fetches the Lucene {@link Document} based on a collection docid.
+   * Returns the Lucene {@link Document} based on a collection docid.
    * The method is named to be consistent with Lucene's {@link IndexReader#document(int)}, contra Java's standard
    * method naming conventions.
    *
@@ -371,6 +371,36 @@ public class IndexReaderUtils {
       return reader.document(IndexReaderUtils.convertDocidToLuceneDocid(reader, docid));
     } catch (Exception e) {
       // Eat any exceptions and just return null.
+      return null;
+    }
+  }
+
+  /**
+   * Fetches the Lucene {@link Document} based on some field other than its unique collection docid.
+   * For example, scientific articles might have DOIs.
+   * The method is named to be consistent with Lucene's {@link IndexReader#document(int)}, contra Java's standard
+   * method naming conventions.
+   *
+   * @param reader index reader
+   * @param field field
+   * @param id unique id
+   * @return corresponding Lucene {@link Document} based on the value of a specific field
+   */
+  public static Document documentByField(IndexReader reader, String field, String id) {
+    try {
+      IndexSearcher searcher = new IndexSearcher(reader);
+      Query q = new TermQuery(new Term(field, id));
+      TopDocs rs = searcher.search(q, 1);
+      ScoreDoc[] hits = rs.scoreDocs;
+
+      if (hits == null || hits.length == 0) {
+        // Silently eat the error and return -1
+        return null;
+      }
+
+      return reader.document(hits[0].doc);
+    } catch (IOException e) {
+      // Silently eat the error and return null
       return null;
     }
   }
@@ -407,34 +437,6 @@ public class IndexReaderUtils {
       return reader.document(convertDocidToLuceneDocid(reader, docid)).get(IndexArgs.CONTENTS);
     } catch (Exception e) {
       // Eat any exceptions and just return null.
-      return null;
-    }
-  }
-
-  /**
-   * Returns the Lucene document based on some field beside its unique collection docid. For example, scientific
-   * articles might have DOIs.
-   *
-   * @param reader index reader
-   * @param field field
-   * @param query id to search
-   * @return the Lucene document
-   */
-  public static Document documentByField(IndexReader reader, String field, String query) {
-    try {
-      IndexSearcher searcher = new IndexSearcher(reader);
-      Query q = new TermQuery(new Term(field, query));
-      TopDocs rs = searcher.search(q, 1);
-      ScoreDoc[] hits = rs.scoreDocs;
-
-      if (hits == null || hits.length == 0) {
-        // Silently eat the error and return -1
-        return null;
-      }
-
-      return reader.document(hits[0].doc);
-    } catch (IOException e) {
-      // Silently eat the error and return null
       return null;
     }
   }

--- a/src/main/java/io/anserini/search/SimpleSearcher.java
+++ b/src/main/java/io/anserini/search/SimpleSearcher.java
@@ -414,7 +414,7 @@ public class SimpleSearcher implements Closeable {
   }
 
   /**
-   * Fetches the Lucene {@link Document} based on a collection docid.
+   * Returns the Lucene {@link Document} based on a collection docid.
    * The method is named to be consistent with Lucene's {@link IndexReader#document(int)}, contra Java's standard
    * method naming conventions.
    *
@@ -423,6 +423,20 @@ public class SimpleSearcher implements Closeable {
    */
   public Document document(String docid) {
     return IndexReaderUtils.document(reader, docid);
+  }
+
+  /**
+   * Fetches the Lucene {@link Document} based on some field other than its unique collection docid.
+   * For example, scientific articles might have DOIs.
+   * The method is named to be consistent with Lucene's {@link IndexReader#document(int)}, contra Java's standard
+   * method naming conventions.
+   *
+   * @param field field
+   * @param id unique id
+   * @return corresponding Lucene {@link Document} based on the value of a specific field
+   */
+  public Document documentByField(String field, String id) {
+    return IndexReaderUtils.documentByField(reader, field, id);
   }
 
   /**

--- a/src/test/java/io/anserini/search/SimpleSearcherTest.java
+++ b/src/test/java/io/anserini/search/SimpleSearcherTest.java
@@ -35,20 +35,28 @@ public class SimpleSearcherTest extends IndexerTestBase {
     SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
 
     assertEquals("here is some text here is some more text. city.",
-        searcher.document(0).getField("contents").stringValue());
-    assertEquals("more texts",
-        searcher.document(1).getField("contents").stringValue());
-    assertEquals("here is a test",
-        searcher.document(2).getField("contents").stringValue());
+        searcher.document(0).get("contents"));
+    assertEquals("more texts", searcher.document(1).get("contents"));
+    assertEquals("here is a test", searcher.document(2).get("contents"));
     assertNull(searcher.document(3));
 
     assertEquals("here is some text here is some more text. city.",
-        searcher.document("doc1").getField("contents").stringValue());
-    assertEquals("more texts",
-        searcher.document("doc2").getField("contents").stringValue());
-    assertEquals("here is a test",
-        searcher.document("doc3").getField("contents").stringValue());
+        searcher.document("doc1").get("contents"));
+    assertEquals("more texts", searcher.document("doc2").get("contents"));
+    assertEquals("here is a test", searcher.document("doc3").get("contents"));
     assertNull(searcher.document(3));
+
+    searcher.close();
+  }
+
+  @Test
+  public void testGetDocByField() throws Exception {
+    SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
+
+    assertEquals("here is some text here is some more text. city.",
+        searcher.documentByField("id", "doc1").get("contents"));
+    assertEquals("more texts", searcher.documentByField("id", "doc2").get("contents"));
+    assertEquals("here is a test", searcher.documentByField("id", "doc3").get("contents"));
 
     searcher.close();
   }


### PR DESCRIPTION
`IndexReaderUtils` and `SimpleSearcher` should have the same methods for access documents. Implements `documentByField`, which was previous missing in `SimpleSearcher`. Also aligns documentation so they say the same thing.
