### PR TITLE
MSMARCO doc/passage reproduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,6 @@ Then, build using using Maven:
 mvn clean package appassembler:assemble
 ```
 
-Depending on the version of the Java you are using, you might need to use:
-
-```
-mvn clean package appassembler:assemble -DskipTests -Dmaven.javadoc.skip=true
-```
-
-
 The `tools/` directory, which contains evaluation tools and other scripts, is actually [this repo](https://github.com/castorini/anserini-tools), integrated as a [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) (so that it can be shared across related projects).
 Build as follows (you might get warnings, but okay to ignore):
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Then, build using using Maven:
 mvn clean package appassembler:assemble
 ```
 
+Depending on the version of the Java you are using, you might need to use:
+
+```
+mvn clean package appassembler:assemble -DskipTests -Dmaven.javadoc.skip=true
+```
+
+
 The `tools/` directory, which contains evaluation tools and other scripts, is actually [this repo](https://github.com/castorini/anserini-tools), integrated as a [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) (so that it can be shared across related projects).
 Build as follows (you might get warnings, but okay to ignore):
 

--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -226,4 +226,4 @@ That's it!
 + Results reproduced by [@Albert-Ma](https://github.com/Albert-Ma) on 2021-05-07 (commit [`5bcbccd`](https://github.com/castorini/anserini/commit/5bcbccdb8e67a1c6a1a74da1219fd344c9e80b0b))
 + Results reproduced by [@rootofallevii](https://github.com/RootofalleviI) on 2021-05-14 (commit [`626da95`](https://github.com/castorini/anserini/commit/626da950249ecc1519c9b07710d1243e0653e1c5))
 + Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-01 (commit [`2591e06`](https://github.com/castorini/anserini/commit/2591e063b4bee8881a641cf2167352ac212865a6))
-+ Results reproduced by [@nimasadri11](https://github.com/nimasadri11) on 2021-06-27 (commit [`1e5436c`](https://github.com/castorini/anserini/commit/1e5436c3a0e44e5eb4e966e7d8009194bf78109e))
++ Results reproduced by [@nimasadri11](https://github.com/nimasadri11) on 2021-06-27 (commit [`6f9352f`](https://github.com/castorini/anserini/commit/6f9352fc5d6a4938fadc2bda9d0c428056eec5f0))

--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -226,3 +226,4 @@ That's it!
 + Results reproduced by [@Albert-Ma](https://github.com/Albert-Ma) on 2021-05-07 (commit [`5bcbccd`](https://github.com/castorini/anserini/commit/5bcbccdb8e67a1c6a1a74da1219fd344c9e80b0b))
 + Results reproduced by [@rootofallevii](https://github.com/RootofalleviI) on 2021-05-14 (commit [`626da95`](https://github.com/castorini/anserini/commit/626da950249ecc1519c9b07710d1243e0653e1c5))
 + Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-01 (commit [`2591e06`](https://github.com/castorini/anserini/commit/2591e063b4bee8881a641cf2167352ac212865a6))
++ Results reproduced by [@nimasadri11](https://github.com/nimasadri11) on 2021-06-27 (commit [`1e5436c`](https://github.com/castorini/anserini/commit/1e5436c3a0e44e5eb4e966e7d8009194bf78109e))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -360,3 +360,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@Albert-Ma](https://github.com/Albert-Ma) on 2021-05-07 (commit [`5bcbccd`](https://github.com/castorini/anserini/commit/5bcbccdb8e67a1c6a1a74da1219fd344c9e80b0b))
 + Results reproduced by [@rootofallevii](https://github.com/RootofalleviI) on 2021-05-14 (commit [`626da95`](https://github.com/castorini/anserini/commit/626da950249ecc1519c9b07710d1243e0653e1c5))
 + Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-01 (commit [`2591e06`](https://github.com/castorini/anserini/commit/2591e063b4bee8881a641cf2167352ac212865a6))
++ Results reproduced by [@nimasadri11](https://github.com/nimasadri11) on 2021-06-27 (commit [`1e5436c`](https://github.com/castorini/anserini/commit/1e5436c3a0e44e5eb4e966e7d8009194bf78109e))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -360,4 +360,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@Albert-Ma](https://github.com/Albert-Ma) on 2021-05-07 (commit [`5bcbccd`](https://github.com/castorini/anserini/commit/5bcbccdb8e67a1c6a1a74da1219fd344c9e80b0b))
 + Results reproduced by [@rootofallevii](https://github.com/RootofalleviI) on 2021-05-14 (commit [`626da95`](https://github.com/castorini/anserini/commit/626da950249ecc1519c9b07710d1243e0653e1c5))
 + Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-01 (commit [`2591e06`](https://github.com/castorini/anserini/commit/2591e063b4bee8881a641cf2167352ac212865a6))
-+ Results reproduced by [@nimasadri11](https://github.com/nimasadri11) on 2021-06-27 (commit [`1e5436c`](https://github.com/castorini/anserini/commit/1e5436c3a0e44e5eb4e966e7d8009194bf78109e))
++ Results reproduced by [@nimasadri11](https://github.com/nimasadri11) on 2021-06-27 (commit [`6f9352f`](https://github.com/castorini/anserini/commit/6f9352fc5d6a4938fadc2bda9d0c428056eec5f0))


### PR DESCRIPTION
## System Configuration and Environment:
* AWS EC2 t3a.2xlarge instance
* OS: Ubuntu
* 256 GB SSD
* 32GB RAM
* OpenJDK version: 11.0.11

## Issues encountered:
When running `mvn clean package appassembler:assemble` I encountered the following error:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.1.0:jar (attach-javadocs) on project anserini: MavenReportException: Error while generating Javadoc: Unable to find javadoc command: The environment variable JAVA_HOME is not correctly set. -> [Help 1]
```
[EDIT] To resolve it, I had to setup my JAVA_HOME env variable accordingly.