### PR TITLE
Replication for MS-MARCO passage & doc

### DIFF
--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -130,3 +130,4 @@ As expected, BM25 tuning makes a big difference!
 + Results replicated by [@estella98](https://github.com/estella98) on 2020-08-05 (commit [`99092a8`](https://github.com/castorini/anserini/commit/99092a82179d7efd38fc0b8c7c967137a40cd96f))
 + Results replicated by [@tangsaidi](https://github.com/tangsaidi) on 2020-08-19 (commit [`aba846`](https://github.com/castorini/anserini/commit/aba846aa07d6f319fb3dc9cb591c20b4ae69f9ef))
 + Results replicated by [@qguo96](https://github.com/qguo96) on 2020-09-07 (commit [`e16b3c1`](https://github.com/castorini/anserini/commit/e16b3c160664057d4e00f2b4030cb6cb0d32fabd))
++ Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-08 (commit [`0f9a8ec`](https://github.com/castorini/anserini/commit/0f9a8ec4f335fb49c9387351745d1c755afc0e84))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -180,3 +180,4 @@ Tuned (`k1=0.82`, `b=0.72`) | 0.1875 | 0.1956 | 0.8578
 + Results replicated by [@tangsaidi](https://github.com/tangsaidi) on 2020-08-19 
 (commit [`aba846`](https://github.com/castorini/anserini/commit/aba846aa07d6f319fb3dc9cb591c20b4ae69f9ef))
 + Results replicated by [@qguo96](https://github.com/qguo96) on 2020-09-07 (commit [`e16b3c1`](https://github.com/castorini/anserini/commit/e16b3c160664057d4e00f2b4030cb6cb0d32fabd))
++ Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-08 (commit [`0f9a8ec`](https://github.com/castorini/anserini/commit/0f9a8ec4f335fb49c9387351745d1c755afc0e84))


### PR DESCRIPTION
### Enviroment:

OS: `Ubuntu 18.04.3 LTS`
Java: `openjdk version "11.0.8" 2020-07-14`
Maven: `Apache Maven 3.6.0`

### Replication results

**Passage**: Identical

```
$ python tools/scripts/msmarco/msmarco_eval.py \
 collections/msmarco-passage/qrels.dev.small.tsv runs/run.msmarco-passage.dev.small.tsv
#####################
MRR @10: 0.18741227770955546
QueriesRanked: 6980
#####################

$ tools/eval/trec_eval.9.0.4/trec_eval -c -mrecall.1000 -mmap \
 collections/msmarco-passage/qrels.dev.small.trec runs/run.msmarco-passage.dev.small.trec
map                   	all	0.1957
recall_1000           	all	0.8573
```

**Document**: Identical
(inference took 3.5 hours w/o SSD for this task) 
```
2020-09-08 22:31:23,156 INFO  [main] search.SearchCollection (SearchCollection.java:715) - Total run time: 03:34:01
```

```
$ tools/eval/trec_eval.9.0.4/trec_eval -c -mmap -mrecall.1000 \
 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.dev.bm25.txt
map                   	all	0.2310
recall_1000           	all	0.8856
```

Small issues:
This [notebook](https://github.com/castorini/anserini-notebooks/blob/master/anserini_robust04_demo.ipynb) has an outdated command: `cd eval` -> `cd tools/eval`