### PR TITLE
Updated tools submodule, consistent naming of MS MARCO eval scripts

### DIFF
--- a/docs/experiments-doc2query.md
+++ b/docs/experiments-doc2query.md
@@ -90,7 +90,7 @@ sh target/appassembler/bin/SearchMsmarco  -hits 1000 -threads 8 \
 Finally, to evaluate:
 
 ```
-python tools/eval/msmarco_eval.py \
+python tools/scripts/msmarco/msmarco_passage_eval.py \
  collections/msmarco-passage/qrels.dev.small.tsv runs/run.msmarco-passage.dev.small.expanded-topk10.tsv
 ```
 

--- a/docs/experiments-msmarco-doc-leaderboard.md
+++ b/docs/experiments-msmarco-doc-leaderboard.md
@@ -32,7 +32,7 @@ sh target/appassembler/bin/SearchMsmarco -hits 100 -k1 0.9 -b 0.4 -threads 9 \
 Evaluation:
 
 ```bash
-$ python tools/scripts/msmarco/ms_marco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/bm25base/dev.txt
+$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/bm25base/dev.txt
 Quantity of Documents ranked for each query is as expected. Evaluating
 #####################
 MRR @100: 0.23005723505603573
@@ -57,7 +57,7 @@ sh target/appassembler/bin/SearchMsmarco -hits 100 -k1 4.46 -b 0.82 -threads 9 \
 Evaluation:
 
 ```bash
-$ python tools/scripts/msmarco/ms_marco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/bm25tuned/dev.txt
+$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/bm25tuned/dev.txt
 Quantity of Documents ranked for each query is as expected. Evaluating
 #####################
 MRR @100: 0.2770296928568702
@@ -91,7 +91,7 @@ sh target/appassembler/bin/SearchMsmarco -hits 100 -k1 4.68 -b 0.87 -threads 9 \
 Evaluation:
 
 ```bash
-$ python tools/scripts/msmarco/ms_marco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/doc2query-t5-per-doc/dev.txt
+$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/doc2query-t5-per-doc/dev.txt
 Quantity of Documents ranked for each query is as expected. Evaluating
 #####################
 MRR @100: 0.3265190296491929
@@ -122,7 +122,7 @@ Note that the passage retrieval functionality is only available in `SearchCollec
 Evaluation:
 
 ```bash
-$ python tools/scripts/msmarco/ms_marco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/doc2query-t5-per-passage/dev.txt
+$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/doc2query-t5-per-passage/dev.txt
 Quantity of Documents ranked for each query is as expected. Evaluating
 #####################
 MRR @100: 0.32081861579183746

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -77,7 +77,7 @@ We can perform multi-threaded retrieval by changing the `-threads` argument.
 Finally, we can evaluate the retrieved documents using this the official MS MARCO evaluation script: 
 
 ```bash
-python tools/scripts/msmarco/msmarco_eval.py \
+python tools/scripts/msmarco/msmarco_passage_eval.py \
  collections/msmarco-passage/qrels.dev.small.tsv runs/run.msmarco-passage.dev.small.tsv
 ```
 

--- a/docs/regressions-msmarco-passage-docTTTTTquery.md
+++ b/docs/regressions-msmarco-passage-docTTTTTquery.md
@@ -96,7 +96,7 @@ Evaluate using the MS MARCO eval script:
 ```bash
 wget https://www.dropbox.com/s/khsplt2fhqwjs0v/qrels.dev.small.tsv
 
-python tools/scripts/msmarco/msmarco_eval.py qrels.dev.small.tsv runs/run.msmarco-passage-docTTTTTquery
+python tools/scripts/msmarco/msmarco_passage_eval.py qrels.dev.small.tsv runs/run.msmarco-passage-docTTTTTquery
 ```
 
 The results should be:

--- a/src/main/resources/docgen/templates/msmarco-passage-docTTTTTquery.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-docTTTTTquery.template
@@ -60,7 +60,7 @@ Evaluate using the MS MARCO eval script:
 ```bash
 wget https://www.dropbox.com/s/khsplt2fhqwjs0v/qrels.dev.small.tsv
 
-python tools/scripts/msmarco/msmarco_eval.py qrels.dev.small.tsv runs/run.msmarco-passage-docTTTTTquery
+python tools/scripts/msmarco/msmarco_passage_eval.py qrels.dev.small.tsv runs/run.msmarco-passage-docTTTTTquery
 ```
 
 The results should be:


### PR DESCRIPTION
Used the following commands to find all instances - and fixed.

```
find src docs -type f | xargs grep 'eval/msmarco_eval.py'
find src docs -type f | xargs grep 'scripts/msmarco/ms_marco_doc_eval.py'
find src docs -type f | xargs grep 'scripts/msmarco/msmarco_eval.py'
```