### PR TITLE
Move measure_judged.py && print formatting

### DIFF
--- a/eval/measure_judged.py
+++ b/eval/measure_judged.py
@@ -28,10 +28,7 @@ def load_qrels(path: str) -> Dict[str, Set[str]]:
             line = ' '.join(line.split())
             query_id, _, doc_id, relevance = line.rstrip().split(' ')
             qrels[query_id].add(doc_id)
-            if i % 1000000 == 0:
-                print('Loading qrels {}'.format(i))
 
-    print('Loading qrels completed')
     return qrels
 
 
@@ -56,10 +53,6 @@ def load_run(path: str) -> Dict[str, List[str]]:
     return sorted_run
 
 
-def print_divider():
-    print('\n--------------------- \n')
-
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='measure the percentage of judged documents at various '
@@ -75,7 +68,6 @@ if __name__ == "__main__":
 
     qrels = load_qrels(args.qrels)
     run = load_run(args.run)
-    print_divider()
 
     for max_rank in args.cutoffs:
         percentage_judged = 0
@@ -88,5 +80,4 @@ if __name__ == "__main__":
         percentage_judged /= max(1, len(run))
         print(f'judged@{max_rank}: {percentage_judged}')
 
-    print_divider()
-    print('Done')
+    print('\nDone')

--- a/eval/measure_judged.py
+++ b/eval/measure_judged.py
@@ -30,6 +30,8 @@ def load_qrels(path: str) -> Dict[str, Set[str]]:
             qrels[query_id].add(doc_id)
             if i % 1000000 == 0:
                 print('Loading qrels {}'.format(i))
+
+    print('Loading qrels completed')
     return qrels
 
 
@@ -54,6 +56,10 @@ def load_run(path: str) -> Dict[str, List[str]]:
     return sorted_run
 
 
+def print_divider():
+    print('\n--------------------- \n')
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='measure the percentage of judged documents at various '
@@ -69,6 +75,7 @@ if __name__ == "__main__":
 
     qrels = load_qrels(args.qrels)
     run = load_run(args.run)
+    print_divider()
 
     for max_rank in args.cutoffs:
         percentage_judged = 0
@@ -81,4 +88,5 @@ if __name__ == "__main__":
         percentage_judged /= max(1, len(run))
         print(f'judged@{max_rank}: {percentage_judged}')
 
+    print_divider()
     print('Done')


### PR DESCRIPTION
Picking up from [PR 1160](https://github.com/castorini/anserini/pull/1160).

- Moving measure_judged.py to `eval/`
- Formatting the print messages

# Example:
```
Loading qrels 0
Loading qrels completed

---------------------

judged@5: 0.2
judged@10: 0.15333333333333335
judged@20: 0.15666666666666662
judged@30: 0.14

---------------------

Done
```