### PR TITLE
Excludes two outlier documents in CORD-19

### DIFF
--- a/src/main/java/io/anserini/index/generator/CovidGenerator.java
+++ b/src/main/java/io/anserini/index/generator/CovidGenerator.java
@@ -89,6 +89,13 @@ public class CovidGenerator implements LuceneDocumentGenerator<CovidCollectionDo
     String content = covidDoc.contents();
     String raw = covidDoc.raw();
 
+    // See https://github.com/castorini/anserini/issues/1127
+    // Corner cases are hard-coded now; if this gets out of hand we should consider implementing a "blacklist" feature
+    // and store these ids externally. Note we use startsWidth here to handle the paragraph indexes as well.
+    if (id.startsWith("ij3ncdb") || id.startsWith("hwjkbpqp")) {
+      throw new SkippedDocumentException();
+    }
+
     if (content == null || content.trim().isEmpty()) {
       throw new EmptyDocumentException();
     }


### PR DESCRIPTION
Closes #1127 (ref #1109)

Small change makes a big difference in the paragraph index.

```bash
$ du -h lucene-index-cord19-*
1.6G	lucene-index-cord19-abstract-2020-04-24
1.6G	lucene-index-cord19-abstract-2020-04-24.old
3.1G	lucene-index-cord19-full-text-2020-04-24
3.1G	lucene-index-cord19-full-text-2020-04-24.old
6.9G	lucene-index-cord19-paragraph-2020-04-24
8.3G	lucene-index-cord19-paragraph-2020-04-24.old
```
