### PR TITLE
Enable query processing methods for udel_fang_run3 of the first round of TREC-COVID

### DIFF
--- a/src/main/java/io/anserini/search/SearchArgs.java
+++ b/src/main/java/io/anserini/search/SearchArgs.java
@@ -43,9 +43,10 @@ public class SearchArgs {
   @Option(name = "-inmem", usage = "Boolean switch to read index in memory")
   public Boolean inmem = false;
 
-  @Option(name = "-topicfield", usage = "Which field of the query should be used, default \"title\"." +
+  @Option(name = "-topicfield", handler = StringArrayOptionHandler.class,
+      usage = "Which field(s) of the query should be used, default \"title\"." +
       " For TREC ad hoc topics, description or narrative can be used.")
-  public String topicfield = "title";
+  public String[] topicfield = new String[]{"title"};
 
   @Option(name = "-skipexists", usage = "When enabled, will skip if the run file exists")
   public Boolean skipexists = false;

--- a/src/main/java/io/anserini/search/SearchArgs.java
+++ b/src/main/java/io/anserini/search/SearchArgs.java
@@ -55,6 +55,9 @@ public class SearchArgs {
       "index created by IndexCollection -collection TweetCollection")
   public Boolean searchtweets = false;
 
+  @Option(name = "-queryconstructor", usage = "specify which query generator to be used ")
+  public String queryconstructor = "BagOfTerms";
+
   @Option(name = "-backgroundlinking", usage = "performs the background linking task as part of the TREC News Track")
   public Boolean backgroundlinking = false;
 

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -162,7 +162,10 @@ public final class SearchCollection implements Closeable {
         PrintWriter out = new PrintWriter(Files.newBufferedWriter(Paths.get(outputPath), StandardCharsets.US_ASCII));
         for (Map.Entry<K, Map<String, String>> entry : topics.entrySet()) {
           K qid = entry.getKey();
-          String queryString = entry.getValue().get(args.topicfield);
+          String queryString = "";
+          for (String singleField : args.topicfield) {
+            queryString += " " + entry.getValue().get(singleField);
+          }
           ScoredDocuments docs;
           if (args.searchtweets) {
             docs = searchTweets(this.searcher, qid, queryString, Long.parseLong(entry.getValue().get("time")), cascade);

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -31,6 +31,7 @@ import io.anserini.rerank.lib.NewsBackgroundLinkingReranker;
 import io.anserini.rerank.lib.Rm3Reranker;
 import io.anserini.rerank.lib.ScoreTiesAdjusterReranker;
 import io.anserini.search.query.BagOfWordsQueryGenerator;
+import io.anserini.search.query.StopwordsRemovedQueryGenerator;
 import io.anserini.search.query.SdmQueryGenerator;
 import io.anserini.search.similarity.AccurateBM25Similarity;
 import io.anserini.search.similarity.TaggedSimilarity;
@@ -124,7 +125,8 @@ public final class SearchCollection implements Closeable {
 
   public enum QueryConstructor {
     BagOfTerms,
-    SequentialDependenceModel
+    SequentialDependenceModel,
+    StopwordsRemoved
   }
 
   private final QueryConstructor qc;
@@ -259,6 +261,9 @@ public final class SearchCollection implements Closeable {
     if (args.sdm) {
       LOG.info("QueryConstructor: SequentialDependenceModel");
       qc = QueryConstructor.SequentialDependenceModel;
+    } else if (args.queryconstructor.equals("StopwordsRemoved")){
+      LOG.info("QueryConstructor: StopwordsRemoved");
+      qc = QueryConstructor.StopwordsRemoved;
     } else {
       LOG.info("QueryConstructor: BagOfTerms");
       qc = QueryConstructor.BagOfTerms;
@@ -453,6 +458,8 @@ public final class SearchCollection implements Closeable {
     Query query = null;
     if (qc == QueryConstructor.SequentialDependenceModel) {
       query = new SdmQueryGenerator(args.sdm_tw, args.sdm_ow, args.sdm_uw).buildQuery(IndexArgs.CONTENTS, analyzer, queryString);
+    } else if (qc == QueryConstructor.StopwordsRemoved) {
+      query = new StopwordsRemovedQueryGenerator().buildQuery(IndexArgs.CONTENTS, analyzer, queryString);
     } else {
       query = new BagOfWordsQueryGenerator().buildQuery(IndexArgs.CONTENTS, analyzer, queryString);
     }

--- a/src/main/java/io/anserini/search/query/StopwordsRemovedQueryGenerator.java
+++ b/src/main/java/io/anserini/search/query/StopwordsRemovedQueryGenerator.java
@@ -1,0 +1,103 @@
+/*
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.search.query;
+
+import io.anserini.analysis.AnalyzerUtils;
+import io.anserini.index.IndexArgs;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class StopwordsRemovedQueryGenerator extends QueryGenerator {
+
+  // stopword list from 
+  // https://github.com/igorbrigadir/stopwords/edit/master/en/galago_inquery.txt
+  private static String [] = {
+    "a", "about", "above", "according", "across", "after", "afterwards", "again", 
+    "against", "albeit", "all", "almost", "alone", "along", "already", "also", "although", 
+    "always", "am", "among", "amongst", "an", "and", "another", "any", "anybody", "anyhow", 
+    "anyone", "anything", "anyway", "anywhere", "apart", "are", "around", "as", "at", "av", 
+    "be", "became", "because", "become", "becomes", "becoming", "been", "before", 
+    "beforehand", "behind", "being", "below", "beside", "besides", "between", "beyond", 
+    "both", "but", "by", "can", "cannot", "canst", "certain", "cf", "choose", 
+    "contrariwise", "cos", "could", "cu", "day", "do", "does", "doesn", "t", "doing", "dost", 
+    "doth", "double", "down", "dual", "during", "each", "either", "else", "elsewhere", 
+    "enough", "et", "etc", "even", "ever", "every", "everybody", "everyone", "everything", 
+    "everywhere", "except", "excepted", "excepting", "exception", "exclude", "excluding", 
+    "exclusive", "far", "farther", "farthest", "few", "ff", "first", "for", "formerly", 
+    "forth", "forward", "from", "front", "further", "furthermore", "furthest", "get", "go", 
+    "had", "halves", "hardly", "has", "hast", "hath", "have", "he", "hence", "henceforth", 
+    "her", "here", "hereabouts", "hereafter", "hereby", "herein", "hereto", "hereupon", 
+    "hers", "herself", "him", "himself", "hindmost", "his", "hither", "hitherto", "how", 
+    "however", "howsoever", "i", "ie", "if", "in", "inasmuch", "inc", "include", "included", 
+    "including", "indeed", "indoors", "inside", "insomuch", "instead", "into", "inward", 
+    "inwards", "is", "it", "its", "itself", "just", "kg", "kind", "km", "last", "latter", 
+    "latterly", "less", "lest", "let", "like", "little", "ltd", "many", "may", "maybe", "me", 
+    "meantime", "meanwhile", "might", "more", "moreover", "most", "mostly", "mr", "mrs", "ms", 
+    "much", "must", "my", "myself", "namely", "need", "neither", "never", "nevertheless", 
+    "next", "no", "nobody", "none", "nonetheless", "noone", "nope", "nor", "not", "nothing", 
+    "notwithstanding", "now", "nowadays", "nowhere", "of", "off", "often", "ok", "on", "once", 
+    "one", "only", "onto", "or", "other", "others", "otherwise", "ought", "our", "ours", 
+    "ourselves", "out", "outside", "over", "own", "per", "perhaps", "plenty", "provide", 
+    "quite", "rather", "really", "round", "said", "sake", "same", "sang", "save", "saw", "see", 
+    "seeing", "seem", "seemed", "seeming", "seems", "seen", "seldom", "selves", "sent", 
+    "several", "shalt", "she", "should", "shown", "sideways", "since", "slept", "slew", 
+    "slung", "slunk", "smote", "so", "some", "somebody", "somehow", "someone", "something", 
+    "sometime", "sometimes", "somewhat", "somewhere", "spake", "spat", "spoke", "spoken", 
+    "sprang", "sprung", "stave", "staves", "still", "such", "supposing", "than", "that", "the", 
+    "thee", "their", "them", "themselves", "then", "thence", "thenceforth", "there", 
+    "thereabout", "thereabouts", "thereafter", "thereby", "therefore", "therein", "thereof", 
+    "thereon", "thereto", "thereupon", "these", "they", "this", "those", "thou", "though", 
+    "thrice", "through", "throughout", "thru", "thus", "thy", "thyself", "till", "to", 
+    "together", "too", "toward", "towards", "ugh", "unable", "under", "underneath", "unless", 
+    "unlike", "until", "up", "upon", "upward", "upwards", "us", "use", "used", "using", "very", 
+    "via", "vs", "want", "was", "we", "week", "well", "were", "what", "whatever", "whatsoever", 
+    "when", "whence", "whenever", "whensoever", "where", "whereabouts", "whereafter", "whereas", 
+    "whereat", "whereby", "wherefore", "wherefrom", "wherein", "whereinto", "whereof", "whereon", 
+    "wheresoever", "whereto", "whereunto", "whereupon", "wherever", "wherewith", "whether", 
+    "whew", "which", "whichever", "whichsoever", "while", "whilst", "whither", "who", "whoa", 
+    "whoever", "whole", "whom", "whomever", "whomsoever", "whose", "whosoever", "why", "will", 
+    "wilt", "with", "within", "without", "worse", "worst", "would", "wow", "ye", "year", "yet", 
+    "yippee", "you", "your", "yours", "yourself", "yourselves"
+  };
+  
+
+  @Override
+  public Query buildQuery(String field, Analyzer analyzer, String queryText) {
+
+    List<String> tokens = AnalyzerUtils.analyze(analyzer, queryText);
+    BooleanQuery.Builder builder = new BooleanQuery.Builder();
+    for (String t : tokens) {
+      if (arr.contains(t)){ // ignore stopwords 
+        continue;
+      }
+      builder.add(new TermQuery(new Term(field, t)), BooleanClause.Occur.SHOULD);
+    }
+
+    return builder.build();
+  }
+}

--- a/src/main/java/io/anserini/search/query/StopwordsRemovedQueryGenerator.java
+++ b/src/main/java/io/anserini/search/query/StopwordsRemovedQueryGenerator.java
@@ -27,16 +27,15 @@ import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 
-import java.util.ArrayList;
+import java.util.Set;
 import java.util.List;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class StopwordsRemovedQueryGenerator extends QueryGenerator {
 
   // stopword list from 
   // https://github.com/igorbrigadir/stopwords/edit/master/en/galago_inquery.txt
-  private static String [] = {
+  private static final Set<String> STOPWORDS = Set.of(
     "a", "about", "above", "according", "across", "after", "afterwards", "again", 
     "against", "albeit", "all", "almost", "alone", "along", "already", "also", "although", 
     "always", "am", "among", "amongst", "an", "and", "another", "any", "anybody", "anyhow", 
@@ -83,7 +82,7 @@ public class StopwordsRemovedQueryGenerator extends QueryGenerator {
     "whoever", "whole", "whom", "whomever", "whomsoever", "whose", "whosoever", "why", "will", 
     "wilt", "with", "within", "without", "worse", "worst", "would", "wow", "ye", "year", "yet", 
     "yippee", "you", "your", "yours", "yourself", "yourselves"
-  };
+  );
   
 
   @Override
@@ -92,7 +91,7 @@ public class StopwordsRemovedQueryGenerator extends QueryGenerator {
     List<String> tokens = AnalyzerUtils.analyze(analyzer, queryText);
     BooleanQuery.Builder builder = new BooleanQuery.Builder();
     for (String t : tokens) {
-      if (arr.contains(t)){ // ignore stopwords 
+      if (STOPWORDS.contains(t)){ // ignore stopwords 
         continue;
       }
       builder.add(new TermQuery(new Term(field, t)), BooleanClause.Occur.SHOULD);

--- a/src/test/java/io/anserini/integration/EndToEndTest.java
+++ b/src/test/java/io/anserini/integration/EndToEndTest.java
@@ -241,7 +241,7 @@ public abstract class EndToEndTest extends LuceneTestCase {
     searchArgs.bm25 = true;
 
     // optional
-    searchArgs.topicfield = "title";
+    searchArgs.topicfield = new String[]{"title"};
     searchArgs.searchtweets = false;
     searchArgs.hits = 1000;
     searchArgs.keepstop = false;


### PR DESCRIPTION
This PR enables the query processing of [udel_fang_run3](https://ir.nist.gov/covidSubmit/archive/round1/udel_fang_run3.pdf). In order to accomplish that, several things are implemented:

- Multiple topic fields
- A query generator that removes stopwords from [Galago stopword list](https://github.com/igorbrigadir/stopwords/edit/master/en/galago_inquery.txt)
- Add an argument `queryconstructor` to expose the generator at run time.