### PR TITLE
reproduce index and search for augmented ms-psg v2

### DIFF
--- a/docs/experiments-msmarco-v2.md
+++ b/docs/experiments-msmarco-v2.md
@@ -208,3 +208,4 @@ recall_100            	all	0.6629
 + Results reproduced by [@ronakice](https://github.com/ronakice) on 2021-06-25 (commit [`ce35d61`](https://github.com/castorini/anserini/commit/ce35d61455d5943e164e31880e517ce091fded66))
 + Results reproduced by [@crystina-z](https://github.com/crystina-z) on 2021-06-25 (commit [`ce35d61`](https://github.com/castorini/anserini/commit/ce35d61455d5943e164e31880e517ce091fded66))
 + Results reproduced by [@spacemanidol](https://github.com/spacemanidol) on 2021-06-28 (commit [`ce35d61`](https://github.com/castorini/anserini/commit/ce35d61455d5943e164e31880e517ce091fded66))
++ Results reproduced by [@crystina-z](https://github.com/crystina-z) on 2021-06-25 (commit [`dbc71ee`](https://github.com/castorini/anserini/commit/dbc71ee51fc7dbcdcb9118c9f7ad554b8b753a27))


### PR DESCRIPTION
```
$ tools/eval/trec_eval.9.0.4/trec_eval -c -m map -m recall.100,1000 -m recip_rank collections/passv2_dev_qrels.uniq.tsv runs/run.msmarco-passage-v2-augmented.dev.txt
map                     all     0.0863
recip_rank              all     0.0872
recall_100              all     0.4030
recall_1000             all     0.4030
$ tools/eval/trec_eval.9.0.4/trec_eval -c -m map -m recall.100,1000 -m recip_rank collections/passv2_dev2_qrels.uniq.tsv runs/run.msmarco-passage-v2-augmented.dev2.txt
map                     all     0.0904
recip_rank              all     0.0917
recall_100              all     0.4159
recall_1000             all     0.4159
```
for both self-built index and the index `/store/scratch/jimmylin/anserini/indexes/msmarco-passage-v2-augmented`