### PR TITLE
Checking experiments-msmarco-v2.md and reproducing results.

### DIFF
--- a/docs/experiments-msmarco-v2.md
+++ b/docs/experiments-msmarco-v2.md
@@ -135,7 +135,7 @@ sh target/appassembler/bin/IndexCollection -collection MsMarcoDocV2Collection \
 ```
 
 Same instructions as above.
-On the same machine, indexing takes around 34min.
+On the same machine, indexing takes around 40 minutes.
 Complete index occupies 134 GB (11,959,635 documents).
 Index size can be reduced by removing the options `-storePositions`, `-storeDocvectors`, `-storeRaw` as appropriate.
 For reference:

--- a/docs/experiments-msmarco-v2.md
+++ b/docs/experiments-msmarco-v2.md
@@ -141,7 +141,7 @@ Index size can be reduced by removing the options `-storePositions`, `-storeDocv
 For reference:
 
 + Without any of the three above option, index size reduces to 9.4 GB (indexed in ~18min).
-+ With just `-storeRaw`, index size reduces to 73 GB (indexed in ~25min). This setting contains the raw JSON document, which makes it suitable for use as first-stage retrieval to support downstream rerankers. Bloat compared to compressed size of raw collection is due to support for per-document random access; evidently, the JSON docs don't compress well.
++ With just `-storeRaw`, index size reduces to 73 GB. This setting contains the raw JSON document, which makes it suitable for use as first-stage retrieval to support downstream rerankers. Bloat compared to compressed size of raw collection is due to support for per-document random access; evidently, the JSON docs don't compress well.
 
 Each "document" in the index comprises the url, title, headings, and body fields concatenated together.
 

--- a/docs/experiments-msmarco-v2.md
+++ b/docs/experiments-msmarco-v2.md
@@ -212,7 +212,7 @@ There are a total of 124,131,414 "documents" in the collection.
 Each "document" comprises the url, title, headings, and segment fields concatenated together.
 With the above indexing configuration, the index size comes to 226 GB (indexed in ~1h).
 However, the index size can be reduced by playing with the indexing options discussed above.
-For example, with just the `-storeRaw` option, which supports bag-of-words first-stage retrieval with stored raw documents that can be fetched and passed to a downstream reranker, the index size comes out to 124 GB (indexed in ~48min).
+For example, with just the `-storeRaw` option, which supports bag-of-words first-stage retrieval with stored raw documents that can be fetched and passed to a downstream reranker, the index size comes out to 124 GB.
 
 Perform runs on the dev queries (both sets):
 

--- a/docs/experiments-msmarco-v2.md
+++ b/docs/experiments-msmarco-v2.md
@@ -210,7 +210,7 @@ sh target/appassembler/bin/IndexCollection -collection MsMarcoDocV2Collection \
 
 There are a total of 124,131,414 "documents" in the collection.
 Each "document" comprises the url, title, headings, and segment fields concatenated together.
-With the above indexing configuration, the index size comes to 226 GB (indexed in ~1h).
+With the above indexing configuration, the index size comes to 226 GB.
 However, the index size can be reduced by playing with the indexing options discussed above.
 For example, with just the `-storeRaw` option, which supports bag-of-words first-stage retrieval with stored raw documents that can be fetched and passed to a downstream reranker, the index size comes out to 124 GB.
 

--- a/docs/experiments-msmarco-v2.md
+++ b/docs/experiments-msmarco-v2.md
@@ -7,7 +7,7 @@ For example, to download passage collection,
 ```
 azcopy copy https://msmarco.blob.core.windows.net/msmarcoranking/msmarco_v2_passage.tar ./collections
 ```
-The speedup using `azcopy` here is significant, in our case, it takes ~1 to 2min to download this tarball, compared to 2+ hours when using `wget`.
+The speedup using `azcopy` is significant compared to `wget`, but the actual downloading time will vary based on your location as well as many other factors.
 
 ## Passage Collection
 

--- a/docs/experiments-msmarco-v2.md
+++ b/docs/experiments-msmarco-v2.md
@@ -89,7 +89,7 @@ sh target/appassembler/bin/IndexCollection -collection MsMarcoPassageV2Collectio
 
 There are a total of 138,364,198 passages in the collection (exactly the same as the original passage collection).
 In each "document" in the index comprises the url, title, headings, and passage fields concatenated together.
-With the above indexing configuration, the index size comes to 162 GB (indexed in ~40min).
+With the above indexing configuration, the index size comes to 162 GB.
 However, the index size can be reduced by playing with the indexing options discussed above.
 For example, with just the `-storeRaw` option, which supports bag-of-words first-stage retrieval with stored raw documents that can be fetched and passed to a downstream reranker, the index size comes out to 95 GB.
 

--- a/docs/experiments-msmarco-v2.md
+++ b/docs/experiments-msmarco-v2.md
@@ -140,7 +140,7 @@ Complete index occupies 134 GB (11,959,635 documents).
 Index size can be reduced by removing the options `-storePositions`, `-storeDocvectors`, `-storeRaw` as appropriate.
 For reference:
 
-+ Without any of the three above option, index size reduces to 9.4 GB (indexed in ~18min).
++ Without any of the three above option, index size reduces to 9.4 GB.
 + With just `-storeRaw`, index size reduces to 73 GB. This setting contains the raw JSON document, which makes it suitable for use as first-stage retrieval to support downstream rerankers. Bloat compared to compressed size of raw collection is due to support for per-document random access; evidently, the JSON docs don't compress well.
 
 Each "document" in the index comprises the url, title, headings, and body fields concatenated together.

--- a/docs/experiments-msmarco-v2.md
+++ b/docs/experiments-msmarco-v2.md
@@ -31,7 +31,7 @@ The index size as well as index time can be reduced by removing the options `-st
 For reference:
 
 + Without any of the three above option, index size reduces to 12 GB (indexed in ~13min).
-+ With just `-storeRaw`, index size reduces to 47 GB (indexed in ~17min). This setting contains the raw JSON document, which makes it suitable for use as first-stage retrieval to support downstream rerankers. Bloat compared to compressed size of raw collection is due to support for per-document random access.
++ With just `-storeRaw`, index size reduces to 47 GB. This setting contains the raw JSON document, which makes it suitable for use as first-stage retrieval to support downstream rerankers. Bloat compared to compressed size of raw collection is due to support for per-document random access.
 
 Download the queries and qrels:
 

--- a/docs/experiments-msmarco-v2.md
+++ b/docs/experiments-msmarco-v2.md
@@ -30,7 +30,7 @@ It's big because it includes postions (for phrase queries), document vectors (fo
 The index size as well as index time can be reduced by removing the options `-storePositions`, `-storeDocvectors`, `-storeRaw` as appropriate.
 For reference:
 
-+ Without any of the three above option, index size reduces to 12 GB (indexed in ~13min).
++ Without any of the three above option, index size reduces to 12 GB.
 + With just `-storeRaw`, index size reduces to 47 GB. This setting contains the raw JSON document, which makes it suitable for use as first-stage retrieval to support downstream rerankers. Bloat compared to compressed size of raw collection is due to support for per-document random access.
 
 Download the queries and qrels:

--- a/docs/experiments-msmarco-v2.md
+++ b/docs/experiments-msmarco-v2.md
@@ -91,7 +91,7 @@ There are a total of 138,364,198 passages in the collection (exactly the same as
 In each "document" in the index comprises the url, title, headings, and passage fields concatenated together.
 With the above indexing configuration, the index size comes to 162 GB (indexed in ~40min).
 However, the index size can be reduced by playing with the indexing options discussed above.
-For example, with just the `-storeRaw` option, which supports bag-of-words first-stage retrieval with stored raw documents that can be fetched and passed to a downstream reranker, the index size comes out to 95 GB (~28 min index time).
+For example, with just the `-storeRaw` option, which supports bag-of-words first-stage retrieval with stored raw documents that can be fetched and passed to a downstream reranker, the index size comes out to 95 GB.
 
 Perform runs on the dev queries (both sets):
 


### PR DESCRIPTION
* added `azcopy` usage (feel free to delete it if it is unnecessary)
* `trec_eval` results reproduced. 
* added index time for each case
* **document (segmented) index size has a little discrepancy**, corrected it.

(all the numbers are extracted from the logs by running a script below, the script is just copy and pastes from experiments-msmarco-v2.md)

```sh
# Experiments are conducted on orca: /home/w32zhong/anserini
# corpus and index directories:
# /store/scratch/w32zhong/indexes
# /store/scratch/w32zhong/collections/
(cd indexes && rm -rf msmarco-*)
(cd runs && rm -rf run.msmarco-*)

## Passage Collection
du -h   collections/msmarco_v2_passage.tar
md5sum  collections/msmarco_v2_passage.tar

sh target/appassembler/bin/IndexCollection -collection MsMarcoPassageV2Collection \
 -generator DefaultLuceneDocumentGenerator -threads 18 \
 -input collections/msmarco_v2_passage \
 -index indexes/msmarco-passage-v2 \
 -storePositions -storeDocvectors -storeRaw

sh target/appassembler/bin/IndexCollection -collection MsMarcoPassageV2Collection \
 -generator DefaultLuceneDocumentGenerator -threads 18 \
 -input collections/msmarco_v2_passage \
 -index indexes/msmarco-passage-v2-small

sh target/appassembler/bin/IndexCollection -collection MsMarcoPassageV2Collection \
 -generator DefaultLuceneDocumentGenerator -threads 18 \
 -input collections/msmarco_v2_passage \
 -index indexes/msmarco-passage-v2-just-json \
 -storeRaw

target/appassembler/bin/SearchCollection -index indexes/msmarco-passage-v2 \
 -topicreader TsvInt -topics collections/passv2_dev_queries.tsv \
 -output runs/run.msmarco-passage-v2.dev1.txt -bm25 -hits 100

target/appassembler/bin/SearchCollection -index indexes/msmarco-passage-v2 \
 -topicreader TsvInt -topics collections/passv2_dev2_queries.tsv \
 -output runs/run.msmarco-passage-v2.dev2.txt -bm25 -hits 100

tools/eval/trec_eval.9.0.4/trec_eval -c -m map -m recall.100 -m recip_rank collections/passv2_dev_qrels.tsv runs/run.msmarco-passage-v2.dev1.txt

tools/eval/trec_eval.9.0.4/trec_eval -c -m map -m recall.100 -m recip_rank collections/passv2_dev2_qrels.tsv runs/run.msmarco-passage-v2.dev2.txt

## Passage Collection (Augmented)
du -h   collections/msmarco_v2_passage_augmented.tar
md5sum  collections/msmarco_v2_passage_augmented.tar

sh target/appassembler/bin/IndexCollection -collection MsMarcoPassageV2Collection \
 -generator DefaultLuceneDocumentGenerator -threads 70 \
 -input collections/msmarco_v2_passage_augmented \
 -index indexes/msmarco-passage-v2-augmented \
 -storePositions -storeDocvectors -storeRaw

sh target/appassembler/bin/IndexCollection -collection MsMarcoPassageV2Collection \
 -generator DefaultLuceneDocumentGenerator -threads 70 \
 -input collections/msmarco_v2_passage_augmented \
 -index indexes/msmarco-passage-v2-augmented-small

sh target/appassembler/bin/IndexCollection -collection MsMarcoPassageV2Collection \
 -generator DefaultLuceneDocumentGenerator -threads 70 \
 -input collections/msmarco_v2_passage_augmented \
 -index indexes/msmarco-passage-v2-augmented-just-json \
 -storeRaw

target/appassembler/bin/SearchCollection -index indexes/msmarco-passage-v2-augmented \
 -topicreader TsvInt -topics collections/passv2_dev_queries.tsv \
 -output runs/run.msmarco-passage-v2-augmented.dev1.txt -bm25 -hits 100

target/appassembler/bin/SearchCollection -index indexes/msmarco-passage-v2-augmented \
 -topicreader TsvInt -topics collections/passv2_dev2_queries.tsv \
 -output runs/run.msmarco-passage-v2-augmented.dev2.txt -bm25 -hits 100

tools/eval/trec_eval.9.0.4/trec_eval -c -m map -m recall.100 -m recip_rank collections/passv2_dev_qrels.tsv runs/run.msmarco-passage-v2-augmented.dev1.txt

tools/eval/trec_eval.9.0.4/trec_eval -c -m map -m recall.100 -m recip_rank collections/passv2_dev2_qrels.tsv runs/run.msmarco-passage-v2-augmented.dev2.txt

## Document Collection
du -h   collections/msmarco_v2_doc.tar
md5sum  collections/msmarco_v2_doc.tar

sh target/appassembler/bin/IndexCollection -collection MsMarcoDocV2Collection \
 -generator DefaultLuceneDocumentGenerator -threads 18 \
 -input collections/msmarco_v2_doc \
 -index indexes/msmarco-doc-v2 \
 -storePositions -storeDocvectors -storeRaw

sh target/appassembler/bin/IndexCollection -collection MsMarcoDocV2Collection \
 -generator DefaultLuceneDocumentGenerator -threads 18 \
 -input collections/msmarco_v2_doc \
 -index indexes/msmarco-doc-v2-small

sh target/appassembler/bin/IndexCollection -collection MsMarcoDocV2Collection \
 -generator DefaultLuceneDocumentGenerator -threads 18 \
 -input collections/msmarco_v2_doc \
 -index indexes/msmarco-doc-v2-just-json \
 -storeRaw

target/appassembler/bin/SearchCollection -index indexes/msmarco-doc-v2 \
 -topicreader TsvInt -topics collections/docv2_dev_queries.tsv \
 -output runs/run.msmarco-doc-v2.dev1.txt -bm25 -hits 100

target/appassembler/bin/SearchCollection -index indexes/msmarco-doc-v2 \
 -topicreader TsvInt -topics collections/docv2_dev2_queries.tsv \
 -output runs/run.msmarco-doc-v2.dev2.txt -bm25 -hits 100

tools/eval/trec_eval.9.0.4/trec_eval -c -m map -m recall.100 -m recip_rank collections/docv2_dev_qrels.tsv runs/run.msmarco-doc-v2.dev1.txt

tools/eval/trec_eval.9.0.4/trec_eval -c -m map -m recall.100 -m recip_rank collections/docv2_dev2_qrels.tsv runs/run.msmarco-doc-v2.dev2.txt

## Document Collection (Segmented)
du -h   collections/msmarco_v2_doc_segmented.tar
md5sum  collections/msmarco_v2_doc_segmented.tar

sh target/appassembler/bin/IndexCollection -collection MsMarcoDocV2Collection \
 -generator DefaultLuceneDocumentGenerator -threads 10 \
 -input collections/msmarco_v2_doc_segmented \
 -index indexes/msmarco-doc-v2-segmented \
 -storePositions -storeDocvectors -storeRaw

sh target/appassembler/bin/IndexCollection -collection MsMarcoDocV2Collection \
 -generator DefaultLuceneDocumentGenerator -threads 10 \
 -input collections/msmarco_v2_doc_segmented \
 -index indexes/msmarco-doc-v2-segmented-just-json \
 -storeRaw

target/appassembler/bin/SearchCollection -index indexes/msmarco-doc-v2-segmented \
  -topicreader TsvInt -topics collections/docv2_dev_queries.tsv -output runs/run.msmarco-doc-v2-segmented.dev1.txt \
  -bm25 -hits 1000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100

target/appassembler/bin/SearchCollection -index indexes/msmarco-doc-v2-segmented \
  -topicreader TsvInt -topics collections/docv2_dev2_queries.tsv -output runs/run.msmarco-doc-v2-segmented.dev2.txt \
  -bm25 -hits 1000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100

tools/eval/trec_eval.9.0.4/trec_eval -c -m map -m recall.100 -m recip_rank collections/docv2_dev_qrels.tsv runs/run.msmarco-doc-v2-segmented.dev1.txt

tools/eval/trec_eval.9.0.4/trec_eval -c -m map -m recall.100 -m recip_rank collections/docv2_dev2_qrels.tsv runs/run.msmarco-doc-v2-segmented.dev2.txt

```

Logs: https://drive.google.com/file/d/1uvRs1J8V980euvjiVxNUD-_uo-OB8rUj/view?usp=sharing