### PR TITLE
Updated TREC-COVID doc2query baselines post Round 5

### DIFF
--- a/docs/experiments-covid-doc2query.md
+++ b/docs/experiments-covid-doc2query.md
@@ -54,6 +54,57 @@ $ python src/main/python/trec-covid/download_doc2query_indexes.py --date 2020-07
 $ python src/main/python/trec-covid/generate_round5_doc2query_baselines.py
 ```
 
+### Evaluation with Round 5 Qrels
+
+Since the above runs were prepared _for_ round 5, we do not know how well they actually performed until the round 5 judgments from NIST were released.
+Here, we provide these evaluation results.
+
+Note that the runs posted on the [TREC-COVID archive](https://ir.nist.gov/covidSubmit/archive.html) are _not_ exactly the same the runs we submitted.
+According to NIST (from email to participants), they removed "documents that were previously judged but had id changes from the Round 5 submissions for scoring, even though the change in `cord_uid` was unknown at submission time."
+The actual evaluated runs are (mirrored from URL above):
+
+| group | runtag | run file | checksum |
+|:------|:-------|:---------|:---------|
+| `anserini` | `r5.d2q.fusion1` (NIST post-processed) | [[download](https://www.dropbox.com/s/ojphpgilqs8xexc/expanded.anserini.final-r5.fusion1.post-processed.txt)] | `03ad001d94c772649e17f4d164d4b2e2` |
+| `anserini` | `r5.d2q.fusion2` (NIST post-processed) | [[download](https://www.dropbox.com/s/q7vx0l8n2u81s7z/expanded.anserini.final-r5.fusion2.post-processed.txt)] | `4137c93e76970616e0eff2803501cd08` |
+| `anserini` | `r5.d2q.rf` (NIST post-processed)      | [[download](https://www.dropbox.com/s/l4l1bbbi8msmrfh/expanded.anserini.final-r5.rf.post-processed.txt)]      | `3dfba85c0630865a7b581c4358cf4587` |
+
+Effectiveness results (note that starting in Round 4, NIST changed from nDCG@10 to nDCG@20):
+
+| group | runtag | nDCG@20 | J@20 | AP   | R@1k |
+|:------|:-------|--------:|-----:|-----:|-----:|
+| `anserini` | `r5.d2q.fusion1`                       | 0.5374 | 0.8530 | 0.2236 | 0.5798
+| `anserini` | `r5.d2q.fusion1` (NIST post-processed) | 0.5414 | 0.8610 | 0.2246 | 0.5798
+| `anserini` | `r5.d2q.fusion2`                       | 0.5393 | 0.8650 | 0.2310 | 0.5861
+| `anserini` | `r5.d2q.fusion2` (NIST post-processed) | 0.5436 | 0.8700 | 0.2319 | 0.5861
+| `anserini` | `r5.d2q.rf`                            | 0.6040 | 0.8370 | 0.2410 | 0.6039
+| `anserini` | `r5.d2q.rf` (NIST post-processed)      | 0.6124 | 0.8470 | 0.2433 | 0.6039
+
+The scores of the post-processed runs match those reported by NIST.
+We see that that NIST post-processing improves scores slightly.
+
+Below, we report the effectiveness of the runs using the "complete" cumulative qrels file (covering rounds 1 through 5).
+This qrels file, provided by NIST as [`qrels-covid_d5_j0.5-5.txt`](https://ir.nist.gov/covidSubmit/data/qrels-covid_d5_j0.5-5.txt), is stored in our repo as [`qrels.covid-complete.txt`](../src/main/resources/topics-and-qrels/qrels.covid-complete.txt)).
+
+|    | index     | field(s)                 | nDCG@10 | J@10 | nDCG@20 | J@20 | AP | R@1k | J@1k |
+|---:|:----------|:-------------------------|--------:|-----:|--------:|-----:|---:|-----:|-----:|
+|  1 | abstract  | query+question                  | 0.6808 | 0.9980 | 0.6375 | 0.9600 | 0.2718 | 0.4550 | 0.3845
+|  2 | abstract  | UDel qgen                       | 0.6939 | 0.9920 | 0.6524 | 0.9610 | 0.2752 | 0.4595 | 0.3825
+|  3 | full-text | query+question                  | 0.6300 | 0.9680 | 0.5843 | 0.9260 | 0.2475 | 0.4201 | 0.3921
+|  4 | full-text | UDel qgen                       | 0.6611 | 0.9800 | 0.6360 | 0.9610 | 0.2746 | 0.4496 | 0.4073
+|  5 | paragraph | query+question                  | 0.6827 | 0.9800 | 0.6477 | 0.9670 | 0.3080 | 0.4936 | 0.4360
+|  6 | paragraph | UDel qgen                       | 0.7067 | 0.9960 | 0.6614 | 0.9760 | 0.3127 | 0.4985 | 0.4328
+|  7 | -         | reciprocal rank fusion(1, 3, 5) | 0.7072 | 1.0000 | 0.6731 | 0.9920 | 0.2964 | 0.5063 | 0.4528
+|  8 | -         | reciprocal rank fusion(2, 4, 6) | 0.7131 | 1.0000 | 0.6755 | 0.9910 | 0.3036 | 0.5166 | 0.4518
+|  9 | abstract  | UDel qgen + RF                  | 0.8160 | 1.0000 | 0.7787 | 0.9960 | 0.3421 | 0.5249 | 0.4107
+
+Note that all of the results above can be replicated with the following script:
+
+```bash
+$ python src/main/python/trec-covid/download_doc2query_indexes.py --date 2020-07-16
+$ python src/main/python/trec-covid/generate_round5_doc2query_baselines.py
+```
+
 
 ## Round 4
 

--- a/src/main/python/trec-covid/covid_baseline_tools.py
+++ b/src/main/python/trec-covid/covid_baseline_tools.py
@@ -246,9 +246,9 @@ def verify_stored_runs(runs):
         pyserini.util.download_url(url, 'runs/', force=True, md5=runs[url])
 
         # Ugly hack the rename filename with '+' in it, which is URL encoded.
-        if '5%2B' in url:
+        if '%2B' in url:
             filename = url.split('/')[-1]
             filename = re.sub('\\?dl=1$', '', filename)  # Remove the Dropbox 'force download' parameter
             destination_path = os.path.join('runs/', filename)
 
-            os.rename(destination_path, destination_path.replace('5%2B', '+'))
+            os.rename(destination_path, destination_path.replace('%2B', '+'))

--- a/src/main/python/trec-covid/generate_round3_baselines.py
+++ b/src/main/python/trec-covid/generate_round3_baselines.py
@@ -100,11 +100,11 @@ def main():
     verify_stored_runs(stored_runs)
     perform_runs(3, indexes)
     perform_fusion(3, cumulative_runs, check_md5=True)
-    prepare_final_submissions(3, final_runs)
+    prepare_final_submissions(3, final_runs, check_md5=True)
 
-    evaluate_runs(round2_cumulative_qrels, cumulative_runs)
-    evaluate_runs(round3_cumulative_qrels, cumulative_runs)
-    evaluate_runs(round3_qrels, final_runs)
+    evaluate_runs(round2_cumulative_qrels, cumulative_runs, check_md5=True)
+    evaluate_runs(round3_cumulative_qrels, cumulative_runs, check_md5=True)
+    evaluate_runs(round3_qrels, final_runs, check_md5=True)
 
 
 if __name__ == '__main__':

--- a/src/main/python/trec-covid/generate_round4_baselines.py
+++ b/src/main/python/trec-covid/generate_round4_baselines.py
@@ -100,7 +100,7 @@ def main():
 
     evaluate_runs(round3_cumulative_qrels, cumulative_runs, check_md5=True)
     evaluate_runs(round4_cumulative_qrels, cumulative_runs, check_md5=True)
-    evaluate_runs(round4_qrels, final_runs)
+    evaluate_runs(round4_qrels, final_runs, check_md5=True)
 
 
 if __name__ == '__main__':

--- a/src/main/python/trec-covid/generate_round4_doc2query_baselines.py
+++ b/src/main/python/trec-covid/generate_round4_doc2query_baselines.py
@@ -222,7 +222,7 @@ def main():
     prepare_final_submissions(round3_cumulative_qrels)
 
     evaluate_runs(round4_cumulative_qrels, cumulative_runs, check_md5=True)
-    evaluate_runs(round4_qrels, final_runs)
+    evaluate_runs(round4_qrels, final_runs, check_md5=True)
 
 
 if __name__ == '__main__':

--- a/src/main/python/trec-covid/generate_round5_baselines.py
+++ b/src/main/python/trec-covid/generate_round5_baselines.py
@@ -100,7 +100,7 @@ def main():
 
     evaluate_runs(round4_cumulative_qrels, cumulative_runs, check_md5=True)
     evaluate_runs(complete_qrels, cumulative_runs, check_md5=True)
-    evaluate_runs(round5_qrels, final_runs)
+    evaluate_runs(round5_qrels, final_runs, check_md5=True)
 
 
 if __name__ == '__main__':

--- a/src/main/python/trec-covid/generate_round5_doc2query_baselines.py
+++ b/src/main/python/trec-covid/generate_round5_doc2query_baselines.py
@@ -52,8 +52,11 @@ cumulative_runs = {
 
 final_runs = {
     'expanded.anserini.final-r5.fusion1.txt': '2295216ed623d2621f00c294f7c389e1',
+    'expanded.anserini.final-r5.fusion1.post-processed.txt': '03ad001d94c772649e17f4d164d4b2e2',
     'expanded.anserini.final-r5.fusion2.txt': 'a65fabe7b5b7bc4216be632296269ce6',
-    'expanded.anserini.final-r5.rf.txt': '24f0b75a25273b7b00d3e65065e98147'
+    'expanded.anserini.final-r5.fusion2.post-processed.txt': '4137c93e76970616e0eff2803501cd08',
+    'expanded.anserini.final-r5.rf.txt': '24f0b75a25273b7b00d3e65065e98147',
+    'expanded.anserini.final-r5.rf.post-processed.txt': '3dfba85c0630865a7b581c4358cf4587'
 }
 
 stored_runs = {
@@ -80,7 +83,13 @@ stored_runs = {
     'https://www.dropbox.com/s/j1qdqr88cbsybae/expanded.anserini.final-r5.fusion2.txt?dl=1':
         final_runs['expanded.anserini.final-r5.fusion2.txt'],
     'https://www.dropbox.com/s/5bm4pdngh5bx3px/expanded.anserini.final-r5.rf.txt?dl=1':
-        final_runs['expanded.anserini.final-r5.rf.txt']
+        final_runs['expanded.anserini.final-r5.rf.txt'],
+    'https://www.dropbox.com/s/ojphpgilqs8xexc/expanded.anserini.final-r5.fusion1.post-processed.txt?dl=1':
+        final_runs['expanded.anserini.final-r5.fusion1.post-processed.txt'],
+    'https://www.dropbox.com/s/q7vx0l8n2u81s7z/expanded.anserini.final-r5.fusion2.post-processed.txt?dl=1':
+        final_runs['expanded.anserini.final-r5.fusion2.post-processed.txt'],
+    'https://www.dropbox.com/s/l4l1bbbi8msmrfh/expanded.anserini.final-r5.rf.post-processed.txt?dl=1':
+        final_runs['expanded.anserini.final-r5.rf.post-processed.txt'],
 }
 
 
@@ -212,13 +221,18 @@ def main():
     if not (os.path.isdir(indexes[0]) and os.path.isdir(indexes[1]) and os.path.isdir(indexes[2])):
         print('Required indexes do not exist. Please download first.')
 
-    cumulative_qrels = 'src/main/resources/topics-and-qrels/qrels.covid-round4-cumulative.txt'
+    round4_cumulative_qrels = 'src/main/resources/topics-and-qrels/qrels.covid-round4-cumulative.txt'
+    complete_qrels = 'src/main/resources/topics-and-qrels/qrels.covid-complete.txt'
+    round5_qrels = 'src/main/resources/topics-and-qrels/qrels.covid-round5.txt'
 
     verify_stored_runs(stored_runs)
     perform_runs()
     perform_fusion()
-    prepare_final_submissions(cumulative_qrels)
-    evaluate_runs(cumulative_qrels, cumulative_runs)
+    prepare_final_submissions(round4_cumulative_qrels)
+
+    evaluate_runs(round4_cumulative_qrels, cumulative_runs, check_md5=True)
+    evaluate_runs(complete_qrels, cumulative_runs, check_md5=True)
+    evaluate_runs(round5_qrels, final_runs, check_md5=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Updating doc2query baselines after TREC-COVID Round 5 qrels have been posted.