### PR TITLE
Reproduce Anserini: BM25 Baselines for MS MARCO Passage/Document Ranking Experiment

### DIFF
--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -226,3 +226,4 @@ That's it!
 + Results reproduced by [@Albert-Ma](https://github.com/Albert-Ma) on 2021-05-07 (commit [`5bcbccd`](https://github.com/castorini/anserini/commit/5bcbccdb8e67a1c6a1a74da1219fd344c9e80b0b))
 + Results reproduced by [@rootofallevii](https://github.com/RootofalleviI) on 2021-05-14 (commit [`626da95`](https://github.com/castorini/anserini/commit/626da950249ecc1519c9b07710d1243e0653e1c5))
 + Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-01 (commit [`2591e06`](https://github.com/castorini/anserini/commit/2591e063b4bee8881a641cf2167352ac212865a6))
++ Results reproduced by [@mzzchy](https://github.com/mzzchy) on 2021-07-05 (commit [`873401c`](https://github.com/castorini/anserini/commit/873401c912dcc3212e763dd4979c628a7aeb1704))

--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -226,4 +226,4 @@ That's it!
 + Results reproduced by [@Albert-Ma](https://github.com/Albert-Ma) on 2021-05-07 (commit [`5bcbccd`](https://github.com/castorini/anserini/commit/5bcbccdb8e67a1c6a1a74da1219fd344c9e80b0b))
 + Results reproduced by [@rootofallevii](https://github.com/RootofalleviI) on 2021-05-14 (commit [`626da95`](https://github.com/castorini/anserini/commit/626da950249ecc1519c9b07710d1243e0653e1c5))
 + Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-01 (commit [`2591e06`](https://github.com/castorini/anserini/commit/2591e063b4bee8881a641cf2167352ac212865a6))
-+ Results reproduced by [@mzzchy](https://github.com/mzzchy) on 2021-07-05 (commit [`873401c`](https://github.com/castorini/anserini/commit/873401c912dcc3212e763dd4979c628a7aeb1704))
++ Results reproduced by [@mzzchy](https://github.com/mzzchy) on 2021-07-05 (commit [`589928b`](https://github.com/castorini/anserini/commit/589928b1873b3ebe00234becd8b5da9d573dda6d))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -360,4 +360,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@Albert-Ma](https://github.com/Albert-Ma) on 2021-05-07 (commit [`5bcbccd`](https://github.com/castorini/anserini/commit/5bcbccdb8e67a1c6a1a74da1219fd344c9e80b0b))
 + Results reproduced by [@rootofallevii](https://github.com/RootofalleviI) on 2021-05-14 (commit [`626da95`](https://github.com/castorini/anserini/commit/626da950249ecc1519c9b07710d1243e0653e1c5))
 + Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-01 (commit [`2591e06`](https://github.com/castorini/anserini/commit/2591e063b4bee8881a641cf2167352ac212865a6))
-+ Results reproduced by [@mzzchy](https://github.com/mzzchy) on 2021-07-05 (commit [`873401c`](https://github.com/castorini/anserini/commit/873401c912dcc3212e763dd4979c628a7aeb1704))
++ Results reproduced by [@mzzchy](https://github.com/mzzchy) on 2021-07-05 (commit [`589928b`](https://github.com/castorini/anserini/commit/589928b1873b3ebe00234becd8b5da9d573dda6d))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -360,3 +360,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@Albert-Ma](https://github.com/Albert-Ma) on 2021-05-07 (commit [`5bcbccd`](https://github.com/castorini/anserini/commit/5bcbccdb8e67a1c6a1a74da1219fd344c9e80b0b))
 + Results reproduced by [@rootofallevii](https://github.com/RootofalleviI) on 2021-05-14 (commit [`626da95`](https://github.com/castorini/anserini/commit/626da950249ecc1519c9b07710d1243e0653e1c5))
 + Results reproduced by [@jpark621](https://github.com/jpark621) on 2021-06-01 (commit [`2591e06`](https://github.com/castorini/anserini/commit/2591e063b4bee8881a641cf2167352ac212865a6))
++ Results reproduced by [@mzzchy](https://github.com/mzzchy) on 2021-07-05 (commit [`873401c`](https://github.com/castorini/anserini/commit/873401c912dcc3212e763dd4979c628a7aeb1704))


### PR DESCRIPTION
Get exactly same result as provided. Screenshots are post
<img width="638" alt="BM25 Baselines for MS MARCO Document Ranking_6" src="https://user-images.githubusercontent.com/39313997/124510996-09472f80-dda3-11eb-9bf6-5246486f37d8.png">
<img width="652" alt="BM25 Baselines for MS MARCO Passage Ranking_2" src="https://user-images.githubusercontent.com/39313997/124510997-09dfc600-dda3-11eb-8d4f-076bc6535d63.png">

Environment:
OS: macOS Big Sur 11.4
Python: 3.9.5
Java: openjdk 11.0.5 2019-10-15
