### PR TITLE
Fixes encoding error when opening OpenResearch's queries file

### DIFF
--- a/src/main/python/openresearch/retrieve.py
+++ b/src/main/python/openresearch/retrieve.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
 
     with open(args.output, 'w') as fout:
         start_time = time.time()
-        for line_number, line in tqdm(enumerate(open(args.qid_queries))):
+        for line_number, line in tqdm(enumerate(open(args.qid_queries, encoding='utf-8'))):
             query_id, query = line.strip().split('\t')
             # We return one more result because it is almost certain that we will
             # retrieve the document that originated the query.


### PR DESCRIPTION
Fixes UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 119: ordinal not in range(128)
