### PR TITLE
UTF-8 in TweetCollection plain text files

### DIFF
--- a/src/main/java/io/anserini/collection/TweetCollection.java
+++ b/src/main/java/io/anserini/collection/TweetCollection.java
@@ -74,7 +74,7 @@ public class TweetCollection extends DocumentCollection<TweetCollection.Document
                 Files.newInputStream(path, StandardOpenOption.READ), BUFFER_SIZE);
         bufferedReader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
       } else { // plain text file
-        bufferedReader = new BufferedReader(new FileReader(fileName));
+        bufferedReader = new BufferedReader(new FileReader(fileName, StandardCharsets.UTF_8));
       }
     }
 


### PR DESCRIPTION
Plain Text files from Twitter API are by default UFT-8