### PR TITLE
Store CSV and full text in raw field for CORD-19

### DIFF
--- a/src/main/java/io/anserini/collection/CovidCollection.java
+++ b/src/main/java/io/anserini/collection/CovidCollection.java
@@ -103,18 +103,14 @@ public class CovidCollection extends DocumentCollection<CovidCollection.Document
    */
   public class Document extends CovidCollectionDocument {
     public Document(CSVRecord record) {
+      this.record = record;
+
       id = record.get("cord_uid");
       content = record.get("title").replace("\n", " ");
       content += record.get("abstract").isEmpty() ? "" : "\n" + record.get("abstract");
-      this.record = record;
 
       String fullTextJson = getFullTextJson(CovidCollection.this.path.toString());
-      if (fullTextJson != null) {
-        raw = fullTextJson;
-      } else {
-        String recordJson = getRecordJson();
-        raw = recordJson == null ? "" : recordJson;
-      }
+      raw = buildRawJson(fullTextJson);
     }
   }
 }

--- a/src/main/java/io/anserini/collection/CovidCollectionDocument.java
+++ b/src/main/java/io/anserini/collection/CovidCollectionDocument.java
@@ -18,6 +18,7 @@ package io.anserini.collection;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -65,6 +66,25 @@ public abstract class CovidCollectionDocument implements SourceDocument {
       LOG.error("Error writing record to JSON " + record.toString());
     }
     return recordString;
+  }
+
+  protected final String buildRawJson(String fullTextJson) {
+    String recordJson = getRecordJson();
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode rawJsonNode = mapper.createObjectNode();
+
+    if (fullTextJson != null) {
+      try {
+        rawJsonNode = (ObjectNode) mapper.readTree(fullTextJson);
+      } catch (Exception e) {
+        fullTextJson = null;
+      }
+    }
+
+    rawJsonNode.put("cord_uid", record.get("cord_uid"));
+    rawJsonNode.put("has_full_text", fullTextJson != null);
+    rawJsonNode.put("csv_metadata", recordJson);
+    return rawJsonNode.toString();
   }
 
   @Override

--- a/src/main/java/io/anserini/collection/CovidFullTextCollection.java
+++ b/src/main/java/io/anserini/collection/CovidFullTextCollection.java
@@ -105,12 +105,15 @@ public class CovidFullTextCollection extends DocumentCollection<CovidFullTextCol
    */
   public class Document extends CovidCollectionDocument {
     public Document(CSVRecord record) {
+      this.record = record;
+
       id = record.get("cord_uid");
       content = record.get("title").replace("\n", " ");
       content += record.get("abstract").isEmpty() ? "" : "\n" + record.get("abstract");
-      this.record = record;
 
       String fullTextJson = getFullTextJson(CovidFullTextCollection.this.path.toString());
+      raw = buildRawJson(fullTextJson);
+
       if (fullTextJson != null) {
         // For the contents(), we're going to gather up all the text in body_text
         try {
@@ -125,11 +128,6 @@ public class CovidFullTextCollection extends DocumentCollection<CovidFullTextCol
         } catch (IOException e) {
           LOG.error("Error parsing file at " + CovidFullTextCollection.this.path.toString() + "\n" + e.getMessage());
         }
-
-        raw = fullTextJson;
-      } else {
-        String recordJson = getRecordJson();
-        raw = recordJson == null ? "" : recordJson;
       }
     }
   }

--- a/src/main/java/io/anserini/collection/CovidParagraphCollection.java
+++ b/src/main/java/io/anserini/collection/CovidParagraphCollection.java
@@ -138,6 +138,8 @@ public class CovidParagraphCollection extends DocumentCollection<CovidParagraphC
    */
   public class Document extends CovidCollectionDocument {
     public Document(CSVRecord record, String paragraph, Integer paragraphNumber, String recordFullText) {
+      this.record = record;
+
       if (paragraphNumber == 0) {
         id = record.get("cord_uid");
       } else {
@@ -148,8 +150,7 @@ public class CovidParagraphCollection extends DocumentCollection<CovidParagraphC
       content += record.get("abstract").isEmpty() ? "" : "\n" + record.get("abstract");
       content += paragraph.isEmpty() ? "" : "\n" + paragraph;
 
-      this.raw = recordFullText;
-      this.record = record;
+      raw = buildRawJson(recordFullText);
     }
 
     public Document(CSVRecord record, String paragraph, Integer paragraphNumber) {


### PR DESCRIPTION
Fixes #1105

The `raw` field now contains the following for all documents:

```
{
   "cord_uid": ID,
   "has_full_text": true/false,
   "csv_metadata": { ... }
   ...(rest of fields from full text inline)
}
```

For tests, the reason the `raw` field length decreased is because I load the original full-text JSON string, add the new fields ("cord_uid", "has_full_text", "csv_metadata") and then re-serialize to string which removes a lot of whitespace characters. 