### PR TITLE
MS MARCO Doc and Passage Retrieval Successful Replication 

### DIFF
--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -134,3 +134,4 @@ As expected, BM25 tuning makes a big difference!
 + Results replicated by [@wiltan-uw](https://github.com/wiltan-uw) on 2020-09-09 (commit [`93d913f`](https://github.com/castorini/anserini/commit/93d913f2619c44451be3d46816c7b9c44cbeb091))
 + Results replicated by [@JeffreyCA](https://github.com/JeffreyCA) on 2020-09-13 (commit [`bc2628b`](https://github.com/castorini/anserini/commit/bc2628b9916ce42b8026497c695d4c4198547f04))
 + Results replicated by [@jhuang265](https://github.com/jhuang265) on 2020-10-15 (commit [`66711b9`](https://github.com/castorini/anserini/commit/66711b9ff7722e2aea4ce2f59ca26ead5c091cac))
++ Results replicated by [@rayyang29](https://github.com/rayyang29) on 2020-10-27 (commit [`ad8cc5a`](https://github.com/castorini/anserini/commit/ad8cc5a02a53f09a83a8a6bfd7d187c9c3f96bd5))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -184,3 +184,4 @@ Tuned (`k1=0.82`, `b=0.72`) | 0.1875 | 0.1956 | 0.8578
 + Results replicated by [@wiltan-uw](https://github.com/wiltan-uw) on 2020-09-09 (commit [`93d913f`](https://github.com/castorini/anserini/commit/93d913f2619c44451be3d46816c7b9c44cbeb091))
 + Results replicated by [@JeffreyCA](https://github.com/JeffreyCA) on 2020-09-13 (commit [`bc2628b`](https://github.com/castorini/anserini/commit/bc2628b9916ce42b8026497c695d4c4198547f04))
 + Results replicated by [@jhuang265](https://github.com/jhuang265) on 2020-10-15 (commit [`66711b9`](https://github.com/castorini/anserini/commit/66711b9ff7722e2aea4ce2f59ca26ead5c091cac))
++ Results replicated by [@rayyang29](https://github.com/rayyang29) on 2020-10-27 (commit [`ad8cc5a`](https://github.com/castorini/anserini/commit/ad8cc5a02a53f09a83a8a6bfd7d187c9c3f96bd5))


### PR DESCRIPTION
OS: Mac OS Catalina
Java: openjdk version "12.0.2"
Maven: Apache Maven "3.6.3"

_Replication Results for MS MARCO Passage Retrieval:_

```
$ python tools/scripts/msmarco/msmarco_eval.py \ collections/msmarco-passage/qrels.dev.small.tsv runs/run.msmarco-passage.dev.small.tsv
#####################
MRR @10: 0.18741227770955546
QueriesRanked: 6980
#####################
$ python tools/scripts/msmarco/convert_msmarco_to_trec_run.py \ --input runs/run.msmarco-passage.dev.small.tsv \ --output runs/run.msmarco-passage.dev.small.trec
Done!
$ python tools/scripts/msmarco/convert_msmarco_to_trec_qrels.py \ --input collections/msmarco-passage/qrels.dev.small.tsv \ --output collections/msmarco-passage/qrels.dev.small.trec
Done!
$ tools/eval/trec_eval.9.0.4/trec_eval -c -mrecall.1000 -mmap \ collections/msmarco-passage/qrels.dev.small.trec runs/run.msmarco-passage.dev.small.trec
map                   	all	0.1957
recall_1000           	all	0.8573
```

_Replication Results for MS MARCO Doc Retrieval:_

```
$ tools/eval/trec_eval.9.0.4/trec_eval -c -mmap -mrecall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.dev.bm25.txt
map                   	all	0.2310
recall_1000           	all	0.8856
$ tools/eval/trec_eval.9.0.4/trec_eval -c -mmap -M 100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/msmarco-docdev-top100
map                   	all	0.2219
$ tools/eval/trec_eval.9.0.4/trec_eval -c -mmap -M 100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.dev.bm25.txt
map                   	all	0.2303
```
The documentation is very clear and helpful throughout the replication process. 