### PR TITLE
More general implementation of segment retrieval (MaxP)

### DIFF
--- a/docs/experiments-covid.md
+++ b/docs/experiments-covid.md
@@ -397,53 +397,59 @@ Here are the replication commands for the individual runs:
 wget https://www.dropbox.com/s/wxjoe4g71zt5za2/lucene-index-cord19-abstract-2020-05-01.tar.gz
 tar xvfz lucene-index-cord19-abstract-2020-05-01.tar.gz
 
-target/appassembler/bin/SearchCollection -index lucene-index-cord19-abstract-2020-05-01 \
- -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round2.xml -topicfield query+question -removedups \
- -bm25 -hits 10000 -output runs/anserini.covid-r2.abstract.qq.bm25.txt -runtag anserini.covid-r2.abstract.qq.bm25.txt
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-cord19-abstract-2020-05-01 \
+ -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round2.xml -topicfield query+question \
+ -output runs/anserini.covid-r2.abstract.qq.bm25.txt -runtag anserini.covid-r2.abstract.qq.bm25.txt \
+ -removedups -bm25 -hits 10000
 
-target/appassembler/bin/SearchCollection -index lucene-index-cord19-abstract-2020-05-01 \
- -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round2-udel.xml -topicfield query -removedups \
- -bm25 -hits 10000 -output runs/anserini.covid-r2.abstract.qdel.bm25.txt -runtag anserini.covid-r2.abstract.qdel.bm25.txt
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-cord19-abstract-2020-05-01 \
+ -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round2-udel.xml -topicfield query \
+ -output runs/anserini.covid-r2.abstract.qdel.bm25.txt -runtag anserini.covid-r2.abstract.qdel.bm25.txt \
+ -removedups -bm25 -hits 10000
 
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/anserini.covid-r2.abstract.qq.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/anserini.covid-r2.abstract.qdel.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/anserini.covid-r2.abstract.qq.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/anserini.covid-r2.abstract.qdel.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
 
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/anserini.covid-r2.abstract.qq.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/anserini.covid-r2.abstract.qdel.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/anserini.covid-r2.abstract.qq.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/anserini.covid-r2.abstract.qdel.bm25.txt
 
 wget https://www.dropbox.com/s/di27r5o2g5kat5k/lucene-index-cord19-full-text-2020-05-01.tar.gz
 tar xvfz lucene-index-cord19-full-text-2020-05-01.tar.gz
 
-target/appassembler/bin/SearchCollection -index lucene-index-cord19-full-text-2020-05-01 \
- -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round2.xml -topicfield query+question -removedups \
- -bm25 -hits 10000 -output runs/anserini.covid-r2.full-text.qq.bm25.txt -runtag anserini.covid-r2.full-text.qq.bm25.txt
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-cord19-full-text-2020-05-01 \
+ -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round2.xml -topicfield query+question \
+ -output runs/anserini.covid-r2.full-text.qq.bm25.txt -runtag anserini.covid-r2.full-text.qq.bm25.txt \
+ -removedups -bm25 -hits 10000
 
-target/appassembler/bin/SearchCollection -index lucene-index-cord19-full-text-2020-05-01 \
- -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round2-udel.xml -topicfield query -removedups \
- -bm25 -hits 10000 -output runs/anserini.covid-r2.full-text.qdel.bm25.txt -runtag anserini.covid-r2.full-text.qdel.bm25.txt
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-cord19-full-text-2020-05-01 \
+ -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round2-udel.xml -topicfield query \
+ -output runs/anserini.covid-r2.full-text.qdel.bm25.txt -runtag anserini.covid-r2.full-text.qdel.bm25.txt \
+ -removedups -bm25 -hits 10000
 
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/anserini.covid-r2.full-text.qq.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/anserini.covid-r2.full-text.qdel.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/anserini.covid-r2.full-text.qq.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/anserini.covid-r2.full-text.qdel.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
 
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/anserini.covid-r2.full-text.qq.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/anserini.covid-r2.full-text.qdel.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/anserini.covid-r2.full-text.qq.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/anserini.covid-r2.full-text.qdel.bm25.txt
 
 wget https://www.dropbox.com/s/6ib71scm925mclk/lucene-index-cord19-paragraph-2020-05-01.tar.gz
 tar xvfz lucene-index-cord19-paragraph-2020-05-01.tar.gz
 
-target/appassembler/bin/SearchCollection -index lucene-index-cord19-paragraph-2020-05-01 \
- -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round2.xml -topicfield query+question -removedups -strip_segment_id \
- -bm25 -hits 10000 -output runs/anserini.covid-r2.paragraph.qq.bm25.txt -runtag anserini.covid-r2.paragraph.qq.bm25.txt
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-cord19-paragraph-2020-05-01 \
+ -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round2.xml -topicfield query+question \
+ -output runs/anserini.covid-r2.paragraph.qq.bm25.txt -runtag anserini.covid-r2.paragraph.qq.bm25.txt \
+ -selectMaxSegment -bm25 -hits 10000
 
-target/appassembler/bin/SearchCollection -index lucene-index-cord19-paragraph-2020-05-01 \
- -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round2-udel.xml -topicfield query -removedups -strip_segment_id \
- -bm25 -hits 10000 -output runs/anserini.covid-r2.paragraph.qdel.bm25.txt -runtag anserini.covid-r2.paragraph.qdel.bm25.txt
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-cord19-paragraph-2020-05-01 \
+ -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round2-udel.xml -topicfield query \
+ -output runs/anserini.covid-r2.paragraph.qdel.bm25.txt -runtag anserini.covid-r2.paragraph.qdel.bm25.txt \
+ -selectMaxSegment -bm25 -hits 10000
 
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/anserini.covid-r2.paragraph.qq.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/anserini.covid-r2.paragraph.qdel.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/anserini.covid-r2.paragraph.qq.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/anserini.covid-r2.paragraph.qdel.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
 
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/anserini.covid-r2.paragraph.qq.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/anserini.covid-r2.paragraph.qdel.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/anserini.covid-r2.paragraph.qq.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/anserini.covid-r2.paragraph.qdel.bm25.txt
 ```
 
 We've written a convenience script to generate fusion runs that wraps [`trectools`](https://github.com/joaopalotti/trectools) (v0.0.43):
@@ -456,34 +462,34 @@ python src/main/python/fusion.py --method RRF --out runs/anserini.covid-r2.fusio
  --runs runs/anserini.covid-r2.abstract.qdel.bm25.txt runs/anserini.covid-r2.full-text.qdel.bm25.txt runs/anserini.covid-r2.paragraph.qdel.bm25.txt
 ```
 
-And to evalute the fusion runs:
+And to evaluate the fusion runs:
 
 ```bash
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/anserini.covid-r2.fusion1.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/anserini.covid-r2.fusion2.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/anserini.covid-r2.fusion1.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/anserini.covid-r2.fusion2.txt | egrep '(ndcg_cut_10 |recall_1000 )'
 
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/anserini.covid-r2.fusion1.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/anserini.covid-r2.fusion2.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/anserini.covid-r2.fusion1.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/anserini.covid-r2.fusion2.txt
 ```
 
 To prepare the final runs for submission (removing round 1 judgments):
 
 ```bash
-python src/main/python/trec-covid/remove_judged_docids.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt \
- --input runs/anserini.covid-r2.fusion1.txt --output anserini.r2.fusion1.txt --runtag r2.fusion1
+python tools/scripts/filter_run_with_qrels.py --discard --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt \
+ --input runs/anserini.covid-r2.fusion1.txt --output runs/anserini.r2.fusion1.txt --runtag r2.fusion1
 
-python src/main/python/trec-covid/remove_judged_docids.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt \
- --input runs/anserini.covid-r2.fusion2.txt --output anserini.r2.fusion2.txt --runtag r2.fusion2
+python tools/scripts/filter_run_with_qrels.py --discard --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt \
+ --input runs/anserini.covid-r2.fusion2.txt --output runs/anserini.r2.fusion2.txt --runtag r2.fusion2
 ```
 
 Evaluating runs with round 2 judgments:
 
 ```bash
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round2.txt runs/anserini.r2.fusion1.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round2.txt runs/anserini.r2.fusion2.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round2.txt runs/anserini.r2.fusion1.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round2.txt runs/anserini.r2.fusion2.txt | egrep '(ndcg_cut_10 |recall_1000 )'
 
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round2.txt --cutoffs 10 --run runs/anserini.r2.fusion1.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round2.txt --cutoffs 10 --run runs/anserini.r2.fusion2.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round2.txt --cutoffs 10 --run runs/anserini.r2.fusion1.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round2.txt --cutoffs 10 --run runs/anserini.r2.fusion2.txt
 ```
 
 ## Round 1: Replication Commands
@@ -495,27 +501,27 @@ wget https://www.dropbox.com/s/j55t617yhvmegy8/lucene-index-covid-2020-04-10.tar
 
 tar xvfz lucene-index-covid-2020-04-10.tar.gz
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-2020-04-10 \
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-2020-04-10 \
  -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield query -removedups \
  -bm25 -output runs/run.covid-r1.abstract.query.bm25.txt
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-2020-04-10 \
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-2020-04-10 \
  -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield question -removedups \
  -bm25 -output runs/run.covid-r1.abstract.question.bm25.txt
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-2020-04-10 \
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-2020-04-10 \
  -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield query+question -removedups \
  -bm25 -output runs/run.covid-r1.abstract.query+question.bm25.txt
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-2020-04-10 \
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-2020-04-10 \
  -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield query+question+narrative -removedups \
  -bm25 -output runs/run.covid-r1.abstract.query+question+narrative.bm25.txt
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-2020-04-10 \
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-2020-04-10 \
  -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1-udel.xml -topicfield query -removedups \
  -bm25 -output runs/run.covid-r1.abstract.query-udel.bm25.txt
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-2020-04-10 \
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-2020-04-10 \
  -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield query -querygenerator Covid19QueryGenerator -removedups \
  -bm25 -output runs/run.covid-r1.abstract.query-covid19.bm25.txt
 ```
@@ -523,19 +529,19 @@ target/appassembler/bin/SearchCollection -index lucene-index-covid-2020-04-10 \
 Here are the commands to evaluate results on the abstract index:
 
 ```bash
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.abstract.query.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.abstract.question.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.abstract.query+question.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.abstract.query+question+narrative.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.abstract.query-udel.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.abstract.query-covid19.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.abstract.query.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.abstract.question.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.abstract.query+question.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.abstract.query+question+narrative.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.abstract.query-udel.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.abstract.query-covid19.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
 
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.abstract.query.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.abstract.question.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.abstract.query+question.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.abstract.query+question+narrative.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.abstract.query-udel.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.abstract.query-covid19.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.abstract.query.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.abstract.question.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.abstract.query+question.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.abstract.query+question+narrative.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.abstract.query-udel.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.abstract.query-covid19.bm25.txt
 ```
 
 Here are the commands to generate the runs on the full-text index:
@@ -545,27 +551,27 @@ wget https://www.dropbox.com/s/gtq2c3xq81mjowk/lucene-index-covid-full-text-2020
 
 tar xvfz lucene-index-covid-full-text-2020-04-10.tar.gz
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-full-text-2020-04-10 \
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-full-text-2020-04-10 \
  -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield query -removedups \
  -bm25 -output runs/run.covid-r1.full-text.query.bm25.txt
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-full-text-2020-04-10 \
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-full-text-2020-04-10 \
  -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield question -removedups \
  -bm25 -output runs/run.covid-r1.full-text.question.bm25.txt
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-full-text-2020-04-10 \
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-full-text-2020-04-10 \
  -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield query+question -removedups \
  -bm25 -output runs/run.covid-r1.full-text.query+question.bm25.txt
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-full-text-2020-04-10 \
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-full-text-2020-04-10 \
  -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield query+question+narrative -removedups \
  -bm25 -output runs/run.covid-r1.full-text.query+question+narrative.bm25.txt
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-full-text-2020-04-10 \
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-full-text-2020-04-10 \
  -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1-udel.xml -topicfield query -removedups \
  -bm25 -output runs/run.covid-r1.full-text.query-udel.bm25.txt
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-full-text-2020-04-10 \
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-full-text-2020-04-10 \
  -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield query -querygenerator Covid19QueryGenerator -removedups \
  -bm25 -output runs/run.covid-r1.full-text.query-covid19.bm25.txt
 ```
@@ -573,19 +579,19 @@ target/appassembler/bin/SearchCollection -index lucene-index-covid-full-text-202
 Here are the commands to evaluate results on the full-text index:
 
 ```bash
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.full-text.query.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.full-text.question.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.full-text.query+question.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.full-text.query+question+narrative.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.full-text.query-udel.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.full-text.query-covid19.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.full-text.query.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.full-text.question.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.full-text.query+question.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.full-text.query+question+narrative.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.full-text.query-udel.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.full-text.query-covid19.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
 
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.full-text.query.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.full-text.question.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.full-text.query+question.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.full-text.query+question+narrative.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.full-text.query-udel.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.full-text.query-covid19.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.full-text.query.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.full-text.question.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.full-text.query+question.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.full-text.query+question+narrative.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.full-text.query-udel.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.full-text.query-covid19.bm25.txt
 ```
 
 Here are the commands to generate the runs on the paragraph index:
@@ -595,47 +601,47 @@ wget https://www.dropbox.com/s/ivk87journyajw3/lucene-index-covid-paragraph-2020
 
 tar xvfz lucene-index-covid-paragraph-2020-04-10.tar.gz
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-paragraph-2020-04-10 \
- -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield query -removedups -strip_segment_id \
- -bm25 -output runs/run.covid-r1.paragraph.query.bm25.txt
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-paragraph-2020-04-10 \
+ -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield query \
+ -selectMaxSegment -bm25 -output runs/run.covid-r1.paragraph.query.bm25.txt
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-paragraph-2020-04-10 \
- -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield question -removedups -strip_segment_id \
- -bm25 -output runs/run.covid-r1.paragraph.question.bm25.txt
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-paragraph-2020-04-10 \
+ -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield question \
+ -selectMaxSegment -bm25 -output runs/run.covid-r1.paragraph.question.bm25.txt
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-paragraph-2020-04-10 \
- -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield query+question -removedups -strip_segment_id \
- -bm25 -output runs/run.covid-r1.paragraph.query+question.bm25.txt
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-paragraph-2020-04-10 \
+ -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield query+question \
+ -selectMaxSegment -bm25 -output runs/run.covid-r1.paragraph.query+question.bm25.txt
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-paragraph-2020-04-10 \
- -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield query+question+narrative -removedups -strip_segment_id \
- -bm25 -output runs/run.covid-r1.paragraph.query+question+narrative.bm25.txt
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-paragraph-2020-04-10 \
+ -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield query+question+narrative \
+ -selectMaxSegment -bm25 -output runs/run.covid-r1.paragraph.query+question+narrative.bm25.txt
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-paragraph-2020-04-10 \
- -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1-udel.xml -topicfield query -removedups -strip_segment_id \
- -bm25 -output runs/run.covid-r1.paragraph.query-udel.bm25.txt
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-paragraph-2020-04-10 \
+ -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1-udel.xml -topicfield query \
+ -selectMaxSegment -bm25 -output runs/run.covid-r1.paragraph.query-udel.bm25.txt
 
-target/appassembler/bin/SearchCollection -index lucene-index-covid-paragraph-2020-04-10 \
- -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield query -querygenerator Covid19QueryGenerator -removedups -strip_segment_id \
- -bm25 -output runs/run.covid-r1.paragraph.query-covid19.bm25.txt
+target/appassembler/bin/SearchCollection -index indexes/lucene-index-covid-paragraph-2020-04-10 \
+ -topicreader Covid -topics src/main/resources/topics-and-qrels/topics.covid-round1.xml -topicfield query -querygenerator Covid19QueryGenerator \
+ -selectMaxSegment -bm25 -output runs/run.covid-r1.paragraph.query-covid19.bm25.txt
 ```
 
 Here are the commands to evaluate results on the paragraph index:
 
 ```bash
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.paragraph.query.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.paragraph.question.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.paragraph.query+question.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.paragraph.query+question+narrative.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.paragraph.query-udel.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.paragraph.query-covid19.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.paragraph.query.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.paragraph.question.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.paragraph.query+question.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.paragraph.query+question+narrative.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.paragraph.query-udel.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.paragraph.query-covid19.bm25.txt | egrep '(ndcg_cut_10 |recall_1000 )'
 
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.paragraph.query.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.paragraph.question.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.paragraph.query+question.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.paragraph.query+question+narrative.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.paragraph.query-udel.bm25.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.paragraph.query-covid19.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.paragraph.query.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.paragraph.question.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.paragraph.query+question.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.paragraph.query+question+narrative.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.paragraph.query-udel.bm25.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.paragraph.query-covid19.bm25.txt
 ```
 
 We've written a convenience script to generate fusion runs that wraps [`trectools`](https://github.com/joaopalotti/trectools) (v0.0.43):
@@ -651,9 +657,9 @@ python src/main/python/fusion.py --method RRF --out runs/run.covid-r1.fusion2.tx
 And to evalute the fusion runs:
 
 ```bash
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.fusion1.txt | egrep '(ndcg_cut_10 |recall_1000 )'
-eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.fusion2.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.fusion1.txt | egrep '(ndcg_cut_10 |recall_1000 )'
+tools/eval/trec_eval.9.0.4/trec_eval -c -M1000 -m all_trec src/main/resources/topics-and-qrels/qrels.covid-round1.txt runs/run.covid-r1.fusion2.txt | egrep '(ndcg_cut_10 |recall_1000 )'
 
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.fusion1.txt
-python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.fusion2.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.fusion1.txt
+python tools/eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round1.txt --cutoffs 10 --run runs/run.covid-r1.fusion2.txt
 ```

--- a/src/main/java/io/anserini/search/SearchArgs.java
+++ b/src/main/java/io/anserini/search/SearchArgs.java
@@ -55,9 +55,6 @@ public class SearchArgs {
   @Option(name = "-removedups", usage = "Remove duplicate docids when writing final run output.")
   public Boolean removedups = false;
 
-  @Option(name = "-strip_segment_id", usage = "Remove the .XXXXX suffix used to denote different segments from an document")
-  public Boolean strip_segment_id = false;
-
   @Option(name = "-skipexists", usage = "When enabled, will skip if the run file exists")
   public Boolean skipexists = false;
 
@@ -99,6 +96,27 @@ public class SearchArgs {
 
   @Option(name = "-runtag", metaVar = "[tag]", usage = "runtag")
   public String runtag = null;
+
+  // ---------------------------------------------
+  // Simple built-in support for passage retrieval
+  // ---------------------------------------------
+
+  // One simple approach to passage retrieval is to pre-segment documents in the corpus. One common convention is to
+  // break "docid" into "docid.00000", "docid.00001", "docid.00002" ... (alternatively, '#' can be used for the
+  // delimiter as well. At retrieval time, we retain only the max scoring segment from each document. The options below
+  // control this behavior.
+
+  @Option(name = "-selectMaxSegment", usage = "Select and retain only the max scoring segment from each document.")
+  public Boolean selectMaxSegment = false;
+
+  @Option(name = "-selectMaxSegment.delimiter", metaVar = "[regexp]",
+      usage = "The delimiter (as a regular regression) for splitting the segment id from the doc id.")
+  public String selectMaxSegment_delimiter = "\\.";
+
+  @Option(name = "-selectMaxSegment.hits", metaVar = "[int]",
+      usage = "Maximum number of hits to return per topic after segment id removal. " +
+              "Note that this is different from '-hits', which specifies the number of hits including the segment id. ")
+  public int selectMaxSegment_hits = 1000;
 
   // -------------------
   // ranking model: bm25

--- a/src/main/java/io/anserini/search/SearchArgs.java
+++ b/src/main/java/io/anserini/search/SearchArgs.java
@@ -116,7 +116,8 @@ public class SearchArgs {
   @Option(name = "-selectMaxSegment.hits", metaVar = "[int]",
       usage = "Maximum number of hits to return per topic after segment id removal. " +
               "Note that this is different from '-hits', which specifies the number of hits including the segment id. ")
-  public int selectMaxSegment_hits = 1000;
+  public int selectMaxSegment_hits = Integer.MAX_VALUE;
+  // Note that by default here we explicitly *don't* restrict the final number of hits returned per topic.
 
   // -------------------
   // ranking model: bm25

--- a/src/main/java/io/anserini/search/SearchArgs.java
+++ b/src/main/java/io/anserini/search/SearchArgs.java
@@ -101,10 +101,17 @@ public class SearchArgs {
   // Simple built-in support for passage retrieval
   // ---------------------------------------------
 
-  // One simple approach to passage retrieval is to pre-segment documents in the corpus. One common convention is to
-  // break "docid" into "docid.00000", "docid.00001", "docid.00002" ... (alternatively, '#' can be used for the
-  // delimiter as well. At retrieval time, we retain only the max scoring segment from each document. The options below
-  // control this behavior.
+  // A simple approach to passage retrieval is to pre-segment documents in the corpus.
+  // At retrieval time, we retain only the max scoring segment from each document; this is often called MaxP, from
+  // Dai and Callan (SIGIR 2019).
+  //
+  // (Note segment = passage in this context.)
+  //
+  // One common convention is to break "docid" into "docid.00000", "docid.00001", "docid.00002", ...
+  // We use this convention in CORD-19. Alternatively, '#' can be used as the delimiter, which is the case with
+  // per-segment document expansion on MS MARCO docs.
+  //
+  // The options below control various aspects of this behavior.
 
   @Option(name = "-selectMaxSegment", usage = "Select and retain only the max scoring segment from each document.")
   public Boolean selectMaxSegment = false;

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -212,8 +212,8 @@ public final class SearchCollection implements Closeable {
           for (int i = 0; i < docs.documents.length; i++) {
             String docid = docs.documents[i].get(IndexArgs.ID);
 
-            if (args.strip_segment_id) {
-              docid = docid.split("\\.")[0];
+            if (args.selectMaxSegment) {
+              docid = docid.split(args.selectMaxSegment_delimiter)[0];
             }
 
             if (docids.contains(docid))
@@ -224,11 +224,18 @@ public final class SearchCollection implements Closeable {
 
             // Note that this option is set to false by default because duplicate documents usually indicate some
             // underlying indexing issues, and we don't want to just eat errors silently.
-            if (args.removedups) {
+            //
+            // However, we we're performing passage retrieval, i.e., with "selectMaxSegment", we *do* want to remove
+            // duplicates.
+            if (args.removedups || args.selectMaxSegment) {
               docids.add(docid);
             }
 
             rank++;
+
+            if (args.selectMaxSegment && rank > args.selectMaxSegment_hits) {
+              break;
+            }
           }
           cnt++;
           if (cnt % 100 == 0) {

--- a/src/main/python/trec-covid/covid_baseline_tools.py
+++ b/src/main/python/trec-covid/covid_baseline_tools.py
@@ -77,12 +77,12 @@ def perform_runs(round_number, indexes):
     paragraph_prefix = f'anserini.covid-r{round_number}.paragraph'
     os.system(f'target/appassembler/bin/SearchCollection -index {paragraph_index} ' +
               f'-topicreader Covid -topics {base_topics} -topicfield query+question ' +
-              f'-removedups -strip_segment_id -bm25 -hits 50000 ' +
+              f'-selectMaxSegment -bm25 -hits 50000 ' +
               f'-output runs/{paragraph_prefix}.qq.bm25.txt -runtag {paragraph_prefix}.qq.bm25.txt')
 
     os.system(f'target/appassembler/bin/SearchCollection -index {paragraph_index} ' +
               f'-topicreader Covid -topics {udel_topics} -topicfield query ' +
-              f'-removedups -strip_segment_id -bm25 -hits 50000 ' +
+              f'-selectMaxSegment -bm25 -hits 50000 ' +
               f'-output runs/{paragraph_prefix}.qdel.bm25.txt -runtag {paragraph_prefix}.qdel.bm25.txt')
 
 

--- a/src/main/python/trec-covid/generate_round4_doc2query_baselines.py
+++ b/src/main/python/trec-covid/generate_round4_doc2query_baselines.py
@@ -134,12 +134,12 @@ def perform_runs(cumulative_qrels):
     paragraph_prefix = 'expanded.anserini.covid-r4.paragraph'
     os.system(f'target/appassembler/bin/SearchCollection -index {paragraph_index} ' +
               f'-topicreader Covid -topics {base_topics} -topicfield query+question ' +
-              f'-removedups -strip_segment_id -bm25 -hits 50000 ' +
+              f'-selectMaxSegment -bm25 -hits 50000 ' +
               f'-output runs/{paragraph_prefix}.qq.bm25.txt -runtag {paragraph_prefix}.qq.bm25.txt')
 
     os.system(f'target/appassembler/bin/SearchCollection -index {paragraph_index} ' +
               f'-topicreader Covid -topics {udel_topics} -topicfield query ' +
-              f'-removedups -strip_segment_id -bm25 -hits 50000 ' +
+              f'-selectMaxSegment -bm25 -hits 50000 ' +
               f'-output runs/{paragraph_prefix}.qdel.bm25.txt -runtag {paragraph_prefix}.qdel.bm25.txt')
 
 

--- a/src/main/python/trec-covid/generate_round5_doc2query_baselines.py
+++ b/src/main/python/trec-covid/generate_round5_doc2query_baselines.py
@@ -143,12 +143,12 @@ def perform_runs():
     paragraph_prefix = 'expanded.anserini.covid-r5.paragraph'
     os.system(f'target/appassembler/bin/SearchCollection -index {paragraph_index} ' +
               f'-topicreader Covid -topics {base_topics} -topicfield query+question ' +
-              f'-removedups -strip_segment_id -bm25 -hits 50000 ' +
+              f'-selectMaxSegment -bm25 -hits 50000 ' +
               f'-output runs/{paragraph_prefix}.qq.bm25.txt -runtag {paragraph_prefix}.qq.bm25.txt')
 
     os.system(f'target/appassembler/bin/SearchCollection -index {paragraph_index} ' +
               f'-topicreader Covid -topics {udel_topics} -topicfield query ' +
-              f'-removedups -strip_segment_id -bm25 -hits 50000 ' +
+              f'-selectMaxSegment -bm25 -hits 50000 ' +
               f'-output runs/{paragraph_prefix}.qdel.bm25.txt -runtag {paragraph_prefix}.qdel.bm25.txt')
 
 

--- a/src/main/python/trec-covid/index_cord19.py
+++ b/src/main/python/trec-covid/index_cord19.py
@@ -163,7 +163,7 @@ def verify_indexes(date):
     paragraph_index = f'indexes/lucene-index-cord19-paragraph-{date} '
     os.system(f'sh target/appassembler/bin/SearchCollection -index {paragraph_index} -topicreader Covid ' +
               f'-topics {topics} -topicfield query+question ' +
-              f'-removedups -strip_segment_id -bm25 -hits 1000 -output runs/verify.{date}.paragraph.txt')
+              f'-selectMaxSegment -bm25 -hits 1000 -output runs/verify.{date}.paragraph.txt')
     os.system(f'python tools/scripts/filter_run.py --whitelist {whitelist} --k 1000 ' +
               f'--input runs/verify.{date}.paragraph.txt --output runs/verify.{date}.paragraph.filtered.txt')
     paragraph_metrics = evaluate_run(f'verify.{date}.paragraph.filtered.txt')

--- a/src/test/java/io/anserini/integration/TrecEndToEndSegmentTest.java
+++ b/src/test/java/io/anserini/integration/TrecEndToEndSegmentTest.java
@@ -1,0 +1,142 @@
+/*
+ * Anserini: A Lucene toolkit for replicable information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.integration;
+
+import io.anserini.collection.TrecCollection;
+import io.anserini.index.IndexArgs;
+import io.anserini.search.SearchArgs;
+
+import java.util.Map;
+
+public class TrecEndToEndSegmentTest extends EndToEndTest {
+  @Override
+  protected IndexArgs getIndexArgs() {
+    IndexArgs indexArgs = createDefaultIndexArgs();
+
+    indexArgs.input = "src/test/resources/sample_docs/trec/collection3";
+    indexArgs.collectionClass = TrecCollection.class.getSimpleName();
+
+    return indexArgs;
+  }
+
+  @Override
+  protected void setCheckIndexGroundTruth() {
+    docCount = 3;
+    documents.put("TREC_DOC_1.00001", Map.of(
+        "contents", "This is head very simple text",
+        "raw", "<HEAD>This is head</HEAD>\n" +
+            "<TEXT>\n" +
+            "very simple\n" +
+            "text\n" +
+            "</TEXT>"));
+    documents.put("WSJ_1", Map.of(
+        "contents", "head text 01/30/03 content",
+        "raw", "<HL>\n" +
+            "head text\n" +
+            "</HL>\n" +
+            "<DATE>\n" +
+            "01/30/03\n" +
+            "</DATE>\n" +
+            "<LP>\n" +
+            "content\n" +
+            "</LP>\n" +
+            "<TEXT>\n" +
+            "</TEXT>"));
+    documents.put("TREC_DOC_1.00002", Map.of(
+        "contents", "HEAD simple enough text text text",
+        "raw", "<HEAD>HEAD</HEAD>\n" +
+            "<TEXT>\n" +
+            "simple\n" +
+            "enough\n" +
+            "text\n" +
+            "text\n" +
+            "text\n" +
+            "</TEXT>"));
+
+    fieldNormStatusTotalFields = 1;  // text
+    termIndexStatusTermCount = 12;   // Note that standard analyzer ignores stopwords; includes docids.
+    termIndexStatusTotFreq = 17;
+    storedFieldStatusTotalDocCounts = 3;
+    // 16 positions for text fields, plus 1 for each document because of id
+    termIndexStatusTotPos = 16 + storedFieldStatusTotalDocCounts;
+    storedFieldStatusTotFields = 9;  // 3 docs * (1 id + 1 text + 1 raw)
+  }
+
+  @Override
+  protected void setSearchGroundTruth() {
+    topicReader = "Trec";
+    topicFile = "src/test/resources/sample_topics/Trec";
+
+    SearchArgs args;
+
+    args = createDefaultSearchArgs().bm25();
+    args.selectMaxSegment = true;
+    testQueries.put("bm25v1", args);
+    referenceRunOutput.put("bm25v1", new String[]{
+        "1 Q0 TREC_DOC_1 1 0.343200 Anserini",
+        "1 Q0 WSJ_1 2 0.068700 Anserini"});
+
+    args = createDefaultSearchArgs().bm25();
+    args.selectMaxSegment = true;
+    args.selectMaxSegment_hits = 1;
+    testQueries.put("bm25v2", args);
+    referenceRunOutput.put("bm25v2", new String[]{
+        "1 Q0 TREC_DOC_1 1 0.343200 Anserini"});
+
+    args = createDefaultSearchArgs().qld();
+    args.selectMaxSegment = true;
+    testQueries.put("qld", args);
+    referenceRunOutput.put("qld", new String[]{
+        "1 Q0 TREC_DOC_1 1 0.002500 Anserini",
+        "1 Q0 WSJ_1 2 0.000000 Anserini"});
+
+    args = createDefaultSearchArgs().qljm();
+    args.selectMaxSegment = true;
+    testQueries.put("qljm", args);
+    referenceRunOutput.put("qljm", new String[]{
+        "1 Q0 TREC_DOC_1 1 4.872300 Anserini",
+        "1 Q0 WSJ_1 2 1.658200 Anserini"});
+
+    args = createDefaultSearchArgs().inl2();
+    args.selectMaxSegment = true;
+    testQueries.put("inl2", args);
+    referenceRunOutput.put("inl2", new String[]{
+        "1 Q0 TREC_DOC_1 1 0.133200 Anserini",
+        "1 Q0 WSJ_1 2 0.021100 Anserini"});
+
+    args = createDefaultSearchArgs().spl();
+    args.selectMaxSegment = true;
+    testQueries.put("spl", args);
+    referenceRunOutput.put("spl", new String[]{
+        "1 Q0 TREC_DOC_1 1 0.446100 Anserini",
+        "1 Q0 WSJ_1 2 0.115900 Anserini"});
+
+    args = createDefaultSearchArgs().f2exp();
+    args.selectMaxSegment = true;
+    testQueries.put("f2exp", args);
+    referenceRunOutput.put("f2exp", new String[]{
+        "1 Q0 TREC_DOC_1 1 1.434700 Anserini",
+        "1 Q0 WSJ_1 2 0.536200 Anserini"});
+
+    args = createDefaultSearchArgs().f2log();
+    args.selectMaxSegment = true;
+    testQueries.put("f2log", args);
+    referenceRunOutput.put("f2log", new String[]{
+        "1 Q0 TREC_DOC_1 1 0.548500 Anserini",
+        "1 Q0 WSJ_1 2 0.139500 Anserini"});
+  }
+}

--- a/src/test/resources/sample_docs/trec/collection3/trec1
+++ b/src/test/resources/sample_docs/trec/collection3/trec1
@@ -1,0 +1,27 @@
+<DOC>
+<DOCNO> TREC_DOC_1.00001 </DOCNO>
+<FILEID>FILEID1</FILEID>
+<FIRST> not sure what is this </FIRST>
+<SECOND> not sure </SECOND>
+<HEAD>This is head</HEAD>
+<DATELINE>TOKYO (AP) </DATELINE>
+<TEXT>
+   very simple
+   text
+</TEXT>
+</DOC>
+<DOC>
+<DOCNO> TREC_DOC_1.00002 </DOCNO>
+<FILEID>FILEID2</FILEID>
+<FIRST> again, not sure</FIRST>
+<SECOND> umh?</SECOND>
+<HEAD>HEAD</HEAD>
+<DATELINE>MEXICO CITY (AP) </DATELINE>
+<TEXT>
+   simple
+   enough
+   text
+   text
+   text
+</TEXT>
+</DOC>

--- a/src/test/resources/sample_docs/trec/collection3/trec2
+++ b/src/test/resources/sample_docs/trec/collection3/trec2
@@ -1,0 +1,39 @@
+<DOC>
+<DOCNO>
+WSJ_1
+</DOCNO>
+<DOCID>
+1A2B3C
+</DOCID>
+<HL>
+   head text
+</HL>
+<DATE>
+01/30/03
+</DATE>
+<SO>
+WALL STREET JOURNAL (J), PAGE -16
+</SO>
+<CO>
+   Anserini Who
+</CO>
+<MS>
+FINANCIAL (FIN)
+</MS>
+<IN>
+CENTRAL U.S. BANKS (BAC)
+</IN>
+<NS>
+ACQUISITIONS &amp; MERGERS, TAKEOVERS, BOARD BATTLES (TNM)
+</NS>
+<RE>
+NORTH AMERICA (NME)
+OHIO (OH)
+UNITED STATES (US)
+</RE>
+<LP>
+   content
+</LP>
+<TEXT>
+</TEXT>
+</DOC>


### PR DESCRIPTION
Improved implementation of segment retrieval for MS MARCO per-segment doc expansion, so that we don't need a post-processing script to compute MaxP.

A similar feature already existed as `-strip_segment_id`, used by TREC-COVID in the paragraph condition. I improved and generalized in to `-selectMaxSegment` option. Added test case.

Had to refactor old TREC-COVID scripts/document to use new option.
