### PR TITLE
Add regressions for uniCOIL for MS MARCO V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For the most part, these runs are based on [_default_ parameter settings](https:
   + Document ranking, sparse learned models: [uniCOIL with doc2query-T5](docs/regressions-dl19-doc-segmented-unicoil.md)
 + Regressions for TREC 2020 Deep Learning Track:
   + Passage ranking: [baselines](docs/regressions-dl20-passage.md), [doc2query-T5](docs/regressions-dl20-passage-docTTTTTquery.md)
-  + Passage ranking, sparse learned models: [uniCOIL with doc2query-T5](docs/regressions-dl19-passage-unicoil.md)
+  + Passage ranking, sparse learned models: [uniCOIL with doc2query-T5](docs/regressions-dl20-passage-unicoil.md)
   + Document ranking, complete doc[*](docs/experiments-msmarco-doc-doc2query-details.md): [baselines](docs/regressions-dl20-doc.md), [doc2query-T5](docs/regressions-dl20-doc-docTTTTTquery.md)
   + Document ranking, segmented doc[*](docs/experiments-msmarco-doc-doc2query-details.md): [baselines](docs/regressions-dl20-doc-segmented.md), [doc2query-T5](docs/regressions-dl20-doc-segmented-docTTTTTquery.md)
   + Document ranking, sparse learned models: [uniCOIL with doc2query-T5](docs/regressions-dl20-doc-segmented-unicoil.md)

--- a/README.md
+++ b/README.md
@@ -56,14 +56,19 @@ For the most part, these runs are based on [_default_ parameter settings](https:
 + Regressions for MS MARCO (V1) Document Ranking:
   + Complete doc[*](docs/experiments-msmarco-doc-doc2query-details.md): [baselines](docs/regressions-msmarco-doc.md), [doc2query-T5](docs/regressions-msmarco-doc-docTTTTTquery.md)
   + Segmented doc[*](docs/experiments-msmarco-doc-doc2query-details.md): [baselines](docs/regressions-msmarco-doc-segmented.md), [doc2query-T5](docs/regressions-msmarco-doc-segmented-docTTTTTquery.md)
+  + Sparse learned models: [uniCOIL with doc2query-T5](docs/regressions-msmarco-doc-segmented-unicoil.md)
 + Regressions for TREC 2019 Deep Learning Track:
   + Passage ranking: [baselines](docs/regressions-dl19-passage.md), [doc2query-T5](docs/regressions-dl19-passage-docTTTTTquery.md)
+  + Passage ranking, sparse learned models: [uniCOIL with doc2query-T5](docs/regressions-dl19-passage-unicoil.md)
   + Document ranking, complete doc[*](docs/experiments-msmarco-doc-doc2query-details.md): [baselines](docs/regressions-dl19-doc.md), [doc2query-T5](docs/regressions-dl19-doc-docTTTTTquery.md)
   + Document ranking, segmented doc[*](docs/experiments-msmarco-doc-doc2query-details.md): [baselines](docs/regressions-dl19-doc-segmented.md), [doc2query-T5](docs/regressions-dl19-doc-segmented-docTTTTTquery.md)
+  + Document ranking, sparse learned models: [uniCOIL with doc2query-T5](docs/regressions-dl19-doc-segmented-unicoil.md)
 + Regressions for TREC 2020 Deep Learning Track:
   + Passage ranking: [baselines](docs/regressions-dl20-passage.md), [doc2query-T5](docs/regressions-dl20-passage-docTTTTTquery.md)
+  + Passage ranking, sparse learned models: [uniCOIL with doc2query-T5](docs/regressions-dl19-passage-unicoil.md)
   + Document ranking, complete doc[*](docs/experiments-msmarco-doc-doc2query-details.md): [baselines](docs/regressions-dl20-doc.md), [doc2query-T5](docs/regressions-dl20-doc-docTTTTTquery.md)
   + Document ranking, segmented doc[*](docs/experiments-msmarco-doc-doc2query-details.md): [baselines](docs/regressions-dl20-doc-segmented.md), [doc2query-T5](docs/regressions-dl20-doc-segmented-docTTTTTquery.md)
+  + Document ranking, sparse learned models: [uniCOIL with doc2query-T5](docs/regressions-dl20-doc-segmented-unicoil.md)
 + Regressions for MS MARCO (V2) Passage Ranking:
   + Bag-of-words models, original corpus: [baselines](docs/regressions-msmarco-v2-passage.md), [doc2query-T5](docs/regressions-msmarco-v2-passage-d2q-t5.md)
   + Bag-of-words models, augmented corpus: [baselines](docs/regressions-msmarco-v2-passage-augmented.md), [doc2query-T5](docs/regressions-msmarco-v2-passage-augmented-d2q-t5.md)

--- a/docs/regressions-dl19-doc-segmented-unicoil.md
+++ b/docs/regressions-dl19-doc-segmented-unicoil.md
@@ -1,0 +1,72 @@
+# Anserini: Regressions for [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html) Segmented w/ uniCOIL
+
+This page describes experiments, integrated into Anserini's regression testing framework, for the TREC 2019 Deep Learning Track (Document Ranking Task) on the MS MARCO document collection using relevance judgments from NIST.
+These runs use the uniCOIL model described in the following paper:
+
+> Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
+
+The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+However, the model is the same, applied to the MS MARCO _segmented_ document corpus (with doc2query-T5 expansions).
+Retrieval uses MaxP technique, where we select the score of the highest-scoring passage from a document as the score for that document to produce a document ranking.
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/dl19-doc-segmented-unicoil.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/dl19-doc-segmented-unicoil.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.
+
+## Indexing
+
+Typical indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/msmarco-doc-segmented-unicoil \
+  -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.msmarco-doc-segmented-unicoil &
+```
+
+The directory `/path/to/msmarco-doc-segmented-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+See [this page](experiments-msmarco-unicoil.md) for additional details.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the 43 topics for which NIST has provided judgments as part of the TREC 2019 Deep Learning Track.
+The original data can be found [here](https://trec.nist.gov/data/deep2019.html).
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.unicoil.0shot.tsv.gz -topicreader TsvInt \
+  -output runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl19-doc.unicoil.0shot.tsv.gz \
+  -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -c -m map -c -m recall.100 -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl19-doc.unicoil.0shot.tsv.gz
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+MAP                                     | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)| 0.3508    |
+
+
+R@100                                   | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)| 0.4099    |
+
+
+nDCG@10                                 | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)| 0.6396    |

--- a/docs/regressions-dl19-doc-segmented-unicoil.md
+++ b/docs/regressions-dl19-doc-segmented-unicoil.md
@@ -5,7 +5,7 @@ These runs use the uniCOIL model described in the following paper:
 
 > Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
 
-The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+The experiments on this page are not actually reported in the paper.
 However, the model is the same, applied to the MS MARCO _segmented_ document corpus (with doc2query-T5 expansions).
 Retrieval uses MaxP technique, where we select the score of the highest-scoring passage from a document as the score for that document to produce a document ranking.
 
@@ -27,7 +27,6 @@ target/appassembler/bin/IndexCollection \
 ```
 
 The directory `/path/to/msmarco-doc-segmented-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
-See [this page](experiments-msmarco-unicoil.md) for additional details.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/docs/regressions-dl19-passage-unicoil.md
+++ b/docs/regressions-dl19-passage-unicoil.md
@@ -1,0 +1,76 @@
+# Anserini: Regressions for [DL19 (Passage)](https://trec.nist.gov/data/deep2019.html) w/ uniCOIL
+
+This page describes document expansion experiments, integrated into Anserini's regression testing framework, for the TREC 2019 Deep Learning Track (Passage Ranking Task) on the MS MARCO passage collection using relevance judgments from NIST.
+These runs use the uniCOIL model described in the following paper:
+
+> Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
+
+The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+However, the model is the same.
+
+Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
+For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/dl19-passage-unicoil.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/dl19-passage-unicoil.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.
+
+## Indexing
+
+Typical indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/msmarco-passage-unicoil \
+  -index indexes/lucene-index.msmarco-passage-unicoil/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.msmarco-passage-unicoil &
+```
+
+The directory `/path/to/msmarco-passage-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+See [this page](experiments-msmarco-unicoil.md) for additional details.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the 43 topics for which NIST has provided judgments as part of the TREC 2019 Deep Learning Track.
+The original data can be found [here](https://trec.nist.gov/data/deep2019.html).
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.msmarco-passage-unicoil/ \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.unicoil.0shot.tsv.gz -topicreader TsvInt \
+  -output runs/run.msmarco-passage-unicoil.unicoil.topics.dl19-passage.unicoil.0shot.tsv.gz \
+  -impact -pretokenized &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 src/main/resources/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl19-passage.unicoil.0shot.tsv.gz
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 src/main/resources/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl19-passage.unicoil.0shot.tsv.gz
+tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c src/main/resources/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl19-passage.unicoil.0shot.tsv.gz
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+MAP                                     | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[DL19 (Passage)](https://trec.nist.gov/data/deep2019.html)| 0.4612    |
+
+
+R@1000                                  | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[DL19 (Passage)](https://trec.nist.gov/data/deep2019.html)| 0.8292    |
+
+
+nDCG@10                                 | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[DL19 (Passage)](https://trec.nist.gov/data/deep2019.html)| 0.7024    |

--- a/docs/regressions-dl19-passage-unicoil.md
+++ b/docs/regressions-dl19-passage-unicoil.md
@@ -5,7 +5,7 @@ These runs use the uniCOIL model described in the following paper:
 
 > Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
 
-The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+The experiments on this page are not actually reported in the paper.
 However, the model is the same.
 
 Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
@@ -29,7 +29,6 @@ target/appassembler/bin/IndexCollection \
 ```
 
 The directory `/path/to/msmarco-passage-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
-See [this page](experiments-msmarco-unicoil.md) for additional details.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/docs/regressions-dl20-doc-segmented-unicoil.md
+++ b/docs/regressions-dl20-doc-segmented-unicoil.md
@@ -1,0 +1,72 @@
+# Anserini: Regressions for [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html) Segmented w/ uniCOIL
+
+This page describes experiments, integrated into Anserini's regression testing framework, for the TREC 2020 Deep Learning Track (Document Ranking Task) on the MS MARCO document collection using relevance judgments from NIST.
+These runs use the uniCOIL model described in the following paper:
+
+> Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
+
+The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+However, the model is the same, applied to the MS MARCO _segmented_ document corpus (with doc2query-T5 expansions).
+Retrieval uses MaxP technique, where we select the score of the highest-scoring passage from a document as the score for that document to produce a document ranking.
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/dl20-doc-segmented-unicoil.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/dl20-doc-segmented-unicoil.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.
+
+## Indexing
+
+Typical indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/msmarco-doc-segmented-unicoil \
+  -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.msmarco-doc-segmented-unicoil &
+```
+
+The directory `/path/to/msmarco-doc-segmented-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+See [this page](experiments-msmarco-unicoil.md) for additional details.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the 45 topics for which NIST has provided judgments as part of the TREC 2020 Deep Learning Track.
+The original data can be found [here](https://trec.nist.gov/data/deep2020.html).
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.unicoil.0shot.tsv.gz -topicreader TsvInt \
+  -output runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl20.unicoil.0shot.tsv.gz \
+  -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -c -m map -c -m recall.100 -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl20.unicoil.0shot.tsv.gz
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+MAP                                     | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[DL20 (Doc)](https://trec.nist.gov/data/deep2019.html)| 0.4126    |
+
+
+R@100                                   | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[DL20 (Doc)](https://trec.nist.gov/data/deep2019.html)| 0.6210    |
+
+
+nDCG@10                                 | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[DL20 (Doc)](https://trec.nist.gov/data/deep2019.html)| 0.6033    |

--- a/docs/regressions-dl20-doc-segmented-unicoil.md
+++ b/docs/regressions-dl20-doc-segmented-unicoil.md
@@ -5,7 +5,7 @@ These runs use the uniCOIL model described in the following paper:
 
 > Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
 
-The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+The experiments on this page are not actually reported in the paper.
 However, the model is the same, applied to the MS MARCO _segmented_ document corpus (with doc2query-T5 expansions).
 Retrieval uses MaxP technique, where we select the score of the highest-scoring passage from a document as the score for that document to produce a document ranking.
 
@@ -27,7 +27,6 @@ target/appassembler/bin/IndexCollection \
 ```
 
 The directory `/path/to/msmarco-doc-segmented-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
-See [this page](experiments-msmarco-unicoil.md) for additional details.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/docs/regressions-dl20-passage-unicoil.md
+++ b/docs/regressions-dl20-passage-unicoil.md
@@ -1,0 +1,88 @@
+# Anserini: Regressions for [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html) w/ uniCOIL
+
+This page describes document expansion experiments, integrated into Anserini's regression testing framework, for the TREC 2020 Deep Learning Track (Passage Ranking Task) on the MS MARCO passage collection using relevance judgments from NIST.
+These runs use the uniCOIL model described in the following paper:
+
+> Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
+
+The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+However, the model is the same.
+
+Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
+For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/dl20-passage-unicoil.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/dl20-passage-unicoil.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.
+
+## Indexing
+
+Typical indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/msmarco-passage-unicoil \
+  -index indexes/lucene-index.msmarco-passage-unicoil/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.msmarco-passage-unicoil &
+```
+
+The directory `/path/to/msmarco-passage-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+See [this page](experiments-msmarco-unicoil.md) for additional details.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the 54 topics for which NIST has provided judgments as part of the TREC 2020 Deep Learning Track.
+The original data can be found [here](https://trec.nist.gov/data/deep2020.html).
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.msmarco-passage-unicoil/ \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.unicoil.0shot.tsv.gz -topicreader TsvInt \
+  -output runs/run.msmarco-passage-unicoil.unicoil.topics.dl20.unicoil.0shot.tsv.gz \
+  -impact -pretokenized &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -c -m map -l 2 src/main/resources/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl20.unicoil.0shot.tsv.gz
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl20.unicoil.0shot.tsv.gz
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recip_rank -l 2 src/main/resources/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl20.unicoil.0shot.tsv.gz
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 -l 2 src/main/resources/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl20.unicoil.0shot.tsv.gz
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 -l 2 src/main/resources/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl20.unicoil.0shot.tsv.gz
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+MAP                                     | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)| 0.4430    |
+
+
+nDCG@10                                 | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)| 0.6745    |
+
+
+MRR                                     | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)| 0.8235    |
+
+
+R@100                                   | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)| 0.7006    |
+
+
+R@1000                                  | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)| 0.8430    |

--- a/docs/regressions-dl20-passage-unicoil.md
+++ b/docs/regressions-dl20-passage-unicoil.md
@@ -5,7 +5,7 @@ These runs use the uniCOIL model described in the following paper:
 
 > Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
 
-The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+The experiments on this page are not actually reported in the paper.
 However, the model is the same.
 
 Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
@@ -29,7 +29,6 @@ target/appassembler/bin/IndexCollection \
 ```
 
 The directory `/path/to/msmarco-passage-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
-See [this page](experiments-msmarco-unicoil.md) for additional details.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/docs/regressions-msmarco-doc-segmented-unicoil.md
+++ b/docs/regressions-msmarco-doc-segmented-unicoil.md
@@ -1,0 +1,71 @@
+# Anserini: Regressions for uniCOIL on [MS MARCO Document](https://github.com/microsoft/MSMARCO-Document-Ranking)
+
+This page documents regression experiments for uniCOIL on the MS MARCO Document Ranking Task, which is integrated into Anserini's regression testing framework.
+The uniCOIL model is described in the following paper:
+
+> Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
+
+The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+However, the model is the same, applied to the MS MARCO _segmented_ document corpus (with doc2query-T5 expansions).
+Retrieval uses MaxP technique, where we select the score of the highest-scoring passage from a document as the score for that document to produce a document ranking.
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/msmarco-doc-segmented-unicoil.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/msmarco-doc-segmented-unicoil.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.
+
+## Indexing
+
+Typical indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/msmarco-doc-segmented-unicoil \
+  -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.msmarco-doc-segmented-unicoil &
+```
+
+The directory `/path/to/msmarco-doc-segmented-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+See [this page](experiments-msmarco-unicoil.md) for additional details.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the 6980 dev set questions; see [this page](experiments-msmarco-passage.md) for more details.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.unicoil.tsv.gz -topicreader TsvInt \
+  -output runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.msmarco-doc.dev.unicoil.tsv.gz \
+  -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -c -m map -c -m recall.100 -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.msmarco-doc.dev.unicoil.tsv.gz
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+MAP                                     | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.3535    |
+
+
+R@100                                   | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.8858    |
+
+
+R@1000                                  | uniCOIL w/ doc2query-T5 expansion|
+:---------------------------------------|-----------|
+[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)| 0.9546    |

--- a/docs/regressions-msmarco-doc-segmented-unicoil.md
+++ b/docs/regressions-msmarco-doc-segmented-unicoil.md
@@ -5,9 +5,11 @@ The uniCOIL model is described in the following paper:
 
 > Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
 
-The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+The experiments on this page are not actually reported in the paper.
 However, the model is the same, applied to the MS MARCO _segmented_ document corpus (with doc2query-T5 expansions).
 Retrieval uses MaxP technique, where we select the score of the highest-scoring passage from a document as the score for that document to produce a document ranking.
+
+For more complete instructions on how to run end-to-end experiments, refer to [this page](experiments-msmarco-unicoil.md).
 
 The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/msmarco-doc-segmented-unicoil.yaml).
 Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/msmarco-doc-segmented-unicoil.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.
@@ -27,7 +29,6 @@ target/appassembler/bin/IndexCollection \
 ```
 
 The directory `/path/to/msmarco-doc-segmented-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
-See [this page](experiments-msmarco-unicoil.md) for additional details.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/docs/regressions-msmarco-passage-unicoil.md
+++ b/docs/regressions-msmarco-passage-unicoil.md
@@ -25,7 +25,6 @@ target/appassembler/bin/IndexCollection \
 ```
 
 The directory `/path/to/msmarco-passage-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
-See [this page](experiments-msmarco-unicoil.md) for additional details.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/docs/regressions.md
+++ b/docs/regressions.md
@@ -67,17 +67,23 @@ nohup python src/main/python/run_regression.py --index --verify --search --regre
 
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-passage >& logs/log.dl19-passage &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-docTTTTTquery >& logs/log.dl19-passage-docTTTTTquery &
+nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-unicoil >& logs/log.dl19-passage-unicoil &
+
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-doc >& logs/log.dl19-doc &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-doc-docTTTTTquery >& logs/log.dl19-doc-docTTTTTquery &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-doc-segmented >& logs/log.dl19-doc-segmented &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-doc-segmented-docTTTTTquery >& logs/log.dl19-doc-segmented-docTTTTTquery &
+nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-doc-segmented-unicoil >& logs/log.dl19-doc-segmented-unicoil &
 
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-passage >& logs/log.dl20-passage &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-docTTTTTquery >& logs/log.dl20-passage-docTTTTTquery &
+nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-unicoil >& logs/log.dl20-passage-unicoil &
+
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-doc >& logs/log.dl20-doc &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-doc-docTTTTTquery >& logs/log.dl20-doc-docTTTTTquery &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-doc-segmented >& logs/log.dl20-doc-segmented &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-doc-segmented-docTTTTTquery >& logs/log.dl20-doc-segmented-docTTTTTquery &
+nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-doc-segmented-unicoil >& logs/log.dl20-doc-segmented-unicoil &
 
 nohup python src/main/python/run_regression.py --index --verify --search --regression msmarco-v2-passage >& logs/log.msmarco-v2-passage &
 nohup python src/main/python/run_regression.py --index --verify --search --regression msmarco-v2-passage-d2q-t5 >& logs/log.msmarco-v2-passage-d2q-t5 &

--- a/docs/regressions.md
+++ b/docs/regressions.md
@@ -63,6 +63,7 @@ nohup python src/main/python/run_regression.py --index --verify --search --regre
 nohup python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc-docTTTTTquery >& logs/log.msmarco-doc-docTTTTTquery &
 nohup python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc-segmented >& logs/log.msmarco-doc-segmented &
 nohup python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc-segmented-docTTTTTquery >& logs/log.msmarco-doc-segmented-docTTTTTquery &
+nohup python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc-segmented-unicoil >& logs/log.msmarco-doc-segmented-unicoil &
 
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-passage >& logs/log.dl19-passage &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-docTTTTTquery >& logs/log.dl19-passage-docTTTTTquery &

--- a/src/main/resources/docgen/templates/dl19-doc-segmented-unicoil.template
+++ b/src/main/resources/docgen/templates/dl19-doc-segmented-unicoil.template
@@ -5,7 +5,7 @@ These runs use the uniCOIL model described in the following paper:
 
 > Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
 
-The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+The experiments on this page are not actually reported in the paper.
 However, the model is the same, applied to the MS MARCO _segmented_ document corpus (with doc2query-T5 expansions).
 Retrieval uses MaxP technique, where we select the score of the highest-scoring passage from a document as the score for that document to produce a document ranking.
 
@@ -21,7 +21,6 @@ ${index_cmds}
 ```
 
 The directory `/path/to/msmarco-doc-segmented-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
-See [this page](experiments-msmarco-unicoil.md) for additional details.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/docgen/templates/dl19-doc-segmented-unicoil.template
+++ b/src/main/resources/docgen/templates/dl19-doc-segmented-unicoil.template
@@ -1,0 +1,50 @@
+# Anserini: Regressions for [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html) Segmented w/ uniCOIL
+
+This page describes experiments, integrated into Anserini's regression testing framework, for the TREC 2019 Deep Learning Track (Document Ranking Task) on the MS MARCO document collection using relevance judgments from NIST.
+These runs use the uniCOIL model described in the following paper:
+
+> Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
+
+The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+However, the model is the same, applied to the MS MARCO _segmented_ document corpus (with doc2query-T5 expansions).
+Retrieval uses MaxP technique, where we select the score of the highest-scoring passage from a document as the score for that document to produce a document ranking.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.
+
+## Indexing
+
+Typical indexing command:
+
+```
+${index_cmds}
+```
+
+The directory `/path/to/msmarco-doc-segmented-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+See [this page](experiments-msmarco-unicoil.md) for additional details.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the 43 topics for which NIST has provided judgments as part of the TREC 2019 Deep Learning Track.
+The original data can be found [here](https://trec.nist.gov/data/deep2019.html).
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/dl19-passage-unicoil.template
+++ b/src/main/resources/docgen/templates/dl19-passage-unicoil.template
@@ -5,7 +5,7 @@ These runs use the uniCOIL model described in the following paper:
 
 > Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
 
-The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+The experiments on this page are not actually reported in the paper.
 However, the model is the same.
 
 Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
@@ -23,7 +23,6 @@ ${index_cmds}
 ```
 
 The directory `/path/to/msmarco-passage-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
-See [this page](experiments-msmarco-unicoil.md) for additional details.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/docgen/templates/dl19-passage-unicoil.template
+++ b/src/main/resources/docgen/templates/dl19-passage-unicoil.template
@@ -1,0 +1,52 @@
+# Anserini: Regressions for [DL19 (Passage)](https://trec.nist.gov/data/deep2019.html) w/ uniCOIL
+
+This page describes document expansion experiments, integrated into Anserini's regression testing framework, for the TREC 2019 Deep Learning Track (Passage Ranking Task) on the MS MARCO passage collection using relevance judgments from NIST.
+These runs use the uniCOIL model described in the following paper:
+
+> Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
+
+The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+However, the model is the same.
+
+Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
+For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.
+
+## Indexing
+
+Typical indexing command:
+
+```
+${index_cmds}
+```
+
+The directory `/path/to/msmarco-passage-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+See [this page](experiments-msmarco-unicoil.md) for additional details.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the 43 topics for which NIST has provided judgments as part of the TREC 2019 Deep Learning Track.
+The original data can be found [here](https://trec.nist.gov/data/deep2019.html).
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/dl20-doc-segmented-unicoil.template
+++ b/src/main/resources/docgen/templates/dl20-doc-segmented-unicoil.template
@@ -5,7 +5,7 @@ These runs use the uniCOIL model described in the following paper:
 
 > Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
 
-The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+The experiments on this page are not actually reported in the paper.
 However, the model is the same, applied to the MS MARCO _segmented_ document corpus (with doc2query-T5 expansions).
 Retrieval uses MaxP technique, where we select the score of the highest-scoring passage from a document as the score for that document to produce a document ranking.
 
@@ -21,7 +21,6 @@ ${index_cmds}
 ```
 
 The directory `/path/to/msmarco-doc-segmented-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
-See [this page](experiments-msmarco-unicoil.md) for additional details.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/docgen/templates/dl20-doc-segmented-unicoil.template
+++ b/src/main/resources/docgen/templates/dl20-doc-segmented-unicoil.template
@@ -1,0 +1,50 @@
+# Anserini: Regressions for [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html) Segmented w/ uniCOIL
+
+This page describes experiments, integrated into Anserini's regression testing framework, for the TREC 2020 Deep Learning Track (Document Ranking Task) on the MS MARCO document collection using relevance judgments from NIST.
+These runs use the uniCOIL model described in the following paper:
+
+> Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
+
+The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+However, the model is the same, applied to the MS MARCO _segmented_ document corpus (with doc2query-T5 expansions).
+Retrieval uses MaxP technique, where we select the score of the highest-scoring passage from a document as the score for that document to produce a document ranking.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.
+
+## Indexing
+
+Typical indexing command:
+
+```
+${index_cmds}
+```
+
+The directory `/path/to/msmarco-doc-segmented-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+See [this page](experiments-msmarco-unicoil.md) for additional details.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the 45 topics for which NIST has provided judgments as part of the TREC 2020 Deep Learning Track.
+The original data can be found [here](https://trec.nist.gov/data/deep2020.html).
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/dl20-passage-unicoil.template
+++ b/src/main/resources/docgen/templates/dl20-passage-unicoil.template
@@ -5,7 +5,7 @@ These runs use the uniCOIL model described in the following paper:
 
 > Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
 
-The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+The experiments on this page are not actually reported in the paper.
 However, the model is the same.
 
 Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
@@ -23,7 +23,6 @@ ${index_cmds}
 ```
 
 The directory `/path/to/msmarco-passage-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
-See [this page](experiments-msmarco-unicoil.md) for additional details.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/docgen/templates/dl20-passage-unicoil.template
+++ b/src/main/resources/docgen/templates/dl20-passage-unicoil.template
@@ -1,0 +1,52 @@
+# Anserini: Regressions for [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html) w/ uniCOIL
+
+This page describes document expansion experiments, integrated into Anserini's regression testing framework, for the TREC 2020 Deep Learning Track (Passage Ranking Task) on the MS MARCO passage collection using relevance judgments from NIST.
+These runs use the uniCOIL model described in the following paper:
+
+> Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
+
+The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+However, the model is the same.
+
+Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
+For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.
+
+## Indexing
+
+Typical indexing command:
+
+```
+${index_cmds}
+```
+
+The directory `/path/to/msmarco-passage-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+See [this page](experiments-msmarco-unicoil.md) for additional details.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the 54 topics for which NIST has provided judgments as part of the TREC 2020 Deep Learning Track.
+The original data can be found [here](https://trec.nist.gov/data/deep2020.html).
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/msmarco-doc-segmented-unicoil.template
+++ b/src/main/resources/docgen/templates/msmarco-doc-segmented-unicoil.template
@@ -5,9 +5,11 @@ The uniCOIL model is described in the following paper:
 
 > Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
 
-The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+The experiments on this page are not actually reported in the paper.
 However, the model is the same, applied to the MS MARCO _segmented_ document corpus (with doc2query-T5 expansions).
 Retrieval uses MaxP technique, where we select the score of the highest-scoring passage from a document as the score for that document to produce a document ranking.
+
+For more complete instructions on how to run end-to-end experiments, refer to [this page](experiments-msmarco-unicoil.md).
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
 Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.
@@ -21,7 +23,6 @@ ${index_cmds}
 ```
 
 The directory `/path/to/msmarco-doc-segmented-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
-See [this page](experiments-msmarco-unicoil.md) for additional details.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/docgen/templates/msmarco-doc-segmented-unicoil.template
+++ b/src/main/resources/docgen/templates/msmarco-doc-segmented-unicoil.template
@@ -1,0 +1,49 @@
+# Anserini: Regressions for uniCOIL on [MS MARCO Document](https://github.com/microsoft/MSMARCO-Document-Ranking)
+
+This page documents regression experiments for uniCOIL on the MS MARCO Document Ranking Task, which is integrated into Anserini's regression testing framework.
+The uniCOIL model is described in the following paper:
+
+> Jimmy Lin and Xueguang Ma. [A Few Brief Notes on DeepImpact, COIL, and a Conceptual Framework for Information Retrieval Techniques.](https://arxiv.org/abs/2106.14807) _arXiv:2106.14807_.
+
+The paper does not actually report on the experiments here; these were created after the paper was posted on arXiv.
+However, the model is the same, applied to the MS MARCO _segmented_ document corpus (with doc2query-T5 expansions).
+Retrieval uses MaxP technique, where we select the score of the highest-scoring passage from a document as the score for that document to produce a document ranking.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.
+
+## Indexing
+
+Typical indexing command:
+
+```
+${index_cmds}
+```
+
+The directory `/path/to/msmarco-doc-segmented-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+See [this page](experiments-msmarco-unicoil.md) for additional details.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the 6980 dev set questions; see [this page](experiments-msmarco-passage.md) for more details.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/msmarco-passage-unicoil.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-unicoil.template
@@ -19,7 +19,6 @@ ${index_cmds}
 ```
 
 The directory `/path/to/msmarco-passage-unicoil/` should be a directory containing the compressed `jsonl` files that comprise the corpus.
-See [this page](experiments-msmarco-unicoil.md) for additional details.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/regression/dl19-doc-segmented-unicoil.yaml
+++ b/src/main/resources/regression/dl19-doc-segmented-unicoil.yaml
@@ -1,16 +1,16 @@
 ---
-corpus: msmarco-passage-unicoil
-corpus_path: collections/msmarco/msmarco-passage-unicoil/
+corpus: msmarco-doc-segmented-unicoil
+corpus_path: collections/msmarco/msmarco-doc-segmented-unicoil/
 
-index_path: indexes/lucene-index.msmarco-passage-unicoil/
+index_path: indexes/lucene-index.msmarco-doc-segmented-unicoil/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 16
 index_options: -impact -pretokenized
 index_stats:
-  documents: 8841823
-  documents (non-empty): 8841823
-  total terms: 44495093768
+  documents: 20545677
+  documents (non-empty): 20545677
+  total terms: 214505277898
 
 metrics:
   - metric: MAP
@@ -20,16 +20,16 @@ metrics:
     parse_index: 2
     metric_precision: 4
     can_combine: true
-  - metric: MRR
+  - metric: R@100
     command: tools/eval/trec_eval.9.0.4/trec_eval
-    params: -c -m recip_rank
+    params: -c -m recall.100
     separator: "\t"
     parse_index: 2
     metric_precision: 4
     can_combine: true
-  - metric: R@1000
+  - metric: nDCG@10
     command: tools/eval/trec_eval.9.0.4/trec_eval
-    params: -c -m recall.1000
+    params: -c -m ndcg_cut.10
     separator: "\t"
     parse_index: 2
     metric_precision: 4
@@ -39,20 +39,19 @@ topic_reader: TsvInt
 topic_root: src/main/resources/topics-and-qrels/
 qrels_root: src/main/resources/topics-and-qrels/
 topics:
-  - name: "[MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)"
-    id: dev
-    path: topics.msmarco-passage.dev-subset.unicoil.tsv.gz
-    qrel: qrels.msmarco-passage.dev-subset.txt
+  - name: "[DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)"
+    id: dl19
+    path: topics.dl19-doc.unicoil.0shot.tsv.gz
+    qrel: qrels.dl19-doc.txt
 
 models:
   - name: unicoil
     display: uniCOIL w/ doc2query-T5 expansion
-    params: -impact -pretokenized
+    params: -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:
       MAP:
-        - 0.3574
-      MRR:
-        - 0.3625
-      R@1000:
-        - 0.9582
-
+        - 0.3508
+      nDCG@10:
+        - 0.6396
+      R@100:
+        - 0.4099

--- a/src/main/resources/regression/dl19-passage-unicoil.yaml
+++ b/src/main/resources/regression/dl19-passage-unicoil.yaml
@@ -1,0 +1,57 @@
+---
+corpus: msmarco-passage-unicoil
+corpus_path: collections/msmarco/msmarco-passage-unicoil/
+
+index_path: indexes/lucene-index.msmarco-passage-unicoil/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 16
+index_options: -impact -pretokenized
+index_stats:
+  documents: 8841823
+  documents (non-empty): 8841823
+  total terms: 44495093768
+
+metrics:
+  - metric: MAP
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m map -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m recall.1000 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@10
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m ndcg_cut.10 -c
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topic_root: src/main/resources/topics-and-qrels/
+qrels_root: src/main/resources/topics-and-qrels/
+topics:
+  - name: "[DL19 (Passage)](https://trec.nist.gov/data/deep2019.html)"
+    id: dl19
+    path: topics.dl19-passage.unicoil.0shot.tsv.gz
+    qrel: qrels.dl19-passage.txt
+
+models:
+  - name: unicoil
+    display: uniCOIL w/ doc2query-T5 expansion
+    params: -impact -pretokenized
+    results:
+      MAP:
+        - 0.4612
+      nDCG@10:
+        - 0.7024
+      R@1000:
+        - 0.8292

--- a/src/main/resources/regression/dl20-doc-segmented-unicoil.yaml
+++ b/src/main/resources/regression/dl20-doc-segmented-unicoil.yaml
@@ -1,16 +1,16 @@
 ---
-corpus: msmarco-passage-unicoil
-corpus_path: collections/msmarco/msmarco-passage-unicoil/
+corpus: msmarco-doc-segmented-unicoil
+corpus_path: collections/msmarco/msmarco-doc-segmented-unicoil/
 
-index_path: indexes/lucene-index.msmarco-passage-unicoil/
+index_path: indexes/lucene-index.msmarco-doc-segmented-unicoil/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 16
 index_options: -impact -pretokenized
 index_stats:
-  documents: 8841823
-  documents (non-empty): 8841823
-  total terms: 44495093768
+  documents: 20545677
+  documents (non-empty): 20545677
+  total terms: 214505277898
 
 metrics:
   - metric: MAP
@@ -20,16 +20,16 @@ metrics:
     parse_index: 2
     metric_precision: 4
     can_combine: true
-  - metric: MRR
+  - metric: R@100
     command: tools/eval/trec_eval.9.0.4/trec_eval
-    params: -c -m recip_rank
+    params: -c -m recall.100
     separator: "\t"
     parse_index: 2
     metric_precision: 4
     can_combine: true
-  - metric: R@1000
+  - metric: nDCG@10
     command: tools/eval/trec_eval.9.0.4/trec_eval
-    params: -c -m recall.1000
+    params: -c -m ndcg_cut.10
     separator: "\t"
     parse_index: 2
     metric_precision: 4
@@ -39,20 +39,19 @@ topic_reader: TsvInt
 topic_root: src/main/resources/topics-and-qrels/
 qrels_root: src/main/resources/topics-and-qrels/
 topics:
-  - name: "[MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)"
-    id: dev
-    path: topics.msmarco-passage.dev-subset.unicoil.tsv.gz
-    qrel: qrels.msmarco-passage.dev-subset.txt
+  - name: "[DL20 (Doc)](https://trec.nist.gov/data/deep2019.html)"
+    id: dl20
+    path: topics.dl20.unicoil.0shot.tsv.gz
+    qrel: qrels.dl20-doc.txt
 
 models:
   - name: unicoil
     display: uniCOIL w/ doc2query-T5 expansion
-    params: -impact -pretokenized
+    params: -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:
       MAP:
-        - 0.3574
-      MRR:
-        - 0.3625
-      R@1000:
-        - 0.9582
-
+        - 0.4126
+      nDCG@10:
+        - 0.6033
+      R@100:
+        - 0.6210

--- a/src/main/resources/regression/dl20-passage-unicoil.yaml
+++ b/src/main/resources/regression/dl20-passage-unicoil.yaml
@@ -1,0 +1,75 @@
+---
+corpus: msmarco-passage-unicoil
+corpus_path: collections/msmarco/msmarco-passage-unicoil/
+
+index_path: indexes/lucene-index.msmarco-passage-unicoil/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 16
+index_options: -impact -pretokenized
+index_stats:
+  documents: 8841823
+  documents (non-empty): 8841823
+  total terms: 44495093768
+
+metrics:
+  - metric: MAP
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -c -m map -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@10
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: MRR
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -c -m recip_rank -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -c -m recall.100 -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -c -m recall.1000 -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topic_root: src/main/resources/topics-and-qrels/
+qrels_root: src/main/resources/topics-and-qrels/
+topics:
+  - name: "[DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)"
+    id: dl20
+    path: topics.dl20.unicoil.0shot.tsv.gz
+    qrel: qrels.dl20-passage.txt
+
+models:
+  - name: unicoil
+    display: uniCOIL w/ doc2query-T5 expansion
+    params: -impact -pretokenized
+    results:
+      MAP:
+        - 0.4430
+      nDCG@10:
+        - 0.6745
+      MRR:
+        - 0.8235
+      R@100:
+        - 0.7006
+      R@1000:
+        - 0.8430

--- a/src/main/resources/regression/msmarco-doc-segmented-unicoil.yaml
+++ b/src/main/resources/regression/msmarco-doc-segmented-unicoil.yaml
@@ -1,16 +1,16 @@
 ---
-corpus: msmarco-passage-unicoil
-corpus_path: collections/msmarco/msmarco-passage-unicoil/
+corpus: msmarco-doc-segmented-unicoil
+corpus_path: collections/msmarco/msmarco-doc-segmented-unicoil/
 
-index_path: indexes/lucene-index.msmarco-passage-unicoil/
+index_path: indexes/lucene-index.msmarco-doc-segmented-unicoil/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 16
 index_options: -impact -pretokenized
 index_stats:
-  documents: 8841823
-  documents (non-empty): 8841823
-  total terms: 44495093768
+  documents: 20545677
+  documents (non-empty): 20545677
+  total terms: 214505277898
 
 metrics:
   - metric: MAP
@@ -20,9 +20,9 @@ metrics:
     parse_index: 2
     metric_precision: 4
     can_combine: true
-  - metric: MRR
+  - metric: R@100
     command: tools/eval/trec_eval.9.0.4/trec_eval
-    params: -c -m recip_rank
+    params: -c -m recall.100
     separator: "\t"
     parse_index: 2
     metric_precision: 4
@@ -39,20 +39,20 @@ topic_reader: TsvInt
 topic_root: src/main/resources/topics-and-qrels/
 qrels_root: src/main/resources/topics-and-qrels/
 topics:
-  - name: "[MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)"
+  - name: "[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)"
     id: dev
-    path: topics.msmarco-passage.dev-subset.unicoil.tsv.gz
-    qrel: qrels.msmarco-passage.dev-subset.txt
+    path: topics.msmarco-doc.dev.unicoil.tsv.gz
+    qrel: qrels.msmarco-doc.dev.txt
 
 models:
   - name: unicoil
     display: uniCOIL w/ doc2query-T5 expansion
-    params: -impact -pretokenized
+    params: -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:
       MAP:
-        - 0.3574
-      MRR:
-        - 0.3625
+        - 0.3535
+      R@100:
+        - 0.8858
       R@1000:
-        - 0.9582
+        - 0.9546
 


### PR DESCRIPTION
+ Add missing regressions for uniCOIL passage on DL19, DL20
+ Add brand new regressions for uniCOIL segmented doc on dev, DL19, and DL20