### PR TITLE
Refactoring of methods for computing {query,term}-document weights

### DIFF
--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -17,7 +17,6 @@
 package io.anserini.index;
 
 import io.anserini.analysis.AnalyzerUtils;
-import io.anserini.analysis.DefaultEnglishAnalyzer;
 import io.anserini.search.SearchArgs;
 import io.anserini.search.query.BagOfWordsQueryGenerator;
 import io.anserini.search.query.PhraseQueryGenerator;
@@ -26,7 +25,6 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
-import org.apache.jute.Index;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;

--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -26,6 +26,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.jute.Index;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
@@ -79,8 +80,6 @@ import static java.util.stream.Collectors.joining;
  */
 public class IndexReaderUtils {
   private static final Logger LOG = LogManager.getLogger(IndexUtils.class);
-  // The default analyzer used in indexing.
-  private static final Analyzer DEFAULT_ANALYZER = IndexCollection.DEFAULT_ANALYZER;
 
   public enum DocumentVectorWeight {NONE, TF_IDF}
 
@@ -213,8 +212,8 @@ public class IndexReaderUtils {
    */
   public static Map<String, Long> getTermCounts(IndexReader reader, String termStr)
       throws IOException {
-    DefaultEnglishAnalyzer ea = DefaultEnglishAnalyzer.newDefaultInstance();
-    return getTermCountsWithAnalyzer(reader, termStr, ea);
+    Analyzer analyzer = IndexCollection.DEFAULT_ANALYZER;
+    return getTermCountsWithAnalyzer(reader, termStr, analyzer);
   }
 
   /**
@@ -467,32 +466,32 @@ public class IndexReaderUtils {
   }
 
   /**
-   * Computes the BM25 weight of an unanalyzed term in a particular document (with Anserini default parameters).
+   * Computes the BM25 weight of an analyzed term in a particular document (with Anserini default parameters).
    *
    * @param reader index reader
    * @param docid collection docid
-   * @param term unanalyzed term
+   * @param term analyzed term
    * @return BM25 weight of the term in the specified document
    * @throws IOException if error encountered during query
    */
-  public static float getBM25TermWeight(IndexReader reader, String docid, String term) throws IOException {
+  public static float getBM25AnalyzedTermWeight(IndexReader reader, String docid, String term) throws IOException {
     SearchArgs args = new SearchArgs();
-    return getBM25TermWeightWithParameters(reader, docid, term,
+    return getBM25AnalyzedTermWeightWithParameters(reader, docid, term,
         Float.parseFloat(args.bm25_k1[0]), Float.parseFloat(args.bm25_b[0]));
   }
 
   /**
-   * Computes the BM25 weight of an unanalyzed term in a particular document.
+   * Computes the BM25 weight of an analyzed term in a particular document.
    *
    * @param reader index reader
    * @param docid collection docid
-   * @param term unanalyzed term
+   * @param term analyzed term
    * @param k1 k1 setting for BM25
    * @param b b setting for BM25
    * @return BM25 weight of the term in the specified document
    * @throws IOException if error encountered during query
    */
-  public static float getBM25TermWeightWithParameters(IndexReader reader, String docid, String term, float k1, float b)
+  public static float getBM25AnalyzedTermWeightWithParameters(IndexReader reader, String docid, String term, float k1, float b)
       throws IOException {
     // We compute the BM25 score by issuing a single-term query with an additional filter clause that restricts
     // consideration to only the docid in question, and then returning the retrieval score.
@@ -517,6 +516,40 @@ public class IndexReaderUtils {
   }
 
   /**
+   * Computes the BM25 weight of an unanalyzed term in a particular document (with Anserini default parameters).
+   *
+   * @param reader index reader
+   * @param docid collection docid
+   * @param term analyzed term
+   * @return BM25 weight of the term in the specified document
+   * @throws IOException if error encountered during query
+   */
+  public static float getBM25UnanalyzedTermWeight(IndexReader reader, String docid, String term) throws IOException {
+    SearchArgs args = new SearchArgs();
+    return getBM25UnanalyzedTermWeightWithParameters(reader, docid, term, IndexCollection.DEFAULT_ANALYZER,
+        Float.parseFloat(args.bm25_k1[0]), Float.parseFloat(args.bm25_b[0]));
+  }
+
+  /**
+   * Computes the BM25 weight of an unanalyzed term in a particular document.
+   *
+   * @param reader index reader
+   * @param docid collection docid
+   * @param term unanalyzed term
+   * @param analyzer analyzer
+   * @param k1 k1 setting for BM25
+   * @param b b setting for BM25
+   * @return BM25 weight of the term in the specified document
+   * @throws IOException if error encountered during query
+   */
+  public static float getBM25UnanalyzedTermWeightWithParameters(IndexReader reader, String docid, String term,
+                                                                Analyzer analyzer, float k1, float b)
+      throws IOException {
+    String analyzed = AnalyzerUtils.analyze(analyzer, term).get(0);
+    return getBM25AnalyzedTermWeightWithParameters(reader, docid, analyzed, k1, b);
+  }
+
+  /**
    * Computes the BM25 score of a document with respect to a query. Assumes default BM25 parameter settings and
    * Anserini's default analyzer.
    *
@@ -527,7 +560,8 @@ public class IndexReaderUtils {
    * @throws IOException if error encountered during query
    */
   public static float computeQueryDocumentScore(IndexReader reader, String docid, String q) throws IOException {
-    return computeQueryDocumentScore(reader, docid, q, new BM25Similarity(), IndexCollection.DEFAULT_ANALYZER);
+    return computeQueryDocumentScoreWithSimilarityAndAnalyzer(reader, docid, q,
+        new BM25Similarity(), IndexCollection.DEFAULT_ANALYZER);
   }
 
   /**
@@ -541,9 +575,11 @@ public class IndexReaderUtils {
    * @return the score of the document with respect to the query
    * @throws IOException if error encountered during query
    */
-  public static float computeQueryDocumentScore(IndexReader reader, String docid, String q, Similarity similarity)
+  public static float computeQueryDocumentScoreWithSimilarity(
+      IndexReader reader, String docid, String q, Similarity similarity)
       throws IOException {
-    return computeQueryDocumentScore(reader, docid, q, similarity, IndexCollection.DEFAULT_ANALYZER);
+    return computeQueryDocumentScoreWithSimilarityAndAnalyzer(reader, docid, q, similarity,
+        IndexCollection.DEFAULT_ANALYZER);
   }
 
   /**
@@ -557,8 +593,9 @@ public class IndexReaderUtils {
    * @return the score of the document with respect to the query
    * @throws IOException if error encountered during query
    */
-  public static float computeQueryDocumentScore(IndexReader reader, String docid, String q,
-                                                Similarity similarity, Analyzer analyzer) throws IOException {
+  public static float computeQueryDocumentScoreWithSimilarityAndAnalyzer(
+      IndexReader reader, String docid, String q, Similarity similarity, Analyzer analyzer)
+      throws IOException {
     // We compute the query-document score by issuing the query with an additional filter clause that restricts
     // consideration to only the docid in question, and then returning the retrieval score.
     //

--- a/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
+++ b/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
@@ -21,7 +21,6 @@ import io.anserini.analysis.AnalyzerUtils;
 import io.anserini.analysis.DefaultEnglishAnalyzer;
 import io.anserini.search.SearchArgs;
 import io.anserini.search.SimpleSearcher;
-import org.apache.jute.Index;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiTerms;

--- a/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
+++ b/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
@@ -21,6 +21,7 @@ import io.anserini.analysis.AnalyzerUtils;
 import io.anserini.analysis.DefaultEnglishAnalyzer;
 import io.anserini.search.SearchArgs;
 import io.anserini.search.SimpleSearcher;
+import org.apache.jute.Index;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiTerms;
@@ -37,7 +38,6 @@ import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
 
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -314,10 +314,36 @@ public class IndexReaderUtilsTest extends IndexerTestBase {
       termsEnum = termVector.iterator();
       while ((text = termsEnum.next()) != null) {
         String term = text.utf8ToString();
-        float weight = IndexReaderUtils.getBM25TermWeight(reader, docid, term);
+        float weight = IndexReaderUtils.getBM25AnalyzedTermWeight(reader, docid, term);
         assertEquals(termDocMatrix.get(term).get(docid), weight, 10e-6);
       }
     }
+
+    reader.close();
+    dir.close();
+  }
+
+  @Test
+  public void computeBM25Weights() throws Exception {
+    SearchArgs args = new SearchArgs();
+
+    Directory dir = FSDirectory.open(tempDir1);
+    IndexReader reader = DirectoryReader.open(dir);
+
+    assertEquals(0.43400, IndexReaderUtils.getBM25UnanalyzedTermWeightWithParameters(reader, "doc1",
+        "city", IndexCollection.DEFAULT_ANALYZER,0.9f, 0.4f), 10e-5);
+    assertEquals(0.43400, IndexReaderUtils.getBM25AnalyzedTermWeightWithParameters(reader, "doc1",
+        "citi", 0.9f, 0.4f), 10e-5);
+
+    assertEquals(0.0f, IndexReaderUtils.getBM25UnanalyzedTermWeightWithParameters(reader, "doc2",
+        "city", IndexCollection.DEFAULT_ANALYZER,0.9f, 0.4f), 10e-5);
+    assertEquals(0.0f, IndexReaderUtils.getBM25AnalyzedTermWeightWithParameters(reader, "doc2",
+        "citi", 0.9f, 0.4f), 10e-5);
+
+    assertEquals(0.570250, IndexReaderUtils.getBM25UnanalyzedTermWeightWithParameters(reader, "doc3",
+        "test", IndexCollection.DEFAULT_ANALYZER,0.9f, 0.4f), 10e-5);
+    assertEquals(0.570250, IndexReaderUtils.getBM25AnalyzedTermWeightWithParameters(reader, "doc3",
+        "test", 0.9f, 0.4f), 10e-5);
 
     reader.close();
     dir.close();
@@ -457,13 +483,14 @@ public class IndexReaderUtilsTest extends IndexerTestBase {
 
       // Strategy is to loop over the results, compute query-document score individually, and compare.
       for (int i = 0; i < results.length; i++) {
-        float score = IndexReaderUtils.computeQueryDocumentScore(reader, results[i].docid, query, similarity);
+        float score = IndexReaderUtils.computeQueryDocumentScoreWithSimilarity(
+            reader, results[i].docid, query, similarity);
         assertEquals(score, results[i].score, 10e-5);
       }
 
       // This is hard coded - doc3 isn't retrieved by any of the queries.
-      assertEquals(0.0f,
-          IndexReaderUtils.computeQueryDocumentScore(reader, "doc3", query, similarity), 10e-6);
+      assertEquals(0.0f, IndexReaderUtils.computeQueryDocumentScoreWithSimilarity(
+              reader, "doc3", query, similarity), 10e-6);
     }
 
     reader.close();


### PR DESCRIPTION
+ Seems like it would make sense to have methods that take an unanalyzed form to compute BM25 weights.
+ Overloaded `computeQueryDocumentScore` methods need to be renamed for proper access from the Python end.