### PR TITLE
---Do not merge --- Add es end to end test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,12 @@
       <version>7.0.0</version>
     </dependency>
     <dependency>
+      <groupId>org.elasticsearch.test</groupId>
+      <artifactId>framework</artifactId>
+      <version>5.6.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.tukaani</groupId>
       <artifactId>xz</artifactId>
       <version>1.5</version>

--- a/src/test/java/io/anserini/integration/ESEndToEndTest.java
+++ b/src/test/java/io/anserini/integration/ESEndToEndTest.java
@@ -1,0 +1,92 @@
+package io.anserini.integration;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
+import org.elasticsearch.test.ESIntegTestCase.Scope;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+/*
+This test followed examples from the following tutorials, as there wasn't any official documentations on ES of 
+how to write ES Integration tests:
+https://www.hascode.com/2016/08/elasticsearch-integration-testing-with-java/
+https://github.com/joel-costigliola/elastic-search-test/blob/master/src/test/java/es/example/test/integration/EsIntegrationTest.java
+*/
+
+@ClusterScope(scope = Scope.SUITE)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+public class ESEndToEndTest extends ESIntegTestCase {
+    private static final Logger LOG = LogManager.getLogger(ESEndToEndTest.class);
+
+    private static final String INDEX = "documentTestIndex";
+    private static final String ID = "documentTestId";
+    private Client client;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.client = client();
+    }
+
+    @Test
+    public void testE2E() throws Exception {
+        Map<String, Object> doc = getTestDocument();
+
+        IndexRequest indexRequest = new IndexRequest(INDEX).id(ID).source(doc);
+        IndexResponse response = client.index(indexRequest).actionGet();
+
+        LOG.info("ESEndToEndTest: entry added to index '%s', doc-version: '%s', doc-id: '%s'\n",
+                response.getIndex(), response.getVersion(), response.getId());
+
+        // Check if the index has been added
+        refresh();
+        indexExists(INDEX);
+        ensureGreen(INDEX);
+
+        SearchResponse searchResponse = client.prepareSearch(INDEX)
+                                        .setQuery(QueryBuilders.termsQuery("content", "hello"))
+                                        .execute()
+                                        .actionGet();
+        SearchHits hits = searchResponse.getHits();
+        assertEquals(hits.getTotalHits(), 1);
+
+        searchResponse = client.prepareSearch(INDEX)
+                                        .setQuery(QueryBuilders.termsQuery("title", "Cord19"))
+                                        .execute()
+                                        .actionGet();
+        hits = searchResponse.getHits();
+        assertEquals(hits.getTotalHits(), 2);
+
+        searchResponse = client.prepareSearch(INDEX)
+                                        .setQuery(QueryBuilders.termsQuery("title", "Covid19"))
+                                        .execute()
+                                        .actionGet();
+        hits = searchResponse.getHits();
+        assertEquals(hits.getTotalHits(), 0);
+    }
+
+    private Map<String, Object> getTestDocument() {
+        Map<String, Object> doc = Map.of(
+            "title", "this is Cord19",
+            "content", "this is the content",
+            "raw", "this is the raw",
+            "title2", "this is also Cord19",
+            "content", "hello");
+        return doc; 
+    } 
+} 


### PR DESCRIPTION
Followed mainly on these two tutorials to create the test, as there weren't much offical documentations on ES Integration tests:
https://www.hascode.com/2016/08/elasticsearch-integration-testing-with-java/
https://github.com/joel-costigliola/elastic-search-test/blob/master/src/test/java/es/example/test/integration/EsIntegrationTest.java

There's no compilation errors, but when I run the maven build, the following exception was raised: 
```
java.lang.NoClassDefFoundError: org/elasticsearch/SecureSM
	at org.elasticsearch.test.ESTestCase.<clinit>(ESTestCase.java:175)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:398)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$2.run(RandomizedRunner.java:623)
Caused by: java.lang.ClassNotFoundException: org.elasticsearch.SecureSM
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	... 4 more
```

followed by:

```
Exception in thread "Thread-18" java.lang.NoClassDefFoundError: Could not initialize class org.elasticsearch.test.ESTestCase
	at java.base/java.lang.Thread.run(Thread.java:834)
	Suppressed: java.lang.IllegalStateException: No context information for thread: Thread[id=107, name=Thread-18, state=RUNNABLE, group=TGRP-ESEndToEndTest]. Is this thread running under a class com.carrotsearch.randomizedtesting.RandomizedRunner runner context? Add @RunWith(class com.carrotsearch.randomizedtesting.RandomizedRunner.class) to your test class. Make sure your code accesses random contexts within @BeforeClass and @AfterClass boundary (for example, static test class initializers are not permitted to access random contexts).
		at com.carrotsearch.randomizedtesting.RandomizedContext.context(RandomizedContext.java:249)
		at com.carrotsearch.randomizedtesting.RandomizedContext.current(RandomizedContext.java:134)
		at com.carrotsearch.randomizedtesting.RandomizedRunner.augmentStackTrace(RandomizedRunner.java:1885)
		at com.carrotsearch.randomizedtesting.RunnerThreadGroup.uncaughtException(RunnerThreadGroup.java:20)
		at java.base/java.lang.Thread.dispatchUncaughtException(Thread.java:2001)

```

It seems like it's complaining about I didn't use `com.carrotsearch.randomizedtesting.RandomizedRunner.class`, even though I've already added it at line 31. 
I've done much investigations regarding this issue, and the closest I've found is this one:
https://discuss.elastic.co/t/could-not-initialize-class-org-elasticsearch-test-estestcase-alternate-solution/117641
He is using `Gradle`, and I tried what he has done in `maven` by excluding `hamcrest ` and `hamcrest -core` in `pom.xml`, there's no luck. 
Would be great if someone more proficient in ES and maven can take a look.  Thanks.