### PR TITLE
Change analyzer for Japanese

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -422,5 +422,10 @@
       <artifactId>commons-csv</artifactId>
       <version>1.8</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-analyzers-kuromoji</artifactId>
+      <version>${lucene.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -61,6 +61,7 @@ import org.apache.lucene.analysis.hi.HindiAnalyzer;
 import org.apache.lucene.analysis.hu.HungarianAnalyzer;
 import org.apache.lucene.analysis.id.IndonesianAnalyzer;
 import org.apache.lucene.analysis.it.ItalianAnalyzer;
+import org.apache.lucene.analysis.ja.JapaneseAnalyzer;
 import org.apache.lucene.analysis.nl.DutchAnalyzer;
 import org.apache.lucene.analysis.no.NorwegianAnalyzer;
 import org.apache.lucene.analysis.pt.PortugueseAnalyzer;
@@ -747,6 +748,7 @@ public final class IndexCollection {
       final HungarianAnalyzer hungarianAnalyzer = new HungarianAnalyzer();
       final IndonesianAnalyzer indonesianAnalyzer = new IndonesianAnalyzer();
       final ItalianAnalyzer italianAnalyzer = new ItalianAnalyzer();
+      final JapaneseAnalyzer japaneseAnalyzer = new JapaneseAnalyzer();
       final NorwegianAnalyzer norwegianAnalyzer = new NorwegianAnalyzer();
       final PortugueseAnalyzer portugueseAnalyzer = new PortugueseAnalyzer();
       final RussianAnalyzer russianAnalyzer = new RussianAnalyzer();
@@ -785,6 +787,8 @@ public final class IndexCollection {
         config = new IndexWriterConfig(indonesianAnalyzer);
       } else if (args.language.equals("it")) {
         config = new IndexWriterConfig(italianAnalyzer);
+      } else if (args.language.equals("ja")) {
+        config = new IndexWriterConfig(japaneseAnalyzer);
       } else if (args.language.equals("nl")) {
         config = new IndexWriterConfig(dutchAnalyzer);
       } else if (args.language.equals("no")) {
@@ -799,7 +803,7 @@ public final class IndexCollection {
         config = new IndexWriterConfig(thaiAnalyzer);
       } else if (args.language.equals("tr")) {
         config = new IndexWriterConfig(turkishAnalyzer);
-      } else if (args.language.equals("zh") || args.language.equals("ja") || args.language.equals("ko")) {
+      } else if (args.language.equals("zh") || args.language.equals("ko")) {
         config = new IndexWriterConfig(chineseAnalyzer);
       } else if (args.pretokenized) {
         config = new IndexWriterConfig(whitespaceAnalyzer);

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -56,6 +56,7 @@ import org.apache.lucene.analysis.hi.HindiAnalyzer;
 import org.apache.lucene.analysis.hu.HungarianAnalyzer;
 import org.apache.lucene.analysis.id.IndonesianAnalyzer;
 import org.apache.lucene.analysis.it.ItalianAnalyzer;
+import org.apache.lucene.analysis.ja.JapaneseAnalyzer;
 import org.apache.lucene.analysis.nl.DutchAnalyzer;
 import org.apache.lucene.analysis.no.NorwegianAnalyzer;
 import org.apache.lucene.analysis.pt.PortugueseAnalyzer;
@@ -325,7 +326,7 @@ public final class SearchCollection implements Closeable {
       analyzer = new ItalianAnalyzer();
       LOG.info("Language: it");
     } else if (args.language.equals("ja")) {
-      analyzer = new CJKAnalyzer();
+      analyzer = new JapaneseAnalyzer();
       LOG.info("Language: ja");
     } else if (args.language.equals("ko")) {
       analyzer = new CJKAnalyzer();

--- a/src/main/java/io/anserini/search/SimpleSearcher.java
+++ b/src/main/java/io/anserini/search/SimpleSearcher.java
@@ -44,6 +44,7 @@ import org.apache.lucene.analysis.hi.HindiAnalyzer;
 import org.apache.lucene.analysis.hu.HungarianAnalyzer;
 import org.apache.lucene.analysis.id.IndonesianAnalyzer;
 import org.apache.lucene.analysis.it.ItalianAnalyzer;
+import org.apache.lucene.analysis.ja.JapaneseAnalyzer;
 import org.apache.lucene.analysis.nl.DutchAnalyzer;
 import org.apache.lucene.analysis.no.NorwegianAnalyzer;
 import org.apache.lucene.analysis.pt.PortugueseAnalyzer;
@@ -262,6 +263,8 @@ public class SimpleSearcher implements Closeable {
       this.analyzer = new IndonesianAnalyzer();
     } else if (language.equals("it")) {
       this.analyzer = new ItalianAnalyzer();
+    } else if (language.equals("ja")) {
+      this.analyzer = new JapaneseAnalyzer();
     } else if (language.equals("nl")) {
       this.analyzer = new DutchAnalyzer();
     } else if (language.equals("no")) {
@@ -276,7 +279,7 @@ public class SimpleSearcher implements Closeable {
       this.analyzer = new ThaiAnalyzer();
     } else if (language.equals("tr")) {
       this.analyzer = new TurkishAnalyzer();
-    } else if (language.equals("zh") || language.equals("ja") || language.equals("ko")) {
+    } else if (language.equals("zh") || language.equals("ko")) {
       this.analyzer = new CJKAnalyzer();
     }
   }


### PR DESCRIPTION
Anserini uses CJKAnalyzer for analyzing Japanese, but it is not commonly used for Japanese.
This pull request includes installing kuromoji, which is a popular analyzer for Japanese, and changing analyzer to use kuromoji for analyzing Japanese.

I'm sorry but I did not write any unit tests in this commit.
However, using the dataset of NTCIR-15 Data Search Track (Japanese subtask), I have confirmed that the IndexCollection command and the SearchCollection command can be run, referring to [this repository](https://github.com/mpkato/ntcir-datasearch).