### PR TITLE
expose document level term positions

### DIFF
--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -394,7 +394,7 @@ public class IndexReaderUtils {
    * @throws IOException if error encountered during query
    * @throws NotStoredException if the term vector is not stored
    */
-  public static Map<String, List<Long>> getTermPositions(IndexReader reader, String docid) throws IOException, NotStoredException {
+  public static Map<String, List<Integer>> getTermPositions(IndexReader reader, String docid) throws IOException, NotStoredException {
     int ldocid = convertDocidToLuceneDocid(reader, docid);
     if (ldocid == -1) {
       return null;
@@ -408,16 +408,16 @@ public class IndexReaderUtils {
       throw new NotStoredException("Document vector not stored!");
     }
 
-    Map<String, List<Long>> termPosition = new HashMap<>();
+    Map<String, List<Integer>> termPosition = new HashMap<>();
     PostingsEnum positionIter = null;
 
     while ((termIter.next()) != null) {
-      List<Long> positions = new ArrayList<>();
+      List<Integer> positions = new ArrayList<>();
       Long termFreq = termIter.totalTermFreq();
       positionIter = termIter.postings(positionIter, PostingsEnum.POSITIONS);
       positionIter.nextDoc();
       for ( int i = 0; i < termFreq; i++ ) {
-        positions.add(Long.valueOf(positionIter.nextPosition()));
+        positions.add(positionIter.nextPosition());
       }
       termPosition.put(termIter.term().utf8ToString(), positions);
     }

--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -384,18 +384,17 @@ public class IndexReaderUtils {
   }
 
   /**
-   * Returns the document posting list for a particular document as a map of terms to term posting list. Note that this
-   * method explicitly returns {@code null} if the document does not exist (as opposed to an empty map), so that the
-   * caller is explicitly forced to handle this case.
+   * Returns the term position mapping for a particular document. Note that this method explicitly returns
+   * {@code null} if the document does not exist (as opposed to an empty map), so that the caller is explicitly forced
+   * to handle this case.
    *
    * @param reader index reader
    * @param docid collection docid
-   * @return the document posting list for a particular document as a map of terms to term posting list or {@code null} if
-   * document does not exist.
+   * @return term position mapping for a particular document or {@code null} if document does not exist.
    * @throws IOException if error encountered during query
    * @throws NotStoredException if the term vector is not stored
    */
-  public static Map<String, List<Long>> getDocumentPostings(IndexReader reader, String docid) throws IOException, NotStoredException {
+  public static Map<String, List<Long>> getPositionList(IndexReader reader, String docid) throws IOException, NotStoredException {
     int ldocid = convertDocidToLuceneDocid(reader, docid);
     if (ldocid == -1) {
       return null;
@@ -409,21 +408,21 @@ public class IndexReaderUtils {
       throw new NotStoredException("Document vector not stored!");
     }
 
-    Map<String, List<Long>> docPostings = new HashMap<>();
-    PostingsEnum positions = null;
+    Map<String, List<Long>> term_position = new HashMap<>();
+    PostingsEnum position_iter = null;
 
     while ((te.next()) != null) {
-      List<Long> postings = new ArrayList<>();
+      List<Long> positions = new ArrayList<>();
       Long freq = te.totalTermFreq();
-      positions = te.postings(positions, PostingsEnum.POSITIONS);
-      positions.nextDoc();
+      position_iter = te.postings(position_iter, PostingsEnum.POSITIONS);
+      position_iter.nextDoc();
       for ( int i = 0; i < freq; i++ ) {
-        postings.add(Long.valueOf(positions.nextPosition()));
+        positions.add(Long.valueOf(position_iter.nextPosition()));
       }
-      docPostings.put(te.term().utf8ToString(), postings);
+      term_position.put(te.term().utf8ToString(), positions);
     }
 
-    return docPostings;
+    return term_position;
   }
 
   /**

--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -394,7 +394,7 @@ public class IndexReaderUtils {
    * @throws IOException if error encountered during query
    * @throws NotStoredException if the term vector is not stored
    */
-  public static Map<String, List<Long>> getPositionList(IndexReader reader, String docid) throws IOException, NotStoredException {
+  public static Map<String, List<Long>> getTermPositions(IndexReader reader, String docid) throws IOException, NotStoredException {
     int ldocid = convertDocidToLuceneDocid(reader, docid);
     if (ldocid == -1) {
       return null;
@@ -403,26 +403,26 @@ public class IndexReaderUtils {
     if (terms == null) {
       throw new NotStoredException("Document vector not stored!");
     }
-    TermsEnum te = terms.iterator();
-    if (te == null) {
+    TermsEnum termIter = terms.iterator();
+    if (termIter == null) {
       throw new NotStoredException("Document vector not stored!");
     }
 
-    Map<String, List<Long>> term_position = new HashMap<>();
-    PostingsEnum position_iter = null;
+    Map<String, List<Long>> termPosition = new HashMap<>();
+    PostingsEnum positionIter = null;
 
-    while ((te.next()) != null) {
+    while ((termIter.next()) != null) {
       List<Long> positions = new ArrayList<>();
-      Long freq = te.totalTermFreq();
-      position_iter = te.postings(position_iter, PostingsEnum.POSITIONS);
-      position_iter.nextDoc();
-      for ( int i = 0; i < freq; i++ ) {
-        positions.add(Long.valueOf(position_iter.nextPosition()));
+      Long termFreq = termIter.totalTermFreq();
+      positionIter = termIter.postings(positionIter, PostingsEnum.POSITIONS);
+      positionIter.nextDoc();
+      for ( int i = 0; i < termFreq; i++ ) {
+        positions.add(Long.valueOf(positionIter.nextPosition()));
       }
-      term_position.put(te.term().utf8ToString(), positions);
+      termPosition.put(termIter.term().utf8ToString(), positions);
     }
 
-    return term_position;
+    return termPosition;
   }
 
   /**

--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -413,7 +413,7 @@ public class IndexReaderUtils {
 
     while ((termIter.next()) != null) {
       List<Integer> positions = new ArrayList<>();
-      Long termFreq = termIter.totalTermFreq();
+      long termFreq = termIter.totalTermFreq();
       positionIter = termIter.postings(positionIter, PostingsEnum.POSITIONS);
       positionIter.nextDoc();
       for ( int i = 0; i < termFreq; i++ ) {

--- a/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
+++ b/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
@@ -382,6 +382,38 @@ public class IndexReaderUtilsTest extends IndexerTestBase {
   }
 
   @Test
+  public void testTermPositions() throws Exception {
+    Directory dir = FSDirectory.open(tempDir1);
+    IndexReader reader = DirectoryReader.open(dir);
+
+    Map<String, List<Long>> termPositions;
+
+    termPositions = IndexReaderUtils.getTermPositions(reader, "doc1");
+    assertEquals(Long.valueOf(0), termPositions.get("here").get(0));
+    assertEquals(Long.valueOf(4), termPositions.get("here").get(1));
+    assertEquals(Long.valueOf(2), termPositions.get("some").get(0));
+    assertEquals(Long.valueOf(6), termPositions.get("some").get(1));
+    assertEquals(Long.valueOf(3), termPositions.get("text").get(0));
+    assertEquals(Long.valueOf(8), termPositions.get("text").get(1));
+    assertEquals(Long.valueOf(7), termPositions.get("more").get(0));
+    assertEquals(Long.valueOf(9), termPositions.get("citi").get(0));
+
+    termPositions = IndexReaderUtils.getTermPositions(reader, "doc2");
+    assertEquals(Long.valueOf(0), termPositions.get("more").get(0));
+    assertEquals(Long.valueOf(1), termPositions.get("text").get(0));
+
+    termPositions = IndexReaderUtils.getTermPositions(reader, "doc3");
+    assertEquals(Long.valueOf(0), termPositions.get("here").get(0));
+    assertEquals(Long.valueOf(3), termPositions.get("test").get(0));
+
+    // Invalid docid.
+    assertTrue(IndexReaderUtils.getDocumentVector(reader, "foo") == null);
+
+    reader.close();
+    dir.close();
+  }
+
+  @Test
   public void testGetDocumentRaw() throws Exception {
     Directory dir = FSDirectory.open(tempDir1);
     IndexReader reader = DirectoryReader.open(dir);

--- a/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
+++ b/src/test/java/io/anserini/index/IndexReaderUtilsTest.java
@@ -386,25 +386,25 @@ public class IndexReaderUtilsTest extends IndexerTestBase {
     Directory dir = FSDirectory.open(tempDir1);
     IndexReader reader = DirectoryReader.open(dir);
 
-    Map<String, List<Long>> termPositions;
+    Map<String, List<Integer>> termPositions;
 
     termPositions = IndexReaderUtils.getTermPositions(reader, "doc1");
-    assertEquals(Long.valueOf(0), termPositions.get("here").get(0));
-    assertEquals(Long.valueOf(4), termPositions.get("here").get(1));
-    assertEquals(Long.valueOf(2), termPositions.get("some").get(0));
-    assertEquals(Long.valueOf(6), termPositions.get("some").get(1));
-    assertEquals(Long.valueOf(3), termPositions.get("text").get(0));
-    assertEquals(Long.valueOf(8), termPositions.get("text").get(1));
-    assertEquals(Long.valueOf(7), termPositions.get("more").get(0));
-    assertEquals(Long.valueOf(9), termPositions.get("citi").get(0));
+    assertEquals(Integer.valueOf(0), termPositions.get("here").get(0));
+    assertEquals(Integer.valueOf(4), termPositions.get("here").get(1));
+    assertEquals(Integer.valueOf(2), termPositions.get("some").get(0));
+    assertEquals(Integer.valueOf(6), termPositions.get("some").get(1));
+    assertEquals(Integer.valueOf(3), termPositions.get("text").get(0));
+    assertEquals(Integer.valueOf(8), termPositions.get("text").get(1));
+    assertEquals(Integer.valueOf(7), termPositions.get("more").get(0));
+    assertEquals(Integer.valueOf(9), termPositions.get("citi").get(0));
 
     termPositions = IndexReaderUtils.getTermPositions(reader, "doc2");
-    assertEquals(Long.valueOf(0), termPositions.get("more").get(0));
-    assertEquals(Long.valueOf(1), termPositions.get("text").get(0));
+    assertEquals(Integer.valueOf(0), termPositions.get("more").get(0));
+    assertEquals(Integer.valueOf(1), termPositions.get("text").get(0));
 
     termPositions = IndexReaderUtils.getTermPositions(reader, "doc3");
-    assertEquals(Long.valueOf(0), termPositions.get("here").get(0));
-    assertEquals(Long.valueOf(3), termPositions.get("test").get(0));
+    assertEquals(Integer.valueOf(0), termPositions.get("here").get(0));
+    assertEquals(Integer.valueOf(3), termPositions.get("test").get(0));
 
     // Invalid docid.
     assertTrue(IndexReaderUtils.getDocumentVector(reader, "foo") == null);


### PR DESCRIPTION
Currently, [get_document_vector](https://github.com/nsndimt/anserini/blob/6b2bd2cd963a476df600f3bf37f3ba4f7b281d25/src/main/java/io/anserini/index/IndexReaderUtils.java#L364) only return terms and corresponding frequencies. This pull request implements a new function called getPositionList in which returns terms and, for each term,  every position this term occurs in the document.