### PR TITLE
[trec-covid/print_run.py] handling missing query id

### DIFF
--- a/src/main/python/trec-covid/print_run.py
+++ b/src/main/python/trec-covid/print_run.py
@@ -28,6 +28,10 @@ run = utils.load_run(args.run)
 metadata = load_metadata(args.metadata)
 
 for query_id, (query, question) in queries.items():
+    if query_id not in run:
+        print(f'>> Missing query_id: {query_id}')
+        continue
+
     print(f'query id: {query_id} | query: {query} | question: {question}')
     output = 'rank | doc_id | title'
     if args.abstract:


### PR DESCRIPTION
When the queries have more topics than the run, skip missing query id.

For example, the queries file has 35 topics, but the run only has 30 topics. Instead of throwing a key not found error, we should handle it gracefully.

```
--------------------------------------------------
query id: 30 | query: coronavirus remdesivir | question: is remdesivir an effective treatment for COVID-19
rank | doc_id | title
1 | j8n06hzx | Treatment options for COVID-19: the reality and challenges
2 | sqrn6kjy | The epidemiological and clinical features of COVID-19 and lessons from this global infectious public health event
3 | j0i9ozsz | Coronavirus Disease 2019 Treatment: A Review of Early and Emerging Options
4 | nz8qvuw6 | Compounds with Therapeutic Potential against Novel Respiratory 2019 Coronavirus
5 | jbtrdvhe | Coronavirus disease 2019 (COVID-19): current status and future perspectives
6 | da61tfr9 | New insights on the antiviral effects of chloroquine against coronavirus: what to expect for COVID-19?
7 | ai2zcke5 | Evaluation of 19 antiviral drugs against SARS-CoV-2 Infection
8 | ztcyvsoi | A Review of Coronavirus Disease-2019 (COVID-19)
9 | 5trqi9tp | A Systematic Review of Lopinavir Therapy for SARS Coronavirus and MERS Coronavirus–A Possible Reference for Coronavirus Disease-19 Treatment Option
10 | 958u08vb | Novel coronavirus disease (COVID-19): a pandemic (epidemiology, pathogenesis and potential therapeutics)
--------------------------------------------------
>> Missing query_id: 31
>> Missing query_id: 32
>> Missing query_id: 33
>> Missing query_id: 34
>> Missing query_id: 35
```