### PR TITLE
MS MARCO Passage and Doc Retrieval Duplication

### DIFF
--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -131,3 +131,4 @@ As expected, BM25 tuning makes a big difference!
 + Results replicated by [@tangsaidi](https://github.com/tangsaidi) on 2020-08-19 (commit [`aba846`](https://github.com/castorini/anserini/commit/aba846aa07d6f319fb3dc9cb591c20b4ae69f9ef))
 + Results replicated by [@qguo96](https://github.com/qguo96) on 2020-09-07 (commit [`e16b3c1`](https://github.com/castorini/anserini/commit/e16b3c160664057d4e00f2b4030cb6cb0d32fabd))
 + Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-08 (commit [`0f9a8ec`](https://github.com/castorini/anserini/commit/0f9a8ec4f335fb49c9387351745d1c755afc0e84))
++ Results replicated by [@wiltan-uw](https://github.com/wiltan-uw) on 2020-09-09 (commit [`93d913f`](https://github.com/castorini/anserini/commit/93d913f2619c44451be3d46816c7b9c44cbeb091))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -181,3 +181,4 @@ Tuned (`k1=0.82`, `b=0.72`) | 0.1875 | 0.1956 | 0.8578
 (commit [`aba846`](https://github.com/castorini/anserini/commit/aba846aa07d6f319fb3dc9cb591c20b4ae69f9ef))
 + Results replicated by [@qguo96](https://github.com/qguo96) on 2020-09-07 (commit [`e16b3c1`](https://github.com/castorini/anserini/commit/e16b3c160664057d4e00f2b4030cb6cb0d32fabd))
 + Results replicated by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-08 (commit [`0f9a8ec`](https://github.com/castorini/anserini/commit/0f9a8ec4f335fb49c9387351745d1c755afc0e84))
++ Results replicated by [@wiltan-uw](https://github.com/wiltan-uw) on 2020-09-09 (commit [`93d913f`](https://github.com/castorini/anserini/commit/93d913f2619c44451be3d46816c7b9c44cbeb091))


### PR DESCRIPTION
Environment: 
OS: Ubuntu 18.04.4 LTS (VM)
Python 3.8.5
Apache Maven 3.6.0

Results: The results are identical to the those on the experiments page.

Passage with default params
![passage_default](https://user-images.githubusercontent.com/61169680/92680144-2b456200-f2f8-11ea-89f1-06a7b825f229.JPG)
Passage with tuned params
![passage](https://user-images.githubusercontent.com/61169680/92680143-2aaccb80-f2f8-11ea-827b-6f4420272c8f.JPG)

Doc with default params
![doc](https://user-images.githubusercontent.com/61169680/92680141-2aaccb80-f2f8-11ea-8f7a-41ef4d20f877.JPG)
Doc with tuned params
![doc_tuned](https://user-images.githubusercontent.com/61169680/92680142-2aaccb80-f2f8-11ea-9981-cadc5e5ce3ac.JPG)

Issues/concerns:
Retrieval runs for Doc took 10~12 hours, in comparison to the 12 minutes in the guideline, which is unexpected.
Might be due to the limitation of VirtualBox VM.
One unit test failed for Pyserini, but did not seem to affect the results of this duplication.

