### PR TITLE
Update replication log for MS MARCO Passage Retrieval, MS MARCO Doc R…

### DIFF
--- a/docs/experiments-doc2query.md
+++ b/docs/experiments-doc2query.md
@@ -168,3 +168,4 @@ TREC CAR corpus v2.0 in this experiment instead of corpus v1.5 used in the paper
 + Results replicated by [@justram](https://github.com/justram) on 2019-08-09 (commit [`5f098f`](https://github.com/justram/Anserini/commit/5f098f23527611bca1224149bc2d155adce1e48))
 + Results replicated by [@ronakice](https://github.com/ronakice) on 2019-08-13 (commit [`5b29d16`](https://github.com/castorini/anserini/commit/5b29d1654abc5e8a014c2230da990ab2f91fb340))
 + Results replicated by [@edwinzhng](https://github.com/edwinzhng) on 2020-01-08 (commit [`5cc923d`](https://github.com/castorini/anserini/commit/5cc923d5c02777d8b25df32ff2e2a59be5badfdd))
++ Results replicated by [@HangCui0510](https://github.com/HangCui0510) on 2020-04-23 (commit [`0ae567d`](https://github.com/castorini/anserini/commit/0ae567df5c8a70ac211efd958c9ca1ff609ff782))

--- a/docs/experiments-doc2query.md
+++ b/docs/experiments-doc2query.md
@@ -48,8 +48,8 @@ We can then reindex the collection:
 
 ```
 sh ./target/appassembler/bin/IndexCollection -collection JsonCollection \
- -generator LuceneDocumentGenerator -threads 9 -input msmarco-passage/collection_jsonl_expanded_topk10 \
- -index msmarco-passage/lucene-index-msmarco-expanded-topk10 -storePositions -storeDocvectors -storeRawDocs
+ -generator DefaultLuceneDocumentGenerator -threads 9 -input msmarco-passage/collection_jsonl_expanded_topk10 \
+ -index msmarco-passage/lucene-index-msmarco-expanded-topk10 -storePositions -storeDocvectors -storeRaw
 ```
 
 And run retrieval (same as above):
@@ -134,7 +134,7 @@ We can then index the expanded documents:
 
 ```
 sh target/appassembler/bin/IndexCollection -collection JsonCollection \
- -generator LuceneDocumentGenerator -threads 30 -input trec_car/collection_jsonl_expanded_topk10 \
+ -generator DefaultLuceneDocumentGenerator -threads 30 -input trec_car/collection_jsonl_expanded_topk10 \
  -index trec_car/lucene-index.car17v2.0
 ```
 

--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -22,8 +22,8 @@ Build the index with the following command:
 
 ```
 nohup sh target/appassembler/bin/IndexCollection -collection TrecCollection \
- -generator LuceneDocumentGenerator -threads 1 -input msmarco-doc/collection \
- -index lucene-index.msmarco-doc.pos+docvectors+rawdocs -storePositions -storeDocvectors -storeRawDocs \
+ -generator DefaultLuceneDocumentGenerator -threads 1 -input msmarco-doc/collection \
+ -index lucene-index.msmarco-doc.pos+docvectors+rawdocs -storePositions -storeDocvectors -storeRaw \
  >& log.msmarco-doc.pos+docvectors+rawdocs &
 ```
 

--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -129,3 +129,4 @@ As expected, BM25 tuning makes a big difference!
 + Results replicated by [@edwinzhng](https://github.com/edwinzhng) on 2020-01-14 (commit [`3964169`](https://github.com/castorini/anserini/commit/3964169bf82a3783f9298907d9794f0bddf306f0))
 + Results replicated by [@nikhilro](https://github.com/nikhilro) on 2020-01-21 (commit [`631589e`](https://github.com/castorini/anserini/commit/631589e9e08326373f46555e007e6c302c19126d))
 + Results replicated by [@yuki617](https://github.com/yuki617) on 2020-03-29 (commit [`074723c`](https://github.com/castorini/anserini/commit/074723cbb10660fb9be2bfe6325739ab5fe0dd8d))
++ Results replicated by [@HangCui0510](https://github.com/HangCui0510) on 2020-04-23 (commit [`0ae567d`](https://github.com/castorini/anserini/commit/0ae567df5c8a70ac211efd958c9ca1ff609ff782))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -157,3 +157,4 @@ Tuned (`k1=0.82`, `b=0.72`) | 0.1875 | 0.1956 | 0.8578
 + Results replicated by [@nikhilro](https://github.com/nikhilro) on 2020-01-21 (commit [`631589e`](https://github.com/castorini/anserini/commit/631589e9e08326373f46555e007e6c302c19126d))
 + Results replicated by [@yuki617](https://github.com/yuki617) on 2020-03-29 (commit [`074723c`](https://github.com/castorini/anserini/commit/074723cbb10660fb9be2bfe6325739ab5fe0dd8d))
 + Results replicated by [@weipang142857](https://github.com/weipang142857) on 2020-04-20 (commit [`074723c`](https://github.com/castorini/anserini/commit/074723cbb10660fb9be2bfe6325739ab5fe0dd8d))
++ Results replicated by [@HangCui0510](https://github.com/HangCui0510) on 2020-04-23 (commit [`0ae567d`](https://github.com/castorini/anserini/commit/0ae567df5c8a70ac211efd958c9ca1ff609ff782))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -32,7 +32,7 @@ We can now index these docs as a `JsonCollection` using Anserini:
 ```
 sh ./target/appassembler/bin/IndexCollection -collection JsonCollection \
  -generator DefaultLuceneDocumentGenerator -threads 9 -input msmarco-passage/collection_jsonl \
- -index msmarco-passage/lucene-index-msmarco -storePositions -storeDocvectors -storeRawDocs 
+ -index msmarco-passage/lucene-index-msmarco -storePositions -storeDocvectors -storeRaw 
 ```
 
 Upon completion, we should have an index with 8,841,823 documents.


### PR DESCRIPTION
**Environment:** macOS Catalina version 10.15.3

**Problems Encountered:** Index command for each experiment, please see details below.
**MS MARCO Passage Retrieval:** 
**Original Command:** 
sh ./target/appassembler/bin/IndexCollection -collection JsonCollection \
 -generator DefaultLuceneDocumentGenerator -threads 9 -input msmarco-passage/collection_jsonl \
 -index msmarco-passage/lucene-index-msmarco -storePositions -storeDocvectors -storeRawDocs

**Correct Command:** 
sh ./target/appassembler/bin/IndexCollection -collection JsonCollection \
 -generator DefaultLuceneDocumentGenerator -threads 9 -input msmarco-passage/collection_jsonl \
 -index msmarco-passage/lucene-index-msmarco -storePositions -storeDocvectors -storeRaw

**MS MARCO Doc Retrieval:**
**Original Command:** 
nohup sh target/appassembler/bin/IndexCollection -collection TrecCollection \
 -generator LuceneDocumentGenerator -threads 1 -input msmarco-doc/collection \
 -index lucene-index.msmarco-doc.pos+docvectors+rawdocs -storePositions -storeDocvectors -storeRawDocs \
 & log.msmarco-doc.pos+docvectors+rawdocs &

**Correct Command:** 
nohup sh target/appassembler/bin/IndexCollection -collection TrecCollection \
 -generator DefaultLuceneDocumentGenerator -threads 1 -input msmarco-doc/collection \
 -index lucene-index.msmarco-doc.pos+docvectors+rawdocs -storePositions -storeDocvectors -storeRaw \
 & log.msmarco-doc.pos+docvectors+rawdocs &

**doc2query:**
**MS MARCO Passage Ranking:**
**Original Command:**
sh ./target/appassembler/bin/IndexCollection -collection JsonCollection \
 -generator LuceneDocumentGenerator -threads 9 -input msmarco-passage/collection_jsonl_expanded_topk10 \
 -index msmarco-passage/lucene-index-msmarco-expanded-topk10 -storePositions -storeDocvectors -storeRawDocs

**Correct Command:**
sh ./target/appassembler/bin/IndexCollection -collection JsonCollection \
 -generator DefaultLuceneDocumentGenerator -threads 9 -input msmarco-passage/collection_jsonl_expanded_topk10 \
 -index msmarco-passage/lucene-index-msmarco-expanded-topk10 -storePositions -storeDocvectors -storeRaw

**TREC Car:**
**Original Command:**
sh target/appassembler/bin/IndexCollection -collection JsonCollection \
 -generator LuceneDocumentGenerator -threads 30 -input trec_car/collection_jsonl_expanded_topk10 \
 -index trec_car/lucene-index.car17v2.0

**Correct Command:**
sh target/appassembler/bin/IndexCollection -collection JsonCollection \
 -generator DefaultLuceneDocumentGenerator -threads 30 -input trec_car/collection_jsonl_expanded_topk10 \
 -index trec_car/lucene-index.car17v2.0

**Output Replication:**
**MS MARCO Passage Retrieval:**
<img width="816" alt="Screen Shot 2020-04-23 at 7 37 48 PM" src="https://user-images.githubusercontent.com/64120158/80185172-e71c2400-85d9-11ea-8c6b-0a8e749d1587.png">
<img width="484" alt="Screen Shot 2020-04-22 at 8 56 51 PM" src="https://user-images.githubusercontent.com/64120158/80184922-7a088e80-85d9-11ea-88de-c652a0b9eb0b.png">
<img width="486" alt="Screen Shot 2020-04-22 at 8 57 05 PM" src="https://user-images.githubusercontent.com/64120158/80184998-9c9aa780-85d9-11ea-90d1-0a156e66f363.png">

**MS MARCO Doc Retrieval:**
<img width="624" alt="Screen Shot 2020-04-23 at 11 38 44 PM" src="https://user-images.githubusercontent.com/64120158/80185245-07e47980-85da-11ea-95c8-91ff1dca4fb7.png">
<img width="451" alt="Screen Shot 2020-04-23 at 11 42 20 PM" src="https://user-images.githubusercontent.com/64120158/80185271-1337a500-85da-11ea-9798-77fcb69ccf16.png">
<img width="484" alt="Screen Shot 2020-04-24 at 12 19 52 AM" src="https://user-images.githubusercontent.com/64120158/80185328-2b0f2900-85da-11ea-9401-eed781716b7b.png">
<img width="492" alt="Screen Shot 2020-04-24 at 12 20 27 AM" src="https://user-images.githubusercontent.com/64120158/80185365-37938180-85da-11ea-8e99-a77768d29258.png">
<img width="488" alt="Screen Shot 2020-04-24 at 12 21 21 AM" src="https://user-images.githubusercontent.com/64120158/80185377-3b270880-85da-11ea-9028-50d1ec0e8cf3.png">

**doc2query:**
**MS MARCO Passage Ranking:**
<img width="625" alt="Screen Shot 2020-04-23 at 7 38 20 PM" src="https://user-images.githubusercontent.com/64120158/80185513-71fd1e80-85da-11ea-90ba-2c9f4ff83b92.png">

**TREC Car:**
<img width="490" alt="Screen Shot 2020-04-24 at 2 03 46 AM" src="https://user-images.githubusercontent.com/64120158/80185557-86d9b200-85da-11ea-976f-be4f962f30e4.png">
