### PR TITLE
Replicated baseline for MS MARCO V2

### DIFF
--- a/docs/experiments-msmarco-v2.md
+++ b/docs/experiments-msmarco-v2.md
@@ -64,3 +64,4 @@ recall_100            	all	0.5956
 ## Reproduction Log[*](reproducibility.md)
 
 + Results reproduced by [@ronakice](https://github.com/ronakice) on 2019-08-12 (commit [`ce35d61`](https://github.com/castorini/anserini/commit/ce35d61455d5943e164e31880e517ce091fded66))
++ Results reproduced by [@crystina-z](https://github.com/crystina-z) on 2021-06-25 (commit [`ce35d61`](https://github.com/castorini/anserini/commit/ce35d61455d5943e164e31880e517ce091fded66))


### PR DESCRIPTION
```
$ tools/eval/trec_eval.9.0.4/trec_eval -c -m map -m recall.100 -m recip_rank collections/docv2_dev_qrels.uniq.tsv runs/run.msmarco-doc-v2.dev.txt
map                     all     0.1552
recip_rank              all     0.1572
recall_100              all     0.5956
```
where the `docv2_dev_qrels.uniq.tsv`  is prepared by
```
cat docv2_dev_qrels.tsv | sort | uniq > docv2_dev_qrels.uniq.tsv 
```