### PR TITLE
Add TREC-COVID round 4 final submissions + refactor round 3 baselines

### DIFF
--- a/docs/experiments-covid.md
+++ b/docs/experiments-covid.md
@@ -19,6 +19,7 @@ They were prepared _for_ round 4 (for participants who wish to have a baseline r
 |  6 | paragraph | UDel qgen                       | 0.4016 | 0.5333 | 0.5050 | [[download](https://www.dropbox.com/s/keuogpx1dzinsgy/anserini.covid-r4.paragraph.qdel.bm25.txt)] | `b7b39629c12573ee0bfed8687dacc743` |
 |  7 | -         | reciprocal rank fusion(1, 3, 5) | 0.3424 | 0.5289 | 0.5033 | [[download](https://www.dropbox.com/s/zjc0069do0a4gu3/anserini.covid-r4.fusion1.txt)]             | `8ae9d1fca05bd1d9bfe7b24d1bdbe270` |
 |  8 | -         | reciprocal rank fusion(2, 4, 6) | 0.4004 | 0.5400 | 0.5291 | [[download](https://www.dropbox.com/s/qekc9vr3oom777n/anserini.covid-r4.fusion2.txt)]             | `e1894209c815c96c6ddd4cacb578261a` |
+|  9 | abstract  | UDel qgen + RF                  | 0.4598 | 0.5044 | 0.5330 | [[download](https://www.dropbox.com/s/2jx27rh3lknps9q/anserini.covid-r4.abstract.qdel.bm25%2Brm3Rf.txt)] | `9d954f31e2f07e11ff559bcb14ef16af` |
 
 **IMPORTANT NOTES!!!**
 
@@ -26,6 +27,15 @@ They were prepared _for_ round 4 (for participants who wish to have a baseline r
 + J@10 refers to Judged@10 and R@1k refers to Recall@1000.
 + The evaluation numbers are produced with the NIST-prepared cumulative qrels from rounds 1, 2, and 3 ([`qrels_covid_d3_j0.5-3.txt`](https://ir.nist.gov/covidSubmit/data/qrels-covid_d3_j0.5-3.txt) provided by NIST, stored in our repo as [`qrels.covid-round3-cumulative.txt`](../src/main/resources/topics-and-qrels/qrels.covid-round3-cumulative.txt)) on the round 4 collection (release of 6/19).
 + For the abstract and full-text indexes, we request up to 10k hits for each topic; the number of actual hits retrieved is fairly close to this (a bit less because of deduping). For the paragraph index, we request up to 50k hits for each topic; because multiple paragraphs are retrieved from the same document, the number of unique documents in each list of hits is much smaller. A cautionary note: our experience is that choosing the top _k_ documents to rerank has a large impact on end-to-end effectiveness. Reranking the top 100 seems to provide higher precision than top 1000, but the likely tradeoff is lower recall. It is very likely the case that you _don't_ want to rerank all available hits.
++ Row 9 represents the feedback baseline condition introduced in round 3: abstract index, UDel query generator, BM25+RM3 relevance feedback (100 feedback terms).
+
+The final runs submitted to NIST, after removing judgments from 1, 2, and 3 (cumulatively), are as follows:
+
+| group | runtag | run file | checksum |
+|:------|:-------|:---------|:---------|
+| `anserini` | `r4.fusion1` = Row 7 | [[download](https://www.dropbox.com/s/g3giixyusk4tzro/anserini.final-r4.fusion1.txt)] | `a8ab52e12c151012adbfc8e37d666760` |
+| `anserini` | `r4.fusion2` = Row 8 | [[download](https://www.dropbox.com/s/z4wbqj9gfos8wln/anserini.final-r4.fusion2.txt)] | `1500104c928f463f38e76b58b91d4c07` |
+| `anserini` | `r4.rf` = Row 9      | [[download](https://www.dropbox.com/s/28w83b07yzndlbg/anserini.final-r4.rf.txt)]      | `41d746eb86a99d2f33068ebc195072cd` |
 
 We have written scripts that make replicating the round 4 baselines easy:
 

--- a/docs/experiments-covid.md
+++ b/docs/experiments-covid.md
@@ -73,7 +73,7 @@ We resolved the issue from round 2 where the final submitted runs have less than
 
 We have written scripts that make replicating the round 3 baselines easy:
 
-```
+```bash
 $ python src/main/python/trec-covid/download_indexes.py --date 2020-05-19
 $ python src/main/python/trec-covid/generate_round3_baselines.py
 ```
@@ -112,26 +112,6 @@ Effectiveness results:
 | `anserini` | `r3.rf`                            | 0.6812 | 0.9600 | 0.2787 | 0.6399
 | `anserini` | `r3.rf` (NIST post-processed)      | 0.6883 | 0.9750 | 0.2817 | 0.6399
 
-Commands for replicating above results:
-
-```
-tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m recall.1000 -m ndcg_cut.10 -m map src/main/resources/topics-and-qrels/qrels.covid-round3.txt runs/anserini.final-r3.fusion1.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m recall.1000 -m ndcg_cut.10 -m map src/main/resources/topics-and-qrels/qrels.covid-round3.txt runs/anserini.final-r3.fusion2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m recall.1000 -m ndcg_cut.10 -m map src/main/resources/topics-and-qrels/qrels.covid-round3.txt runs/anserini.final-r3.rf.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m recall.1000 -m ndcg_cut.10 -m map src/main/resources/topics-and-qrels/qrels.covid-round3.txt runs/anserini.final-r3.fusion1.post-processed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m recall.1000 -m ndcg_cut.10 -m map src/main/resources/topics-and-qrels/qrels.covid-round3.txt runs/anserini.final-r3.fusion2.post-processed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m recall.1000 -m ndcg_cut.10 -m map src/main/resources/topics-and-qrels/qrels.covid-round3.txt runs/anserini.final-r3.rf.post-processed.txt
-
-python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round3.txt --cutoffs 10 --run runs/anserini.final-r3.fusion1.txt
-python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round3.txt --cutoffs 10 --run runs/anserini.final-r3.fusion2.txt
-python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round3.txt --cutoffs 10 --run runs/anserini.final-r3.rf.txt
-
-python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round3.txt --cutoffs 10 --run runs/anserini.final-r3.fusion1.post-processed.txt
-python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round3.txt --cutoffs 10 --run runs/anserini.final-r3.fusion2.post-processed.txt
-python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round3.txt --cutoffs 10 --run runs/anserini.final-r3.rf.post-processed.txt
-```
-
 The scores of the post-processed runs match those reported by NIST.
 We see that that NIST post-processing improves scores slightly.
 
@@ -149,6 +129,12 @@ This qrels file, provided by NIST as [`qrels_covid_d3_j0.5-3.txt`](https://ir.ni
 |  7 | -         | reciprocal rank fusion(1, 3, 5) | 0.5924 | 0.9625 | 0.5956 |
 |  8 | -         | reciprocal rank fusion(2, 4, 6) | 0.6515 | 0.9875 | 0.6194 |
 |  9 | abstract  | UDel qgen + RF           | 0.7459 | 0.9875 | 0.6125 |
+
+Note that all of the results above can be replicated with the following script:
+
+```bash
+$ python src/main/python/trec-covid/generate_round3_baselines.py
+```
 
 
 ## Round 2

--- a/docs/experiments-covid.md
+++ b/docs/experiments-covid.md
@@ -37,7 +37,7 @@ The final runs submitted to NIST, after removing judgments from 1, 2, and 3 (cum
 | `anserini` | `r4.fusion2` = Row 8 | [[download](https://www.dropbox.com/s/z4wbqj9gfos8wln/anserini.final-r4.fusion2.txt)] | `1500104c928f463f38e76b58b91d4c07` |
 | `anserini` | `r4.rf` = Row 9      | [[download](https://www.dropbox.com/s/28w83b07yzndlbg/anserini.final-r4.rf.txt)]      | `41d746eb86a99d2f33068ebc195072cd` |
 
-We have written scripts that make replicating the round 4 baselines easy:
+We have written scripts that automate the replication of these baselines:
 
 ```
 $ python src/main/python/trec-covid/download_indexes.py --date 2020-06-19
@@ -81,7 +81,7 @@ The final runs submitted to NIST, after removing judgments from round 1 and roun
 
 We resolved the issue from round 2 where the final submitted runs have less than 1000 hits per topic.
 
-We have written scripts that make replicating the round 3 baselines easy:
+We have written scripts that automate the replication of these baselines:
 
 ```bash
 $ python src/main/python/trec-covid/download_indexes.py --date 2020-05-19

--- a/src/main/python/trec-covid/covid_baseline_tools.py
+++ b/src/main/python/trec-covid/covid_baseline_tools.py
@@ -97,6 +97,7 @@ def verify_stored_runs(runs):
 
     os.mkdir(tmp)
     for url in runs:
+        print(f'Verifying stored run at {url}...')
         filename = url.split('/')[-1]
         filename = re.sub('\\?dl=1$', '', filename)  # Remove the Dropbox 'force download' parameter
 

--- a/src/main/python/trec-covid/covid_baseline_tools.py
+++ b/src/main/python/trec-covid/covid_baseline_tools.py
@@ -21,6 +21,8 @@ import shutil
 import subprocess
 import sys
 
+from random import randint
+
 sys.path.insert(0, '../pyserini/')
 
 import pyserini.util
@@ -87,17 +89,20 @@ def verify_stored_runs(runs):
     print(f'## Verifying Stored Runs')
     print('')
 
-    if os.path.exists('tmp'):
-        shutil.rmtree('tmp')
+    tmp = f'tmp{randint(0, 10000)}'
 
-    os.mkdir('tmp')
+    # In the rare event there's a collision
+    if os.path.exists(tmp):
+        shutil.rmtree(tmp)
+
+    os.mkdir(tmp)
     for url in runs:
         filename = url.split('/')[-1]
         filename = re.sub('\\?dl=1$', '', filename)  # Remove the Dropbox 'force download' parameter
 
-        pyserini.util.download_url(url, 'tmp', force=True)
+        pyserini.util.download_url(url, tmp, force=True)
 
-        md5 = hashlib.md5(open(f'tmp/{filename}', 'rb').read()).hexdigest()
+        md5 = hashlib.md5(open(f'{tmp}/{filename}', 'rb').read()).hexdigest()
         assert(runs[url] == md5)
         print('')
-    shutil.rmtree('tmp')
+    shutil.rmtree(tmp)

--- a/src/main/python/trec-covid/covid_baseline_tools.py
+++ b/src/main/python/trec-covid/covid_baseline_tools.py
@@ -1,0 +1,74 @@
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import hashlib
+import subprocess
+
+
+def evaluate_run(run, qrels):
+    metrics = {}
+    output = subprocess.check_output(
+        f'tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 -m recall.1000 -m map {qrels} runs/{run}', shell=True)
+
+    lines = output.decode('utf-8').split('\n')
+
+    for line in lines:
+        arr = line.split()
+        if len(arr) == 3:
+            metrics[arr[0]] = float(arr[2])
+
+    output = subprocess.check_output(f'python tools/eval/measure_judged.py --qrels {qrels} ' +
+                                     f'--cutoffs 10 100 1000 --run runs/{run}', shell=True)
+
+    lines = output.decode('utf-8').split('\n')
+
+    for line in lines:
+        arr = line.split()
+        if len(arr) == 3:
+            metrics[arr[0]] = float(arr[2])
+
+    # Count number of unique topics; Note, run through sed first to convert tabs to spaces.
+    output = subprocess.check_output(f"sed 's/\t/ /g' runs/{run} | tr -s ' ' | cut -d ' ' -f 1 | sort | uniq | wc",
+                                     shell=True)
+    arr = output.decode('utf-8').split()
+    metrics['topics'] = int(arr[0])
+
+    metrics['md5'] = hashlib.md5(open(f'runs/{run}', 'rb').read()).hexdigest()
+
+    return metrics
+
+
+def evaluate_runs(qrels, runs):
+    max_length = 0
+    for run in runs:
+        if len(run) > max_length:
+            max_length = len(run)
+
+    padding = 2
+
+    print('')
+    print(f'## Evaluation results w/ {qrels}')
+    print('')
+    print(' ' * (max_length -2) + 'topics nDCG@10   J@10     AP   R@1k   J@1k MD5')
+
+    for run in runs:
+        metrics = evaluate_run(run, qrels)
+
+        print(run + ' ' * ((max_length-len(run)) + padding) +
+              f'{metrics["topics"]}{metrics["ndcg_cut_10"]:8.4f}' +
+              f'{metrics["judged_cut_10"]:7.4f}{metrics["map"]:7.4f}' +
+              f'{metrics["recall_1000"]:7.4f}{metrics["judged_cut_1000"]:7.4f} ' +
+              f'{metrics["md5"]}')

--- a/src/main/python/trec-covid/covid_baseline_tools.py
+++ b/src/main/python/trec-covid/covid_baseline_tools.py
@@ -105,5 +105,7 @@ def verify_stored_runs(runs):
 
         md5 = hashlib.md5(open(f'{tmp}/{filename}', 'rb').read()).hexdigest()
         assert(runs[url] == md5)
+        print('Checksums match!')
         print('')
+
     shutil.rmtree(tmp)

--- a/src/main/python/trec-covid/generate_round3_baselines.py
+++ b/src/main/python/trec-covid/generate_round3_baselines.py
@@ -139,35 +139,36 @@ indexes = ['indexes/lucene-index-cord19-abstract-2020-05-19',
            'indexes/lucene-index-cord19-full-text-2020-05-19',
            'indexes/lucene-index-cord19-paragraph-2020-05-19']
 
-stored_runs = {'https://www.dropbox.com/s/g80cqdxud1l06wq/anserini.covid-r3.abstract.qq.bm25.txt?dl=1':
-                   'd08d85c87e30d6c4abf54799806d282f',
-               'https://www.dropbox.com/s/sjcnxq7h0a3j3xz/anserini.covid-r3.abstract.qdel.bm25.txt?dl=1':
-                   'd552dff90995cd860a5727637f0be4d1',
-               'https://www.dropbox.com/s/4bjx35sgosu0jz0/anserini.covid-r3.full-text.qq.bm25.txt?dl=1':
-                   '6c9f4c09d842b887262ca84d61c61a1f',
-               'https://www.dropbox.com/s/mjt7y1ywae784d0/anserini.covid-r3.full-text.qdel.bm25.txt?dl=1':
-                   'c5f9db7733c72eea78ece2ade44d3d35',
-               'https://www.dropbox.com/s/qwn7jd8vg2chjik/anserini.covid-r3.paragraph.qq.bm25.txt?dl=1':
-                   '872673b3e12c661748d8899f24d3ba48',
-               'https://www.dropbox.com/s/2928i60fj2i09bt/anserini.covid-r3.paragraph.qdel.bm25.txt?dl=1':
-                   'c1b966e4c3f387b6810211f339b35852',
-               'https://www.dropbox.com/s/6vk5iohqf81iy8b/anserini.covid-r3.fusion1.txt?dl=1':
-                   '61cbd73c6e60ba44f18ce967b5b0e5b3',
-               'https://www.dropbox.com/s/n09595t1eqymkks/anserini.covid-r3.fusion2.txt?dl=1':
-                   'd7eabf3dab840104c88de925e918fdab',
-               'https://www.dropbox.com/s/ypoe9tgwef17rak/anserini.final-r3.fusion1.txt?dl=1':
-                   'c1caf63a9c3b02f0b12e233112fc79a6',
-               'https://www.dropbox.com/s/uvfrssp6nw2v2jl/anserini.final-r3.fusion2.txt?dl=1':
-                   '12679197846ed77306ecb2ca7895b011',
-               'https://www.dropbox.com/s/2wrg7ceaca3n7ac/anserini.final-r3.rf.txt?dl=1':
-                   '7192a08c5275b59d5ef18395917ff694',
-               'https://www.dropbox.com/s/ilqgky1tti0zvez/anserini.final-r3.fusion1.post-processed.txt?dl=1':
-                   'f7c69c9bff381a847af86e5a8daf7526',
-               'https://www.dropbox.com/s/ue3z6xxxca9krkb/anserini.final-r3.fusion2.post-processed.txt?dl=1':
-                   '84c5fd2c7de0a0282266033ac4f27c22',
-               'https://www.dropbox.com/s/95vk831wp1ldnpm/anserini.final-r3.rf.post-processed.txt?dl=1':
-                   '3e79099639a9426cb53afe7066239011'
-               }
+stored_runs = {
+    'https://www.dropbox.com/s/g80cqdxud1l06wq/anserini.covid-r3.abstract.qq.bm25.txt?dl=1':
+        'd08d85c87e30d6c4abf54799806d282f',
+    'https://www.dropbox.com/s/sjcnxq7h0a3j3xz/anserini.covid-r3.abstract.qdel.bm25.txt?dl=1':
+        'd552dff90995cd860a5727637f0be4d1',
+    'https://www.dropbox.com/s/4bjx35sgosu0jz0/anserini.covid-r3.full-text.qq.bm25.txt?dl=1':
+        '6c9f4c09d842b887262ca84d61c61a1f',
+    'https://www.dropbox.com/s/mjt7y1ywae784d0/anserini.covid-r3.full-text.qdel.bm25.txt?dl=1':
+        'c5f9db7733c72eea78ece2ade44d3d35',
+    'https://www.dropbox.com/s/qwn7jd8vg2chjik/anserini.covid-r3.paragraph.qq.bm25.txt?dl=1':
+        '872673b3e12c661748d8899f24d3ba48',
+    'https://www.dropbox.com/s/2928i60fj2i09bt/anserini.covid-r3.paragraph.qdel.bm25.txt?dl=1':
+        'c1b966e4c3f387b6810211f339b35852',
+    'https://www.dropbox.com/s/6vk5iohqf81iy8b/anserini.covid-r3.fusion1.txt?dl=1':
+        '61cbd73c6e60ba44f18ce967b5b0e5b3',
+    'https://www.dropbox.com/s/n09595t1eqymkks/anserini.covid-r3.fusion2.txt?dl=1':
+        'd7eabf3dab840104c88de925e918fdab',
+    'https://www.dropbox.com/s/ypoe9tgwef17rak/anserini.final-r3.fusion1.txt?dl=1':
+        'c1caf63a9c3b02f0b12e233112fc79a6',
+    'https://www.dropbox.com/s/uvfrssp6nw2v2jl/anserini.final-r3.fusion2.txt?dl=1':
+        '12679197846ed77306ecb2ca7895b011',
+    'https://www.dropbox.com/s/2wrg7ceaca3n7ac/anserini.final-r3.rf.txt?dl=1':
+        '7192a08c5275b59d5ef18395917ff694',
+    'https://www.dropbox.com/s/ilqgky1tti0zvez/anserini.final-r3.fusion1.post-processed.txt?dl=1':
+        'f7c69c9bff381a847af86e5a8daf7526',
+    'https://www.dropbox.com/s/ue3z6xxxca9krkb/anserini.final-r3.fusion2.post-processed.txt?dl=1':
+        '84c5fd2c7de0a0282266033ac4f27c22',
+    'https://www.dropbox.com/s/95vk831wp1ldnpm/anserini.final-r3.rf.post-processed.txt?dl=1':
+        '3e79099639a9426cb53afe7066239011'
+}
 
 
 def main():

--- a/src/main/python/trec-covid/generate_round3_baselines.py
+++ b/src/main/python/trec-covid/generate_round3_baselines.py
@@ -52,8 +52,7 @@ def perform_runs():
               f'-topicreader Covid -topics {udel_topics} -topicfield query -removedups ' +
               f'-bm25 -rm3 -rm3.fbTerms 100 -hits 10000 ' +
               f'-rf.qrels src/main/resources/topics-and-qrels/qrels.covid-round12.txt ' +
-              f'-output runs/{abstract_prefix}.qdel.bm25+rm3Rf.txt ' +
-              f'-runtag anserini.covid-r3.abstract.qdel.bm25+rm3Rf.txt')
+              f'-output runs/{abstract_prefix}.qdel.bm25+rm3Rf.txt -runtag {abstract_prefix}.qdel.bm25+rm3Rf.txt')
 
     print('')
     print('## Running on full-text index...')
@@ -145,9 +144,9 @@ def main():
     if not (os.path.isdir(indexes[0]) and os.path.isdir(indexes[1]) and os.path.isdir(indexes[2])):
         print('Required indexes do not exist. Please download first.')
 
-    #perform_runs()
-    #perform_fusion()
-    #prepare_final_submissions('src/main/resources/topics-and-qrels/qrels.covid-round12.txt')
+    perform_runs()
+    perform_fusion()
+    prepare_final_submissions('src/main/resources/topics-and-qrels/qrels.covid-round12.txt')
 
     os.system('cat src/main/resources/topics-and-qrels/qrels.covid-round1.txt ' +
               'src/main/resources/topics-and-qrels/qrels.covid-round2.txt ' +

--- a/src/main/python/trec-covid/generate_round3_baselines.py
+++ b/src/main/python/trec-covid/generate_round3_baselines.py
@@ -71,7 +71,7 @@ def perform_runs():
               f'-output runs/{full_text_prefix}.qdel.bm25.txt -runtag {full_text_prefix}.qdel.bm25.txt')
 
     print('')
-    print('## Running on full-text index...')
+    print('## Running on paragraph index...')
     print('')
 
     paragraph_index = indexes[2]

--- a/src/main/python/trec-covid/generate_round3_baselines.py
+++ b/src/main/python/trec-covid/generate_round3_baselines.py
@@ -20,7 +20,7 @@ import hashlib
 import os
 import sys
 
-from covid_baseline_tools import evaluate_runs
+from covid_baseline_tools import evaluate_runs, verify_stored_runs
 
 sys.path.insert(0, './')
 sys.path.insert(0, '../pyserini/')
@@ -139,10 +139,42 @@ indexes = ['indexes/lucene-index-cord19-abstract-2020-05-19',
            'indexes/lucene-index-cord19-full-text-2020-05-19',
            'indexes/lucene-index-cord19-paragraph-2020-05-19']
 
+stored_runs = {'https://www.dropbox.com/s/g80cqdxud1l06wq/anserini.covid-r3.abstract.qq.bm25.txt?dl=1':
+                   'd08d85c87e30d6c4abf54799806d282f',
+               'https://www.dropbox.com/s/sjcnxq7h0a3j3xz/anserini.covid-r3.abstract.qdel.bm25.txt?dl=1':
+                   'd552dff90995cd860a5727637f0be4d1',
+               'https://www.dropbox.com/s/4bjx35sgosu0jz0/anserini.covid-r3.full-text.qq.bm25.txt?dl=1':
+                   '6c9f4c09d842b887262ca84d61c61a1f',
+               'https://www.dropbox.com/s/mjt7y1ywae784d0/anserini.covid-r3.full-text.qdel.bm25.txt?dl=1':
+                   'c5f9db7733c72eea78ece2ade44d3d35',
+               'https://www.dropbox.com/s/qwn7jd8vg2chjik/anserini.covid-r3.paragraph.qq.bm25.txt?dl=1':
+                   '872673b3e12c661748d8899f24d3ba48',
+               'https://www.dropbox.com/s/2928i60fj2i09bt/anserini.covid-r3.paragraph.qdel.bm25.txt?dl=1':
+                   'c1b966e4c3f387b6810211f339b35852',
+               'https://www.dropbox.com/s/6vk5iohqf81iy8b/anserini.covid-r3.fusion1.txt?dl=1':
+                   '61cbd73c6e60ba44f18ce967b5b0e5b3',
+               'https://www.dropbox.com/s/n09595t1eqymkks/anserini.covid-r3.fusion2.txt?dl=1':
+                   'd7eabf3dab840104c88de925e918fdab',
+               'https://www.dropbox.com/s/ypoe9tgwef17rak/anserini.final-r3.fusion1.txt?dl=1':
+                   'c1caf63a9c3b02f0b12e233112fc79a6',
+               'https://www.dropbox.com/s/uvfrssp6nw2v2jl/anserini.final-r3.fusion2.txt?dl=1':
+                   '12679197846ed77306ecb2ca7895b011',
+               'https://www.dropbox.com/s/2wrg7ceaca3n7ac/anserini.final-r3.rf.txt?dl=1':
+                   '7192a08c5275b59d5ef18395917ff694',
+               'https://www.dropbox.com/s/ilqgky1tti0zvez/anserini.final-r3.fusion1.post-processed.txt?dl=1':
+                   'f7c69c9bff381a847af86e5a8daf7526',
+               'https://www.dropbox.com/s/ue3z6xxxca9krkb/anserini.final-r3.fusion2.post-processed.txt?dl=1':
+                   '84c5fd2c7de0a0282266033ac4f27c22',
+               'https://www.dropbox.com/s/95vk831wp1ldnpm/anserini.final-r3.rf.post-processed.txt?dl=1':
+                   '3e79099639a9426cb53afe7066239011'
+               }
+
 
 def main():
     if not (os.path.isdir(indexes[0]) and os.path.isdir(indexes[1]) and os.path.isdir(indexes[2])):
         print('Required indexes do not exist. Please download first.')
+
+    verify_stored_runs(stored_runs)
 
     perform_runs()
     perform_fusion()

--- a/src/main/python/trec-covid/generate_round4_baselines.py
+++ b/src/main/python/trec-covid/generate_round4_baselines.py
@@ -20,7 +20,7 @@ import hashlib
 import os
 import sys
 
-from covid_baseline_tools import evaluate_runs
+from covid_baseline_tools import evaluate_runs, verify_stored_runs
 
 sys.path.insert(0, './')
 sys.path.insert(0, '../pyserini/')
@@ -109,17 +109,73 @@ def perform_fusion():
               f'--runs runs/{set2[0]} runs/{set2[1]} runs/{set2[2]}')
 
 
+def prepare_final_submissions(qrels):
+    print('')
+    print('## Preparing final submission files by removing qrels...')
+    print('')
+
+    run1 = 'anserini.final-r4.fusion1.txt'
+    print(f'Generating {run1}')
+    os.system(f'python tools/scripts/filter_run_with_qrels.py --discard --qrels {qrels} ' +
+              f'--input runs/anserini.covid-r4.fusion1.txt --output runs/{run1} --runtag r4.fusion1')
+
+    run2 = 'anserini.final-r4.fusion2.txt'
+    print(f'Generating {run2}')
+    os.system(f'python tools/scripts/filter_run_with_qrels.py --discard --qrels {qrels} ' +
+              f'--input runs/anserini.covid-r4.fusion2.txt --output runs/{run2} --runtag r4.fusion2')
+
+    run3 = 'anserini.final-r4.rf.txt'
+    print(f'Generating {run3}')
+    os.system(f'python tools/scripts/filter_run_with_qrels.py --discard --qrels {qrels} ' +
+              f'--input runs/anserini.covid-r4.abstract.qdel.bm25+rm3Rf.txt --output runs/{run3} --runtag r4.rf')
+
+    print('')
+    print(f'{run1} checksum=' + hashlib.md5(open(f'runs/{run1}', 'rb').read()).hexdigest())
+    print(f'{run2} checksum=' + hashlib.md5(open(f'runs/{run2}', 'rb').read()).hexdigest())
+    print(f'{run3} checksum=' + hashlib.md5(open(f'runs/{run3}', 'rb').read()).hexdigest())
+
+
 indexes = ['indexes/lucene-index-cord19-abstract-2020-06-19',
            'indexes/lucene-index-cord19-full-text-2020-06-19',
            'indexes/lucene-index-cord19-paragraph-2020-06-19']
+
+stored_runs = {
+    'https://www.dropbox.com/s/mf79huhxfy96g6i/anserini.covid-r4.abstract.qq.bm25.txt?dl=1':
+        '56ac5a0410e235243ca6e9f0f00eefa1',
+    'https://www.dropbox.com/s/4zau6ejrkvgn9m7/anserini.covid-r4.abstract.qdel.bm25.txt?dl=1':
+        '115d6d2e308b47ffacbc642175095c74',
+    'https://www.dropbox.com/s/bpdopie6gqffv0w/anserini.covid-r4.full-text.qq.bm25.txt?dl=1':
+        'af0d10a5344f4007e6781e8d2959eb54',
+    'https://www.dropbox.com/s/rh0uy71ogbpas0v/anserini.covid-r4.full-text.qdel.bm25.txt?dl=1':
+        '594d469b8f45cf808092a3d8e870eaf5',
+    'https://www.dropbox.com/s/ifkjm8ff8g2aoh1/anserini.covid-r4.paragraph.qq.bm25.txt?dl=1':
+        '6f468b7b60aaa05fc215d237b5475aec',
+    'https://www.dropbox.com/s/keuogpx1dzinsgy/anserini.covid-r4.paragraph.qdel.bm25.txt?dl=1':
+        'b7b39629c12573ee0bfed8687dacc743',
+    'https://www.dropbox.com/s/zjc0069do0a4gu3/anserini.covid-r4.fusion1.txt?dl=1':
+        '8ae9d1fca05bd1d9bfe7b24d1bdbe270',
+    'https://www.dropbox.com/s/qekc9vr3oom777n/anserini.covid-r4.fusion2.txt?dl=1':
+        'e1894209c815c96c6ddd4cacb578261a',
+    'https://www.dropbox.com/s/2jx27rh3lknps9q/anserini.covid-r4.abstract.qdel.bm25%2Brm3Rf.txt?dl=1':
+        '9d954f31e2f07e11ff559bcb14ef16af',
+    'https://www.dropbox.com/s/g3giixyusk4tzro/anserini.final-r4.fusion1.txt?dl=1':
+        'a8ab52e12c151012adbfc8e37d666760',
+    'https://www.dropbox.com/s/z4wbqj9gfos8wln/anserini.final-r4.fusion2.txt?dl=1':
+        '1500104c928f463f38e76b58b91d4c07',
+    'https://www.dropbox.com/s/28w83b07yzndlbg/anserini.final-r4.rf.txt?dl=1':
+        '41d746eb86a99d2f33068ebc195072cd'
+}
 
 
 def main():
     if not (os.path.isdir(indexes[0]) and os.path.isdir(indexes[1]) and os.path.isdir(indexes[2])):
         print('Required indexes do not exist. Please download first.')
 
+    verify_stored_runs(stored_runs)
+
     perform_runs()
     perform_fusion()
+    prepare_final_submissions('src/main/resources/topics-and-qrels/qrels.covid-round3-cumulative.txt')
 
     runs = ['anserini.covid-r4.abstract.qq.bm25.txt',
             'anserini.covid-r4.abstract.qdel.bm25.txt',

--- a/src/main/python/trec-covid/generate_round4_baselines.py
+++ b/src/main/python/trec-covid/generate_round4_baselines.py
@@ -55,7 +55,7 @@ def perform_runs():
               f'-output runs/{abstract_prefix}.qdel.bm25+rm3Rf.txt -runtag {abstract_prefix}.qdel.bm25+rm3Rf.txt')
 
     print('')
-    print('## Running on paragraph index...')
+    print('## Running on full-text index...')
     print('')
 
     full_text_index = indexes[1]
@@ -71,7 +71,7 @@ def perform_runs():
               f'-output runs/{full_text_prefix}.qdel.bm25.txt -runtag {full_text_prefix}.qdel.bm25.txt')
 
     print('')
-    print('## Running on full-text index...')
+    print('## Running on paragraph index...')
     print('')
 
     paragraph_index = indexes[2]

--- a/src/main/python/trec-covid/generate_round4_baselines.py
+++ b/src/main/python/trec-covid/generate_round4_baselines.py
@@ -18,38 +18,14 @@
 
 import hashlib
 import os
-import subprocess
 import sys
 
+from covid_baseline_tools import evaluate_runs
+
 sys.path.insert(0, './')
+sys.path.insert(0, '../pyserini/')
 
-
-def evaluate_run(run):
-    qrels = 'src/main/resources/topics-and-qrels/qrels.covid-round3-cumulative.txt'
-    metrics = {}
-    output = subprocess.check_output(
-        f'tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 -m recall.1000 {qrels} runs/{run}', shell=True)
-
-    lines = output.decode('utf-8').split('\n')
-
-    arr = lines[0].split()
-    metrics[arr[0]] = float(arr[2])
-    arr = lines[1].split()
-    metrics[arr[0]] = float(arr[2])
-
-    output = subprocess.check_output(f'python tools/eval/measure_judged.py --qrels {qrels} ' +
-                                     f'--cutoffs 10 100 1000 --run runs/{run}', shell=True)
-
-    arr = output.decode('utf-8').split()
-    metrics[arr[0]] = float(arr[2])
-
-    output = subprocess.check_output(f"cut -d ' ' -f 1 runs/{run} | sort | uniq | wc", shell=True)
-    arr = output.decode('utf-8').split()
-    metrics['topics'] = int(arr[0])
-
-    metrics['md5'] = hashlib.md5(open(f'runs/{run}', 'rb').read()).hexdigest()
-
-    return metrics
+import pyserini.util
 
 
 def perform_runs():
@@ -72,8 +48,14 @@ def perform_runs():
               f'-removedups -bm25 -hits 10000 ' +
               f'-output runs/{abstract_prefix}.qdel.bm25.txt -runtag {abstract_prefix}.qdel.bm25.txt')
 
+    os.system(f'target/appassembler/bin/SearchCollection -index {abstract_index} ' +
+              f'-topicreader Covid -topics {udel_topics} -topicfield query -removedups ' +
+              f'-bm25 -rm3 -rm3.fbTerms 100 -hits 10000 ' +
+              f'-rf.qrels src/main/resources/topics-and-qrels/qrels.covid-round3-cumulative.txt ' +
+              f'-output runs/{abstract_prefix}.qdel.bm25+rm3Rf.txt -runtag {abstract_prefix}.qdel.bm25+rm3Rf.txt')
+
     print('')
-    print('## Running on full-text index...')
+    print('## Running on paragraph index...')
     print('')
 
     full_text_index = indexes[1]
@@ -127,60 +109,6 @@ def perform_fusion():
               f'--runs runs/{set2[0]} runs/{set2[1]} runs/{set2[2]}')
 
 
-def evaluate_runs():
-    qq_a_metrics = evaluate_run('anserini.covid-r4.abstract.qq.bm25.txt')
-    qd_a_metrics = evaluate_run('anserini.covid-r4.abstract.qdel.bm25.txt')
-
-    qq_f_metrics = evaluate_run('anserini.covid-r4.full-text.qq.bm25.txt')
-    qd_f_metrics = evaluate_run('anserini.covid-r4.full-text.qdel.bm25.txt')
-
-    qq_p_metrics = evaluate_run('anserini.covid-r4.paragraph.qq.bm25.txt')
-    qd_p_metrics = evaluate_run('anserini.covid-r4.paragraph.qdel.bm25.txt')
-
-    qq_u_metrics = evaluate_run('anserini.covid-r4.fusion1.txt')
-    qd_u_metrics = evaluate_run('anserini.covid-r4.fusion2.txt')
-
-    print('')
-    print('## Evaluation results')
-    print('')
-    print(f'                                          topics   nDCG@10   Judged@10   Recall@1000')
-    print(f'anserini.covid-r4.abstract.qq.bm25.txt' +
-          f'      {qq_a_metrics["topics"]}      {qq_a_metrics["ndcg_cut_10"]:.4f}' +
-          f'    {qq_a_metrics["judged_cut_10"]:.4f}      {qq_a_metrics["recall_1000"]:.4f}' +
-          f'    {qq_a_metrics["md5"]}')
-    print(f'anserini.covid-r4.abstract.qdel.bm25.txt' +
-          f'    {qd_a_metrics["topics"]}      {qd_a_metrics["ndcg_cut_10"]:.4f}' +
-          f'    {qd_a_metrics["judged_cut_10"]:.4f}      {qd_a_metrics["recall_1000"]:.4f}' +
-          f'    {qd_a_metrics["md5"]}')
-
-    print(f'anserini.covid-r4.full-text.qq.bm25.txt' +
-          f'     {qq_f_metrics["topics"]}      {qq_f_metrics["ndcg_cut_10"]:.4f}' +
-          f'    {qq_f_metrics["judged_cut_10"]:.4f}      {qq_f_metrics["recall_1000"]:.4f}' +
-          f'    {qq_f_metrics["md5"]}')
-    print(f'anserini.covid-r4.full-text.qdel.bm25.txt' +
-          f'   {qd_f_metrics["topics"]}      {qd_f_metrics["ndcg_cut_10"]:.4f}' +
-          f'    {qd_f_metrics["judged_cut_10"]:.4f}      {qd_f_metrics["recall_1000"]:.4f}' +
-          f'    {qd_f_metrics["md5"]}')
-
-    print(f'anserini.covid-r4.paragraph.qq.bm25.txt' +
-          f'     {qq_p_metrics["topics"]}      {qq_p_metrics["ndcg_cut_10"]:.4f}' +
-          f'    {qq_p_metrics["judged_cut_10"]:.4f}      {qq_p_metrics["recall_1000"]:.4f}' +
-          f'    {qq_p_metrics["md5"]}')
-    print(f'anserini.covid-r4.paragraph.qdel.bm25.txt' +
-          f'   {qd_p_metrics["topics"]}      {qd_p_metrics["ndcg_cut_10"]:.4f}' +
-          f'    {qd_p_metrics["judged_cut_10"]:.4f}      {qd_p_metrics["recall_1000"]:.4f}' +
-          f'    {qd_p_metrics["md5"]}')
-
-    print(f'anserini.covid-r4.fusion1.txt' +
-          f'               {qq_u_metrics["topics"]}      {qq_u_metrics["ndcg_cut_10"]:.4f}' +
-          f'    {qq_u_metrics["judged_cut_10"]:.4f}      {qq_u_metrics["recall_1000"]:.4f}' +
-          f'    {qq_u_metrics["md5"]}')
-    print(f'anserini.covid-r4.fusion2.txt' +
-          f'               {qd_u_metrics["topics"]}      {qd_u_metrics["ndcg_cut_10"]:.4f}' +
-          f'    {qd_u_metrics["judged_cut_10"]:.4f}      {qd_u_metrics["recall_1000"]:.4f}' +
-          f'    {qd_u_metrics["md5"]}')
-
-
 indexes = ['indexes/lucene-index-cord19-abstract-2020-06-19',
            'indexes/lucene-index-cord19-full-text-2020-06-19',
            'indexes/lucene-index-cord19-paragraph-2020-06-19']
@@ -192,7 +120,18 @@ def main():
 
     perform_runs()
     perform_fusion()
-    evaluate_runs()
+
+    runs = ['anserini.covid-r4.abstract.qq.bm25.txt',
+            'anserini.covid-r4.abstract.qdel.bm25.txt',
+            'anserini.covid-r4.full-text.qq.bm25.txt',
+            'anserini.covid-r4.full-text.qdel.bm25.txt',
+            'anserini.covid-r4.paragraph.qq.bm25.txt',
+            'anserini.covid-r4.paragraph.qdel.bm25.txt',
+            'anserini.covid-r4.fusion1.txt',
+            'anserini.covid-r4.fusion2.txt',
+            'anserini.covid-r4.abstract.qdel.bm25+rm3Rf.txt']
+
+    evaluate_runs('src/main/resources/topics-and-qrels/qrels.covid-round3-cumulative.txt', runs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Can I get a replication on both r3 and r4 baselines as a final sanity check?

```
$ python src/main/python/trec-covid/generate_round3_baselines.py
$ python src/main/python/trec-covid/generate_round4_baselines.py
```

@lukuang can you please check the RF run to make sure I got everything correct?

If this checks out, we're ready for Round 4 submission.