### PR TITLE
Experiment on different CORD-19 paragraph indexing conditions

### DIFF
--- a/src/main/java/io/anserini/collection/Cord19ParagraphCollection.java
+++ b/src/main/java/io/anserini/collection/Cord19ParagraphCollection.java
@@ -52,7 +52,7 @@ public class Cord19ParagraphCollection extends DocumentCollection<Cord19Paragrap
   //   + docid.00003: title + abstract + 3rd paragraph
   //   + ...
   //
-  // But an equally reasonable alternative would be to *not* repeat the paragraph, which is actually the setup in [1]:
+  // But an equally reasonable alternative would be to *not* repeat the abstract, which is actually the setup in [1]:
   //
   //   + docid: title + abstract
   //   + docid.00001: title + 1st paragraph

--- a/src/main/java/io/anserini/collection/Cord19ParagraphCollection.java
+++ b/src/main/java/io/anserini/collection/Cord19ParagraphCollection.java
@@ -52,7 +52,7 @@ public class Cord19ParagraphCollection extends DocumentCollection<Cord19Paragrap
   //   + docid.00003: title + abstract + 3rd paragraph
   //   + ...
   //
-  // But an equally reasonable alternative would be to *not* repeat the abstract, which is actually the setup in [1]:
+  // But an equally reasonable alternative would be *not* to repeat the abstract, which is actually the setup in [1]:
   //
   //   + docid: title + abstract
   //   + docid.00001: title + 1st paragraph

--- a/src/main/java/io/anserini/collection/Cord19ParagraphCollection.java
+++ b/src/main/java/io/anserini/collection/Cord19ParagraphCollection.java
@@ -42,7 +42,7 @@ import java.util.Set;
 public class Cord19ParagraphCollection extends DocumentCollection<Cord19ParagraphCollection.Document> {
   private static final Logger LOG = LogManager.getLogger(Cord19ParagraphCollection.class);
 
-  private static final boolean DUPLICATE_PARAGRAPH = true;
+  private static final boolean DUPLICATE_ABSTRACT = true;
   // With paragraph indexing, early on in TREC-COVID, we had a question about exactly how to decompose full text into
   // paragraphs. The initial implementation was:
   //
@@ -60,8 +60,8 @@ public class Cord19ParagraphCollection extends DocumentCollection<Cord19Paragrap
   //   + docid.00003: title + 3rd paragraph
   //   + ...
   //
-  // With TREC-COVID round 2 data, we can empirically confirm that the first method is more effective, which is
-  // implemented by DUPLICATE_PARAGRAPH = true above. However, since this remains an interesting question that should
+  // With TREC-COVID rounds 1+2 data, we can empirically confirm that the first method is more effective, which is
+  // implemented by DUPLICATE_ABSTRACT = true above. However, since this remains an interesting question that should
   // be revisited from time to time, we're leaving a flag to switch between the different indexing modes easily.
   //
   // [1] Lin. Is Searching Full Text More Effective Than Searching Abstracts? BMC Bioinformatics, 10:46, 2009.
@@ -167,7 +167,7 @@ public class Cord19ParagraphCollection extends DocumentCollection<Cord19Paragrap
         id = record.get("cord_uid") + "." + String.format("%05d", paragraphNumber);
       }
 
-      if (DUPLICATE_PARAGRAPH) {
+      if (DUPLICATE_ABSTRACT) {
         content = record.get("title").replace("\n", " ");
         content += record.get("abstract").isEmpty() ? "" : "\n" + record.get("abstract");
         content += paragraph.isEmpty() ? "" : "\n" + paragraph;

--- a/src/main/java/io/anserini/collection/Cord19ParagraphCollection.java
+++ b/src/main/java/io/anserini/collection/Cord19ParagraphCollection.java
@@ -42,6 +42,30 @@ import java.util.Set;
 public class Cord19ParagraphCollection extends DocumentCollection<Cord19ParagraphCollection.Document> {
   private static final Logger LOG = LogManager.getLogger(Cord19ParagraphCollection.class);
 
+  private static final boolean DUPLICATE_PARAGRAPH = true;
+  // With paragraph indexing, early on in TREC-COVID, we had a question about exactly how to decompose full text into
+  // paragraphs. The initial implementation was:
+  //
+  //   + docid: title + abstract
+  //   + docid.00001: title + abstract + 1st paragraph
+  //   + docid.00002: title + abstract + 2nd paragraph
+  //   + docid.00003: title + abstract + 3rd paragraph
+  //   + ...
+  //
+  // But an equally reasonable alternative would be to *not* repeat the paragraph, which is actually the setup in [1]:
+  //
+  //   + docid: title + abstract
+  //   + docid.00001: title + 1st paragraph
+  //   + docid.00002: title + 2nd paragraph
+  //   + docid.00003: title + 3rd paragraph
+  //   + ...
+  //
+  // With TREC-COVID round 2 data, we can empirically confirm that the first method is more effective, which is
+  // implemented by DUPLICATE_PARAGRAPH = true above. However, since this remains an interesting question that should
+  // be revisited from time to time, we're leaving a flag to switch between the different indexing modes easily.
+  //
+  // [1] Lin. Is Searching Full Text More Effective Than Searching Abstracts? BMC Bioinformatics, 10:46, 2009.
+
   public Cord19ParagraphCollection(Path path){
     this.path = path;
     this.allowedFileSuffix = Set.of(".csv");
@@ -143,9 +167,19 @@ public class Cord19ParagraphCollection extends DocumentCollection<Cord19Paragrap
         id = record.get("cord_uid") + "." + String.format("%05d", paragraphNumber);
       }
 
-      content = record.get("title").replace("\n", " ");
-      content += record.get("abstract").isEmpty() ? "" : "\n" + record.get("abstract");
-      content += paragraph.isEmpty() ? "" : "\n" + paragraph;
+      if (DUPLICATE_PARAGRAPH) {
+        content = record.get("title").replace("\n", " ");
+        content += record.get("abstract").isEmpty() ? "" : "\n" + record.get("abstract");
+        content += paragraph.isEmpty() ? "" : "\n" + paragraph;
+      } else {
+        if (paragraphNumber == 0) {
+          content = record.get("title").replace("\n", " ");
+          content += record.get("abstract").isEmpty() ? "" : "\n" + record.get("abstract");
+        } else {
+          content = record.get("title").replace("\n", " ");
+          content += paragraph.isEmpty() ? "" : "\n" + paragraph;
+        }
+      }
 
       raw = buildRawJson(recordFullText);
     }

--- a/src/main/python/trec-covid/filter_run.py
+++ b/src/main/python/trec-covid/filter_run.py
@@ -1,0 +1,75 @@
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+from collections import defaultdict
+
+
+def read_file(file):
+    docids = set()
+    with open(file) as f:
+        for line in f:
+            cols = line.split()
+            if len(cols) > 0:
+                docids.add(cols[0])
+    return docids
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Filter a TREC run.")
+    parser.add_argument('--whitelist', type=str, metavar='docids', help='qrels', required=True)
+    parser.add_argument('--input', type=str, metavar='run', help='input run', required=True)
+    parser.add_argument('--output', type=str, metavar='run', help='output run', required=True)
+    parser.add_argument('--runtag', type=str, default=None, metavar='runtag', help='run tag')
+    parser.add_argument('--k', type=int, default=1000, help='the number of results to keep per topic')
+    args = parser.parse_args()
+
+    docids = read_file(args.whitelist)
+    print(f'Read {len(docids)} docids from {args.whitelist}')
+    counts = defaultdict(int)
+
+    prev_score = None
+    check_score = True
+    with open(args.output, 'w') as output_f:
+        with open(args.input) as input_f:
+            for line in input_f:
+                cols = line.split()
+                qid = cols[0]
+                docid = cols[2]
+                score = float(cols[4])
+                tag = cols[5]
+
+                if args.runtag:
+                    tag = args.runtag
+
+                if counts[qid] >= args.k:
+                    if check_score:
+                        if score == prev_score:
+                            print(f'Warning: scores of {qid} do not strictly decrease at {docid}')
+                        check_score = False
+                        continue
+                    else:
+                        continue
+
+                if docid in docids:
+                    counts[qid] += 1
+                    prev_score = float(cols[4])
+                    check_score = True
+                    output_f.write(f'{qid} Q0 {docid} {counts[qid]} {score} {tag}\n')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
hey @rodrigonogueira4 remember when we had a discussion about exactly how to index paragraphs?

The old (existing) implement was:

+ docid: title + abstract
+ docid.00001: title + abstract + 1st paragraph
+ docid.00002: title + abstract + 2nd paragraph
+ docid.00003: title + abstract + 3rd paragraph
+ ...

But an equally reasonable alternative would be to *not* repeat the abstract:

+ docid: title + abstract
+ docid.00001: title + 1st paragraph
+ docid.00002: title + 2nd paragraph
+ docid.00003: title + 3rd paragraph
+ ...

I ran an experiment comparing the old and the new approaches, and the tl;dr is that the old approach is more effective:

|    | index | nDCG@10 | Judged@10 | MAP    | Recall@1k | Judged@1k |
|---:|:--------------|--------:|----------:|-------:|----------:|----------:|
|  1 | old qry+ques           | 0.4738  | 0.9457    | 0.2330 | 0.6332    | 0.2459    |
|  2 | old UDel     | 0.5508  | 0.9686    | 0.2572 | 0.6466    | 0.2411    |
|  3 | new qry+ques           | 0.4161  | 0.8800    | 0.2045 | 0.6190    | 0.2353    |
|  4 | new UDel   | 0.4865  | 0.8943    | 0.2273 | 0.6264    | 0.2307    |

I first ran retrieval to 50k hits on 5/19 index and then filtered down to only `cord_uid`s in the 5/1 corpus, and then evaluated on the union of round 1 and round 2 qrels. Each topic has 1k hits, so the comparison is fair.

For NDCG@10, new index is a lot lower, but judged is lower also. At depth 1k, judged is comparable, but MAP and recall for new is lower.

So I think we can conclude that the old indexing scheme is still better?

