### PR TITLE
Add index statistics function

### DIFF
--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -30,6 +30,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiTerms;
 import org.apache.lucene.index.PostingsEnum;
@@ -767,5 +769,34 @@ public class IndexReaderUtils {
       // Eat any exceptions and just return null.
       return null;
     }
+  }
+
+  /**
+   * Returns index statistics
+   *
+   * @param reader index reader
+   * @return Index statistics as a map of statistic's name to statistic.
+   * @throws IOException
+   */
+  public static Map<String, Object> getIndexStats(IndexReader reader) throws IOException {
+    Map<String, Object> indexStats = new HashMap<String, Object>();
+    try {
+      Terms terms = MultiTerms.getTerms(reader, IndexArgs.CONTENTS);
+
+      indexStats.put("documents", reader.numDocs());
+      indexStats.put("documents (non-empty)", reader.getDocCount(IndexArgs.CONTENTS));
+      indexStats.put("unique terms", terms.size());
+      indexStats.put("total terms", reader.getSumTotalTermFreq(IndexArgs.CONTENTS));
+
+      FieldInfos fieldInfos = FieldInfos.getMergedFieldInfos(reader);
+      for (FieldInfo fi : fieldInfos) {
+        indexStats.put(fi.name, "indexOption: " + fi.getIndexOptions() +
+            ", hasVectors: " + fi.hasVectors());
+      }
+    } catch (IOException e) {
+      // Eat any exceptions and just return null.
+      return null;
+    }
+    return indexStats;
   }
 }

--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -784,9 +784,9 @@ public class IndexReaderUtils {
       Terms terms = MultiTerms.getTerms(reader, IndexArgs.CONTENTS);
 
       indexStats.put("documents", reader.numDocs());
-      indexStats.put("documents (non-empty)", reader.getDocCount(IndexArgs.CONTENTS));
-      indexStats.put("unique terms", terms.size());
-      indexStats.put("total terms", reader.getSumTotalTermFreq(IndexArgs.CONTENTS));
+      indexStats.put("non_empty_documents", reader.getDocCount(IndexArgs.CONTENTS));
+      indexStats.put("unique_terms", terms.size());
+      indexStats.put("total_terms", reader.getSumTotalTermFreq(IndexArgs.CONTENTS));
 
       FieldInfos fieldInfos = FieldInfos.getMergedFieldInfos(reader);
       for (FieldInfo fi : fieldInfos) {

--- a/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
+++ b/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
@@ -505,7 +505,7 @@ public class IndexReaderUtilsTest extends IndexerTestBase {
     IndexReader reader = DirectoryReader.open(dir);
 
     assertEquals(3, IndexReaderUtils.getIndexStats(reader).get("documents"));
-    assertEquals(Long.valueOf(6), IndexReaderUtils.getIndexStats(reader).get("unique terms"));
+    assertEquals(Long.valueOf(6), IndexReaderUtils.getIndexStats(reader).get("unique_terms"));
 
     reader.close();
     dir.close();

--- a/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
+++ b/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
@@ -498,4 +498,16 @@ public class IndexReaderUtilsTest extends IndexerTestBase {
     reader.close();
     dir.close();
   }
+
+  @Test
+  public void testGetIndexStats() throws Exception {
+    Directory dir = FSDirectory.open(tempDir1);
+    IndexReader reader = DirectoryReader.open(dir);
+
+    assertEquals(3, IndexReaderUtils.getIndexStats(reader).get("documents"));
+    assertEquals(Long.valueOf(6), IndexReaderUtils.getIndexStats(reader).get("unique terms"));
+
+    reader.close();
+    dir.close();
+  }
 }


### PR DESCRIPTION
Adds function that returns selection of index statistics in map format (as previously printed in `IndexUtils`)