### PR TITLE
UniCOIL reproduced by ArvinZhuang

### DIFF
--- a/docs/experiments-msmarco-passage-unicoil.md
+++ b/docs/experiments-msmarco-passage-unicoil.md
@@ -98,3 +98,4 @@ QueriesRanked: 6980
 + Results reproduced by [@lintool](https://github.com/lintool) on 2021-06-28 (commit [`1550683`](https://github.com/castorini/anserini/commit/1550683e41cefe89b7e67c0a5f0e147bc70dfcda))
 + Results reproduced by [@JMMackenzie](https://github.com/JMMackenzie) on 2021-07-02 (commit [`e4c5127`](https://github.com/castorini/anserini/commit/e4c51278d375ebad9aa2bf9bde66cab32260d6b4))
 + Results reproduced by [@amallia](https://github.com/amallia) on 2021-07-14 (commit [`dad4b82`](https://github.com/castorini/anserini/commit/dad4b82cba2d879ae20147b2abdd04564331ea6f))
++ Results reproduced by [@ArvinZhuang](https://github.com/ArvinZhuang) on 2021-07-16 (commit [`43ad899`](https://github.com/castorini/anserini/commit/43ad899337ac5e3b219d899bb218c4bcae18b1e6))


### PR DESCRIPTION
Got the same MRR@10 score by using provided collection and queries.
More than that, I actually followed the uniCOIL repo (https://github.com/luyug/COIL/tree/main/uniCOIL) retrained the model with a different seed, and recreated the collection and queries, I got the MRR@10 score of 0.350, pretty close, I'm happy with that.

One question, I notice that uniCOIL retrieval is much slower than bm25, it actually took me more than 1.5 hours on my old laptop. Any insight why this is the case? My guess is because of the small vocab size and super long average posting list?