### PR TITLE
New indexes CORD-19 04/17 data drop

### DIFF
--- a/docs/experiments-covid.md
+++ b/docs/experiments-covid.md
@@ -13,9 +13,9 @@ If you don't want to build the index yourself, you can download the latest pre-b
 
 | Type | Version | Size | Link| Checksum |
 |:-----|:--------|:-----|:----|:---------|
-| Title + Abstract | 2020-04-10 | 1.2G | [[Dropbox]](https://www.dropbox.com/s/j55t617yhvmegy8/lucene-index-covid-2020-04-10.tar.gz) | `ec239d56498c0e7b74e3b41e1ce5d42a`
-| Full-Text | 2020-04-10 | 3.3G | [[Dropbox]](https://www.dropbox.com/s/gtq2c3xq81mjowk/lucene-index-covid-full-text-2020-04-10.tar.gz) | `401a6f5583b0f05340c73fbbeb3279c8`
-| Paragraph | 2020-04-10 | 3.4G| [[Dropbox]](https://www.dropbox.com/s/ivk87journyajw3/lucene-index-covid-paragraph-2020-04-10.tar.gz) | `8b87a2c55bc0a15b87f11e796860216a`
+| Title + Abstract | 2020-04-17 | 1.2G | [[Dropbox]](https://www.dropbox.com/s/xogxcrvyx75vxoj/lucene-index-covid-2020-04-17.tar.gz) | `d57b17eadb1b44fc336b4121c139a598`
+| Full-Text | 2020-04-17 | 2.2G | [[Dropbox]](https://www.dropbox.com/s/gs054ecxna5xm0f/lucene-index-covid-full-text-2020-04-17.tar.gz) | `677546e0a1b7855a48eee8b6fbd7d7af`
+| Paragraph | 2020-04-17 | 4.7G| [[Dropbox]](https://www.dropbox.com/s/u3a0z53pdaxekfe/lucene-index-covid-paragraph-2020-04-17.tar.gz) | `c11e46230b744a46747f84e49acc9c2b`
 
 "Size" refers to the output of `ls -lh`, "Version" refers to the dataset release date from AI2.
 For our answer to the question, "which one should I use?" see below.
@@ -24,11 +24,11 @@ We've kept around older versions of the index for archival purposes &mdash; scro
 
 ## Data Prep
 
-The latest distribution available is from 2020/04/03.
+The latest distribution available is from 2020/04/17.
 First, download the data:
 
 ```bash
-DATE=2020-04-10
+DATE=2020-04-17
 DATA_DIR=./covid-"${DATE}"
 mkdir "${DATA_DIR}"
 
@@ -72,7 +72,7 @@ sh target/appassembler/bin/IndexCollection \
 The output message should be something like this:
 
 ```bash
-2020-04-10 21:11:39,825 INFO  [main] index.IndexCollection (IndexCollection.java:879) - Total 51,069 documents indexed in 00:01:12
+2020-04-20 11:42:44,075 INFO  [main] index.IndexCollection (IndexCollection.java:879) - Total 52,389 documents indexed in 00:01:11
 ```
 
 The `contents` field of each Lucene document is a concatenation of the article's title and abstract.
@@ -92,7 +92,7 @@ sh target/appassembler/bin/IndexCollection \
 The output message should be something like this:
 
 ```bash
-2020-04-10 21:17:24,625 INFO  [main] index.IndexCollection (IndexCollection.java:879) - Total 51,071 documents indexed in 00:05:00
+2020-04-20 11:47:06,839 INFO  [main] index.IndexCollection (IndexCollection.java:879) - Total 52,391 documents indexed in 00:03:31
 ```
 
 The `contents` field of each Lucene document is a concatenation of the article's title and abstract, and the full text JSON (if available).
@@ -112,7 +112,7 @@ sh target/appassembler/bin/IndexCollection \
 The output message should be something like this:
 
 ```bash
-2020-04-10 21:30:21,760 INFO  [main] index.IndexCollection (IndexCollection.java:879) - Total 1,412,648 documents indexed in 00:10:21
+2020-04-20 12:20:33,823 INFO  [main] index.IndexCollection (IndexCollection.java:879) - Total 1,455,628 documents indexed in 00:14:54
 ```
 
 In this configuration, the indexer creates multiple Lucene Documents for each source article:
@@ -173,7 +173,7 @@ solrini/bin/solr create -n anserini -c covid
 We can now index into Solr:
 
 ```
-DATE=2020-04-03
+DATE=2020-04-17
 DATA_DIR=./covid-"${DATE}"
 
 sh target/appassembler/bin/IndexCollection -collection CovidCollection -generator CovidGenerator \
@@ -190,14 +190,17 @@ All versions of pre-built indexes:
 
 | Type | Version | Size | Link| Checksum |
 |:-----|:--------|:-----|:----|:---------|
+| Title + Abstract | 2020-04-17 | 1.2G | [[Dropbox]](https://www.dropbox.com/s/xogxcrvyx75vxoj/lucene-index-covid-2020-04-17.tar.gz) | `d57b17eadb1b44fc336b4121c139a598`
 | Title + Abstract | 2020-04-10 | 1.2G | [[Dropbox]](https://www.dropbox.com/s/j55t617yhvmegy8/lucene-index-covid-2020-04-10.tar.gz) | `ec239d56498c0e7b74e3b41e1ce5d42a`
 | Title + Abstract | 2020-04-03 | 1.1G | [[Dropbox]](https://www.dropbox.com/s/d6v9fensyi7q3gb/lucene-index-covid-2020-04-03.tar.gz) | `5d0d222e746d522a75f94240f5ab9f23`
 | Title + Abstract | 2020-03-27 | 1.1G | [[Dropbox]](https://www.dropbox.com/s/j1epbu4ufunbbzv/lucene-index-covid-2020-03-27.tar.gz) | `c5f7247e921c80f41ac6b54ff38eb229`
 | Title + Abstract | 2020-03-20 | 1.0G | [[Dropbox]](https://www.dropbox.com/s/uvjwgy4re2myq5s/lucene-index-covid-2020-03-20.tar.gz) | `281c632034643665d52a544fed23807a`
+| Full-Text | 2020-04-17 | 2.2G | [[Dropbox]](https://www.dropbox.com/s/gs054ecxna5xm0f/lucene-index-covid-full-text-2020-04-17.tar.gz) | `677546e0a1b7855a48eee8b6fbd7d7af`
 | Full-Text | 2020-04-10 | 3.3G | [[Dropbox]](https://www.dropbox.com/s/gtq2c3xq81mjowk/lucene-index-covid-full-text-2020-04-10.tar.gz) | `401a6f5583b0f05340c73fbbeb3279c8`
 | Full-Text | 2020-04-03 | 3.0G | [[Dropbox]](https://www.dropbox.com/s/abhuqks7aa1xs79/lucene-index-covid-full-text-2020-04-03.tar.gz) | `9aafb86fec39e0882bd9ef0688d7a9cc`
 | Full-Text | 2020-03-27 | 2.9G | [[Dropbox]](https://www.dropbox.com/s/hjsf7qldn4t10vm/lucene-index-covid-full-text-2020-03-27.tar.gz) | `3c126344f9711720e6cf627c9bc415eb`
 | Full-Text | 2020-03-20 | 2.6G | [[Dropbox]](https://www.dropbox.com/s/w74nmpmvdgw7o00/lucene-index-covid-full-text-2020-03-20.tar.gz) | `30cae90b85fa8f1b53acaa62413756e3`
+| Paragraph | 2020-04-17 | 4.7G| [[Dropbox]](https://www.dropbox.com/s/u3a0z53pdaxekfe/lucene-index-covid-paragraph-2020-04-17.tar.gz) | `c11e46230b744a46747f84e49acc9c2b`
 | Paragraph | 2020-04-10 | 3.4G| [[Dropbox]](https://www.dropbox.com/s/ivk87journyajw3/lucene-index-covid-paragraph-2020-04-10.tar.gz) | `8b87a2c55bc0a15b87f11e796860216a`
 | Paragraph | 2020-04-03 | 3.1G| [[Dropbox]](https://www.dropbox.com/s/rfzxrrstwlck4wh/lucene-index-covid-paragraph-2020-04-03.tar.gz) | `523894cfb52fc51c4202e76af79e1b10`
 | Paragraph | 2020-03-27 | 3.1G| [[Dropbox]](https://www.dropbox.com/s/o95pehyzem0yalp/lucene-index-covid-paragraph-2020-03-27.tar.gz) | `8e02de859317918af4829c6188a89086`


### PR DESCRIPTION
@edwinzhng  @rodrigonogueira4 

Minor concern is that for paragraph index, size went up from 3.4G to 4.7G. The only relevant commit I can see that would impact this is: https://github.com/castorini/anserini/commit/cc3b0a3bd2eb83d8f4802fe2e57e37187586a5be where we us pmc json is available.

Thoughts?