### PR TITLE
eval/measure_judged.py should split by white space not limited to sin…

### DIFF
--- a/eval/measure_judged.py
+++ b/eval/measure_judged.py
@@ -42,7 +42,7 @@ def load_run(path: str) -> Dict[str, List[str]]:
     run = collections.OrderedDict()
     with open(path) as f:
         for line in f:
-            query_id, _, doc_title, rank, _, _ = line.split(' ')
+            query_id, _, doc_title, rank, _, _ = line.split()
             if query_id not in run:
                 run[query_id] = []
             run[query_id].append((doc_title, int(rank)))


### PR DESCRIPTION
eval/measure_judged.py splits the qrun file by a single space (' '), but there are cases when the qrun file is separated by `\t`. Here's an example that the current `measure_judged.py` fails on [Round 2 covidex.t5](https://ir.nist.gov/covidSubmit/archive/round2/covidex.t5). 

Hence measure_judged.py should handle either case.

According to [this post on Stack Overflow](https://stackoverflow.com/questions/25253120/python-split-string-by-space-and-strip-newline-char/25253160), `line.split()` should handle both single space and `\t`.