### PR TITLE
Untangle SimpleSearcher form SimpleTweetSearcher + verification script

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,10 @@
               <id>SimpleSearcher</id>
             </program>
             <program>
+              <mainClass>io.anserini.search.SimpleTweetSearcher</mainClass>
+              <id>SimpleTweetSearcher</id>
+            </program>
+            <program>
                <mainClass>io.anserini.util.DumpAnalyzedQueries</mainClass>
                <id>DumpAnalyzedQueries</id>
             </program>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,10 @@
               <id>SearchMsmarco</id>
             </program>
             <program>
+              <mainClass>io.anserini.search.SimpleSearcher</mainClass>
+              <id>SimpleSearcher</id>
+            </program>
+            <program>
                <mainClass>io.anserini.util.DumpAnalyzedQueries</mainClass>
                <id>DumpAnalyzedQueries</id>
             </program>

--- a/src/main/java/io/anserini/search/SimpleSearcher.java
+++ b/src/main/java/io/anserini/search/SimpleSearcher.java
@@ -154,8 +154,10 @@ public class SimpleSearcher implements Closeable {
       throw new IllegalArgumentException(indexDir + " does not exist or is not a directory.");
     }
 
+    SearchArgs defaults = new SearchArgs();
+
     this.reader = DirectoryReader.open(FSDirectory.open(indexPath));
-    this.similarity = new BM25Similarity(0.9f, 0.4f);
+    this.similarity = new BM25Similarity(Float.parseFloat(defaults.bm25_k1[0]), Float.parseFloat(defaults.bm25_b[0]));
     this.analyzer = analyzer;
     this.isRerank = false;
     cascade = new RerankerCascade();
@@ -195,7 +197,9 @@ public class SimpleSearcher implements Closeable {
   }
 
   public void setRM3Reranker() {
-    setRM3Reranker(10, 10, 0.5f, false);
+    SearchArgs defaults = new SearchArgs();
+
+    setRM3Reranker(Integer.parseInt(defaults.rm3_fbTerms[0]), 10, 0.5f, false);
   }
 
   public void setRM3Reranker(int fbTerms, int fbDocs, float originalQueryWeight) {
@@ -539,7 +543,7 @@ public class SimpleSearcher implements Closeable {
 
       Map<String, Result[]> allResults = searcher.batchSearch(queries, qids, searchArgs.hits, searchArgs.threads);
 
-      // We iterate though, in natural object order.
+      // We iterate through, in natural object order.
       for (Object id : topics.keySet()) {
         Result[] results = allResults.get(id.toString());
 

--- a/src/main/java/io/anserini/search/SimpleSearcher.java
+++ b/src/main/java/io/anserini/search/SimpleSearcher.java
@@ -83,7 +83,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Class that exposes basic search functionality, designed specifically to provide the bridge between Java and Python
- * via pyjnius.
+ * via Pyjnius.
  */
 public class SimpleSearcher implements Closeable {
   public static final Sort BREAK_SCORE_TIES_BY_DOCID =
@@ -110,13 +110,13 @@ public class SimpleSearcher implements Closeable {
     public int threads = 1;
   }
 
-  private IndexReader reader;
-  private Similarity similarity;
-  private Analyzer analyzer;
-  private RerankerCascade cascade;
-  private boolean isRerank;
+  protected IndexReader reader;
+  protected Similarity similarity;
+  protected Analyzer analyzer;
+  protected RerankerCascade cascade;
+  protected boolean isRerank;
 
-  private IndexSearcher searcher = null;
+  protected IndexSearcher searcher = null;
 
   /**
    * This class is meant to serve as the bridge between Anserini and Pyserini.
@@ -526,7 +526,6 @@ public class SimpleSearcher implements Closeable {
 
     if (searchArgs.threads == 1) {
       for (Object id : topics.keySet()) {
-        LOG.info(String.format("Running topic %s", id));
         Result[] results = searcher.search(topics.get(id).get("title"), searchArgs.hits);
 
         for (int i = 0; i < results.length; i++) {

--- a/src/main/java/io/anserini/search/SimpleTweetSearcher.java
+++ b/src/main/java/io/anserini/search/SimpleTweetSearcher.java
@@ -1,0 +1,296 @@
+/*
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.search;
+
+import io.anserini.analysis.AnalyzerUtils;
+import io.anserini.analysis.TweetAnalyzer;
+import io.anserini.index.IndexArgs;
+import io.anserini.index.IndexCollection;
+import io.anserini.index.IndexReaderUtils;
+import io.anserini.index.generator.TweetGenerator;
+import io.anserini.rerank.RerankerCascade;
+import io.anserini.rerank.RerankerContext;
+import io.anserini.rerank.ScoredDocuments;
+import io.anserini.rerank.lib.Rm3Reranker;
+import io.anserini.rerank.lib.ScoreTiesAdjusterReranker;
+import io.anserini.search.query.BagOfWordsQueryGenerator;
+import io.anserini.search.query.QueryGenerator;
+import io.anserini.search.topicreader.TopicReader;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.ar.ArabicAnalyzer;
+import org.apache.lucene.analysis.bn.BengaliAnalyzer;
+import org.apache.lucene.analysis.cjk.CJKAnalyzer;
+import org.apache.lucene.analysis.de.GermanAnalyzer;
+import org.apache.lucene.analysis.en.EnglishAnalyzer;
+import org.apache.lucene.analysis.es.SpanishAnalyzer;
+import org.apache.lucene.analysis.fr.FrenchAnalyzer;
+import org.apache.lucene.analysis.hi.HindiAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.similarities.BM25Similarity;
+import org.apache.lucene.search.similarities.LMDirichletSimilarity;
+import org.apache.lucene.search.similarities.Similarity;
+import org.apache.lucene.store.FSDirectory;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.OptionHandlerFilter;
+import org.kohsuke.args4j.ParserProperties;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Class that exposes basic search functionality, designed specifically to provide the bridge between Java and Python
+ * via pyjnius.
+ */
+public class SimpleTweetSearcher extends SimpleSearcher implements Closeable {
+  public static final Sort BREAK_SCORE_TIES_BY_TWEETID =
+      new Sort(SortField.FIELD_SCORE,
+          new SortField(TweetGenerator.TweetField.ID_LONG.name, SortField.Type.LONG, true));
+  private static final Logger LOG = LogManager.getLogger(SimpleTweetSearcher.class);
+
+  public static final class Args {
+    @Option(name = "-index", metaVar = "[path]", required = true, usage = "Path to Lucene index.")
+    public String index;
+
+    @Option(name = "-topics", metaVar = "[file]", required = true, usage = "Topics file.")
+    public String topics;
+
+    @Option(name = "-output", metaVar = "[file]", required = true, usage = "Output run file.")
+    public String output;
+
+    @Option(name = "-rm3", usage = "Flag to use RM3.")
+    public Boolean useRM3 = false;
+
+    @Option(name = "-hits", metaVar = "[number]", usage = "max number of hits to return")
+    public int hits = 1000;
+  }
+
+  private IndexReader reader;
+  private Similarity similarity;
+  private Analyzer analyzer;
+  private RerankerCascade cascade;
+  private boolean isRerank;
+
+  private IndexSearcher searcher = null;
+
+  protected SimpleTweetSearcher() {
+  }
+
+  public SimpleTweetSearcher(String indexDir) throws IOException {
+    this(indexDir, new TweetAnalyzer());
+  }
+
+  public SimpleTweetSearcher(String indexDir, Analyzer analyzer) throws IOException {
+    Path indexPath = Paths.get(indexDir);
+
+    if (!Files.exists(indexPath) || !Files.isDirectory(indexPath) || !Files.isReadable(indexPath)) {
+      throw new IllegalArgumentException(indexDir + " does not exist or is not a directory.");
+    }
+
+    this.reader = DirectoryReader.open(FSDirectory.open(indexPath));
+    this.similarity = new BM25Similarity(0.9f, 0.4f);
+    this.analyzer = analyzer;
+    this.isRerank = false;
+    cascade = new RerankerCascade();
+    cascade.add(new ScoreTiesAdjusterReranker());
+  }
+
+  public void setAnalyzer(Analyzer analyzer) {
+    this.analyzer = analyzer;
+  }
+
+  public Analyzer getAnalyzer(){
+    return this.analyzer;
+  }
+
+  public void unsetRM3Reranker() {
+    this.isRerank = false;
+    cascade = new RerankerCascade();
+    cascade.add(new ScoreTiesAdjusterReranker());
+  }
+
+  public void setRM3Reranker() {
+    setRM3Reranker(10, 10, 0.5f, false);
+  }
+
+  public void setRM3Reranker(int fbTerms, int fbDocs, float originalQueryWeight) {
+    setRM3Reranker(fbTerms, fbDocs, originalQueryWeight, false);
+  }
+
+  public void setRM3Reranker(int fbTerms, int fbDocs, float originalQueryWeight, boolean rm3_outputQuery) {
+    isRerank = true;
+    cascade = new RerankerCascade("rm3");
+    cascade.add(new Rm3Reranker(this.analyzer, IndexArgs.CONTENTS,
+        fbTerms, fbDocs, originalQueryWeight, rm3_outputQuery));
+    cascade.add(new ScoreTiesAdjusterReranker());
+  }
+
+  public void setLMDirichletSimilarity(float mu) {
+    this.similarity = new LMDirichletSimilarity(mu);
+
+    // We need to re-initialize the searcher
+    searcher = new IndexSearcher(reader);
+    searcher.setSimilarity(similarity);
+  }
+
+  public void setBM25Similarity(float k1, float b) {
+    this.similarity = new BM25Similarity(k1, b);
+
+    // We need to re-initialize the searcher
+    searcher = new IndexSearcher(reader);
+    searcher.setSimilarity(similarity);
+  }
+
+  @Override
+  public void close() throws IOException {
+    reader.close();
+  }
+
+  public Result[] searchTweets(String q, int k, long t) throws IOException {
+    Query query = new BagOfWordsQueryGenerator().buildQuery(IndexArgs.CONTENTS, analyzer, q);
+    List<String> queryTokens = AnalyzerUtils.analyze(analyzer, q);
+
+    return searchTweets(query, queryTokens, q, k, t);
+  }
+
+  protected Result[] searchTweets(Query query, List<String> queryTokens, String queryString, int k, long t)
+      throws IOException {
+    // Create an IndexSearch only once. Note that the object is thread safe.
+    if (searcher == null) {
+      searcher = new IndexSearcher(reader);
+      searcher.setSimilarity(similarity);
+    }
+
+    SearchArgs searchArgs = new SearchArgs();
+    searchArgs.arbitraryScoreTieBreak = false;
+    searchArgs.hits = k;
+    searchArgs.searchtweets = true;
+
+    TopDocs rs;
+    RerankerContext context;
+
+    // Do not consider the tweets with tweet ids that are beyond the queryTweetTime
+    // <querytweettime> tag contains the timestamp of the query in terms of the
+    // chronologically nearest tweet id within the corpus
+    Query filter = LongPoint.newRangeQuery(TweetGenerator.TweetField.ID_LONG.name, 0L, t);
+    BooleanQuery.Builder builder = new BooleanQuery.Builder();
+    builder.add(filter, BooleanClause.Occur.FILTER);
+    builder.add(query, BooleanClause.Occur.MUST);
+    Query compositeQuery = builder.build();
+    rs = searcher.search(compositeQuery, isRerank ? searchArgs.rerankcutoff :
+        k, BREAK_SCORE_TIES_BY_TWEETID, true);
+    context = new RerankerContext<>(searcher, null, compositeQuery, null,
+        queryString, queryTokens, filter, searchArgs);
+
+    ScoredDocuments hits = cascade.run(ScoredDocuments.fromTopDocs(rs, searcher), context);
+
+    Result[] results = new Result[hits.ids.length];
+    for (int i = 0; i < hits.ids.length; i++) {
+      Document doc = hits.documents[i];
+      String docid = doc.getField(IndexArgs.ID).stringValue();
+
+      IndexableField field;
+      field = doc.getField(IndexArgs.CONTENTS);
+      String contents = field == null ? null : field.stringValue();
+
+      field = doc.getField(IndexArgs.RAW);
+      String raw = field == null ? null : field.stringValue();
+
+      results[i] = new Result(docid, hits.ids[i], hits.scores[i], contents, raw, doc);
+    }
+
+    return results;
+  }
+
+  // Note that this class is primarily meant to be used by automated regression scripts, not humans!
+  // tl;dr - Do not use this class for running experiments. Use SearchCollection instead!
+  //
+  // SimpleTweetSearcher is the main class that exposes search functionality for Pyserini (in Python).
+  // As such, it has a different code path than SearchCollection, the preferred entry point for running experiments
+  // from Java. The main method here exposes only barebone options, primarily designed to verify that results from
+  // SimpleSearcher are *exactly* the same as SearchCollection (e.g., via automated regression scripts).
+  public static void main(String[] args) throws Exception {
+    Args searchArgs = new Args();
+    CmdLineParser parser = new CmdLineParser(searchArgs, ParserProperties.defaults().withUsageWidth(100));
+
+    try {
+      parser.parseArgument(args);
+    } catch (CmdLineException e) {
+      System.err.println(e.getMessage());
+      parser.printUsage(System.err);
+      System.err.println("Example: SimpleTweetSearcher" + parser.printExample(OptionHandlerFilter.REQUIRED));
+      return;
+    }
+
+    final long start = System.nanoTime();
+    SimpleTweetSearcher searcher = new SimpleTweetSearcher(searchArgs.index);
+    SortedMap<Object, Map<String, String>> topics = TopicReader.getTopicsByFile(searchArgs.topics);
+
+    PrintWriter out = new PrintWriter(Files.newBufferedWriter(Paths.get(searchArgs.output), StandardCharsets.US_ASCII));
+
+    if (searchArgs.useRM3) {
+      searcher.setRM3Reranker();
+    }
+
+    for (Object id : topics.keySet()) {
+      LOG.info(String.format("Running topic %s", id));
+      long t = Long.parseLong(topics.get(id).get("time"));
+      Result[] results = searcher.searchTweets(topics.get(id).get("title"), 1000, t);
+
+      for (int i=0; i<results.length; i++) {
+        out.println(String.format(Locale.US, "%s Q0 %s %d %f Anserini",
+            id, results[i].docid, (i+1), results[i].score));
+      }
+    }
+    out.close();
+
+    final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+    LOG.info("Total run time: " + DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss"));
+  }
+}

--- a/src/main/java/io/anserini/search/topicreader/TopicReader.java
+++ b/src/main/java/io/anserini/search/topicreader/TopicReader.java
@@ -83,7 +83,7 @@ public abstract class TopicReader<K> {
    * @param file topics file
    * @return the {@link TopicReader} class corresponding to a known topics file, or <code>null</code> if unknown.
    */
-  public static Class<? extends TopicReader> getTopicReaderByFile(String file) {
+  public static Class<? extends TopicReader> getTopicReaderClassByFile(String file) {
     // If we're given something that looks like a path with directories, pull out only the file name at the end.
     if (file.contains("/")) {
       String[] parts = file.split("/");
@@ -141,6 +141,26 @@ public abstract class TopicReader<K> {
       TopicReader<K> reader = (TopicReader<K>) ctors[0].newInstance(Paths.get("."));
       return reader.read(raw);
 
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /**
+   * Returns evaluation topics, automatically trying to infer its type and format.
+   *
+   * @param file topics file
+   * @param <K> type of topic id
+   * @return a set of evaluation topics
+   */
+  @SuppressWarnings("unchecked")
+  public static <K> SortedMap<K, Map<String, String>> getTopicsByFile(String file) {
+    try {
+      // Get the constructor
+      Constructor[] ctors = getTopicReaderClassByFile(file).getDeclaredConstructors();
+      // The one we want is always the zero-th one; pass in a dummy Path.
+      TopicReader<K> reader = (TopicReader<K>) ctors[0].newInstance(Paths.get(file));
+      return reader.read();
     } catch (Exception e) {
       return null;
     }

--- a/src/main/java/io/anserini/util/DumpAnalyzedQueries.java
+++ b/src/main/java/io/anserini/util/DumpAnalyzedQueries.java
@@ -66,7 +66,7 @@ public class DumpAnalyzedQueries {
     TopicReader<?> tr;
     try {
       // Can we infer the TopicReader?
-      Class<? extends TopicReader> clazz = TopicReader.getTopicReaderByFile(args.topicsFile.toString());
+      Class<? extends TopicReader> clazz = TopicReader.getTopicReaderClassByFile(args.topicsFile.toString());
       if (clazz != null) {
         System.out.println(String.format("Inferring %s has TopicReader class %s.", args.topicsFile, clazz));
       } else {

--- a/src/main/python/verify_simplesearcher.py
+++ b/src/main/python/verify_simplesearcher.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+'''
+Anserini: A Lucene toolkit for replicable information retrieval research
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+
+import logging
+import regression_utils
+
+logger = logging.getLogger('run_es_regression')
+ch = logging.StreamHandler()
+ch.setFormatter(logging.Formatter('%(asctime)s %(levelname)s - %(message)s'))
+logger.addHandler(ch)
+logger.setLevel(logging.INFO)
+
+sc_command = 'target/appassembler/bin/SearchCollection   '
+ss_command = 'target/appassembler/bin/SimpleSearcher     '
+st_command = 'target/appassembler/bin/SimpleTweetSearcher'
+robust04_index = 'indexes/lucene-index.robust04.pos+docvectors+raw'
+robust04_topics = 'src/main/resources/topics-and-qrels/topics.robust04.txt'
+mb11_index = 'indexes/lucene-index.mb11.pos+docvectors+raw'
+mb11_topics = 'src/main/resources/topics-and-qrels/topics.microblog2011.txt'
+
+# Raw data for verification: array of arrays
+# Each top level array contains commands whose outputs should be *identical*
+# Note that spacing is intentional to make command easy to read.
+groups = [ [ f'{sc_command} -index {robust04_index} -topicreader Trec -topics {robust04_topics} -bm25            -output', \
+             f'{ss_command} -index {robust04_index}                   -topics {robust04_topics}                  -output', \
+             f'{ss_command} -index {robust04_index}                   -topics {robust04_topics}       -threads 4 -output' ], \
+           [ f'{sc_command} -index {robust04_index} -topicreader Trec -topics {robust04_topics} -bm25 -rm3            -output', \
+             f'{ss_command} -index {robust04_index}                   -topics {robust04_topics}       -rm3            -output', \
+             f'{ss_command} -index {robust04_index}                   -topics {robust04_topics}       -rm3 -threads 4 -output' ], \
+           [ f'{sc_command} -index {mb11_index} -topicreader Microblog -topics {mb11_topics} -bm25 -searchtweets -output', \
+             f'{st_command} -index {mb11_index}                        -topics {mb11_topics}                     -output'], \
+           [ f'{sc_command} -index {mb11_index} -topicreader Microblog -topics {mb11_topics} -bm25 -rm3 -searchtweets -output', \
+             f'{st_command} -index {mb11_index}                        -topics {mb11_topics}       -rm3               -output'], \
+         ]
+
+if __name__ == '__main__':
+    group_cnt = 0
+    for group in groups:
+        print(f'# Verifying Group {group_cnt}')
+        entry_cnt = 0
+        group_runs = []
+        for entry in group:
+             run_file = f'runs/run.ss_verify.g{group_cnt}.e{entry_cnt}.txt'
+             cmd = f'{entry} {run_file}'
+             print(f'Running: {cmd}')
+             regression_utils.run_shell_command(cmd, logger, echo=False)
+
+             # Load in the run file.
+             with open(run_file, 'r') as file:
+               group_runs.append(file.read().replace('\n', ''))
+
+             entry_cnt += 1
+
+        # Check that all run files are identical.
+        for i in range(len(group_runs)):
+            if group_runs[0] != group_runs[i]:
+                raise ValueError(f'Group {group_cnt}: Results are not identical!')
+
+        print(f'# Group {group_cnt}: Results identical')
+        group_cnt += 1
+
+    print('All tests passed!')

--- a/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
@@ -29,18 +29,31 @@ public class TopicReaderTest {
   @Test
   public void testTopicReaderClassLookup() {
     assertEquals(TrecTopicReader.class,
-        TopicReader.getTopicReaderByFile("src/main/resources/topics-and-qrels/topics.robust04.txt"));
+        TopicReader.getTopicReaderClassByFile("src/main/resources/topics-and-qrels/topics.robust04.txt"));
     assertEquals(TrecTopicReader.class,
-        TopicReader.getTopicReaderByFile("topics.robust04.txt"));
+        TopicReader.getTopicReaderClassByFile("topics.robust04.txt"));
 
     assertEquals(CovidTopicReader.class,
-        TopicReader.getTopicReaderByFile("src/main/resources/topics-and-qrels/topics.covid-round1.xml"));
+        TopicReader.getTopicReaderClassByFile("src/main/resources/topics-and-qrels/topics.covid-round1.xml"));
     assertEquals(CovidTopicReader.class,
-        TopicReader.getTopicReaderByFile("topics.covid-round1.xml"));
+        TopicReader.getTopicReaderClassByFile("topics.covid-round1.xml"));
 
     // Unknown TopicReader class.
     assertEquals(null,
-        TopicReader.getTopicReaderByFile("topics.unknown.txt"));
+        TopicReader.getTopicReaderClassByFile("topics.unknown.txt"));
+  }
+
+  @Test
+  public void testGetTopicsByFile() {
+    SortedMap<Object, Map<String, String>> topics =
+        TopicReader.getTopicsByFile("src/main/resources/topics-and-qrels/topics.robust04.txt");
+
+    assertNotNull(topics);
+    assertEquals(250, topics.size());
+    assertEquals(301, (int) topics.firstKey());
+    assertEquals("International Organized Crime", topics.get(topics.firstKey()).get("title"));
+    assertEquals(700, (int) topics.lastKey());
+    assertEquals("gasoline tax U.S.", topics.get(topics.lastKey()).get("title"));
   }
 
   @Test


### PR DESCRIPTION
Previously, `SimpleSearcher` had different code paths for searching "normal" documents and searching tweets (which has additional temporal logic). I've untangled into `SimpleSearcher` and `SimpleTweetSearcher` for better maintainability.

Also, I added a `verify_simplesearcher.py` script to confirm that the output of `SimpleSearcher` and `SimpleTweetSearcher` matches _exactly_ the output of `SearchCollection` - i.e., that the different code paths give identical results.
