### PR TITLE
CORD-19: changed 'csv_metadata' into JSON

### DIFF
--- a/src/main/java/io/anserini/collection/Cord19BaseDocument.java
+++ b/src/main/java/io/anserini/collection/Cord19BaseDocument.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Map;
 
 public abstract class Cord19BaseDocument implements SourceDocument {
   private static final Logger LOG = LogManager.getLogger(Cord19BaseDocument.class);
@@ -69,7 +70,6 @@ public abstract class Cord19BaseDocument implements SourceDocument {
   }
 
   protected final String buildRawJson(String fullTextJson) {
-    String recordJson = getRecordJson();
     ObjectMapper mapper = new ObjectMapper();
     ObjectNode rawJsonNode = mapper.createObjectNode();
 
@@ -83,7 +83,13 @@ public abstract class Cord19BaseDocument implements SourceDocument {
 
     rawJsonNode.put("cord_uid", record.get("cord_uid"));
     rawJsonNode.put("has_full_text", fullTextJson != null);
-    rawJsonNode.put("csv_metadata", recordJson);
+
+    ObjectNode csvMetadaNode = mapper.createObjectNode();
+    for (Map.Entry<String, String> entry : record.toMap().entrySet()) {
+      csvMetadaNode.put(entry.getKey(), entry.getValue());
+    }
+
+    rawJsonNode.put("csv_metadata", csvMetadaNode);
     return rawJsonNode.toString();
   }
 

--- a/src/test/java/io/anserini/collection/Cord19AbstractCollectionTest.java
+++ b/src/test/java/io/anserini/collection/Cord19AbstractCollectionTest.java
@@ -50,8 +50,8 @@ public class Cord19AbstractCollectionTest extends DocumentCollectionTest<Cord19A
     doc1.put("contents_ends_with", "cannot distinguish UV inactivated virus from infectious viral particles.");
     doc1.put("contents_length", "1803");
     doc1.put("has_full_text", "true");
-    doc1.put("metadata_length", "2426");
-    doc1.put("raw_length", "48090");
+    doc1.put("metadata_length", "2352");
+    doc1.put("raw_length", "48016");
     expected.put("xqhn0vbp", doc1);
 
     // In the 2020/04/10 version, has_pdf_parse=FALSE, has_pmc_xml_parse=FALSE
@@ -62,8 +62,8 @@ public class Cord19AbstractCollectionTest extends DocumentCollectionTest<Cord19A
     doc2.put("contents_ends_with", "The need for critical evaluation of all of these technologies is stressed.");
     doc2.put("contents_length", "1264");
     doc2.put("has_full_text", "false");
-    doc2.put("metadata_length", "1797");
-    doc2.put("raw_length", "1858");
+    doc2.put("metadata_length", "1711");
+    doc2.put("raw_length", "1772");
     expected.put("28wrp74k", doc2);
 
     // In the 2020/04/10 version, has_pdf_parse=TRUE, has_pmc_xml_parse=FALSE
@@ -75,8 +75,8 @@ public class Cord19AbstractCollectionTest extends DocumentCollectionTest<Cord19A
     doc3.put("contents_ends_with", "Beyond Picomolar Affinities: Quantitative Aspects of Noncovalent and Covalent Binding of Drugs to Proteins");
     doc3.put("contents_length", "106");
     doc3.put("has_full_text", "true");
-    doc3.put("metadata_length", "724");
-    doc3.put("raw_length", "94712");
+    doc3.put("metadata_length", "650");
+    doc3.put("raw_length", "94638");
     expected.put("a8cps3ko", doc3);
   }
 
@@ -95,8 +95,10 @@ public class Cord19AbstractCollectionTest extends DocumentCollectionTest<Cord19A
       JsonNode jsonNode = mapper.readTree(covidDoc.raw());
       assertEquals(expected.get("id"), jsonNode.get("cord_uid").asText());
       assertEquals(expected.get("has_full_text"), jsonNode.get("has_full_text").asText());
+      assertEquals(true, jsonNode.get("csv_metadata").isObject());
       assertEquals(Integer.parseInt(expected.get("metadata_length")),
-        jsonNode.get("csv_metadata").toString().length());
+          jsonNode.get("csv_metadata").toString().length());
+
     } catch (Exception e) {
       assertTrue("Failed to parse raw JSON", false);
     }

--- a/src/test/java/io/anserini/collection/Cord19FullTextCollectionTest.java
+++ b/src/test/java/io/anserini/collection/Cord19FullTextCollectionTest.java
@@ -50,8 +50,8 @@ public class Cord19FullTextCollectionTest extends DocumentCollectionTest<Cord19F
     doc1.put("contents_ends_with", "The pre-publication history for this paper can be accessed here:\n");
     doc1.put("contents_length", "22834");
     doc1.put("has_full_text", "true");
-    doc1.put("metadata_length", "2426");
-    doc1.put("raw_length", "48090");
+    doc1.put("metadata_length", "2352");
+    doc1.put("raw_length", "48016");
     expected.put("xqhn0vbp", doc1);
 
     // In the 2020/04/10 version, has_pdf_parse=FALSE, has_pmc_xml_parse=FALSE
@@ -62,8 +62,8 @@ public class Cord19FullTextCollectionTest extends DocumentCollectionTest<Cord19F
     doc2.put("contents_ends_with", "The need for critical evaluation of all of these technologies is stressed.");
     doc2.put("contents_length", "1264");
     doc2.put("has_full_text", "false");
-    doc2.put("metadata_length", "1797");
-    doc2.put("raw_length", "1858");
+    doc2.put("metadata_length", "1711");
+    doc2.put("raw_length", "1772");
     expected.put("28wrp74k", doc2);
 
     // In the 2020/04/10 version, has_pdf_parse=TRUE, has_pmc_xml_parse=FALSE
@@ -75,8 +75,8 @@ public class Cord19FullTextCollectionTest extends DocumentCollectionTest<Cord19F
     doc3.put("contents_ends_with", "Copyright 2005 Americal Chemical Society. ");
     doc3.put("contents_length", "33583");
     doc3.put("has_full_text", "true");
-    doc3.put("metadata_length", "724");
-    doc3.put("raw_length", "94712");
+    doc3.put("metadata_length", "650");
+    doc3.put("raw_length", "94638");
     expected.put("a8cps3ko", doc3);
   }
 


### PR DESCRIPTION
Before, `csv_metadata` was the string representation of JSON, which meant that when we fetched the `raw` field, we had to parse the JSON, and then parse the `csv_metadata` value again. This way, the value of `csv_metadata` is an actual JSON object.
