### PR TITLE
Local replication of Passage and Doc, via anserini

### DIFF
--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -137,3 +137,4 @@ As expected, BM25 tuning makes a big difference!
 + Results replicated by [@Dahlia-Chehata](https://github.com/Dahlia-Chehata) on 2020-11-12 (commit [`22c0ad3`](https://github.com/castorini/anserini/commit/22c0ad3ebcff22c34a69ee3a7c122c4a9fb27a0e))
 + Results replicated by [@rakeeb123](https://github.com/rakeeb123) on 2020-12-07 (commit [`f50dcce`](https://github.com/castorini/anserini/commit/f50dcceb6cd0ec3403c1e77066aa51bb3275d24e))
 + Results replicated by [@jrzhang12](https://github.com/jrzhang12) on 2021-01-02 (commit [`be4e44d`](https://github.com/castorini/anserini/commit/be4e44d5ac1e898469fc179f8e6a336234b23d93))
++ Results replicated by [@HEC2018](https://github.com/HEC2018) on 2021-01-04 (commit [`4de21ec`](https://github.com/castorini/anserini/commit/4de21ece5e53cf20b4fcc711b575606b83c0d1f1))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -185,3 +185,4 @@ To replicate these results, the `SearchMsmarco` class above takes `k1` and `b` p
 + Results replicated by [@Dahlia-Chehata](https://github.com/Dahlia-Chehata) on 2020-11-11 (commit [`22c0ad3`](https://github.com/castorini/anserini/commit/22c0ad3ebcff22c34a69ee3a7c122c4a9fb27a0e))
 + Results replicated by [@rakeeb123](https://github.com/rakeeb123) on 2020-12-07 (commit [`f50dcce`](https://github.com/castorini/anserini/commit/f50dcceb6cd0ec3403c1e77066aa51bb3275d24e))
 + Results replicated by [@jrzhang12](https://github.com/jrzhang12) on 2021-01-02 (commit [`be4e44d`](https://github.com/castorini/anserini/commit/be4e44d5ac1e898469fc179f8e6a336234b23d93))
++ Results replicated by [@HEC2018](https://github.com/HEC2018) on 2021-01-04 (commit [`4de21ec`](https://github.com/castorini/anserini/commit/4de21ece5e53cf20b4fcc711b575606b83c0d1f1))


### PR DESCRIPTION
## Environment

- OS: Ubuntu 20.04.1 LTS
- Maven: 3.6.3
- Jdk: 11.0.9.1

## Issues

1. Had a problem in JAVA_HOME when building via maven. Solved by adding "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/" to the ~/.bashrc file
2. Once lose connection in downloading the dataset for Doc experiment. The script is able to restart the downloading process.
3. Cost 15 mins to finish the process of "Performing Retrieval on the Dev Queries" in Doc experiment in a laptop of GTX2060 card and SSD, little longer than 12 mins.

## Results
For passage experiment:
![Passage](https://user-images.githubusercontent.com/44350020/103521798-57589600-4e47-11eb-9dda-6217317577f2.png)
For Doc experiment:
![Doc](https://user-images.githubusercontent.com/44350020/103522107-e82f7180-4e47-11eb-93f3-b185700020b0.png)
