### PR TITLE
Add replication log to msmarco-passage and msmarco-doc

### DIFF
--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -125,3 +125,4 @@ As expected, BM25 tuning makes a big difference!
 + Results replicated by [@TianchengY](https://github.com/TianchengY) on 2020-05-28 (commit [`2947a16`](https://github.com/castorini/anserini/commit/2947a1622efae35637b83e321aba8e6fccd43489))
 + Results replicated by [@stariqmi](https://github.com/stariqmi) on 2020-05-28 (commit [`4914305`](https://github.com/castorini/anserini/commit/455169ea6a09f637817a6c4b4f6837dcc845f5f7))
 + Results replicated by [@justinborromeo](https://github.com/justinborromeo) on 2020-06-11 (commit[`7954eab`](https://github.com/castorini/anserini/commit/7954eab43f17bb8d254987d5873933c0b9596bb4))
++ Results replicated by [@yxzhu16](https://github.com/yxzhu16) on 2020-07-03 (commit [`68ace26`](https://github.com/castorini/anserini/commit/68ace26d0418a769df3d2b21e946495e54d462f6))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -65,7 +65,7 @@ sh target/appassembler/bin/SearchMsmarco -hits 1000 -threads 1 \
 ```
 
 Note that by default, the above script uses BM25 with tuned parameters `k1=0.82`, `b=0.68`.
-The option `-hits` specifies the of documents per query to be retrieved.
+The option `-hits` specifies the number of documents per query to be retrieved.
 Thus, the output file should have approximately 6980 × 1000 = 6.9M lines.
 
 Retrieval speed will vary by machine:

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -173,3 +173,5 @@ Tuned (`k1=0.82`, `b=0.72`) | 0.1875 | 0.1956 | 0.8578
 + Results replicated by [@TianchengY](https://github.com/TianchengY) on 2020-05-28 (commit [`2947a16`](https://github.com/castorini/anserini/commit/2947a1622efae35637b83e321aba8e6fccd43489))
 + Results replicated by [@stariqmi](https://github.com/stariqmi) on 2020-05-28 (commit [`4914305`](https://github.com/castorini/anserini/commit/455169ea6a09f637817a6c4b4f6837dcc845f5f7))
 + Results replicated by [@justinborromeo](https://github.com/justinborromeo) on 2020-06-10 (commit [`7954eab`](https://github.com/castorini/anserini/commit/7954eab43f17bb8d254987d5873933c0b9596bb4))
++ Results replicated by [@yxzhu16](https://github.com/yxzhu16) on 2020-07-03 (commit [`68ace26`](https://github.com/castorini/anserini/commit/68ace26d0418a769df3d2b21e946495e54d462f6))
+


### PR DESCRIPTION
OS: macOS Catalina 10.15.4
Java: 11.0.7 2020-04-14 LTS 
Python: 3.8.3

No issues encountered when running the experiments, results are identical. 

Fixed a small typo in doc.

### Results for msmacro-passage
default parameters (k1 = 0.9, b = 0.4):
<img width="1276" alt="Screen Shot 2020-07-04 at 3 25 56 PM" src="https://user-images.githubusercontent.com/36939877/86519659-b727a300-be0a-11ea-85e6-62e485c88579.png">
 tuned parameters (k1 = 0.82, b = 0.68)
<img width="1112" alt="Screen Shot 2020-07-04 at 3 26 06 PM" src="https://user-images.githubusercontent.com/36939877/86519660-ba229380-be0a-11ea-849a-b02080ee23a2.png">

### Results for msmacro-doc

![image](https://user-images.githubusercontent.com/36939877/86519577-f3a6cf00-be09-11ea-9295-d5d2f32b6b2d.png)
