### PR TITLE
Replicated MS MARCO passage/document ranking results with Anserini

### DIFF
--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -210,3 +210,4 @@ That's it!
 + Results replicated by [@jrzhang12](https://github.com/jrzhang12) on 2021-01-02 (commit [`be4e44d`](https://github.com/castorini/anserini/commit/be4e44d5ac1e898469fc179f8e6a336234b23d93))
 + Results replicated by [@HEC2018](https://github.com/HEC2018) on 2021-01-04 (commit [`4de21ec`](https://github.com/castorini/anserini/commit/4de21ece5e53cf20b4fcc711b575606b83c0d1f1))
 + Results replicated by [@KaiSun314](https://github.com/KaiSun314) on 2021-01-08 (commit [`113f1c7`](https://github.com/castorini/anserini/commit/113f1c78c3ffc8681a06c571901cf9ad8f5ee633))
++ Results replicated by [@yemiliey](https://github.com/yemiliey) on 2021-01-18 (commit [`179c242`](https://github.com/castorini/anserini/commit/179c242562bbb990e421f315370f34d4d19bbb9f))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -187,3 +187,4 @@ To replicate these results, the `SearchMsmarco` class above takes `k1` and `b` p
 + Results replicated by [@jrzhang12](https://github.com/jrzhang12) on 2021-01-02 (commit [`be4e44d`](https://github.com/castorini/anserini/commit/be4e44d5ac1e898469fc179f8e6a336234b23d93))
 + Results replicated by [@HEC2018](https://github.com/HEC2018) on 2021-01-04 (commit [`4de21ec`](https://github.com/castorini/anserini/commit/4de21ece5e53cf20b4fcc711b575606b83c0d1f1))
 + Results replicated by [@KaiSun314](https://github.com/KaiSun314) on 2021-01-08 (commit [`113f1c7`](https://github.com/castorini/anserini/commit/113f1c78c3ffc8681a06c571901cf9ad8f5ee633))
++ Results replicated by [@yemiliey](https://github.com/yemiliey) on 2021-01-18 (commit [`179c242`](https://github.com/castorini/anserini/commit/179c242562bbb990e421f315370f34d4d19bbb9f))


### PR DESCRIPTION
# Environment
- Google Colab (Python3 Google Compute Engine Backend)
- Python 3.6

**Replicated results are exactly the same as the given results**

# Passage Replication Results

> Given Results

![Screenshot from 2021-01-17 03-39-13](https://user-images.githubusercontent.com/35389425/104980466-986ab180-59d4-11eb-8e79-ff1c30fe2702.png)

>My Results

![Screenshot from 2021-01-17 03-40-55](https://user-images.githubusercontent.com/35389425/104980504-ad474500-59d4-11eb-8d23-5561ca8364de.png)

# Document Replication Results
>Given Results

![Screenshot from 2021-01-17 04-13-08](https://user-images.githubusercontent.com/35389425/104980538-c223d880-59d4-11eb-8fd9-814b1b63232b.png)

>My Results

![Screenshot from 2021-01-17 04-11-20](https://user-images.githubusercontent.com/35389425/104980555-cea83100-59d4-11eb-91a0-1538c868825c.png)
