### PR TITLE
Improved documentation of MS MARCO doc regressions

### DIFF
--- a/docs/experiments-msmarco-doc-leaderboard.md
+++ b/docs/experiments-msmarco-doc-leaderboard.md
@@ -70,12 +70,12 @@ QueriesRanked: 5193
 #####################
 ```
 
-Note that this run was _not_ submitted to the MS MARCO document ranking leaderboard.
+This run was _not_ submitted to the MS MARCO document ranking leaderboard.
 
 
 ### Per-Passage
 
-Note that the passage retrieval functionality is only available in `SearchCollection`; we use a simple script to convert back into MS MARCO format.
+The passage retrieval functionality is only available in `SearchCollection`; we use a simple script to convert back into MS MARCO format.
 
 Run with **per-passage** configuration, BM25 default parameters:
 
@@ -107,7 +107,7 @@ QueriesRanked: 5193
 #####################
 ```
 
-Note that this run was _not_ submitted to the MS MARCO document ranking leaderboard.
+This run was _not_ submitted to the MS MARCO document ranking leaderboard.
 
 Run with **per-passage** configuration, BM25 tuned parameters, optimized for recall@100 (`k1=2.16`, `b=0.61`):
 
@@ -139,7 +139,7 @@ QueriesRanked: 5193
 #####################
 ```
 
-Note that this run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25 (per passage), parameters tuned for recall@100 (k1=2.16, b=0.61)" dated 2021/01/20.		
+This run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25 (per passage), parameters tuned for recall@100 (k1=2.16, b=0.61)" dated 2021/01/20.		
 
 
 ## Document Expansion Baselines
@@ -177,12 +177,12 @@ QueriesRanked: 5193
 #####################
 ```
 
-Note that this run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25 + doc2query-T5 expansion (per document), parameters tuned for recall@100 (k1=4.68, b=0.87)" dated 2020/12/11.		
+This run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25 + doc2query-T5 expansion (per document), parameters tuned for recall@100 (k1=4.68, b=0.87)" dated 2020/12/11.		
 
 
 ### Per-Passage
 
-Note that the passage retrieval functionality is only available in `SearchCollection`; we use a simple script to convert back into MS MARCO format.
+The passage retrieval functionality is only available in `SearchCollection`; we use a simple script to convert back into MS MARCO format.
 
 Anserini's BM25 + doc2query-T5 expansion (per passage), parameters tuned for recall@100 (k1=2.56, b=0.59):
 
@@ -214,7 +214,7 @@ QueriesRanked: 5193
 #####################
 ```
 
-Note that this run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25 + doc2query-T5 expansion (per passage), parameters tuned for recall@100 (k1=2.56, b=0.59)" dated 2020/12/11.		
+This run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25 + doc2query-T5 expansion (per passage), parameters tuned for recall@100 (k1=2.56, b=0.59)" dated 2020/12/11.		
 
 
 ## Reproduction Log[*](reproducibility.md)

--- a/docs/experiments-msmarco-doc-leaderboard.md
+++ b/docs/experiments-msmarco-doc-leaderboard.md
@@ -44,6 +44,8 @@ QueriesRanked: 5193
 #####################
 ```
 
+Note that this run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25, default parameters (k1=0.9, b=0.4)" dated 2020/08/16.		
+
 Run with **per-document** configuration, BM25 tuned parameters, optimized for recall@100 (`k1=4.46`, `b=0.82`):
 
 ```bash
@@ -68,7 +70,12 @@ QueriesRanked: 5193
 #####################
 ```
 
+Note that this run was _not_ submitted to the MS MARCO document ranking leaderboard.
+
+
 ### Per-Passage
+
+Note that the passage retrieval functionality is only available in `SearchCollection`; we use a simple script to convert back into MS MARCO format.
 
 Run with **per-passage** configuration, BM25 default parameters:
 
@@ -100,6 +107,8 @@ QueriesRanked: 5193
 #####################
 ```
 
+Note that this run was _not_ submitted to the MS MARCO document ranking leaderboard.
+
 Run with **per-passage** configuration, BM25 tuned parameters, optimized for recall@100 (`k1=2.16`, `b=0.61`):
 
 ```bash
@@ -129,6 +138,9 @@ MRR @100: 0.2751202109946902
 QueriesRanked: 5193
 #####################
 ```
+
+Note that this run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25 (per passage), parameters tuned for recall@100 (k1=2.16, b=0.61)" dated 2021/01/20.		
+
 
 ## Document Expansion Baselines
 
@@ -165,7 +177,12 @@ QueriesRanked: 5193
 #####################
 ```
 
+Note that this run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25 + doc2query-T5 expansion (per document), parameters tuned for recall@100 (k1=4.68, b=0.87)" dated 2020/12/11.		
+
+
 ### Per-Passage
+
+Note that the passage retrieval functionality is only available in `SearchCollection`; we use a simple script to convert back into MS MARCO format.
 
 Anserini's BM25 + doc2query-T5 expansion (per passage), parameters tuned for recall@100 (k1=2.56, b=0.59):
 
@@ -187,8 +204,6 @@ target/appassembler/bin/SearchCollection -topicreader TsvString -topics src/main
 python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/doc2query-t5-per-passage/eval.trec.txt --output runs/doc2query-t5-per-passage/eval.txt
 ```
 
-Note that the passage retrieval functionality is only available in `SearchCollection`; we use a simple script to convert back into MS MARCO format.
-
 Evaluation:
 
 ```bash
@@ -198,6 +213,9 @@ MRR @100: 0.32081861579183746
 QueriesRanked: 5193
 #####################
 ```
+
+Note that this run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25 + doc2query-T5 expansion (per passage), parameters tuned for recall@100 (k1=2.56, b=0.59)" dated 2020/12/11.		
+
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-msmarco-doc-docTTTTTquery-per-doc.md
+++ b/docs/regressions-msmarco-doc-docTTTTTquery-per-doc.md
@@ -61,35 +61,41 @@ With the above commands, you should be able to reproduce the following results:
 
 MAP                                     | BM25 (Default)| BM25 (Tuned)|
 :---------------------------------------|-----------|-----------|
-[MS MARCO Doc Ranking: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.2886    | 0.3270    |
+[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.2886    | 0.3270    |
 
 
 R@100                                   | BM25 (Default)| BM25 (Tuned)|
 :---------------------------------------|-----------|-----------|
-[MS MARCO Doc Ranking: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.7990    | 0.8608    |
+[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.7990    | 0.8608    |
 
 
 R@1000                                  | BM25 (Default)| BM25 (Tuned)|
 :---------------------------------------|-----------|-----------|
-[MS MARCO Doc Ranking: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.9259    | 0.9553    |
+[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.9259    | 0.9553    |
 
 The setting "default" refers the default BM25 settings of `k1=0.9`, `b=0.4`, while "tuned" refers to the tuned setting of `k1=4.68`, `b=0.87`.
-Note that here we are using `trec_eval` to evaluate the top 1000 hits for each query; beware, an official MS MARCO document ranking task leaderboard submission comprises only 100 hits per query.
+An important note here is that tuning was performed on _on the original documents_, not the expanded documents; see [this page](experiments-msmarco-doc.md) for more details.
+Here we are using `trec_eval` to evaluate the top 1000 hits for each query; beware, an official MS MARCO document ranking task leaderboard submission comprises only 100 hits per query.
+See [this page](experiments-msmarco-doc-leaderboard.md) for details on Anserini baseline runs that were submitted to the official leaderboard.
 
-Use the following commands to convert the TREC run files into the MS MARCO format and use the official eval script to compute MRR@100:
+Note that leaderboard runs were generated with `SearchMsmarco` in the MS MARCO format.
+Conversion of a run in that format into the TREC format is slightly lossy due to tie-breaking effects.
+
+To generate an MS MARCO submission with the BM25 tuned parameters, corresponding to "BM25 (Tuned)" above:
 
 ```bash
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-default.topics.msmarco-doc.dev.txt --output runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-default.topics.msmarco-doc.dev.msmarco.txt --k 100 --quiet
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-default.topics.msmarco-doc.dev.msmarco.txt
-#####################
-MRR @100: 0.28805221173885914
-QueriesRanked: 5193
-#####################
+$ sh target/appassembler/bin/SearchMsmarco -hits 100 -k1 4.68 -b 0.87 -threads 9 \
+   -index indexes/lucene-index.msmarco-doc-docTTTTTquery-per-doc.pos+docvectors+raw \
+   -queries src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+   -output runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-tuned.txt
 
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-tuned.topics.msmarco-doc.dev.txt --output runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-tuned.topics.msmarco-doc.dev.msmarco.txt --k 100 --quiet
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-tuned.topics.msmarco-doc.dev.msmarco.txt
+$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+   --run runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-tuned.txt
+
 #####################
-MRR @100: 0.32651902964919355
+MRR @100: 0.3265190296491929
 QueriesRanked: 5193
 #####################
 ```
+
+This run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25 + doc2query-T5 expansion (per document), parameters tuned for recall@100 (k1=4.68, b=0.87)" dated 2020/12/11.

--- a/docs/regressions-msmarco-doc-docTTTTTquery-per-doc.md
+++ b/docs/regressions-msmarco-doc-docTTTTTquery-per-doc.md
@@ -89,7 +89,8 @@ $ sh target/appassembler/bin/SearchMsmarco -hits 100 -k1 4.68 -b 0.87 -threads 9
    -queries src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
    -output runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-tuned.txt
 
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+$ python tools/scripts/msmarco/msmarco_doc_eval.py \
+   --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
    --run runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-tuned.txt
 
 #####################

--- a/docs/regressions-msmarco-doc-docTTTTTquery-per-passage.md
+++ b/docs/regressions-msmarco-doc-docTTTTTquery-per-passage.md
@@ -61,35 +61,42 @@ With the above commands, you should be able to reproduce the following results:
 
 MAP                                     | BM25 (Default)| BM25 (Tuned)|
 :---------------------------------------|-----------|-----------|
-[MS MARCO Doc Ranking: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.3182    | 0.3211    |
+[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.3182    | 0.3211    |
 
 
 R@100                                   | BM25 (Default)| BM25 (Tuned)|
 :---------------------------------------|-----------|-----------|
-[MS MARCO Doc Ranking: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.8481    | 0.8627    |
+[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.8481    | 0.8627    |
 
 
 R@1000                                  | BM25 (Default)| BM25 (Tuned)|
 :---------------------------------------|-----------|-----------|
-[MS MARCO Doc Ranking: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.9490    | 0.9530    |
+[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.9490    | 0.9530    |
 
 The setting "default" refers the default BM25 settings of `k1=0.9`, `b=0.4`, while "tuned" refers to the tuned setting of `k1=2.56`, `b=0.59`.
 Note that here we are using `trec_eval` to evaluate the top 1000 hits for each query; beware, an official MS MARCO document ranking task leaderboard submission comprises only 100 hits per query.
+See [this page](experiments-msmarco-doc-leaderboard.md) for details on Anserini baseline runs that were submitted to the official leaderboard.
 
-Use the following commands to convert the TREC run files into the MS MARCO format and use the official eval script to compute MRR@100:
+The passage retrieval functionality is only available in `SearchCollection`; we use a simple script to convert back into MS MARCO format.
+
+To generate an MS MARCO submission with the BM25 tuned parameters, corresponding to "BM25 (Tuned)" above:
 
 ```bash
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-default.topics.msmarco-doc.dev.txt --output runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-default.topics.msmarco-doc.dev.msmarco.txt --k 100 --quiet
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-default.topics.msmarco-doc.dev.msmarco.txt
-#####################
-MRR @100: 0.31779258157039647
-QueriesRanked: 5193
-#####################
+$ target/appassembler/bin/SearchCollection -topicreader TsvString -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+   -index indexes/lucene-index.msmarco-doc-per-passage.pos+docvectors+raw \
+   -output runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
+   -bm25 -bm25.k1 2.56 -bm25.b 0.59 -hits 1000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
 
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-tuned.topics.msmarco-doc.dev.txt --output runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-tuned.topics.msmarco-doc.dev.msmarco.txt --k 100 --quiet
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-tuned.topics.msmarco-doc.dev.msmarco.txt
+$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
+   --output runs/run.msmarco-doc-per-passage.bm25-tuned.txt
+
+$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+   --run runs/run.msmarco-doc-per-passage.bm25-tuned.txt
+
 #####################
-MRR @100: 0.32081861579183807
+MRR @100: 0.32081861579183746
 QueriesRanked: 5193
 #####################
 ```
+
+This run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25 + doc2query-T5 expansion (per passage), parameters tuned for recall@100 (k1=2.56, b=0.59)" dated 2020/12/11.

--- a/docs/regressions-msmarco-doc-docTTTTTquery-per-passage.md
+++ b/docs/regressions-msmarco-doc-docTTTTTquery-per-passage.md
@@ -84,7 +84,7 @@ To generate an MS MARCO submission with the BM25 tuned parameters, corresponding
 ```bash
 $ target/appassembler/bin/SearchCollection -topicreader TsvString \
    -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-   -index indexes/lucene-index.msmarco-doc-per-passage.pos+docvectors+raw \
+   -index indexes/lucene-index.msmarco-doc-docTTTTTquery-per-passage.pos+docvectors+raw \
    -output runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-tuned.trec \
    -bm25 -bm25.k1 2.56 -bm25.b 0.59 -hits 1000 \
    -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100

--- a/docs/regressions-msmarco-doc-docTTTTTquery-per-passage.md
+++ b/docs/regressions-msmarco-doc-docTTTTTquery-per-passage.md
@@ -82,15 +82,19 @@ The passage retrieval functionality is only available in `SearchCollection`; we 
 To generate an MS MARCO submission with the BM25 tuned parameters, corresponding to "BM25 (Tuned)" above:
 
 ```bash
-$ target/appassembler/bin/SearchCollection -topicreader TsvString -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+$ target/appassembler/bin/SearchCollection -topicreader TsvString \
+   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
    -index indexes/lucene-index.msmarco-doc-per-passage.pos+docvectors+raw \
    -output runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
-   -bm25 -bm25.k1 2.56 -bm25.b 0.59 -hits 1000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
+   -bm25 -bm25.k1 2.56 -bm25.b 0.59 -hits 1000 \
+   -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
 
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
+$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py \
+   --input runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
    --output runs/run.msmarco-doc-per-passage.bm25-tuned.txt
 
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+$ python tools/scripts/msmarco/msmarco_doc_eval.py \
+   --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
    --run runs/run.msmarco-doc-per-passage.bm25-tuned.txt
 
 #####################

--- a/docs/regressions-msmarco-doc-docTTTTTquery-per-passage.md
+++ b/docs/regressions-msmarco-doc-docTTTTTquery-per-passage.md
@@ -85,17 +85,17 @@ To generate an MS MARCO submission with the BM25 tuned parameters, corresponding
 $ target/appassembler/bin/SearchCollection -topicreader TsvString \
    -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
    -index indexes/lucene-index.msmarco-doc-per-passage.pos+docvectors+raw \
-   -output runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
+   -output runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-tuned.trec \
    -bm25 -bm25.k1 2.56 -bm25.b 0.59 -hits 1000 \
    -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
 
 $ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py \
-   --input runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
-   --output runs/run.msmarco-doc-per-passage.bm25-tuned.txt
+   --input runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-tuned.trec \
+   --output runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-tuned.txt
 
 $ python tools/scripts/msmarco/msmarco_doc_eval.py \
    --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
-   --run runs/run.msmarco-doc-per-passage.bm25-tuned.txt
+   --run runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-tuned.txt
 
 #####################
 MRR @100: 0.32081861579183746

--- a/docs/regressions-msmarco-doc-per-passage.md
+++ b/docs/regressions-msmarco-doc-per-passage.md
@@ -124,15 +124,19 @@ The passage retrieval functionality is only available in `SearchCollection`; we 
 To generate an MS MARCO submission with the BM25 default parameters, corresponding to "BM25 (Default)" above:
 
 ```bash
-$ target/appassembler/bin/SearchCollection -topicreader TsvString -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+$ target/appassembler/bin/SearchCollection -topicreader TsvString \
+   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
    -index indexes/lucene-index.msmarco-doc-per-passage.pos+docvectors+raw \
    -output runs/run.msmarco-doc-per-passage.bm25-default.trec \
-   -bm25 -bm25.k1 0.9 -bm25.b 0.4 -hits 1000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
+   -bm25 -bm25.k1 0.9 -bm25.b 0.4 -hits 1000 \
+   -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
 
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-per-passage.bm25-default.trec \
+$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py \
+   --input runs/run.msmarco-doc-per-passage.bm25-default.trec \
    --output runs/run.msmarco-doc-per-passage.bm25-default.txt
 
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+$ python tools/scripts/msmarco/msmarco_doc_eval.py \
+   --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
    --run runs/run.msmarco-doc-per-passage.bm25-default.txt
 
 #####################
@@ -146,15 +150,19 @@ This run was _not_ submitted to the MS MARCO document ranking leaderboard.
 To generate an MS MARCO submission with the BM25 tuned parameters, corresponding to "BM25 (Tuned)" above:
 
 ```bash
-$ target/appassembler/bin/SearchCollection -topicreader TsvString -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+$ target/appassembler/bin/SearchCollection -topicreader TsvString \
+   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
    -index indexes/lucene-index.msmarco-doc-per-passage.pos+docvectors+raw \
    -output runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
-   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -hits 1000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
+   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -hits 1000 \
+   -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
 
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
+$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py \
+   --input runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
    --output runs/run.msmarco-doc-per-passage.bm25-tuned.txt
 
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+$ python tools/scripts/msmarco/msmarco_doc_eval.py \
+   --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
    --run runs/run.msmarco-doc-per-passage.bm25-tuned.txt
 
 #####################

--- a/docs/regressions-msmarco-doc-per-passage.md
+++ b/docs/regressions-msmarco-doc-per-passage.md
@@ -103,35 +103,64 @@ With the above commands, you should be able to reproduce the following results:
 
 MAP                                     | BM25 (Default)| +RM3      | +Ax       | +PRF      | BM25 (Tuned)| +RM3      | +Ax       | +PRF      |
 :---------------------------------------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
-[MS MARCO Doc Ranking: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.2688    | 0.2416    | 0.2229    | 0.2325    | 0.2756    | 0.2443    | 0.2350    | 0.2271    |
+[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.2688    | 0.2416    | 0.2229    | 0.2325    | 0.2756    | 0.2443    | 0.2350    | 0.2271    |
 
 
 R@100                                   | BM25 (Default)| +RM3      | +Ax       | +PRF      | BM25 (Tuned)| +RM3      | +Ax       | +PRF      |
 :---------------------------------------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
-[MS MARCO Doc Ranking: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.7849    | 0.7876    | 0.7703    | 0.7714    | 0.8009    | 0.7955    | 0.7909    | 0.7685    |
+[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.7849    | 0.7876    | 0.7703    | 0.7714    | 0.8009    | 0.7955    | 0.7909    | 0.7685    |
 
 
 R@1000                                  | BM25 (Default)| +RM3      | +Ax       | +PRF      | BM25 (Tuned)| +RM3      | +Ax       | +PRF      |
 :---------------------------------------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
-[MS MARCO Doc Ranking: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.9180    | 0.9355    | 0.9266    | 0.9187    | 0.9311    | 0.9359    | 0.9341    | 0.9162    |
+[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.9180    | 0.9355    | 0.9266    | 0.9187    | 0.9311    | 0.9359    | 0.9341    | 0.9162    |
 
 The setting "default" refers the default BM25 settings of `k1=0.9`, `b=0.4`, while "tuned" refers to the tuned setting of `k1=2.16`, `b=0.61`.
 Note that here we are using `trec_eval` to evaluate the top 1000 hits for each query; beware, an official MS MARCO document ranking task leaderboard submission comprises only 100 hits per query.
+See [this page](experiments-msmarco-doc-leaderboard.md) for details on Anserini baseline runs that were submitted to the official leaderboard.
 
-Use the following commands to convert the TREC run files into the MS MARCO format and use the official eval script to compute MRR@100:
+The passage retrieval functionality is only available in `SearchCollection`; we use a simple script to convert back into MS MARCO format.
+
+To generate an MS MARCO submission with the BM25 default parameters, corresponding to "BM25 (Default)" above:
 
 ```bash
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-per-passage.bm25-default.topics.msmarco-doc.dev.txt --output runs/run.msmarco-doc-per-passage.bm25-default.topics.msmarco-doc.dev.msmarco.txt --k 100 --quiet
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/run.msmarco-doc-per-passage.bm25-default.topics.msmarco-doc.dev.msmarco.txt
-#####################
-MRR @100: 0.26823493089465705
-QueriesRanked: 5193
-#####################
+$ target/appassembler/bin/SearchCollection -topicreader TsvString -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+   -index indexes/lucene-index.msmarco-doc-per-passage.pos+docvectors+raw \
+   -output runs/run.msmarco-doc-per-passage.bm25-default.trec \
+   -bm25 -bm25.k1 0.9 -bm25.b 0.4 -hits 1000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
 
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-per-passage.bm25-tuned.topics.msmarco-doc.dev.txt --output runs/run.msmarco-doc-per-passage.bm25-tuned.topics.msmarco-doc.dev.msmarco.txt --k 100 --quiet
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/run.msmarco-doc-per-passage.bm25-tuned.topics.msmarco-doc.dev.msmarco.txt
+$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-per-passage.bm25-default.trec \
+   --output runs/run.msmarco-doc-per-passage.bm25-default.txt
+
+$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+   --run runs/run.msmarco-doc-per-passage.bm25-default.txt
+
 #####################
-MRR @100: 0.2751202109946906
+MRR @100: 0.2682349308946578
 QueriesRanked: 5193
 #####################
 ```
+
+This run was _not_ submitted to the MS MARCO document ranking leaderboard.
+
+To generate an MS MARCO submission with the BM25 tuned parameters, corresponding to "BM25 (Tuned)" above:
+
+```bash
+$ target/appassembler/bin/SearchCollection -topicreader TsvString -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+   -index indexes/lucene-index.msmarco-doc-per-passage.pos+docvectors+raw \
+   -output runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
+   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -hits 1000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
+
+$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
+   --output runs/run.msmarco-doc-per-passage.bm25-tuned.txt
+
+$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+   --run runs/run.msmarco-doc-per-passage.bm25-tuned.txt
+
+#####################
+MRR @100: 0.2751202109946902
+QueriesRanked: 5193
+#####################
+```
+
+This run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25 (per passage), parameters tuned for recall@100 (k1=2.16, b=0.61)" dated 2021/01/20.

--- a/docs/regressions-msmarco-doc.md
+++ b/docs/regressions-msmarco-doc.md
@@ -128,9 +128,11 @@ To generate an MS MARCO submission with the BM25 default parameters, correspondi
 ```bash
 $ sh target/appassembler/bin/SearchMsmarco -hits 100 -k1 0.9 -b 0.4 -threads 9 \
    -index indexes/lucene-index.msmarco-doc.pos+docvectors+raw \
-   -queries src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -output runs/run.msmarco-doc.bm25-default.txt
+   -queries src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+   -output runs/run.msmarco-doc.bm25-default.txt
 
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+$ python tools/scripts/msmarco/msmarco_doc_eval.py \
+   --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
    --run runs/run.msmarco-doc.bm25-default.txt
 
 #####################
@@ -146,9 +148,11 @@ To generate an MS MARCO submission with the BM25 tuned parameters, corresponding
 ```bash
 $ sh target/appassembler/bin/SearchMsmarco -hits 100 -k1 4.46 -b 0.82 -threads 9 \
    -index indexes/lucene-index.msmarco-doc.pos+docvectors+raw \
-   -queries src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -output runs/run.msmarco-doc.bm25-tuned.txt
+   -queries src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+   -output runs/run.msmarco-doc.bm25-tuned.txt
 
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+$ python tools/scripts/msmarco/msmarco_doc_eval.py \
+   --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
    --run runs/run.msmarco-doc.bm25-tuned.txt
 
 #####################

--- a/docs/regressions-msmarco-doc.md
+++ b/docs/regressions-msmarco-doc.md
@@ -103,36 +103,58 @@ With the above commands, you should be able to reproduce the following results:
 
 MAP                                     | BM25 (Default)| +RM3      | +Ax       | +PRF      | BM25 (Tuned)| +RM3      | +Ax       | +PRF      |
 :---------------------------------------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
-[MS MARCO Doc Ranking: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.2310    | 0.1632    | 0.1147    | 0.1357    | 0.2775    | 0.2238    | 0.1885    | 0.1531    |
+[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.2310    | 0.1632    | 0.1147    | 0.1357    | 0.2775    | 0.2238    | 0.1885    | 0.1531    |
 
 
 R@100                                   | BM25 (Default)| +RM3      | +Ax       | +PRF      | BM25 (Tuned)| +RM3      | +Ax       | +PRF      |
 :---------------------------------------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
-[MS MARCO Doc Ranking: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.7279    | 0.6765    | 0.5750    | 0.6362    | 0.8076    | 0.7789    | 0.7510    | 0.6819    |
+[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.7279    | 0.6765    | 0.5750    | 0.6362    | 0.8076    | 0.7789    | 0.7510    | 0.6819    |
 
 
 R@1000                                  | BM25 (Default)| +RM3      | +Ax       | +PRF      | BM25 (Tuned)| +RM3      | +Ax       | +PRF      |
 :---------------------------------------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
-[MS MARCO Doc Ranking: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.8856    | 0.8785    | 0.8369    | 0.8471    | 0.9357    | 0.9307    | 0.9249    | 0.8752    |
+[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.8856    | 0.8785    | 0.8369    | 0.8471    | 0.9357    | 0.9307    | 0.9249    | 0.8752    |
 
 The setting "default" refers the default BM25 settings of `k1=0.9`, `b=0.4`, while "tuned" refers to the tuned setting of `k1=4.46`, `b=0.82`.
 See [this page](experiments-msmarco-doc.md) for more details.
 Note that here we are using `trec_eval` to evaluate the top 1000 hits for each query; beware, an official MS MARCO document ranking task leaderboard submission comprises only 100 hits per query.
+See [this page](experiments-msmarco-doc-leaderboard.md) for details on Anserini baseline runs that were submitted to the official leaderboard.
 
-Use the following commands to convert the TREC run files into the MS MARCO format and use the official eval script to compute MRR@100:
+Note that leaderboard runs were generated with `SearchMsmarco` in the MS MARCO format.
+Conversion of a run in that format into the TREC format is slightly lossy due to tie-breaking effects.
+
+To generate an MS MARCO submission with the BM25 default parameters, corresponding to "BM25 (Default)" above:
 
 ```bash
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc.bm25-default.topics.msmarco-doc.dev.txt --output runs/run.msmarco-doc.bm25-default.topics.msmarco-doc.dev.msmarco.txt --k 100 --quiet
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/run.msmarco-doc.bm25-default.topics.msmarco-doc.dev.msmarco.txt
-#####################
-MRR @100: 0.23005723505603545
-QueriesRanked: 5193
-#####################
+$ sh target/appassembler/bin/SearchMsmarco -hits 100 -k1 0.9 -b 0.4 -threads 9 \
+   -index indexes/lucene-index.msmarco-doc.pos+docvectors+raw \
+   -queries src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -output runs/run.msmarco-doc.bm25-default.txt
 
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc.bm25-tuned.topics.msmarco-doc.dev.txt --output runs/run.msmarco-doc.bm25-tuned.topics.msmarco-doc.dev.msmarco.txt --k 100 --quiet
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/run.msmarco-doc.bm25-tuned.topics.msmarco-doc.dev.msmarco.txt
+$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+   --run runs/run.msmarco-doc.bm25-default.txt
+
 #####################
-MRR @100: 0.2770296928568709
+MRR @100: 0.23005723505603573
 QueriesRanked: 5193
 #####################
 ```
+
+This run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25, default parameters (k1=0.9, b=0.4)" dated 2020/08/16.
+
+To generate an MS MARCO submission with the BM25 tuned parameters, corresponding to "BM25 (Tuned)" above:
+
+```bash
+$ sh target/appassembler/bin/SearchMsmarco -hits 100 -k1 4.46 -b 0.82 -threads 9 \
+   -index indexes/lucene-index.msmarco-doc.pos+docvectors+raw \
+   -queries src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -output runs/run.msmarco-doc.bm25-tuned.txt
+
+$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+   --run runs/run.msmarco-doc.bm25-tuned.txt
+
+#####################
+MRR @100: 0.2770296928568702
+QueriesRanked: 5193
+#####################
+```
+
+This run was _not_ submitted to the MS MARCO document ranking leaderboard.

--- a/src/main/resources/docgen/templates/msmarco-doc-docTTTTTquery-per-doc.template
+++ b/src/main/resources/docgen/templates/msmarco-doc-docTTTTTquery-per-doc.template
@@ -47,22 +47,28 @@ With the above commands, you should be able to reproduce the following results:
 ${effectiveness}
 
 The setting "default" refers the default BM25 settings of `k1=0.9`, `b=0.4`, while "tuned" refers to the tuned setting of `k1=4.68`, `b=0.87`.
-Note that here we are using `trec_eval` to evaluate the top 1000 hits for each query; beware, an official MS MARCO document ranking task leaderboard submission comprises only 100 hits per query.
+An important note here is that tuning was performed on _on the original documents_, not the expanded documents; see [this page](experiments-msmarco-doc.md) for more details.
+Here we are using `trec_eval` to evaluate the top 1000 hits for each query; beware, an official MS MARCO document ranking task leaderboard submission comprises only 100 hits per query.
+See [this page](experiments-msmarco-doc-leaderboard.md) for details on Anserini baseline runs that were submitted to the official leaderboard.
 
-Use the following commands to convert the TREC run files into the MS MARCO format and use the official eval script to compute MRR@100:
+Note that leaderboard runs were generated with `SearchMsmarco` in the MS MARCO format.
+Conversion of a run in that format into the TREC format is slightly lossy due to tie-breaking effects.
+
+To generate an MS MARCO submission with the BM25 tuned parameters, corresponding to "BM25 (Tuned)" above:
 
 ```bash
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-default.topics.msmarco-doc.dev.txt --output runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-default.topics.msmarco-doc.dev.msmarco.txt --k 100 --quiet
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-default.topics.msmarco-doc.dev.msmarco.txt
-#####################
-MRR @100: 0.28805221173885914
-QueriesRanked: 5193
-#####################
+$ sh target/appassembler/bin/SearchMsmarco -hits 100 -k1 4.68 -b 0.87 -threads 9 \
+   -index indexes/lucene-index.msmarco-doc-docTTTTTquery-per-doc.pos+docvectors+raw \
+   -queries src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+   -output runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-tuned.txt
 
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-tuned.topics.msmarco-doc.dev.txt --output runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-tuned.topics.msmarco-doc.dev.msmarco.txt --k 100 --quiet
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-tuned.topics.msmarco-doc.dev.msmarco.txt
+$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+   --run runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-tuned.txt
+
 #####################
-MRR @100: 0.32651902964919355
+MRR @100: 0.3265190296491929
 QueriesRanked: 5193
 #####################
 ```
+
+This run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25 + doc2query-T5 expansion (per document), parameters tuned for recall@100 (k1=4.68, b=0.87)" dated 2020/12/11.

--- a/src/main/resources/docgen/templates/msmarco-doc-docTTTTTquery-per-doc.template
+++ b/src/main/resources/docgen/templates/msmarco-doc-docTTTTTquery-per-doc.template
@@ -62,7 +62,8 @@ $ sh target/appassembler/bin/SearchMsmarco -hits 100 -k1 4.68 -b 0.87 -threads 9
    -queries src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
    -output runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-tuned.txt
 
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+$ python tools/scripts/msmarco/msmarco_doc_eval.py \
+   --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
    --run runs/run.msmarco-doc-docTTTTTquery-per-doc.bm25-tuned.txt
 
 #####################

--- a/src/main/resources/docgen/templates/msmarco-doc-docTTTTTquery-per-passage.template
+++ b/src/main/resources/docgen/templates/msmarco-doc-docTTTTTquery-per-passage.template
@@ -57,7 +57,7 @@ To generate an MS MARCO submission with the BM25 tuned parameters, corresponding
 ```bash
 $ target/appassembler/bin/SearchCollection -topicreader TsvString \
    -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-   -index indexes/lucene-index.msmarco-doc-per-passage.pos+docvectors+raw \
+   -index indexes/lucene-index.msmarco-doc-docTTTTTquery-per-passage.pos+docvectors+raw \
    -output runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-tuned.trec \
    -bm25 -bm25.k1 2.56 -bm25.b 0.59 -hits 1000 \
    -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100

--- a/src/main/resources/docgen/templates/msmarco-doc-docTTTTTquery-per-passage.template
+++ b/src/main/resources/docgen/templates/msmarco-doc-docTTTTTquery-per-passage.template
@@ -55,15 +55,19 @@ The passage retrieval functionality is only available in `SearchCollection`; we 
 To generate an MS MARCO submission with the BM25 tuned parameters, corresponding to "BM25 (Tuned)" above:
 
 ```bash
-$ target/appassembler/bin/SearchCollection -topicreader TsvString -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+$ target/appassembler/bin/SearchCollection -topicreader TsvString \
+   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
    -index indexes/lucene-index.msmarco-doc-per-passage.pos+docvectors+raw \
    -output runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
-   -bm25 -bm25.k1 2.56 -bm25.b 0.59 -hits 1000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
+   -bm25 -bm25.k1 2.56 -bm25.b 0.59 -hits 1000 \
+   -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
 
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
+$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py \
+   --input runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
    --output runs/run.msmarco-doc-per-passage.bm25-tuned.txt
 
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+$ python tools/scripts/msmarco/msmarco_doc_eval.py \
+   --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
    --run runs/run.msmarco-doc-per-passage.bm25-tuned.txt
 
 #####################

--- a/src/main/resources/docgen/templates/msmarco-doc-docTTTTTquery-per-passage.template
+++ b/src/main/resources/docgen/templates/msmarco-doc-docTTTTTquery-per-passage.template
@@ -58,17 +58,17 @@ To generate an MS MARCO submission with the BM25 tuned parameters, corresponding
 $ target/appassembler/bin/SearchCollection -topicreader TsvString \
    -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
    -index indexes/lucene-index.msmarco-doc-per-passage.pos+docvectors+raw \
-   -output runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
+   -output runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-tuned.trec \
    -bm25 -bm25.k1 2.56 -bm25.b 0.59 -hits 1000 \
    -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
 
 $ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py \
-   --input runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
-   --output runs/run.msmarco-doc-per-passage.bm25-tuned.txt
+   --input runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-tuned.trec \
+   --output runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-tuned.txt
 
 $ python tools/scripts/msmarco/msmarco_doc_eval.py \
    --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
-   --run runs/run.msmarco-doc-per-passage.bm25-tuned.txt
+   --run runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-tuned.txt
 
 #####################
 MRR @100: 0.32081861579183746

--- a/src/main/resources/docgen/templates/msmarco-doc-docTTTTTquery-per-passage.template
+++ b/src/main/resources/docgen/templates/msmarco-doc-docTTTTTquery-per-passage.template
@@ -48,21 +48,28 @@ ${effectiveness}
 
 The setting "default" refers the default BM25 settings of `k1=0.9`, `b=0.4`, while "tuned" refers to the tuned setting of `k1=2.56`, `b=0.59`.
 Note that here we are using `trec_eval` to evaluate the top 1000 hits for each query; beware, an official MS MARCO document ranking task leaderboard submission comprises only 100 hits per query.
+See [this page](experiments-msmarco-doc-leaderboard.md) for details on Anserini baseline runs that were submitted to the official leaderboard.
 
-Use the following commands to convert the TREC run files into the MS MARCO format and use the official eval script to compute MRR@100:
+The passage retrieval functionality is only available in `SearchCollection`; we use a simple script to convert back into MS MARCO format.
+
+To generate an MS MARCO submission with the BM25 tuned parameters, corresponding to "BM25 (Tuned)" above:
 
 ```bash
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-default.topics.msmarco-doc.dev.txt --output runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-default.topics.msmarco-doc.dev.msmarco.txt --k 100 --quiet
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-default.topics.msmarco-doc.dev.msmarco.txt
-#####################
-MRR @100: 0.31779258157039647
-QueriesRanked: 5193
-#####################
+$ target/appassembler/bin/SearchCollection -topicreader TsvString -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+   -index indexes/lucene-index.msmarco-doc-per-passage.pos+docvectors+raw \
+   -output runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
+   -bm25 -bm25.k1 2.56 -bm25.b 0.59 -hits 1000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
 
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-tuned.topics.msmarco-doc.dev.txt --output runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-tuned.topics.msmarco-doc.dev.msmarco.txt --k 100 --quiet
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/run.msmarco-doc-docTTTTTquery-per-passage.bm25-tuned.topics.msmarco-doc.dev.msmarco.txt
+$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
+   --output runs/run.msmarco-doc-per-passage.bm25-tuned.txt
+
+$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+   --run runs/run.msmarco-doc-per-passage.bm25-tuned.txt
+
 #####################
-MRR @100: 0.32081861579183807
+MRR @100: 0.32081861579183746
 QueriesRanked: 5193
 #####################
 ```
+
+This run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25 + doc2query-T5 expansion (per passage), parameters tuned for recall@100 (k1=2.56, b=0.59)" dated 2020/12/11.

--- a/src/main/resources/docgen/templates/msmarco-doc-per-passage.template
+++ b/src/main/resources/docgen/templates/msmarco-doc-per-passage.template
@@ -48,21 +48,50 @@ ${effectiveness}
 
 The setting "default" refers the default BM25 settings of `k1=0.9`, `b=0.4`, while "tuned" refers to the tuned setting of `k1=2.16`, `b=0.61`.
 Note that here we are using `trec_eval` to evaluate the top 1000 hits for each query; beware, an official MS MARCO document ranking task leaderboard submission comprises only 100 hits per query.
+See [this page](experiments-msmarco-doc-leaderboard.md) for details on Anserini baseline runs that were submitted to the official leaderboard.
 
-Use the following commands to convert the TREC run files into the MS MARCO format and use the official eval script to compute MRR@100:
+The passage retrieval functionality is only available in `SearchCollection`; we use a simple script to convert back into MS MARCO format.
+
+To generate an MS MARCO submission with the BM25 default parameters, corresponding to "BM25 (Default)" above:
 
 ```bash
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-per-passage.bm25-default.topics.msmarco-doc.dev.txt --output runs/run.msmarco-doc-per-passage.bm25-default.topics.msmarco-doc.dev.msmarco.txt --k 100 --quiet
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/run.msmarco-doc-per-passage.bm25-default.topics.msmarco-doc.dev.msmarco.txt
-#####################
-MRR @100: 0.26823493089465705
-QueriesRanked: 5193
-#####################
+$ target/appassembler/bin/SearchCollection -topicreader TsvString -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+   -index indexes/lucene-index.msmarco-doc-per-passage.pos+docvectors+raw \
+   -output runs/run.msmarco-doc-per-passage.bm25-default.trec \
+   -bm25 -bm25.k1 0.9 -bm25.b 0.4 -hits 1000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
 
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-per-passage.bm25-tuned.topics.msmarco-doc.dev.txt --output runs/run.msmarco-doc-per-passage.bm25-tuned.topics.msmarco-doc.dev.msmarco.txt --k 100 --quiet
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/run.msmarco-doc-per-passage.bm25-tuned.topics.msmarco-doc.dev.msmarco.txt
+$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-per-passage.bm25-default.trec \
+   --output runs/run.msmarco-doc-per-passage.bm25-default.txt
+
+$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+   --run runs/run.msmarco-doc-per-passage.bm25-default.txt
+
 #####################
-MRR @100: 0.2751202109946906
+MRR @100: 0.2682349308946578
 QueriesRanked: 5193
 #####################
 ```
+
+This run was _not_ submitted to the MS MARCO document ranking leaderboard.
+
+To generate an MS MARCO submission with the BM25 tuned parameters, corresponding to "BM25 (Tuned)" above:
+
+```bash
+$ target/appassembler/bin/SearchCollection -topicreader TsvString -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+   -index indexes/lucene-index.msmarco-doc-per-passage.pos+docvectors+raw \
+   -output runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
+   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -hits 1000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
+
+$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
+   --output runs/run.msmarco-doc-per-passage.bm25-tuned.txt
+
+$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+   --run runs/run.msmarco-doc-per-passage.bm25-tuned.txt
+
+#####################
+MRR @100: 0.2751202109946902
+QueriesRanked: 5193
+#####################
+```
+
+This run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25 (per passage), parameters tuned for recall@100 (k1=2.16, b=0.61)" dated 2021/01/20.

--- a/src/main/resources/docgen/templates/msmarco-doc-per-passage.template
+++ b/src/main/resources/docgen/templates/msmarco-doc-per-passage.template
@@ -55,15 +55,19 @@ The passage retrieval functionality is only available in `SearchCollection`; we 
 To generate an MS MARCO submission with the BM25 default parameters, corresponding to "BM25 (Default)" above:
 
 ```bash
-$ target/appassembler/bin/SearchCollection -topicreader TsvString -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+$ target/appassembler/bin/SearchCollection -topicreader TsvString \
+   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
    -index indexes/lucene-index.msmarco-doc-per-passage.pos+docvectors+raw \
    -output runs/run.msmarco-doc-per-passage.bm25-default.trec \
-   -bm25 -bm25.k1 0.9 -bm25.b 0.4 -hits 1000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
+   -bm25 -bm25.k1 0.9 -bm25.b 0.4 -hits 1000 \
+   -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
 
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-per-passage.bm25-default.trec \
+$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py \
+   --input runs/run.msmarco-doc-per-passage.bm25-default.trec \
    --output runs/run.msmarco-doc-per-passage.bm25-default.txt
 
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+$ python tools/scripts/msmarco/msmarco_doc_eval.py \
+   --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
    --run runs/run.msmarco-doc-per-passage.bm25-default.txt
 
 #####################
@@ -77,15 +81,19 @@ This run was _not_ submitted to the MS MARCO document ranking leaderboard.
 To generate an MS MARCO submission with the BM25 tuned parameters, corresponding to "BM25 (Tuned)" above:
 
 ```bash
-$ target/appassembler/bin/SearchCollection -topicreader TsvString -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+$ target/appassembler/bin/SearchCollection -topicreader TsvString \
+   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
    -index indexes/lucene-index.msmarco-doc-per-passage.pos+docvectors+raw \
    -output runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
-   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -hits 1000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
+   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -hits 1000 \
+   -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
 
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
+$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py \
+   --input runs/run.msmarco-doc-per-passage.bm25-tuned.trec \
    --output runs/run.msmarco-doc-per-passage.bm25-tuned.txt
 
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+$ python tools/scripts/msmarco/msmarco_doc_eval.py \
+   --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
    --run runs/run.msmarco-doc-per-passage.bm25-tuned.txt
 
 #####################

--- a/src/main/resources/docgen/templates/msmarco-doc.template
+++ b/src/main/resources/docgen/templates/msmarco-doc.template
@@ -59,9 +59,11 @@ To generate an MS MARCO submission with the BM25 default parameters, correspondi
 ```bash
 $ sh target/appassembler/bin/SearchMsmarco -hits 100 -k1 0.9 -b 0.4 -threads 9 \
    -index indexes/lucene-index.msmarco-doc.pos+docvectors+raw \
-   -queries src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -output runs/run.msmarco-doc.bm25-default.txt
+   -queries src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+   -output runs/run.msmarco-doc.bm25-default.txt
 
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+$ python tools/scripts/msmarco/msmarco_doc_eval.py \
+   --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
    --run runs/run.msmarco-doc.bm25-default.txt
 
 #####################
@@ -77,9 +79,11 @@ To generate an MS MARCO submission with the BM25 tuned parameters, corresponding
 ```bash
 $ sh target/appassembler/bin/SearchMsmarco -hits 100 -k1 4.46 -b 0.82 -threads 9 \
    -index indexes/lucene-index.msmarco-doc.pos+docvectors+raw \
-   -queries src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -output runs/run.msmarco-doc.bm25-tuned.txt
+   -queries src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+   -output runs/run.msmarco-doc.bm25-tuned.txt
 
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+$ python tools/scripts/msmarco/msmarco_doc_eval.py \
+   --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
    --run runs/run.msmarco-doc.bm25-tuned.txt
 
 #####################

--- a/src/main/resources/docgen/templates/msmarco-doc.template
+++ b/src/main/resources/docgen/templates/msmarco-doc.template
@@ -49,21 +49,43 @@ ${effectiveness}
 The setting "default" refers the default BM25 settings of `k1=0.9`, `b=0.4`, while "tuned" refers to the tuned setting of `k1=4.46`, `b=0.82`.
 See [this page](experiments-msmarco-doc.md) for more details.
 Note that here we are using `trec_eval` to evaluate the top 1000 hits for each query; beware, an official MS MARCO document ranking task leaderboard submission comprises only 100 hits per query.
+See [this page](experiments-msmarco-doc-leaderboard.md) for details on Anserini baseline runs that were submitted to the official leaderboard.
 
-Use the following commands to convert the TREC run files into the MS MARCO format and use the official eval script to compute MRR@100:
+Note that leaderboard runs were generated with `SearchMsmarco` in the MS MARCO format.
+Conversion of a run in that format into the TREC format is slightly lossy due to tie-breaking effects.
+
+To generate an MS MARCO submission with the BM25 default parameters, corresponding to "BM25 (Default)" above:
 
 ```bash
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc.bm25-default.topics.msmarco-doc.dev.txt --output runs/run.msmarco-doc.bm25-default.topics.msmarco-doc.dev.msmarco.txt --k 100 --quiet
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/run.msmarco-doc.bm25-default.topics.msmarco-doc.dev.msmarco.txt
-#####################
-MRR @100: 0.23005723505603545
-QueriesRanked: 5193
-#####################
+$ sh target/appassembler/bin/SearchMsmarco -hits 100 -k1 0.9 -b 0.4 -threads 9 \
+   -index indexes/lucene-index.msmarco-doc.pos+docvectors+raw \
+   -queries src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -output runs/run.msmarco-doc.bm25-default.txt
 
-$ python tools/scripts/msmarco/convert_trec_to_msmarco_run.py --input runs/run.msmarco-doc.bm25-tuned.topics.msmarco-doc.dev.txt --output runs/run.msmarco-doc.bm25-tuned.topics.msmarco-doc.dev.msmarco.txt --k 100 --quiet
-$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt --run runs/run.msmarco-doc.bm25-tuned.topics.msmarco-doc.dev.msmarco.txt
+$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+   --run runs/run.msmarco-doc.bm25-default.txt
+
 #####################
-MRR @100: 0.2770296928568709
+MRR @100: 0.23005723505603573
 QueriesRanked: 5193
 #####################
 ```
+
+This run corresponds to the MS MARCO document ranking leaderboard entry "Anserini's BM25, default parameters (k1=0.9, b=0.4)" dated 2020/08/16.
+
+To generate an MS MARCO submission with the BM25 tuned parameters, corresponding to "BM25 (Tuned)" above:
+
+```bash
+$ sh target/appassembler/bin/SearchMsmarco -hits 100 -k1 4.46 -b 0.82 -threads 9 \
+   -index indexes/lucene-index.msmarco-doc.pos+docvectors+raw \
+   -queries src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -output runs/run.msmarco-doc.bm25-tuned.txt
+
+$ python tools/scripts/msmarco/msmarco_doc_eval.py --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
+   --run runs/run.msmarco-doc.bm25-tuned.txt
+
+#####################
+MRR @100: 0.2770296928568702
+QueriesRanked: 5193
+#####################
+```
+
+This run was _not_ submitted to the MS MARCO document ranking leaderboard.

--- a/src/main/resources/regression/msmarco-doc-docTTTTTquery-per-doc.yaml
+++ b/src/main/resources/regression/msmarco-doc-docTTTTTquery-per-doc.yaml
@@ -54,7 +54,7 @@ index_stats:
   documents (non-empty): 3213834
   total terms: 3748332076
 topics:
-  - name: "[MS MARCO Doc Ranking: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)"
+  - name: "[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)"
     path: topics.msmarco-doc.dev.txt
     qrel: qrels.msmarco-doc.dev.txt
 models:

--- a/src/main/resources/regression/msmarco-doc-docTTTTTquery-per-passage.yaml
+++ b/src/main/resources/regression/msmarco-doc-docTTTTTquery-per-passage.yaml
@@ -54,7 +54,7 @@ index_stats:
   documents (non-empty): 20544550
   total terms: 4203956960
 topics:
-  - name: "[MS MARCO Doc Ranking: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)"
+  - name: "[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)"
     path: topics.msmarco-doc.dev.txt
     qrel: qrels.msmarco-doc.dev.txt
 models:

--- a/src/main/resources/regression/msmarco-doc-per-passage.yaml
+++ b/src/main/resources/regression/msmarco-doc-per-passage.yaml
@@ -54,7 +54,7 @@ index_stats:
   documents (non-empty): 20544550
   total terms: 3197886407
 topics:
-  - name: "[MS MARCO Doc Ranking: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)"
+  - name: "[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)"
     path: topics.msmarco-doc.dev.txt
     qrel: qrels.msmarco-doc.dev.txt
 models:

--- a/src/main/resources/regression/msmarco-doc.yaml
+++ b/src/main/resources/regression/msmarco-doc.yaml
@@ -54,7 +54,7 @@ index_stats:
   documents (non-empty): 3213835
   total terms: 2748636047
 topics:
-  - name: "[MS MARCO Doc Ranking: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)"
+  - name: "[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)"
     path: topics.msmarco-doc.dev.txt
     qrel: qrels.msmarco-doc.dev.txt
 models:


### PR DESCRIPTION
+ Covers {BM25 per doc, BM25 per passage} x {no expansion, docTTTTTquery}
+ Scores didn't change - just better documentation connecting regressions to official leaderboard submissions.