### PR TITLE
Fix sendBulkRequest exception

### DIFF
--- a/src/main/java/io/anserini/index/IndexArgs.java
+++ b/src/main/java/io/anserini/index/IndexArgs.java
@@ -184,6 +184,10 @@ public class IndexArgs {
       usage = "Elasticsearch batch index requests size.")
   public int esBatch = 1000;
 
+  @Option(name = "-es.bulk", metaVar = "[n]",
+      usage = "Elasticsearch max bulk requests size in bytes.")
+  public int esBulk = 80000000;
+
   @Option(name = "-es.hostname", metaVar = "[host]",
       usage = "Elasticsearch host.")
   public String esHostname = "localhost";


### PR DESCRIPTION
Fix exception related to [#1322](https://github.com/castorini/anserini/pull/1322). The exception is caused by the request size reaching the maximum ES bulk size. Originally, a `bulkRequest` is sent whenever the batch size reaches 1000. We could reduce the batch size, but this may have a big impact on runtime. I think a better way to do it is to not only check if the batch size, but also the request bulk size(in bytes). If either the batch size or the bulk size is reached to a threshold, send the `bulkRequest`. It has been tested on Abstract and Paragraph, and the impact on runtime is minimal. The runtime seems to be better than reducing the batch size only. 

Also, logging of the 10 largest `cord_uid` has been added when the exception is raised, for debugging purposes.
