### PR TITLE
JsoupGenerator -> DefaultLuceneDocumentGenerator in doc

### DIFF
--- a/docs/solrini.md
+++ b/docs/solrini.md
@@ -59,7 +59,7 @@ solrini/bin/solr create -n anserini -c robust04
 Run the Solr indexing command for `robust04`:
 
 ```
-sh target/appassembler/bin/IndexCollection -collection TrecCollection -generator JsoupGenerator \
+sh target/appassembler/bin/IndexCollection -collection TrecCollection -generator DefaultLuceneDocumentGenerator \
   -threads 8 -input /path/to/robust04 \
   -solr -solr.index robust04 -solr.zkUrl localhost:9983 \
   -storePositions -storeDocvectors -storeRaw


### PR DESCRIPTION
Seems like [`JsoupGenerator`](https://github.com/castorini/anserini/blob/anserini-0.8.1/src/main/java/io/anserini/index/generator/JsoupGenerator.java) was removed in commit [`9a28a0`](https://github.com/castorini/anserini/commit/9a28a098dfd85366be29a6feb385c9e2493f988c) (04/07/2020), but there are some lingering appearances of it:

```
docs/document-matchzoo.md:13: -generator JsoupGenerator -threads 16 -input /path/to/robust04 \
docs/regressions-log.md:25:Previously, Core17 used the `NewYorkTimesCollection` and was indexed with `JsoupGenerator` as the generator, which assumes that the input is HTML (or XML) and removes tags.
docs/runbook-ecir2019-ccrf.md:68: -generator JsoupGenerator -threads 16 -input /path/to/robust04 \
docs/runbook-ecir2019-ccrf.md:73: -generator JsoupGenerator -threads 16 -input /path/to/robust05 \
docs/runbook-ecir2019-ccrf.md:78: -generator JsoupGenerator -threads 16 -input /path/to/core17 \
docs/runbook-trec2018-anserini.md:117: -generator JsoupGenerator -threads 44 -input /path/to/cw12 -index lucene-index.cw12.pos+docvectors+rawdocs \
docs/runbook-trec2018-anserini.md:135: -generator JsoupGenerator -threads 44 -storePositions -storeDocvectors -storeRawDocs -optimize \
docs/runbook-trec2018-anserini.md:145: -generator JsoupGenerator -threads 44 -input /path/to/cw12 -index \
docs/runbook-trec2018-anserini.md:164: -generator JsoupGenerator -threads 44 -storePositions -storeDocvectors -storeRawDocs \
docs/runbook-trec2018-anserini.md:174: -generator JsoupGenerator -threads 44 -input /path/to/cw12 -index \
docs/runbook-trec2018-anserini.md:185: -generator JsoupGenerator -threads 8 -uniqueDocid -storePositions -storeDocvectors \
docs/runbook-trec2018-anserini.md:195:    -generator JsoupGenerator -threads 8 -uniqueDocid -storePositions -storeDocvectors \
docs/runbook-trec2018-anserini.md:209:-generator JsoupGenerator -threads 16 -input enwiki-20180620-pages-articles.xml.bz2 -index \
docs/runbook-trec2018-h2oloo.md:20: -generator JsoupGenerator -threads 16 -input /path/to/robust04 \
docs/runbook-trec2018-h2oloo.md:29: -generator JsoupGenerator -threads 16 -input /path/to/robust05 \
docs/runbook-trec2018-h2oloo.md:38: -generator JsoupGenerator -threads 16 -input /path/to/core17 \
src/main/python/paragraph_indexing/README.md:48: -input /path/to/disk45/ -generator JsoupGenerator \
src/main/python/passage_retrieval/example/robust04.md:10:--generator JsoupGenerator \
src/main/python/passage_retrieval/example/robust04.md:20:--generator JsoupGenerator \
src/main/python/passage_retrieval/example/robust04.md:31:--generator JsoupGenerator \
src/main/python/passage_retrieval/example/robust04.md:39:nohup sh target/appassembler/bin/IndexCollection -collection JsonCollection -generator JsoupGenerator
src/main/resources/fine_tuning/collections.yaml:16:      generator: JsoupGenerator
src/main/resources/fine_tuning/collections.yaml:49:      generator: JsoupGenerator
```

Most of these are non-code usages with the exception of [`collections.yaml`](https://github.com/castorini/anserini/blob/master/src/main/resources/fine_tuning/collections.yaml#L16) which seems to be used by [`fine_tuning/run_batch.py`](https://github.com/castorini/anserini/blob/master/src/main/python/fine_tuning/run_batch.py#L243)

@lintool should these be updated accordingly? I fixed the one in `solrini.md` because I ran into it.