### PR TITLE
Fix bug in run_regression re: scoping of variables

### DIFF
--- a/src/main/python/run_regression.py
+++ b/src/main/python/run_regression.py
@@ -174,8 +174,7 @@ def evaluate_and_verify(yaml_data, dry_run):
 
 def run_search(cmd):
     logger.info(' '.join(cmd))
-    if not args.dry_run:
-        call(' '.join(cmd), shell=True)
+    call(' '.join(cmd), shell=True)
 
 
 if __name__ == '__main__':
@@ -225,7 +224,11 @@ if __name__ == '__main__':
     if args.search:
         logger.info('='*10 + ' Ranking ' + '='*10)
         search_cmds = construct_search_commands(yaml_data)
-        p = Pool(args.search_pool)
-        p.map(run_search, search_cmds)
+        if args.dry_run:
+            for cmd in search_cmds:
+                logger.info(' '.join(cmd))
+        else:
+            p = Pool(args.search_pool)
+            p.map(run_search, search_cmds)
 
         evaluate_and_verify(yaml_data, args.dry_run)


### PR DESCRIPTION
Interesting bug. `args.dry_run` is not in scope within the function `run_search`, but on Python 3.6 this works... whereas _not_ on Python 3.8.