### PR TITLE
Add new MS MARCO (V1) passage docTTTTTquery expansion

### DIFF
--- a/src/main/resources/regression/msmarco-passage-docTTTTTquery.yaml
+++ b/src/main/resources/regression/msmarco-passage-docTTTTTquery.yaml
@@ -1,11 +1,11 @@
 ---
 corpus: msmarco-passage-docTTTTTquery
-corpus_path: collections/msmarco/passage-docTTTTTquery/
+corpus_path: collections/msmarco/msmarco-passage-docTTTTTquery/
 
 index_path: indexes/lucene-index.msmarco-passage-docTTTTTquery/
 collection_class: JsonCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 9
+index_threads: 18
 index_options: -storePositions -storeDocvectors -storeRaw
 index_stats:
   documents: 8841823


### PR DESCRIPTION
Closes #1730 - since the only changes to the corpus involve whitespace, the results are exactly the same.

I only had to update the corpus path.