### PR TITLE
Add evaluation of TREC COVID round 4 baselines with round 4 qrels

### DIFF
--- a/docs/experiments-covid-doc2query.md
+++ b/docs/experiments-covid-doc2query.md
@@ -16,7 +16,7 @@ These expansions were then appended to the abstract, full-text, and paragraph in
 
 ## Round 5
 
-These are runs that can be easily replicated with Anserini, from pre-built doc2query expanded CORD-19 indexes we have provided (version from 2020/07/16, which is the official corpus used in round 5).
+These are runs that can be easily replicated with Anserini, from pre-built doc2query expanded CORD-19 indexes we have provided (version from 2020/07/16, the official corpus used in round 5).
 They were prepared _for_ round 5 (for participants who wish to have a baseline run to rerank); to provide a sense of effectiveness, we present evaluation results with the cumulative qrels from rounds 1, 2, 3, and 4 ([`qrels_covid_d4_j0.5-4.txt`](https://ir.nist.gov/covidSubmit/data/qrels-covid_d4_j0.5-4.txt) provided by NIST, stored in our repo as [`qrels.covid-round4-cumulative.txt`](../src/main/resources/topics-and-qrels/qrels.covid-round4-cumulative.txt)).
 
 |    | index     | field(s)                        | nDCG@10 | J@10 | R@1k | run file | checksum |
@@ -33,7 +33,7 @@ They were prepared _for_ round 5 (for participants who wish to have a baseline r
 
 **IMPORTANT NOTES!!!**
 
-+ These runs are performed at [`539f7d4`](https://github.com/castorini/anserini/commit/539f7d43a0183454a633f34aa20b46d2eeec1a19).
++ These runs are performed at [`539f7d`](https://github.com/castorini/anserini/commit/539f7d43a0183454a633f34aa20b46d2eeec1a19), 2020/07/24.
 + J@10 refers to Judged@10 and R@1k refers to Recall@1000.
 + The evaluation numbers are produced with the NIST-prepared cumulative qrels from rounds 1, 2, 3, and 4 ([`qrels_covid_d4_j0.5-4.txt`](https://ir.nist.gov/covidSubmit/data/qrels-covid_d4_j0.5-4.txt) provided by NIST, stored in our repo as [`qrels.covid-round4-cumulative.txt`](../src/main/resources/topics-and-qrels/qrels.covid-round4-cumulative.txt)) on the round 5 collection (release of 7/16).
 + For the abstract and full-text indexes, we request up to 10k hits for each topic; the number of actual hits retrieved is fairly close to this (a bit less because of deduping). For the paragraph index, we request up to 50k hits for each topic; because multiple paragraphs are retrieved from the same document, the number of unique documents in each list of hits is much smaller. A cautionary note: our experience is that choosing the top _k_ documents to rerank has a large impact on end-to-end effectiveness. Reranking the top 100 seems to provide higher precision than top 1000, but the likely tradeoff is lower recall. It is very likely the case that you _don't_ want to rerank all available hits.

--- a/docs/experiments-covid-doc2query.md
+++ b/docs/experiments-covid-doc2query.md
@@ -3,6 +3,17 @@
 This document describes various doc2query baselines for the [TREC-COVID Challenge](https://ir.nist.gov/covidSubmit/), which uses the [COVID-19 Open Research Dataset (CORD-19)](https://pages.semanticscholar.org/coronavirus-research) from the [Allen Institute for AI](https://allenai.org/).
 Here, we focus on running retrieval experiments; for basic instructions on building Anserini indexes, see [this page](experiments-cord19.md) and for instructions specific to building doc2query expanded Anserini indexes, see [this page](https://github.com/castorini/docTTTTTquery/).
 
+doc2query describes a family of document expansion techniques:
+
++ Rodrigo Nogueira, Wei Yang, Jimmy Lin, Kyunghyun Cho. [Document Expansion by Query Prediction](https://arxiv.org/abs/1904.08375). _arXiv:1904.08375_.
++ Rodrigo Nogueira and Jimmy Lin. [From doc2query to docTTTTTquery](https://cs.uwaterloo.ca/~jimmylin/publications/Nogueira_Lin_2019_docTTTTTquery-v2.pdf). December 2019.
+
+The idea is conceptually simple: prior to indexing, for each document, we use a model to predict queries for which that document will be relevant.
+These predicted queries are then appended to the original document and indexed as usual.
+
+For CORD-19, these predictions were made using only article title and abstracts with T5 trained on MS MARCO passage date.
+These expansions were then appended to the abstract, full-text, and paragraph index conditions, as described on [this page](experiments-cord19.md).
+
 ## Round 5
 
 These are runs that can be easily replicated with Anserini, from pre-built doc2query expanded CORD-19 indexes we have provided (version from 2020/07/16, which is the official corpus used in round 5).
@@ -47,7 +58,7 @@ $ python src/main/python/trec-covid/generate_round5_doc2query_baselines.py
 ## Round 4
 
 Document expansion with doc2query was introduced in our round 4 submissions.
-The runs below represent correspond to our [TREC-COVID baselines](experiments-covid.md), except on pre-built CORD-19 indexes (version from 2020/06/19, which is the official corpus used in round 4) that have been expanded using doc2query.
+The runs below represent correspond to our [TREC-COVID baselines](experiments-covid.md), except on pre-built CORD-19 indexes that have been expanded using doc2query (version from 2020/06/19, the official corpus used in round 4).
 
 |    | index     | field(s)                        | run file | checksum |
 |---:|:----------|:--------------------------------|:---------|----------|
@@ -61,7 +72,7 @@ The runs below represent correspond to our [TREC-COVID baselines](experiments-co
 |  8 | -         | reciprocal rank fusion(2, 4, 6) | [[download](https://www.dropbox.com/s/e7ki5e8jqi718bp/expanded.anserini.covid-r4.fusion2.txt)]                    | `1e7bb2a6e483d3629378c3107457b216` |
 |  9 | abstract  | UDel qgen + RF                  | [[download](https://www.dropbox.com/s/1uzy5ni33kvxq2o/expanded.anserini.covid-r4.abstract.qdel.bm25%2Brm3Rf.txt)] | `b6b1d949fff00e54b13e533e27455731` |
 
-+ These runs are performed at [`539f7d`](https://github.com/castorini/anserini/commit/539f7d43a0183454a633f34aa20b46d2eeec1a19), 2020/07/24. Note that these runs were created _after_ the round 4 qrels became available, so this is a post-hoc simulation of "what would have happened".
+These runs are performed at [`539f7d`](https://github.com/castorini/anserini/commit/539f7d43a0183454a633f34aa20b46d2eeec1a19), 2020/07/24. Note that these runs were created _after_ the round 4 qrels became available, so this is a post-hoc simulation of "what would have happened".
 
 The final runs, after removing judgments from 1, 2, and 3 (cumulatively), are as follows:
 

--- a/docs/experiments-covid-doc2query.md
+++ b/docs/experiments-covid-doc2query.md
@@ -46,28 +46,22 @@ $ python src/main/python/trec-covid/generate_round5_doc2query_baselines.py
 
 ## Round 4
 
-These are runs that can be easily replicated with Anserini, from pre-built doc2query expanded CORD-19 indexes we have provided (version from 2020/06/19, which is the official corpus used in round 4).
-To provide a sense of effectiveness, we present evaluation results with the cumulative qrels from rounds 1, 2, and 3 ([`qrels_covid_d3_j0.5-3.txt`](https://ir.nist.gov/covidSubmit/data/qrels-covid_d3_j0.5-3.txt) provided by NIST, stored in our repo as [`qrels.covid-round3-cumulative.txt`](../src/main/resources/topics-and-qrels/qrels.covid-round3-cumulative.txt)).
+Document expansion with doc2query was introduced in our round 4 submissions.
+The runs below represent correspond to our [TREC-COVID baselines](experiments-covid.md), except on pre-built CORD-19 indexes (version from 2020/06/19, which is the official corpus used in round 4) that have been expanded using doc2query.
 
-|    | index     | field(s)                        | nDCG@10 | J@10 | R@1k | run file | checksum |
-|---:|:----------|:--------------------------------|--------:|-----:|-----:|:---------|----------|
-|  1 | abstract  | query+question                  | 0.3249 | 0.3933 | 0.4264 | [[download](https://www.dropbox.com/s/yxapvqec9o2ucon/expanded.anserini.covid-r4.abstract.qq.bm25.txt)]    | `d1d32cd6962c4e355a47e7f1fdfb0c74` |
-|  2 | abstract  | UDel qgen                       | 0.3301 | 0.3733 | 0.4288 | [[download](https://www.dropbox.com/s/vnk3swwwfcncolk/expanded.anserini.covid-r4.abstract.qdel.bm25.txt)]  | `55ae93b92bae20ed64fc9f191c6ea667` |
-|  3 | full-text | query+question                  | 0.3302 | 0.4511 | 0.4556 | [[download](https://www.dropbox.com/s/pkk3m90bv0rpxru/expanded.anserini.covid-r4.full-text.qq.bm25.txt)]   | `512e14c6d15eb36f7fc9c537281badd3` |
-|  4 | full-text | UDel qgen                       | 0.3565 | 0.4356 | 0.4789 | [[download](https://www.dropbox.com/s/44hoa9xkf6tv0hq/expanded.anserini.covid-r4.full-text.qdel.bm25.txt)] | `0901d7b083aa28afd431cf330fe7293c` |
-|  5 | paragraph | query+question                  | 0.3638 | 0.4533 | 0.5062 | [[download](https://www.dropbox.com/s/z90xag7eh5pi53e/expanded.anserini.covid-r4.paragraph.qq.bm25.txt)]   | `f8512ba33d5cc79176d71424d05f81cb` |
-|  6 | paragraph | UDel qgen                       | 0.3665 | 0.4311 | 0.5062 | [[download](https://www.dropbox.com/s/eno3z8pi7bnfy2p/expanded.anserini.covid-r4.paragraph.qdel.bm25.txt)] | `123896c0af4cdbae471c21d2da7de1f7` |
-|  7 | -         | reciprocal rank fusion(1, 3, 5) | 0.3781 | 0.4600 | 0.5112 | [[download](https://www.dropbox.com/s/zfbt15ivm37tolt/expanded.anserini.covid-r4.fusion1.txt)]             | `77b619a2e6e87852b85d31637ceb6219` |
-|  8 | -         | reciprocal rank fusion(2, 4, 6) | 0.3692 | 0.4378 | 0.5182 | [[download](https://www.dropbox.com/s/e7ki5e8jqi718bp/expanded.anserini.covid-r4.fusion2.txt)]             | `1e7bb2a6e483d3629378c3107457b216` |
-|  9 | abstract  | UDel qgen + RF                  | 0.4469 | 0.4444 | 0.5172 | [[download](https://www.dropbox.com/s/1uzy5ni33kvxq2o/expanded.anserini.covid-r4.abstract.qdel.bm25%2Brm3Rf.txt)] | `b6b1d949fff00e54b13e533e27455731` |
+|    | index     | field(s)                        | run file | checksum |
+|---:|:----------|:--------------------------------|:---------|----------|
+|  1 | abstract  | query+question                  | [[download](https://www.dropbox.com/s/yxapvqec9o2ucon/expanded.anserini.covid-r4.abstract.qq.bm25.txt)]           | `d1d32cd6962c4e355a47e7f1fdfb0c74` |
+|  2 | abstract  | UDel qgen                       | [[download](https://www.dropbox.com/s/vnk3swwwfcncolk/expanded.anserini.covid-r4.abstract.qdel.bm25.txt)]         | `55ae93b92bae20ed64fc9f191c6ea667` |
+|  3 | full-text | query+question                  | [[download](https://www.dropbox.com/s/pkk3m90bv0rpxru/expanded.anserini.covid-r4.full-text.qq.bm25.txt)]          | `512e14c6d15eb36f7fc9c537281badd3` |
+|  4 | full-text | UDel qgen                       | [[download](https://www.dropbox.com/s/44hoa9xkf6tv0hq/expanded.anserini.covid-r4.full-text.qdel.bm25.txt)]        | `0901d7b083aa28afd431cf330fe7293c` |
+|  5 | paragraph | query+question                  | [[download](https://www.dropbox.com/s/z90xag7eh5pi53e/expanded.anserini.covid-r4.paragraph.qq.bm25.txt)]          | `f8512ba33d5cc79176d71424d05f81cb` |
+|  6 | paragraph | UDel qgen                       | [[download](https://www.dropbox.com/s/eno3z8pi7bnfy2p/expanded.anserini.covid-r4.paragraph.qdel.bm25.txt)]        | `123896c0af4cdbae471c21d2da7de1f7` |
+|  7 | -         | reciprocal rank fusion(1, 3, 5) | [[download](https://www.dropbox.com/s/zfbt15ivm37tolt/expanded.anserini.covid-r4.fusion1.txt)]                    | `77b619a2e6e87852b85d31637ceb6219` |
+|  8 | -         | reciprocal rank fusion(2, 4, 6) | [[download](https://www.dropbox.com/s/e7ki5e8jqi718bp/expanded.anserini.covid-r4.fusion2.txt)]                    | `1e7bb2a6e483d3629378c3107457b216` |
+|  9 | abstract  | UDel qgen + RF                  | [[download](https://www.dropbox.com/s/1uzy5ni33kvxq2o/expanded.anserini.covid-r4.abstract.qdel.bm25%2Brm3Rf.txt)] | `b6b1d949fff00e54b13e533e27455731` |
 
-**IMPORTANT NOTES!!!**
-
-+ These runs are performed at [`539f7d4`](https://github.com/castorini/anserini/commit/539f7d43a0183454a633f34aa20b46d2eeec1a19).
-+ J@10 refers to Judged@10 and R@1k refers to Recall@1000.
-+ The evaluation numbers are produced with the NIST-prepared cumulative qrels from rounds 1, 2, and 3 ([`qrels_covid_d3_j0.5-3.txt`](https://ir.nist.gov/covidSubmit/data/qrels-covid_d3_j0.5-3.txt) provided by NIST, stored in our repo as [`qrels.covid-round3-cumulative.txt`](../src/main/resources/topics-and-qrels/qrels.covid-round3-cumulative.txt)) on the round 4 collection (release of 6/19).
-+ For the abstract and full-text indexes, we request up to 10k hits for each topic; the number of actual hits retrieved is fairly close to this (a bit less because of deduping). For the paragraph index, we request up to 50k hits for each topic; because multiple paragraphs are retrieved from the same document, the number of unique documents in each list of hits is much smaller. A cautionary note: our experience is that choosing the top _k_ documents to rerank has a large impact on end-to-end effectiveness. Reranking the top 100 seems to provide higher precision than top 1000, but the likely tradeoff is lower recall. It is very likely the case that you _don't_ want to rerank all available hits.
-+ Row 9 represents the feedback baseline condition introduced in round 3: abstract index, UDel query generator, BM25+RM3 relevance feedback (100 feedback terms).
++ These runs are performed at [`539f7d`](https://github.com/castorini/anserini/commit/539f7d43a0183454a633f34aa20b46d2eeec1a19), 2020/07/24. Note that these runs were created _after_ the round 4 qrels became available, so this is a post-hoc simulation of "what would have happened".
 
 The final runs, after removing judgments from 1, 2, and 3 (cumulatively), are as follows:
 
@@ -84,4 +78,25 @@ $ python src/main/python/trec-covid/download_doc2query_indexes.py --date 2020-06
 $ python src/main/python/trec-covid/generate_round4_doc2query_baselines.py
 ```
 
+Effectiveness results, based on round 4 qrels:
 
+| group | runtag | nDCG@20 | J@20 | AP   | R@1k |
+|:------|:-------|--------:|-----:|-----:|-----:|
+| `anserini` | `r4.fusion1` | 0.5115 | 0.6944 | 0.2498 | 0.6717
+| `anserini` | `r4.fusion2` | 0.5175 | 0.6911 | 0.2550 | 0.6800
+| `anserini` | `r4.rf`      | 0.5606 | 0.6833 | 0.2658 | 0.6759
+
+Below, we report the effectiveness of the runs using the cumulative qrels file from round 4.
+This qrels file, provided by NIST as [`qrels_covid_d4_j0.5-4.txt`](https://ir.nist.gov/covidSubmit/data/qrels-covid_d4_j0.5-4.txt), is stored in our repo as [`qrels.covid-round4-cumulative.txt`](../src/main/resources/topics-and-qrels/qrels.covid-round4-cumulative.txt)).
+
+|    | index     | field(s)                 | nDCG@10 | J@10 | nDCG@20 | J@20 | AP | R@1k | J@1k |
+|---:|:----------|:-------------------------|--------:|-----:|--------:|-----:|---:|-----:|-----:|
+|  1 | abstract  | query+question                  | 0.6115 | 0.8022 | 0.5823 | 0.7900 | 0.2499 | 0.5038 | 0.2676
+|  2 | abstract  | UDel qgen                       | 0.6321 | 0.8022 | 0.5922 | 0.7678 | 0.2528 | 0.5098 | 0.2672
+|  3 | full-text | query+question                  | 0.6045 | 0.9044 | 0.5640 | 0.8522 | 0.2420 | 0.4996 | 0.3037
+|  4 | full-text | UDel qgen                       | 0.6514 | 0.9289 | 0.5991 | 0.8711 | 0.2665 | 0.5240 | 0.3114
+|  5 | paragraph | query+question                  | 0.6429 | 0.8622 | 0.6080 | 0.8333 | 0.2932 | 0.5635 | 0.3256
+|  6 | paragraph | UDel qgen                       | 0.6694 | 0.8622 | 0.6229 | 0.8411 | 0.2953 | 0.5677 | 0.3232
+|  7 | -         | reciprocal rank fusion(1, 3, 5) | 0.6739 | 0.8778 | 0.6188 | 0.8533 | 0.2914 | 0.5750 | 0.3362
+|  8 | -         | reciprocal rank fusion(2, 4, 6) | 0.6618 | 0.8622 | 0.6331 | 0.8444 | 0.2974 | 0.5847 | 0.3344
+|  9 | abstract  | UDel qgen + RF                  | 0.7447 | 0.8933 | 0.7067 | 0.8589 | 0.3182 | 0.5812 | 0.2904

--- a/docs/experiments-covid.md
+++ b/docs/experiments-covid.md
@@ -85,6 +85,56 @@ $ python src/main/python/trec-covid/download_indexes.py --date 2020-06-19
 $ python src/main/python/trec-covid/generate_round4_baselines.py
 ```
 
+### Evaluation with Round 4 Qrels
+
+Since the above runs were prepared _for_ round 4, we do not know how well they actually performed until the round 4 judgments from NIST were released.
+Here, we provide these evaluation results.
+
+Note that the runs posted on the [TREC-COVID archive](https://ir.nist.gov/covidSubmit/archive.html) are _not_ exactly the same the runs we submitted.
+According to NIST (from email to participants), they removed "documents that were previously judged but had id changes from the Round 4 submissions for scoring, even though the change in `cord_uid` was unknown at submission time."
+The actual evaluated runs are (mirrored from URL above):
+
+| group | runtag | run file | checksum |
+|:------|:-------|:---------|:---------|
+| `anserini` | `r4.fusion1` (NIST post-processed) | [[download](https://www.dropbox.com/s/wccmsmj2cz4h1t4/anserini.final-r4.fusion1.post-processed.txt)] | `b0ebafe36d8fc721ea6923da5837aa8c` |
+| `anserini` | `r4.fusion2` (NIST post-processed) | [[download](https://www.dropbox.com/s/kwgnbgofaql3k4l/anserini.final-r4.fusion2.post-processed.txt)] | `e7e0b870c6822e7127df71608923e76b` |
+| `anserini` | `r4.rf` (NIST post-processed)      | [[download](https://www.dropbox.com/s/gvha3nj004osrme/anserini.final-r4.rf.post-processed.txt)]      | `2fcd53854461e0cbe3c9170c0da234d9` |
+
+Effectiveness results (note that NIST changed from nDCG@10 to nDCG@20 for this round):
+
+| group | runtag | nDCG@20 | J@20 | AP   | R@1k |
+|:------|:-------|--------:|-----:|-----:|-----:|
+| `anserini` | `r4.fusion1`                       | 0.5204 | 0.7922 | 0.2656 | 0.6571
+| `anserini` | `r4.fusion1` (NIST post-processed) | 0.5244 | 0.7978 | 0.2666 | 0.6571
+| `anserini` | `r4.fusion2`                       | 0.6047 | 0.8978 | 0.3078 | 0.6928
+| `anserini` | `r4.fusion2` (NIST post-processed) | 0.6089 | 0.9022 | 0.3088 | 0.6928
+| `anserini` | `r4.rf`                            | 0.6940 | 0.9233 | 0.3506 | 0.6962
+| `anserini` | `r4.rf` (NIST post-processed)      | 0.6976 | 0.9278 | 0.3519 | 0.6962
+
+The scores of the post-processed runs match those reported by NIST.
+We see that that NIST post-processing improves scores slightly.
+
+Below, we report the effectiveness of the runs using the cumulative qrels file from round 4.
+This qrels file, provided by NIST as [`qrels_covid_d4_j0.5-4.txt`](https://ir.nist.gov/covidSubmit/data/qrels-covid_d4_j0.5-4.txt), is stored in our repo as [`qrels.covid-round4-cumulative.txt`](../src/main/resources/topics-and-qrels/qrels.covid-round4-cumulative.txt)).
+
+|    | index     | field(s)                 | nDCG@10 | J@10 | nDCG@20 | J@20 | AP | R@1k | J@1k |
+|---:|:----------|:-------------------------|--------:|-----:|--------:|-----:|---:|-----:|-----:|
+|  1 | abstract  | query+question                  | 0.6600 | 0.9356 | 0.6120 | 0.9111 | 0.2780 | 0.5019 | 0.2876
+|  2 | abstract  | UDel qgen                       | 0.7081 | 0.9844 | 0.6650 | 0.9622 | 0.2994 | 0.5233 | 0.2987
+|  3 | full-text | query+question                  | 0.4192 | 0.8067 | 0.3984 | 0.7544 | 0.1712 | 0.4139 | 0.2740
+|  4 | full-text | UDel qgen                       | 0.6110 | 0.9400 | 0.5668 | 0.8933 | 0.2344 | 0.4856 | 0.3079
+|  5 | paragraph | query+question                  | 0.5610 | 0.9133 | 0.5324 | 0.8756 | 0.2713 | 0.5385 | 0.3386
+|  6 | paragraph | UDel qgen                       | 0.6477 | 0.9644 | 0.6084 | 0.9322 | 0.2975 | 0.5625 | 0.3443
+|  7 | -         | reciprocal rank fusion(1, 3, 5) | 0.6271 | 0.9689 | 0.5968 | 0.9422 | 0.2904 | 0.5623 | 0.3519
+|  8 | -         | reciprocal rank fusion(2, 4, 6) | 0.6802 | 1.0000 | 0.6573 | 0.9956 | 0.3286 | 0.5946 | 0.3625
+|  9 | abstract  | UDel qgen + RF                  | 0.8056 | 1.0000 | 0.7649 | 0.9967 | 0.3663 | 0.5955 | 0.3229
+
+Note that all of the results above can be replicated with the following script:
+
+```bash
+$ python src/main/python/trec-covid/generate_round4_baselines.py
+```
+
 
 ## Round 3
 

--- a/docs/experiments-covid.md
+++ b/docs/experiments-covid.md
@@ -119,15 +119,15 @@ This qrels file, provided by NIST as [`qrels_covid_d4_j0.5-4.txt`](https://ir.ni
 
 |    | index     | field(s)                 | nDCG@10 | J@10 | nDCG@20 | J@20 | AP | R@1k | J@1k |
 |---:|:----------|:-------------------------|--------:|-----:|--------:|-----:|---:|-----:|-----:|
-|  1 | abstract  | query+question                  | 0.6600 | 0.9356 | 0.6120 | 0.9111 | 0.2780 | 0.5019 | 0.2876
-|  2 | abstract  | UDel qgen                       | 0.7081 | 0.9844 | 0.6650 | 0.9622 | 0.2994 | 0.5233 | 0.2987
-|  3 | full-text | query+question                  | 0.4192 | 0.8067 | 0.3984 | 0.7544 | 0.1712 | 0.4139 | 0.2740
-|  4 | full-text | UDel qgen                       | 0.6110 | 0.9400 | 0.5668 | 0.8933 | 0.2344 | 0.4856 | 0.3079
-|  5 | paragraph | query+question                  | 0.5610 | 0.9133 | 0.5324 | 0.8756 | 0.2713 | 0.5385 | 0.3386
-|  6 | paragraph | UDel qgen                       | 0.6477 | 0.9644 | 0.6084 | 0.9322 | 0.2975 | 0.5625 | 0.3443
-|  7 | -         | reciprocal rank fusion(1, 3, 5) | 0.6271 | 0.9689 | 0.5968 | 0.9422 | 0.2904 | 0.5623 | 0.3519
-|  8 | -         | reciprocal rank fusion(2, 4, 6) | 0.6802 | 1.0000 | 0.6573 | 0.9956 | 0.3286 | 0.5946 | 0.3625
-|  9 | abstract  | UDel qgen + RF                  | 0.8056 | 1.0000 | 0.7649 | 0.9967 | 0.3663 | 0.5955 | 0.3229
+|  1 | abstract  | query+question                  | 0.6600 | 0.9356 | 0.6120 | 0.9111 | 0.2780 | 0.5019 | 0.2876 |
+|  2 | abstract  | UDel qgen                       | 0.7081 | 0.9844 | 0.6650 | 0.9622 | 0.2994 | 0.5233 | 0.2987 |
+|  3 | full-text | query+question                  | 0.4192 | 0.8067 | 0.3984 | 0.7544 | 0.1712 | 0.4139 | 0.2740 |
+|  4 | full-text | UDel qgen                       | 0.6110 | 0.9400 | 0.5668 | 0.8933 | 0.2344 | 0.4856 | 0.3079 |
+|  5 | paragraph | query+question                  | 0.5610 | 0.9133 | 0.5324 | 0.8756 | 0.2713 | 0.5385 | 0.3386 |
+|  6 | paragraph | UDel qgen                       | 0.6477 | 0.9644 | 0.6084 | 0.9322 | 0.2975 | 0.5625 | 0.3443 |
+|  7 | -         | reciprocal rank fusion(1, 3, 5) | 0.6271 | 0.9689 | 0.5968 | 0.9422 | 0.2904 | 0.5623 | 0.3519 |
+|  8 | -         | reciprocal rank fusion(2, 4, 6) | 0.6802 | 1.0000 | 0.6573 | 0.9956 | 0.3286 | 0.5946 | 0.3625 |
+|  9 | abstract  | UDel qgen + RF                  | 0.8056 | 1.0000 | 0.7649 | 0.9967 | 0.3663 | 0.5955 | 0.3229 |
 
 Note that all of the results above can be replicated with the following script:
 
@@ -219,17 +219,17 @@ We see that that NIST post-processing improves scores slightly.
 Below, we report the effectiveness of the runs using the cumulative qrels file from round 3.
 This qrels file, provided by NIST as [`qrels_covid_d3_j0.5-3.txt`](https://ir.nist.gov/covidSubmit/data/qrels-covid_d3_j0.5-3.txt), is stored in our repo as [`qrels.covid-round3-cumulative.txt`](../src/main/resources/topics-and-qrels/qrels.covid-round3-cumulative.txt).
 
-|    | index     | field(s)                 | nDCG@10 | J@10 | R@1k |
-|---:|:----------|:-------------------------|--------:|-----:|-----:|
-|  1 | abstract  | query+question           | 0.5781 | 0.8875 | 0.5040 |
-|  2 | abstract  | UDel qgen                | 0.6291 | 0.9300 | 0.5215 |
-|  3 | full-text | query+question           | 0.3977 | 0.7500 | 0.4708 |
-|  4 | full-text | UDel qgen                | 0.5790 | 0.9050 | 0.5313 |
-|  5 | paragraph | query+question           | 0.5396 | 0.9425 | 0.5766 |
-|  6 | paragraph | UDel qgen                | 0.6327 | 0.9600 | 0.5923 |
-|  7 | -         | reciprocal rank fusion(1, 3, 5) | 0.5924 | 0.9625 | 0.5956 |
-|  8 | -         | reciprocal rank fusion(2, 4, 6) | 0.6515 | 0.9875 | 0.6194 |
-|  9 | abstract  | UDel qgen + RF           | 0.7459 | 0.9875 | 0.6125 |
+|    | index     | field(s)                 | nDCG@10 | J@10 | nDCG@20 | J@20 | AP | R@1k | J@1k |
+|---:|:----------|:-------------------------|--------:|-----:|--------:|-----:|---:|-----:|-----:|
+|  1 | abstract  | query+question                  | 0.5781 | 0.8875 | 0.5359 | 0.8325 | 0.2348 | 0.5040 | 0.2351 |
+|  2 | abstract  | UDel qgen                       | 0.6291 | 0.9300 | 0.5972 | 0.8925 | 0.2525 | 0.5215 | 0.2370 |
+|  3 | full-text | query+question                  | 0.3977 | 0.7500 | 0.3681 | 0.7213 | 0.1646 | 0.4708 | 0.2471 |
+|  4 | full-text | UDel qgen                       | 0.5790 | 0.9050 | 0.5234 | 0.8525 | 0.2236 | 0.5313 | 0.2693 |
+|  5 | paragraph | query+question                  | 0.5396 | 0.9425 | 0.5079 | 0.9050 | 0.2498 | 0.5766 | 0.2978 |
+|  6 | paragraph | UDel qgen                       | 0.6327 | 0.9600 | 0.5793 | 0.9162 | 0.2753 | 0.5923 | 0.2956 |
+|  7 | -         | reciprocal rank fusion(1, 3, 5) | 0.5924 | 0.9625 | 0.5563 | 0.9362 | 0.2700 | 0.5956 | 0.3045 |
+|  8 | -         | reciprocal rank fusion(2, 4, 6) | 0.6515 | 0.9875 | 0.6200 | 0.9675 | 0.3027 | 0.6194 | 0.3076 |
+|  9 | abstract  | UDel qgen + RF                  | 0.7459 | 0.9875 | 0.7023 | 0.9637 | 0.3190 | 0.6125 | 0.2600 |
 
 Note that all of the results above can be replicated with the following script:
 

--- a/docs/experiments-covid.md
+++ b/docs/experiments-covid.md
@@ -5,7 +5,7 @@ Here, we focus on running retrieval experiments; for basic instructions on build
 
 ## Round 5
 
-These are runs that can be easily replicated with Anserini, from pre-built indexes available [here](experiments-cord19.md#pre-built-indexes-all-versions) (version from 2020/07/16, which is the official corpus used in round 5).
+These are runs that can be easily replicated with Anserini, from pre-built indexes available [here](experiments-cord19.md#pre-built-indexes-all-versions) (version from 2020/07/16, the official corpus used in round 5).
 They were prepared _for_ round 5 (for participants who wish to have a baseline run to rerank); to provide a sense of effectiveness, we present evaluation results with the cumulative qrels from rounds 1, 2, 3, and 4 ([`qrels_covid_d4_j0.5-4.txt`](https://ir.nist.gov/covidSubmit/data/qrels-covid_d4_j0.5-4.txt) provided by NIST, stored in our repo as [`qrels.covid-round4-cumulative.txt`](../src/main/resources/topics-and-qrels/qrels.covid-round4-cumulative.txt)).
 
 |    | index     | field(s)                        | nDCG@10 | J@10 | R@1k | run file | checksum |
@@ -47,7 +47,7 @@ $ python src/main/python/trec-covid/generate_round5_baselines.py
 
 ## Round 4
 
-These are runs that can be easily replicated with Anserini, from pre-built indexes available [here](experiments-cord19.md#pre-built-indexes-all-versions) (version from 2020/06/19, which is the official corpus used in round 4).
+These are runs that can be easily replicated with Anserini, from pre-built indexes available [here](experiments-cord19.md#pre-built-indexes-all-versions) (version from 2020/06/19, the official corpus used in round 4).
 They were prepared _for_ round 4 (for participants who wish to have a baseline run to rerank); to provide a sense of effectiveness, we present evaluation results with the cumulative qrels from rounds 1, 2, and 3 ([`qrels_covid_d3_j0.5-3.txt`](https://ir.nist.gov/covidSubmit/data/qrels-covid_d3_j0.5-3.txt) provided by NIST, stored in our repo as [`qrels.covid-round3-cumulative.txt`](../src/main/resources/topics-and-qrels/qrels.covid-round3-cumulative.txt)).
 
 |    | index     | field(s)                        | nDCG@10 | J@10 | R@1k | run file | checksum |
@@ -138,7 +138,7 @@ $ python src/main/python/trec-covid/generate_round4_baselines.py
 
 ## Round 3
 
-These are runs that can be easily replicated with Anserini, from pre-built indexes available [here](experiments-cord19.md#pre-built-indexes-all-versions) (version from 2020/05/19, which is the official corpus used in round 3).
+These are runs that can be easily replicated with Anserini, from pre-built indexes available [here](experiments-cord19.md#pre-built-indexes-all-versions) (version from 2020/05/19, the official corpus used in round 3).
 They were prepared _for_ round 3 (for participants who wish to have a baseline run to rerank); to provide a sense of effectiveness, we present evaluation results with the union of round 1 and round 2 qrels.
 
 |    | index     | field(s)                 | nDCG@10 | J@10 | R@1k | run file | checksum |
@@ -240,7 +240,7 @@ $ python src/main/python/trec-covid/generate_round3_baselines.py
 
 ## Round 2
 
-These are runs that can be easily replicated with Anserini, from pre-built indexes available [here](experiments-cord19.md#pre-built-indexes-all-versions) (version from 2020/05/01, which is the official corpus used in the evaluation).
+These are runs that can be easily replicated with Anserini, from pre-built indexes available [here](experiments-cord19.md#pre-built-indexes-all-versions) (version from 2020/05/01, the official corpus used in round 2).
 They were prepared _for_ round 2 (for participants who wish to have a baseline run to rerank), and so effectiveness is computed with round 1 qrels.
 
 |    | index     | field(s)       | nDCG@10 | J@10 | R@1k | run file | checksum |
@@ -284,7 +284,7 @@ Exact commands for replicating these runs are found [further down on this page](
 
 ## Round 1
 
-These are runs that can be easily replicated with Anserini, from pre-built indexes available [here](experiments-cord19.md#pre-built-indexes-all-versions) (version from 2020/04/10, which is the official corpus used in the evaluation).
+These are runs that can be easily replicated with Anserini, from pre-built indexes available [here](experiments-cord19.md#pre-built-indexes-all-versions) (version from 2020/04/10, the official corpus used in round 1).
 They were prepared _after_ round 1, and so we can report effectiveness results.
 
 |    | index     | field(s)                          | nDCG@10 | Judged@10 | Recall@1000 |

--- a/src/main/python/trec-covid/covid_baseline_tools.py
+++ b/src/main/python/trec-covid/covid_baseline_tools.py
@@ -14,13 +14,10 @@
 # limitations under the License.
 #
 
-import hashlib
+import re
 import os
-import shutil
 import subprocess
 import sys
-
-from random import randint
 
 sys.path.insert(0, '../pyserini/')
 
@@ -39,8 +36,19 @@ def evaluate_run(run, qrels):
         if len(arr) == 3:
             metrics[arr[0]] = float(arr[2])
 
+    # trec_eval doesn't seem to be able to evaluate the same metric at different cutoffs, so we have to run again
+    output = subprocess.check_output(
+        f'tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.20 {qrels} runs/{run}', shell=True)
+
+    lines = output.decode('utf-8').split('\n')
+
+    for line in lines:
+        arr = line.split()
+        if len(arr) == 3:
+            metrics[arr[0]] = float(arr[2])
+
     output = subprocess.check_output(f'python tools/eval/measure_judged.py --qrels {qrels} ' +
-                                     f'--cutoffs 10 100 1000 --run runs/{run}', shell=True)
+                                     f'--cutoffs 10 20 100 1000 --run runs/{run}', shell=True)
 
     lines = output.decode('utf-8').split('\n')
 
@@ -71,7 +79,7 @@ def evaluate_runs(qrels, runs, check_md5=True):
     print('')
     print(f'## Evaluation results w/ {qrels}')
     print('')
-    print(' ' * (max_length - 2) + 'topics nDCG@10   J@10     AP   R@1k   J@1k MD5')
+    print(' ' * (max_length - 2) + 'topics nDCG@10   J@10 nDCG@20   J@20     AP   R@1k   J@1k MD5')
 
     for run in runs:
         metrics = evaluate_run(run, qrels)
@@ -81,9 +89,9 @@ def evaluate_runs(qrels, runs, check_md5=True):
         # We use this trick to get the right amount of space padding for the first column.
         format_string = '<' + str(max_length + padding)
         print(f'{run:{format_string}}' +
-              f'{metrics["topics"]}{metrics["ndcg_cut_10"]:8.4f}' +
-              f'{metrics["judged_cut_10"]:7.4f}{metrics["map"]:7.4f}' +
-              f'{metrics["recall_1000"]:7.4f}{metrics["judged_cut_1000"]:7.4f} ' +
+              f'{metrics["topics"]}{metrics["ndcg_cut_10"]:8.4f}{metrics["judged_cut_10"]:7.4f}'
+              f'{metrics["ndcg_cut_20"]:8.4f}{metrics["judged_cut_20"]:7.4f}'
+              f'{metrics["map"]:7.4f}{metrics["recall_1000"]:7.4f}{metrics["judged_cut_1000"]:7.4f} ' +
               f'{metrics["md5"]}')
 
         if check_md5:
@@ -91,20 +99,16 @@ def evaluate_runs(qrels, runs, check_md5=True):
 
 
 def verify_stored_runs(runs):
-    print('')
-    print(f'## Verifying Stored Runs')
-    print('')
-
-    tmp = f'tmp{randint(0, 10000)}'
-
-    # In the rare event there's a collision
-    if os.path.exists(tmp):
-        shutil.rmtree(tmp)
-
-    os.mkdir(tmp)
+    # It's okay to store in runs/ since we're going to regenerate runs anyway.
     for url in runs:
         print(f'Verifying stored run at {url}...')
         # Use pyserini tools to download and check the API at the same time.
-        pyserini.util.download_url(url, tmp, force=True, md5=runs[url])
+        pyserini.util.download_url(url, 'runs/', force=True, md5=runs[url])
 
-    shutil.rmtree(tmp)
+        # Ugly hack the rename filename with '+' in it, which is URL encoded.
+        if '5%2B' in url:
+            filename = url.split('/')[-1]
+            filename = re.sub('\\?dl=1$', '', filename)  # Remove the Dropbox 'force download' parameter
+            destination_path = os.path.join('runs/', filename)
+
+            os.rename(destination_path, destination_path.replace('5%2B', '+'))

--- a/src/main/python/trec-covid/generate_round3_baselines.py
+++ b/src/main/python/trec-covid/generate_round3_baselines.py
@@ -220,26 +220,17 @@ def main():
               'src/main/resources/topics-and-qrels/qrels.covid-round2.txt ' +
               '> src/main/resources/topics-and-qrels/qrels.covid-round12.txt')
 
-    round3_qrels = 'src/main/resources/topics-and-qrels/qrels.covid-round3.txt'
     round2_cumulative_qrels = 'src/main/resources/topics-and-qrels/qrels.covid-round12.txt'
+    round3_qrels = 'src/main/resources/topics-and-qrels/qrels.covid-round3.txt'
     round3_cumulative_qrels = 'src/main/resources/topics-and-qrels/qrels.covid-round3-cumulative.txt'
 
     verify_stored_runs(stored_runs)
     perform_runs()
     perform_fusion()
     prepare_final_submissions(round2_cumulative_qrels)
+
     evaluate_runs(round2_cumulative_qrels, cumulative_runs)
     evaluate_runs(round3_cumulative_qrels, cumulative_runs)
-
-    # Download the NIST post-processed runs.
-    print('')
-    download_url('https://www.dropbox.com/s/ilqgky1tti0zvez/anserini.final-r3.fusion1.post-processed.txt?dl=1',
-                 'runs', force=True)
-    download_url('https://www.dropbox.com/s/ue3z6xxxca9krkb/anserini.final-r3.fusion2.post-processed.txt?dl=1',
-                 'runs', force=True)
-    download_url('https://www.dropbox.com/s/95vk831wp1ldnpm/anserini.final-r3.rf.post-processed.txt?dl=1',
-                 'runs', force=True)
-
     evaluate_runs(round3_qrels, final_runs)
 
 

--- a/src/main/python/trec-covid/generate_round4_baselines.py
+++ b/src/main/python/trec-covid/generate_round4_baselines.py
@@ -50,8 +50,11 @@ cumulative_runs = {
 
 final_runs = {
     'anserini.final-r4.fusion1.txt': 'a8ab52e12c151012adbfc8e37d666760',
+    'anserini.final-r4.fusion1.post-processed.txt': 'b0ebafe36d8fc721ea6923da5837aa8c',
     'anserini.final-r4.fusion2.txt': '1500104c928f463f38e76b58b91d4c07',
-    'anserini.final-r4.rf.txt': '41d746eb86a99d2f33068ebc195072cd'
+    'anserini.final-r4.fusion2.post-processed.txt': 'e7e0b870c6822e7127df71608923e76b',
+    'anserini.final-r4.rf.txt': '41d746eb86a99d2f33068ebc195072cd',
+    'anserini.final-r4.rf.post-processed.txt': '2fcd53854461e0cbe3c9170c0da234d9'
 }
 
 stored_runs = {
@@ -75,10 +78,16 @@ stored_runs = {
         cumulative_runs['anserini.covid-r4.abstract.qdel.bm25+rm3Rf.txt'],
     'https://www.dropbox.com/s/g3giixyusk4tzro/anserini.final-r4.fusion1.txt?dl=1':
         final_runs['anserini.final-r4.fusion1.txt'],
+    'https://www.dropbox.com/s/wccmsmj2cz4h1t4/anserini.final-r4.fusion1.post-processed.txt?dl=1':
+        final_runs['anserini.final-r4.fusion1.post-processed.txt'],
     'https://www.dropbox.com/s/z4wbqj9gfos8wln/anserini.final-r4.fusion2.txt?dl=1':
         final_runs['anserini.final-r4.fusion2.txt'],
+    'https://www.dropbox.com/s/kwgnbgofaql3k4l/anserini.final-r4.fusion2.post-processed.txt?dl=1':
+        final_runs['anserini.final-r4.fusion2.post-processed.txt'],
     'https://www.dropbox.com/s/28w83b07yzndlbg/anserini.final-r4.rf.txt?dl=1':
-        final_runs['anserini.final-r4.rf.txt']
+        final_runs['anserini.final-r4.rf.txt'],
+    'https://www.dropbox.com/s/gvha3nj004osrme/anserini.final-r4.rf.post-processed.txt?dl=1':
+        final_runs['anserini.final-r4.rf.post-processed.txt'],
 }
 
 
@@ -212,13 +221,18 @@ def main():
     if not (os.path.isdir(indexes[0]) and os.path.isdir(indexes[1]) and os.path.isdir(indexes[2])):
         print('Required indexes do not exist. Please download first.')
 
-    cumulative_qrels = 'src/main/resources/topics-and-qrels/qrels.covid-round3-cumulative.txt'
+    round3_cumulative_qrels = 'src/main/resources/topics-and-qrels/qrels.covid-round3-cumulative.txt'
+    round4_qrels = 'src/main/resources/topics-and-qrels/qrels.covid-round4.txt'
+    round4_cumulative_qrels = 'src/main/resources/topics-and-qrels/qrels.covid-round4-cumulative.txt'
 
     verify_stored_runs(stored_runs)
-    perform_runs(cumulative_qrels)
+    perform_runs(round3_cumulative_qrels)
     perform_fusion(check_md5=True)
-    prepare_final_submissions(cumulative_qrels)
-    evaluate_runs(cumulative_qrels, cumulative_runs, check_md5=True)
+    prepare_final_submissions(round3_cumulative_qrels)
+
+    evaluate_runs(round3_cumulative_qrels, cumulative_runs, check_md5=True)
+    evaluate_runs(round4_cumulative_qrels, cumulative_runs, check_md5=True)
+    evaluate_runs(round4_qrels, final_runs)
 
 
 if __name__ == '__main__':

--- a/src/main/python/trec-covid/generate_round4_doc2query_baselines.py
+++ b/src/main/python/trec-covid/generate_round4_doc2query_baselines.py
@@ -84,7 +84,7 @@ stored_runs = {
 }
 
 
-def perform_runs():
+def perform_runs(cumulative_qrels):
     base_topics = 'src/main/resources/topics-and-qrels/topics.covid-round4.xml'
     udel_topics = 'src/main/resources/topics-and-qrels/topics.covid-round4-udel.xml'
 
@@ -107,7 +107,7 @@ def perform_runs():
     os.system(f'target/appassembler/bin/SearchCollection -index {abstract_index} ' +
               f'-topicreader Covid -topics {udel_topics} -topicfield query -removedups ' +
               f'-bm25 -rm3 -rm3.fbTerms 100 -hits 10000 ' +
-              f'-rf.qrels src/main/resources/topics-and-qrels/qrels.covid-round3-cumulative.txt ' +
+              f'-rf.qrels {cumulative_qrels} ' +
               f'-output runs/{abstract_prefix}.qdel.bm25+rm3Rf.txt -runtag {abstract_prefix}.qdel.bm25+rm3Rf.txt')
 
     print('')
@@ -212,13 +212,17 @@ def main():
     if not (os.path.isdir(indexes[0]) and os.path.isdir(indexes[1]) and os.path.isdir(indexes[2])):
         print('Required indexes do not exist. Please download first.')
 
-    cumulative_qrels = 'src/main/resources/topics-and-qrels/qrels.covid-round3-cumulative.txt'
+    round3_cumulative_qrels = 'src/main/resources/topics-and-qrels/qrels.covid-round3-cumulative.txt'
+    round4_qrels = 'src/main/resources/topics-and-qrels/qrels.covid-round4.txt'
+    round4_cumulative_qrels = 'src/main/resources/topics-and-qrels/qrels.covid-round4-cumulative.txt'
 
     verify_stored_runs(stored_runs)
-    perform_runs()
+    perform_runs(round3_cumulative_qrels)
     perform_fusion()
-    prepare_final_submissions(cumulative_qrels)
-    evaluate_runs(cumulative_qrels, cumulative_runs)
+    prepare_final_submissions(round3_cumulative_qrels)
+
+    evaluate_runs(round4_cumulative_qrels, cumulative_runs, check_md5=True)
+    evaluate_runs(round4_qrels, final_runs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
+ evaluation of TREC COVID round 4 baselines with round 4 qrels - both bow and doc2query
+ refactored round 3 baselines: no runs changed, only scripts and results presentation