### PR TITLE
Bindings for TREC News topics

### DIFF
--- a/src/main/java/io/anserini/search/topicreader/TopicReader.java
+++ b/src/main/java/io/anserini/search/topicreader/TopicReader.java
@@ -76,7 +76,9 @@ public abstract class TopicReader<K> {
       Map.entry("topics.covid-round2.xml", CovidTopicReader.class),
       Map.entry("topics.covid-round2-udel.xml", CovidTopicReader.class),
       Map.entry("topics.covid-round3.xml", CovidTopicReader.class),
-      Map.entry("topics.covid-round3-udel.xml", CovidTopicReader.class)
+      Map.entry("topics.covid-round3-udel.xml", CovidTopicReader.class),
+      Map.entry("topics.backgroundlinking18.txt", BackgroundLinkingTopicReader.class),
+      Map.entry("topics.backgroundlinking19.txt", BackgroundLinkingTopicReader.class)
   );
 
   /**

--- a/src/main/java/io/anserini/search/topicreader/Topics.java
+++ b/src/main/java/io/anserini/search/topicreader/Topics.java
@@ -58,7 +58,9 @@ public enum Topics {
   COVID_ROUND2(CovidTopicReader.class, "topics-and-qrels/topics.covid-round2.xml"),
   COVID_ROUND2_UDEL(CovidTopicReader.class, "topics-and-qrels/topics.covid-round2-udel.xml"),
   COVID_ROUND3(CovidTopicReader.class, "topics-and-qrels/topics.covid-round3.xml"),
-  COVID_ROUND3_UDEL(CovidTopicReader.class, "topics-and-qrels/topics.covid-round3-udel.xml");
+  COVID_ROUND3_UDEL(CovidTopicReader.class, "topics-and-qrels/topics.covid-round3-udel.xml"),
+  TREC2018_BL(BackgroundLinkingTopicReader.class, "topics-and-qrels/topics.backgroundlinking18.txt"),
+  TREC2019_BL(BackgroundLinkingTopicReader.class, "topics-and-qrels/topics.backgroundlinking19.txt");
 
   public final String path;
   public final Class readerClass;

--- a/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
@@ -691,4 +691,39 @@ public class TopicReaderTest {
 
     assertEquals("coronavirus mutations observed mutations SARS-CoV-2 genome mutations", topics.get("40").get("query"));
   }
+
+  @Test
+  public void testBackgroundLinkingTopics() {
+    SortedMap<Integer, Map<String, String>> topics;
+
+    topics = TopicReader.getTopics(Topics.TREC2018_BL);
+
+    assertEquals(50, topics.keySet().size());
+    assertEquals(321, (int) topics.firstKey());
+    assertEquals("9171debc316e5e2782e0d2404ca7d09d", topics.get(topics.firstKey()).get("title"));
+    assertEquals("https://www.washingtonpost.com/news/worldviews/wp/2016/09/01/" +
+        "women-are-half-of-the-world-but-only-22-percent-of-its-parliaments/",
+        topics.get(topics.firstKey()).get("url"));
+
+    assertEquals(825, (int) topics.lastKey());
+    assertEquals("a1c41a70-35c7-11e3-8a0e-4e2cf80831fc", topics.get(topics.lastKey()).get("title"));
+    assertEquals("https://www.washingtonpost.com/business/economy/" +
+        "cellulosic-ethanol-once-the-way-of-the-future-is-off-to-a-delayed-boisterous-start/" +
+        "2013/11/08/a1c41a70-35c7-11e3-8a0e-4e2cf80831fc_story.html", topics.get(topics.lastKey()).get("url"));
+
+    topics = TopicReader.getTopics(Topics.TREC2019_BL);
+    
+    assertEquals(60, topics.keySet().size());
+    assertEquals(826, (int) topics.firstKey());
+    assertEquals("96ab542e-6a07-11e6-ba32-5a4bf5aad4fa", topics.get(topics.firstKey()).get("title"));
+    assertEquals("https://www.washingtonpost.com/sports/nationals/" +
+        "the-minor-leagues-life-in-pro-baseballs-shadowy-corner/" +
+        "2016/08/26/96ab542e-6a07-11e6-ba32-5a4bf5aad4fa_story.html", topics.get(topics.firstKey()).get("url"));
+
+    assertEquals(885, (int) topics.lastKey());
+    assertEquals("5ae44bfd66a49bcad7b55b29b55d63b6", topics.get(topics.lastKey()).get("title"));
+    assertEquals("https://www.washingtonpost.com/news/capital-weather-gang/wp/2017/07/14/" +
+        "sun-erupts-to-mark-another-bastille-day-aurora-possible-in-new-england-sunday-night/",
+        topics.get(topics.lastKey()).get("url"));
+  }
 }


### PR DESCRIPTION
TREC News topics were not yet accessible via the `TopicReader`.

I copied test cases from `BackgroundLinkingTopicReaderTest` to be complete, but it seems a bit excessive to do same tests again, thoughts?