### PR TITLE
Tweak docgen code that generates regression documentation

### DIFF
--- a/docs/regressions-backgroundlinking18.md
+++ b/docs/regressions-backgroundlinking18.md
@@ -35,19 +35,22 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wapo.v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt -topicreader BackgroundLinking \
+  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt \
+  -topicreader BackgroundLinking \
   -output runs/run.wapo.v2.bm25.topics.backgroundlinking18.txt \
   -backgroundlinking -backgroundlinking.k 100 -bm25 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wapo.v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt -topicreader BackgroundLinking \
+  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt \
+  -topicreader BackgroundLinking \
   -output runs/run.wapo.v2.bm25+rm3.topics.backgroundlinking18.txt \
   -backgroundlinking -backgroundlinking.k 100 -bm25 -rm3 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wapo.v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt -topicreader BackgroundLinking \
+  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt \
+  -topicreader BackgroundLinking \
   -output runs/run.wapo.v2.bm25+rm3+df.topics.backgroundlinking18.txt \
   -backgroundlinking -backgroundlinking.datefilter -backgroundlinking.k 100 -bm25 -rm3 -hits 100 &
 ```

--- a/docs/regressions-backgroundlinking19.md
+++ b/docs/regressions-backgroundlinking19.md
@@ -35,19 +35,22 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wapo.v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt -topicreader BackgroundLinking \
+  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt \
+  -topicreader BackgroundLinking \
   -output runs/run.wapo.v2.bm25.topics.backgroundlinking19.txt \
   -backgroundlinking -backgroundlinking.k 100 -bm25 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wapo.v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt -topicreader BackgroundLinking \
+  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt \
+  -topicreader BackgroundLinking \
   -output runs/run.wapo.v2.bm25+rm3.topics.backgroundlinking19.txt \
   -backgroundlinking -backgroundlinking.k 100 -bm25 -rm3 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wapo.v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt -topicreader BackgroundLinking \
+  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt \
+  -topicreader BackgroundLinking \
   -output runs/run.wapo.v2.bm25+rm3+df.topics.backgroundlinking19.txt \
   -backgroundlinking -backgroundlinking.datefilter -backgroundlinking.k 100 -bm25 -rm3 -hits 100 &
 ```

--- a/docs/regressions-backgroundlinking20.md
+++ b/docs/regressions-backgroundlinking20.md
@@ -35,19 +35,22 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wapo.v3/ \
-  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking20.txt -topicreader BackgroundLinking \
+  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking20.txt \
+  -topicreader BackgroundLinking \
   -output runs/run.wapo.v3.bm25.topics.backgroundlinking20.txt \
   -backgroundlinking -backgroundlinking.k 100 -bm25 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wapo.v3/ \
-  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking20.txt -topicreader BackgroundLinking \
+  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking20.txt \
+  -topicreader BackgroundLinking \
   -output runs/run.wapo.v3.bm25+rm3.topics.backgroundlinking20.txt \
   -backgroundlinking -backgroundlinking.k 100 -bm25 -rm3 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wapo.v3/ \
-  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking20.txt -topicreader BackgroundLinking \
+  -topics src/main/resources/topics-and-qrels/topics.backgroundlinking20.txt \
+  -topicreader BackgroundLinking \
   -output runs/run.wapo.v3.bm25+rm3+df.topics.backgroundlinking20.txt \
   -backgroundlinking -backgroundlinking.datefilter -backgroundlinking.k 100 -bm25 -rm3 -hits 100 &
 ```

--- a/docs/regressions-car17v1.5.md
+++ b/docs/regressions-car17v1.5.md
@@ -36,37 +36,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v1.5/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v1.5.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v1.5.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v1.5.bm25.topics.car17v1.5.benchmarkY1test.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v1.5/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v1.5.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v1.5.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v1.5.bm25+rm3.topics.car17v1.5.benchmarkY1test.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v1.5/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v1.5.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v1.5.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v1.5.bm25+ax.topics.car17v1.5.benchmarkY1test.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v1.5/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v1.5.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v1.5.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v1.5.ql.topics.car17v1.5.benchmarkY1test.txt \
   -qld &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v1.5/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v1.5.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v1.5.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v1.5.ql+rm3.topics.car17v1.5.benchmarkY1test.txt \
   -qld -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v1.5/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v1.5.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v1.5.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v1.5.ql+ax.topics.car17v1.5.benchmarkY1test.txt \
   -qld -axiom -axiom.deterministic -rerankCutoff 20 &
 ```

--- a/docs/regressions-car17v2.0-doc2query.md
+++ b/docs/regressions-car17v2.0-doc2query.md
@@ -42,37 +42,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v2.0-doc2query/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v2.0-doc2query.bm25.topics.car17v2.0.benchmarkY1test.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v2.0-doc2query/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v2.0-doc2query.bm25+rm3.topics.car17v2.0.benchmarkY1test.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v2.0-doc2query/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v2.0-doc2query.bm25+ax.topics.car17v2.0.benchmarkY1test.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v2.0-doc2query/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v2.0-doc2query.ql.topics.car17v2.0.benchmarkY1test.txt \
   -qld &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v2.0-doc2query/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v2.0-doc2query.ql+rm3.topics.car17v2.0.benchmarkY1test.txt \
   -qld -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v2.0-doc2query/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v2.0-doc2query.ql+ax.topics.car17v2.0.benchmarkY1test.txt \
   -qld -axiom -axiom.deterministic -rerankCutoff 20 &
 ```

--- a/docs/regressions-car17v2.0.md
+++ b/docs/regressions-car17v2.0.md
@@ -36,37 +36,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v2.0/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v2.0.bm25.topics.car17v2.0.benchmarkY1test.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v2.0/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v2.0.bm25+rm3.topics.car17v2.0.benchmarkY1test.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v2.0/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v2.0.bm25+ax.topics.car17v2.0.benchmarkY1test.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v2.0/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v2.0.ql.topics.car17v2.0.benchmarkY1test.txt \
   -qld &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v2.0/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v2.0.ql+rm3.topics.car17v2.0.benchmarkY1test.txt \
   -qld -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.car-paragraphCorpus.v2.0/ \
-  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt -topicreader Car \
+  -topics src/main/resources/topics-and-qrels/topics.car17v2.0.benchmarkY1test.txt \
+  -topicreader Car \
   -output runs/run.car-paragraphCorpus.v2.0.ql+ax.topics.car17v2.0.benchmarkY1test.txt \
   -qld -axiom -axiom.deterministic -rerankCutoff 20 &
 ```

--- a/docs/regressions-clef06-fr.md
+++ b/docs/regressions-clef06-fr.md
@@ -38,7 +38,8 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.clef06-fr/ \
-  -topics src/main/resources/topics-and-qrels/topics.clef06fr.mono.fr.txt -topicreader TsvString \
+  -topics src/main/resources/topics-and-qrels/topics.clef06fr.mono.fr.txt \
+  -topicreader TsvString \
   -output runs/run.clef06-fr.bm25.topics.clef06fr.mono.fr.txt \
   -bm25 -language fr &
 ```

--- a/docs/regressions-core17.md
+++ b/docs/regressions-core17.md
@@ -35,37 +35,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.nyt/ \
-  -topics src/main/resources/topics-and-qrels/topics.core17.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.core17.txt \
+  -topicreader Trec \
   -output runs/run.nyt.bm25.topics.core17.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.nyt/ \
-  -topics src/main/resources/topics-and-qrels/topics.core17.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.core17.txt \
+  -topicreader Trec \
   -output runs/run.nyt.bm25+rm3.topics.core17.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.nyt/ \
-  -topics src/main/resources/topics-and-qrels/topics.core17.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.core17.txt \
+  -topicreader Trec \
   -output runs/run.nyt.bm25+ax.topics.core17.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.nyt/ \
-  -topics src/main/resources/topics-and-qrels/topics.core17.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.core17.txt \
+  -topicreader Trec \
   -output runs/run.nyt.ql.topics.core17.txt \
   -qld &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.nyt/ \
-  -topics src/main/resources/topics-and-qrels/topics.core17.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.core17.txt \
+  -topicreader Trec \
   -output runs/run.nyt.ql+rm3.topics.core17.txt \
   -qld -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.nyt/ \
-  -topics src/main/resources/topics-and-qrels/topics.core17.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.core17.txt \
+  -topicreader Trec \
   -output runs/run.nyt.ql+ax.topics.core17.txt \
   -qld -axiom -axiom.deterministic -rerankCutoff 20 &
 ```

--- a/docs/regressions-core18.md
+++ b/docs/regressions-core18.md
@@ -35,37 +35,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wapo.v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.core18.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.core18.txt \
+  -topicreader Trec \
   -output runs/run.wapo.v2.bm25.topics.core18.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wapo.v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.core18.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.core18.txt \
+  -topicreader Trec \
   -output runs/run.wapo.v2.bm25+rm3.topics.core18.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wapo.v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.core18.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.core18.txt \
+  -topicreader Trec \
   -output runs/run.wapo.v2.bm25+ax.topics.core18.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wapo.v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.core18.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.core18.txt \
+  -topicreader Trec \
   -output runs/run.wapo.v2.ql.topics.core18.txt \
   -qld &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wapo.v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.core18.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.core18.txt \
+  -topicreader Trec \
   -output runs/run.wapo.v2.ql+rm3.topics.core18.txt \
   -qld -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wapo.v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.core18.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.core18.txt \
+  -topicreader Trec \
   -output runs/run.wapo.v2.ql+ax.topics.core18.txt \
   -qld -axiom -axiom.deterministic -rerankCutoff 20 &
 ```

--- a/docs/regressions-cw09b.md
+++ b/docs/regressions-cw09b.md
@@ -40,97 +40,115 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.bm25.topics.web.51-100.txt \
   -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.bm25.topics.web.101-150.txt \
   -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.bm25.topics.web.151-200.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.bm25+rm3.topics.web.51-100.txt \
   -bm25 -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.bm25+rm3.topics.web.101-150.txt \
   -bm25 -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.bm25+rm3.topics.web.151-200.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.bm25+ax.topics.web.51-100.txt \
   -bm25 -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.bm25+ax.topics.web.101-150.txt \
   -bm25 -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.bm25+ax.topics.web.151-200.txt \
   -bm25 -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.ql.topics.web.51-100.txt \
   -qld &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.ql.topics.web.101-150.txt \
   -qld &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.ql.topics.web.151-200.txt \
   -qld &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.ql+rm3.topics.web.51-100.txt \
   -qld -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.ql+rm3.topics.web.101-150.txt \
   -qld -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.ql+rm3.topics.web.151-200.txt \
   -qld -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.ql+ax.topics.web.51-100.txt \
   -qld -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.ql+ax.topics.web.101-150.txt \
   -qld -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt \
+  -topicreader Webxml \
   -output runs/run.cw09b.ql+ax.topics.web.151-200.txt \
   -qld -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
 ```

--- a/docs/regressions-cw12.md
+++ b/docs/regressions-cw12.md
@@ -36,45 +36,53 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt \
+  -topicreader Webxml \
   -output runs/run.cw12.bm25.topics.web.201-250.txt \
   -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt \
+  -topicreader Webxml \
   -output runs/run.cw12.bm25.topics.web.251-300.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt \
+  -topicreader Webxml \
   -output runs/run.cw12.bm25+rm3.topics.web.201-250.txt \
   -bm25 -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt \
+  -topicreader Webxml \
   -output runs/run.cw12.bm25+rm3.topics.web.251-300.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt \
+  -topicreader Webxml \
   -output runs/run.cw12.ql.topics.web.201-250.txt \
   -qld &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt \
+  -topicreader Webxml \
   -output runs/run.cw12.ql.topics.web.251-300.txt \
   -qld &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt \
+  -topicreader Webxml \
   -output runs/run.cw12.ql+rm3.topics.web.201-250.txt \
   -qld -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt \
+  -topicreader Webxml \
   -output runs/run.cw12.ql+rm3.topics.web.251-300.txt \
   -qld -rm3 &
 ```

--- a/docs/regressions-cw12b13.md
+++ b/docs/regressions-cw12b13.md
@@ -36,67 +36,79 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt \
+  -topicreader Webxml \
   -output runs/run.cw12b13.bm25.topics.web.201-250.txt \
   -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt \
+  -topicreader Webxml \
   -output runs/run.cw12b13.bm25.topics.web.251-300.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt \
+  -topicreader Webxml \
   -output runs/run.cw12b13.bm25+rm3.topics.web.201-250.txt \
   -bm25 -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt \
+  -topicreader Webxml \
   -output runs/run.cw12b13.bm25+rm3.topics.web.251-300.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt \
+  -topicreader Webxml \
   -output runs/run.cw12b13.bm25+ax.topics.web.201-250.txt \
   -bm25 -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt \
+  -topicreader Webxml \
   -output runs/run.cw12b13.bm25+ax.topics.web.251-300.txt \
   -bm25 -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt \
+  -topicreader Webxml \
   -output runs/run.cw12b13.ql.topics.web.201-250.txt \
   -qld &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt \
+  -topicreader Webxml \
   -output runs/run.cw12b13.ql.topics.web.251-300.txt \
   -qld &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt \
+  -topicreader Webxml \
   -output runs/run.cw12b13.ql+rm3.topics.web.201-250.txt \
   -qld -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt \
+  -topicreader Webxml \
   -output runs/run.cw12b13.ql+rm3.topics.web.251-300.txt \
   -qld -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt \
+  -topicreader Webxml \
   -output runs/run.cw12b13.ql+ax.topics.web.201-250.txt \
   -qld -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
-  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt -topicreader Webxml \
+  -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt \
+  -topicreader Webxml \
   -output runs/run.cw12b13.ql+ax.topics.web.251-300.txt \
   -qld -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
 ```

--- a/docs/regressions-disk12.md
+++ b/docs/regressions-disk12.md
@@ -38,97 +38,115 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.51-100.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.51-100.txt \
+  -topicreader Trec \
   -output runs/run.disk12.bm25.topics.adhoc.51-100.txt \
   -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.101-150.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.101-150.txt \
+  -topicreader Trec \
   -output runs/run.disk12.bm25.topics.adhoc.101-150.txt \
   -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.151-200.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.151-200.txt \
+  -topicreader Trec \
   -output runs/run.disk12.bm25.topics.adhoc.151-200.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.51-100.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.51-100.txt \
+  -topicreader Trec \
   -output runs/run.disk12.bm25+rm3.topics.adhoc.51-100.txt \
   -bm25 -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.101-150.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.101-150.txt \
+  -topicreader Trec \
   -output runs/run.disk12.bm25+rm3.topics.adhoc.101-150.txt \
   -bm25 -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.151-200.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.151-200.txt \
+  -topicreader Trec \
   -output runs/run.disk12.bm25+rm3.topics.adhoc.151-200.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.51-100.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.51-100.txt \
+  -topicreader Trec \
   -output runs/run.disk12.bm25+ax.topics.adhoc.51-100.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.101-150.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.101-150.txt \
+  -topicreader Trec \
   -output runs/run.disk12.bm25+ax.topics.adhoc.101-150.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.151-200.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.151-200.txt \
+  -topicreader Trec \
   -output runs/run.disk12.bm25+ax.topics.adhoc.151-200.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.51-100.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.51-100.txt \
+  -topicreader Trec \
   -output runs/run.disk12.ql.topics.adhoc.51-100.txt \
   -qld &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.101-150.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.101-150.txt \
+  -topicreader Trec \
   -output runs/run.disk12.ql.topics.adhoc.101-150.txt \
   -qld &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.151-200.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.151-200.txt \
+  -topicreader Trec \
   -output runs/run.disk12.ql.topics.adhoc.151-200.txt \
   -qld &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.51-100.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.51-100.txt \
+  -topicreader Trec \
   -output runs/run.disk12.ql+rm3.topics.adhoc.51-100.txt \
   -qld -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.101-150.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.101-150.txt \
+  -topicreader Trec \
   -output runs/run.disk12.ql+rm3.topics.adhoc.101-150.txt \
   -qld -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.151-200.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.151-200.txt \
+  -topicreader Trec \
   -output runs/run.disk12.ql+rm3.topics.adhoc.151-200.txt \
   -qld -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.51-100.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.51-100.txt \
+  -topicreader Trec \
   -output runs/run.disk12.ql+ax.topics.adhoc.51-100.txt \
   -qld -axiom -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.101-150.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.101-150.txt \
+  -topicreader Trec \
   -output runs/run.disk12.ql+ax.topics.adhoc.101-150.txt \
   -qld -axiom -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk12/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.151-200.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.151-200.txt \
+  -topicreader Trec \
   -output runs/run.disk12.ql+ax.topics.adhoc.151-200.txt \
   -qld -axiom -axiom.deterministic -rerankCutoff 20 &
 ```

--- a/docs/regressions-disk45.md
+++ b/docs/regressions-disk45.md
@@ -37,97 +37,115 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.351-400.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.351-400.txt \
+  -topicreader Trec \
   -output runs/run.disk45.bm25.topics.adhoc.351-400.txt \
   -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.401-450.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.401-450.txt \
+  -topicreader Trec \
   -output runs/run.disk45.bm25.topics.adhoc.401-450.txt \
   -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.robust04.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.robust04.txt \
+  -topicreader Trec \
   -output runs/run.disk45.bm25.topics.robust04.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.351-400.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.351-400.txt \
+  -topicreader Trec \
   -output runs/run.disk45.bm25+rm3.topics.adhoc.351-400.txt \
   -bm25 -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.401-450.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.401-450.txt \
+  -topicreader Trec \
   -output runs/run.disk45.bm25+rm3.topics.adhoc.401-450.txt \
   -bm25 -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.robust04.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.robust04.txt \
+  -topicreader Trec \
   -output runs/run.disk45.bm25+rm3.topics.robust04.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.351-400.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.351-400.txt \
+  -topicreader Trec \
   -output runs/run.disk45.bm25+ax.topics.adhoc.351-400.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.401-450.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.401-450.txt \
+  -topicreader Trec \
   -output runs/run.disk45.bm25+ax.topics.adhoc.401-450.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.robust04.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.robust04.txt \
+  -topicreader Trec \
   -output runs/run.disk45.bm25+ax.topics.robust04.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.351-400.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.351-400.txt \
+  -topicreader Trec \
   -output runs/run.disk45.ql.topics.adhoc.351-400.txt \
   -qld &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.401-450.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.401-450.txt \
+  -topicreader Trec \
   -output runs/run.disk45.ql.topics.adhoc.401-450.txt \
   -qld &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.robust04.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.robust04.txt \
+  -topicreader Trec \
   -output runs/run.disk45.ql.topics.robust04.txt \
   -qld &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.351-400.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.351-400.txt \
+  -topicreader Trec \
   -output runs/run.disk45.ql+rm3.topics.adhoc.351-400.txt \
   -qld -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.401-450.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.401-450.txt \
+  -topicreader Trec \
   -output runs/run.disk45.ql+rm3.topics.adhoc.401-450.txt \
   -qld -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.robust04.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.robust04.txt \
+  -topicreader Trec \
   -output runs/run.disk45.ql+rm3.topics.robust04.txt \
   -qld -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.351-400.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.351-400.txt \
+  -topicreader Trec \
   -output runs/run.disk45.ql+ax.topics.adhoc.351-400.txt \
   -qld -axiom -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.401-450.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.401-450.txt \
+  -topicreader Trec \
   -output runs/run.disk45.ql+ax.topics.adhoc.401-450.txt \
   -qld -axiom -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.disk45/ \
-  -topics src/main/resources/topics-and-qrels/topics.robust04.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.robust04.txt \
+  -topicreader Trec \
   -output runs/run.disk45.ql+ax.topics.robust04.txt \
   -qld -axiom -axiom.deterministic -rerankCutoff 20 &
 ```

--- a/docs/regressions-dl19-doc-docTTTTTquery.md
+++ b/docs/regressions-dl19-doc-docTTTTTquery.md
@@ -49,25 +49,29 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-docTTTTTquery.bm25-default.topics.dl19-doc.txt \
   -bm25 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-docTTTTTquery.bm25-default+rm3.topics.dl19-doc.txt \
   -bm25 -rm3 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-docTTTTTquery.bm25-tuned.topics.dl19-doc.txt \
   -bm25 -bm25.k1 4.68 -bm25.b 0.87 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-docTTTTTquery.bm25-tuned+rm3.topics.dl19-doc.txt \
   -bm25 -bm25.k1 4.68 -bm25.b 0.87 -rm3 -hits 100 &
 ```

--- a/docs/regressions-dl19-doc-segmented-docTTTTTquery.md
+++ b/docs/regressions-dl19-doc-segmented-docTTTTTquery.md
@@ -50,25 +50,29 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default.topics.dl19-doc.txt \
   -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default+rm3.topics.dl19-doc.txt \
   -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned.topics.dl19-doc.txt \
   -bm25 -bm25.k1 2.56 -bm25.b 0.59 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned+rm3.topics.dl19-doc.txt \
   -bm25 -bm25.k1 2.56 -bm25.b 0.59 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 ```

--- a/docs/regressions-dl19-doc-segmented-unicoil.md
+++ b/docs/regressions-dl19-doc-segmented-unicoil.md
@@ -41,8 +41,9 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.unicoil.0shot.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl19-doc.unicoil.0shot.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.unicoil.0shot.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl19-doc.unicoil.0shot.txt \
   -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 

--- a/docs/regressions-dl19-doc-segmented.md
+++ b/docs/regressions-dl19-doc-segmented.md
@@ -50,49 +50,57 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-default.topics.dl19-doc.txt \
   -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-default+rm3.topics.dl19-doc.txt \
   -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-default+ax.topics.dl19-doc.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-default+prf.topics.dl19-doc.txt \
   -bm25 -bm25prf -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-tuned.topics.dl19-doc.txt \
   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-tuned+rm3.topics.dl19-doc.txt \
   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-tuned+ax.topics.dl19-doc.txt \
   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -axiom -axiom.deterministic -rerankCutoff 20 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-tuned+prf.topics.dl19-doc.txt \
   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -bm25prf -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 ```

--- a/docs/regressions-dl19-doc.md
+++ b/docs/regressions-dl19-doc.md
@@ -49,49 +49,57 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc.bm25-default.topics.dl19-doc.txt \
   -bm25 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc.bm25-default+rm3.topics.dl19-doc.txt \
   -bm25 -rm3 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc.bm25-default+ax.topics.dl19-doc.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc.bm25-default+prf.topics.dl19-doc.txt \
   -bm25 -bm25prf -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc.bm25-tuned.topics.dl19-doc.txt \
   -bm25 -bm25.k1 3.44 -bm25.b 0.87 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc.bm25-tuned+rm3.topics.dl19-doc.txt \
   -bm25 -bm25.k1 3.44 -bm25.b 0.87 -rm3 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc.bm25-tuned+ax.topics.dl19-doc.txt \
   -bm25 -bm25.k1 3.44 -bm25.b 0.87 -axiom -axiom.deterministic -rerankCutoff 20 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-doc.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc.bm25-tuned+prf.topics.dl19-doc.txt \
   -bm25 -bm25.k1 3.44 -bm25.b 0.87 -bm25prf -hits 100 &
 ```

--- a/docs/regressions-dl19-passage-docTTTTTquery.md
+++ b/docs/regressions-dl19-passage-docTTTTTquery.md
@@ -39,37 +39,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-default.topics.dl19-passage.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-default+rm3.topics.dl19-passage.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned.topics.dl19-passage.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rm3.topics.dl19-passage.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2.topics.dl19-passage.txt \
   -bm25 -bm25.k1 2.18 -bm25.b 0.86 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rm3.topics.dl19-passage.txt \
   -bm25 -bm25.k1 2.18 -bm25.b 0.86 -rm3 &
 ```

--- a/docs/regressions-dl19-passage-unicoil.md
+++ b/docs/regressions-dl19-passage-unicoil.md
@@ -43,8 +43,9 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.unicoil.0shot.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-passage-unicoil.unicoil.topics.dl19-passage.unicoil.0shot.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.unicoil.0shot.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-passage-unicoil.unicoil.topics.dl19-passage.unicoil.0shot.txt \
   -impact -pretokenized &
 ```
 

--- a/docs/regressions-dl19-passage.md
+++ b/docs/regressions-dl19-passage.md
@@ -38,49 +38,57 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-default.topics.dl19-passage.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-default+rm3.topics.dl19-passage.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-default+ax.topics.dl19-passage.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-default+prf.topics.dl19-passage.txt \
   -bm25 -bm25prf &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-tuned.topics.dl19-passage.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-tuned+rm3.topics.dl19-passage.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-tuned+ax.topics.dl19-passage.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl19-passage.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-tuned+prf.topics.dl19-passage.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 -bm25prf &
 ```

--- a/docs/regressions-dl20-doc-docTTTTTquery.md
+++ b/docs/regressions-dl20-doc-docTTTTTquery.md
@@ -49,25 +49,29 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-docTTTTTquery.bm25-default.topics.dl20.txt \
   -bm25 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-docTTTTTquery.bm25-default+rm3.topics.dl20.txt \
   -bm25 -rm3 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-docTTTTTquery.bm25-tuned.topics.dl20.txt \
   -bm25 -bm25.k1 4.68 -bm25.b 0.87 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-docTTTTTquery.bm25-tuned+rm3.topics.dl20.txt \
   -bm25 -bm25.k1 4.68 -bm25.b 0.87 -rm3 -hits 100 &
 ```

--- a/docs/regressions-dl20-doc-segmented-docTTTTTquery.md
+++ b/docs/regressions-dl20-doc-segmented-docTTTTTquery.md
@@ -50,25 +50,29 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default.topics.dl20.txt \
   -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default+rm3.topics.dl20.txt \
   -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned.topics.dl20.txt \
   -bm25 -bm25.k1 2.56 -bm25.b 0.59 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned+rm3.topics.dl20.txt \
   -bm25 -bm25.k1 2.56 -bm25.b 0.59 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 ```

--- a/docs/regressions-dl20-doc-segmented-unicoil.md
+++ b/docs/regressions-dl20-doc-segmented-unicoil.md
@@ -41,8 +41,9 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.unicoil.0shot.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl20.unicoil.0shot.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.unicoil.0shot.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl20.unicoil.0shot.txt \
   -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 

--- a/docs/regressions-dl20-doc-segmented.md
+++ b/docs/regressions-dl20-doc-segmented.md
@@ -50,49 +50,57 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-default.topics.dl20.txt \
   -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-default+rm3.topics.dl20.txt \
   -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-default+ax.topics.dl20.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-default+prf.topics.dl20.txt \
   -bm25 -bm25prf -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-tuned.topics.dl20.txt \
   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-tuned+rm3.topics.dl20.txt \
   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-tuned+ax.topics.dl20.txt \
   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -axiom -axiom.deterministic -rerankCutoff 20 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-tuned+prf.topics.dl20.txt \
   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -bm25prf -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100 &
 ```

--- a/docs/regressions-dl20-doc.md
+++ b/docs/regressions-dl20-doc.md
@@ -49,37 +49,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmacro-doc.bm25-default.topics.dl20.txt \
   -bm25 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmacro-doc.bm25-default+rm3.topics.dl20.txt \
   -bm25 -rm3 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmacro-doc.bm25-tuned.topics.dl20.txt \
   -bm25 -bm25.k1 3.44 -bm25.b 0.87 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmacro-doc.bm25-tuned+rm3.topics.dl20.txt \
   -bm25 -bm25.k1 3.44 -bm25.b 0.87 -rm3 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmacro-doc.bm25-tuned2.topics.dl20.txt \
   -bm25 -bm25.k1 4.46 -bm25.b 0.82 -hits 100 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmacro-doc.bm25-tuned2+rm3.topics.dl20.txt \
   -bm25 -bm25.k1 4.46 -bm25.b 0.82 -rm3 -hits 100 &
 ```

--- a/docs/regressions-dl20-passage-docTTTTTquery.md
+++ b/docs/regressions-dl20-passage-docTTTTTquery.md
@@ -39,37 +39,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-default.topics.dl20.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-default+rm3.topics.dl20.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned.topics.dl20.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rm3.topics.dl20.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2.topics.dl20.txt \
   -bm25 -bm25.k1 2.18 -bm25.b 0.86 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rm3.topics.dl20.txt \
   -bm25 -bm25.k1 2.18 -bm25.b 0.86 -rm3 &
 ```

--- a/docs/regressions-dl20-passage-unicoil.md
+++ b/docs/regressions-dl20-passage-unicoil.md
@@ -43,8 +43,9 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.unicoil.0shot.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-passage-unicoil.unicoil.topics.dl20.unicoil.0shot.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.unicoil.0shot.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-passage-unicoil.unicoil.topics.dl20.unicoil.0shot.txt \
   -impact -pretokenized &
 ```
 

--- a/docs/regressions-dl20-passage.md
+++ b/docs/regressions-dl20-passage.md
@@ -38,49 +38,57 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-default.topics.dl20.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-default+rm3.topics.dl20.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-default+ax.topics.dl20.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-default+prf.topics.dl20.txt \
   -bm25 -bm25prf &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-tuned.topics.dl20.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-tuned+rm3.topics.dl20.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-tuned+ax.topics.dl20.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl20.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl20.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-tuned+prf.topics.dl20.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 -bm25prf &
 ```

--- a/docs/regressions-dl21-doc-d2q-t5.md
+++ b/docs/regressions-dl21-doc-d2q-t5.md
@@ -47,13 +47,15 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-d2q-t5.bm25-default.topics.dl21.txt \
   -hits 1000 -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rm3.topics.dl21.txt \
   -hits 1000 -bm25 -rm3 &
 ```

--- a/docs/regressions-dl21-doc-segmented-d2q-t5.md
+++ b/docs/regressions-dl21-doc-segmented-d2q-t5.md
@@ -47,13 +47,15 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default.topics.dl21.txt \
   -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rm3.topics.dl21.txt \
   -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -bm25 -rm3 &
 ```

--- a/docs/regressions-dl21-doc-segmented-unicoil-0shot.md
+++ b/docs/regressions-dl21-doc-segmented-unicoil-0shot.md
@@ -42,8 +42,9 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.unicoil.0shot.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot.unicoil-0shot.topics.dl21.unicoil.0shot.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.unicoil.0shot.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot.unicoil-0shot.topics.dl21.unicoil.0shot.txt \
   -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized &
 ```
 

--- a/docs/regressions-dl21-doc-segmented-unicoil-noexp-0shot.md
+++ b/docs/regressions-dl21-doc-segmented-unicoil-noexp-0shot.md
@@ -42,8 +42,9 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.unicoil-noexp.0shot.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot.unicoil-noexp-0shot.topics.dl21.unicoil-noexp.0shot.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.unicoil-noexp.0shot.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot.unicoil-noexp-0shot.topics.dl21.unicoil-noexp.0shot.txt \
   -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized &
 ```
 

--- a/docs/regressions-dl21-doc-segmented.md
+++ b/docs/regressions-dl21-doc-segmented.md
@@ -47,25 +47,29 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default.topics.dl21.txt \
   -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default+rm3.topics.dl21.txt \
   -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default+ax.topics.dl21.txt \
   -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default+prf.topics.dl21.txt \
   -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -bm25 -bm25prf &
 ```

--- a/docs/regressions-dl21-doc.md
+++ b/docs/regressions-dl21-doc.md
@@ -47,25 +47,29 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default.topics.dl21.txt \
   -hits 1000 -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default+rm3.topics.dl21.txt \
   -hits 1000 -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default+ax.topics.dl21.txt \
   -hits 1000 -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default+prf.topics.dl21.txt \
   -hits 1000 -bm25 -bm25prf &
 ```

--- a/docs/regressions-dl21-passage-augmented-d2q-t5.md
+++ b/docs/regressions-dl21-passage-augmented-d2q-t5.md
@@ -42,13 +42,15 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default.topics.dl21.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rm3.topics.dl21.txt \
   -bm25 -rm3 &
 ```

--- a/docs/regressions-dl21-passage-augmented.md
+++ b/docs/regressions-dl21-passage-augmented.md
@@ -42,25 +42,29 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default.topics.dl21.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+rm3.topics.dl21.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+ax.topics.dl21.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+prf.topics.dl21.txt \
   -bm25 -bm25prf &
 ```

--- a/docs/regressions-dl21-passage-d2q-t5.md
+++ b/docs/regressions-dl21-passage-d2q-t5.md
@@ -42,13 +42,15 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default.topics.dl21.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rm3.topics.dl21.txt \
   -bm25 -rm3 &
 ```

--- a/docs/regressions-dl21-passage-unicoil-0shot.md
+++ b/docs/regressions-dl21-passage-unicoil-0shot.md
@@ -42,8 +42,9 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.unicoil.0shot.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot.topics.dl21.unicoil.0shot.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.unicoil.0shot.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot.topics.dl21.unicoil.0shot.txt \
   -impact -pretokenized &
 ```
 

--- a/docs/regressions-dl21-passage-unicoil-noexp-0shot.md
+++ b/docs/regressions-dl21-passage-unicoil-noexp-0shot.md
@@ -42,8 +42,9 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.unicoil-noexp.0shot.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot.topics.dl21.unicoil-noexp.0shot.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.unicoil-noexp.0shot.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot.topics.dl21.unicoil-noexp.0shot.txt \
   -impact -pretokenized &
 ```
 

--- a/docs/regressions-dl21-passage.md
+++ b/docs/regressions-dl21-passage.md
@@ -42,25 +42,29 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default.topics.dl21.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+rm3.topics.dl21.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+ax.topics.dl21.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.dl21.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+prf.topics.dl21.txt \
   -bm25 -bm25prf &
 ```

--- a/docs/regressions-fever.md
+++ b/docs/regressions-fever.md
@@ -34,13 +34,15 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.fever-paragraph/ \
-  -topics src/main/resources/topics-and-qrels/topics.fever.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.fever.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.fever.bm25-default.topics.fever.dev.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.fever-paragraph/ \
-  -topics src/main/resources/topics-and-qrels/topics.fever.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.fever.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.fever.bm25-tuned.topics.fever.dev.txt \
   -bm25 -bm25.k1 0.9 -bm25.b 0.1 &
 ```

--- a/docs/regressions-fire12-bn.md
+++ b/docs/regressions-fire12-bn.md
@@ -37,7 +37,8 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.fire12-bn/ \
-  -topics src/main/resources/topics-and-qrels/topics.fire12bn.176-225.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.fire12bn.176-225.txt \
+  -topicreader Trec \
   -output runs/run.fire12-bn.bm25.topics.fire12bn.176-225.txt \
   -bm25 -language bn &
 ```

--- a/docs/regressions-fire12-en.md
+++ b/docs/regressions-fire12-en.md
@@ -37,7 +37,8 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.fire12-en/ \
-  -topics src/main/resources/topics-and-qrels/topics.fire12en.176-225.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.fire12en.176-225.txt \
+  -topicreader Trec \
   -output runs/run.fire12-en.bm25.topics.fire12en.176-225.txt \
   -bm25 -language en &
 ```

--- a/docs/regressions-fire12-hi.md
+++ b/docs/regressions-fire12-hi.md
@@ -37,7 +37,8 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.fire12-hi/ \
-  -topics src/main/resources/topics-and-qrels/topics.fire12hi.176-225.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.fire12hi.176-225.txt \
+  -topicreader Trec \
   -output runs/run.fire12-hi.bm25.topics.fire12hi.176-225.txt \
   -bm25 -language hi &
 ```

--- a/docs/regressions-gov2.md
+++ b/docs/regressions-gov2.md
@@ -38,97 +38,115 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte04.701-750.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte04.701-750.txt \
+  -topicreader Trec \
   -output runs/run.gov2.bm25.topics.terabyte04.701-750.txt \
   -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte05.751-800.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte05.751-800.txt \
+  -topicreader Trec \
   -output runs/run.gov2.bm25.topics.terabyte05.751-800.txt \
   -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte06.801-850.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte06.801-850.txt \
+  -topicreader Trec \
   -output runs/run.gov2.bm25.topics.terabyte06.801-850.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte04.701-750.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte04.701-750.txt \
+  -topicreader Trec \
   -output runs/run.gov2.bm25+rm3.topics.terabyte04.701-750.txt \
   -bm25 -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte05.751-800.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte05.751-800.txt \
+  -topicreader Trec \
   -output runs/run.gov2.bm25+rm3.topics.terabyte05.751-800.txt \
   -bm25 -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte06.801-850.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte06.801-850.txt \
+  -topicreader Trec \
   -output runs/run.gov2.bm25+rm3.topics.terabyte06.801-850.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte04.701-750.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte04.701-750.txt \
+  -topicreader Trec \
   -output runs/run.gov2.bm25+ax.topics.terabyte04.701-750.txt \
   -bm25 -axiom -axiom.beta 0.1 -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte05.751-800.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte05.751-800.txt \
+  -topicreader Trec \
   -output runs/run.gov2.bm25+ax.topics.terabyte05.751-800.txt \
   -bm25 -axiom -axiom.beta 0.1 -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte06.801-850.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte06.801-850.txt \
+  -topicreader Trec \
   -output runs/run.gov2.bm25+ax.topics.terabyte06.801-850.txt \
   -bm25 -axiom -axiom.beta 0.1 -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte04.701-750.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte04.701-750.txt \
+  -topicreader Trec \
   -output runs/run.gov2.ql.topics.terabyte04.701-750.txt \
   -qld &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte05.751-800.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte05.751-800.txt \
+  -topicreader Trec \
   -output runs/run.gov2.ql.topics.terabyte05.751-800.txt \
   -qld &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte06.801-850.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte06.801-850.txt \
+  -topicreader Trec \
   -output runs/run.gov2.ql.topics.terabyte06.801-850.txt \
   -qld &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte04.701-750.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte04.701-750.txt \
+  -topicreader Trec \
   -output runs/run.gov2.ql+rm3.topics.terabyte04.701-750.txt \
   -qld -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte05.751-800.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte05.751-800.txt \
+  -topicreader Trec \
   -output runs/run.gov2.ql+rm3.topics.terabyte05.751-800.txt \
   -qld -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte06.801-850.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte06.801-850.txt \
+  -topicreader Trec \
   -output runs/run.gov2.ql+rm3.topics.terabyte06.801-850.txt \
   -qld -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte04.701-750.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte04.701-750.txt \
+  -topicreader Trec \
   -output runs/run.gov2.ql+ax.topics.terabyte04.701-750.txt \
   -qld -axiom -axiom.beta 0.1 -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte05.751-800.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte05.751-800.txt \
+  -topicreader Trec \
   -output runs/run.gov2.ql+ax.topics.terabyte05.751-800.txt \
   -qld -axiom -axiom.beta 0.1 -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.gov2/ \
-  -topics src/main/resources/topics-and-qrels/topics.terabyte06.801-850.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.terabyte06.801-850.txt \
+  -topicreader Trec \
   -output runs/run.gov2.ql+ax.topics.terabyte06.801-850.txt \
   -qld -axiom -axiom.beta 0.1 -axiom.deterministic -rerankCutoff 20 &
 ```

--- a/docs/regressions-mb11.md
+++ b/docs/regressions-mb11.md
@@ -44,67 +44,79 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb11/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt \
+  -topicreader Microblog \
   -output runs/run.mb11.bm25.topics.microblog2011.txt \
   -searchtweets -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb11/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt \
+  -topicreader Microblog \
   -output runs/run.mb11.bm25.topics.microblog2012.txt \
   -searchtweets -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb11/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt \
+  -topicreader Microblog \
   -output runs/run.mb11.bm25+rm3.topics.microblog2011.txt \
   -searchtweets -bm25 -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb11/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt \
+  -topicreader Microblog \
   -output runs/run.mb11.bm25+rm3.topics.microblog2012.txt \
   -searchtweets -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb11/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt \
+  -topicreader Microblog \
   -output runs/run.mb11.bm25+ax.topics.microblog2011.txt \
   -searchtweets -bm25 -axiom -axiom.beta 1.0 -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb11/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt \
+  -topicreader Microblog \
   -output runs/run.mb11.bm25+ax.topics.microblog2012.txt \
   -searchtweets -bm25 -axiom -axiom.beta 1.0 -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb11/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt \
+  -topicreader Microblog \
   -output runs/run.mb11.ql.topics.microblog2011.txt \
   -searchtweets -qld &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb11/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt \
+  -topicreader Microblog \
   -output runs/run.mb11.ql.topics.microblog2012.txt \
   -searchtweets -qld &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb11/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt \
+  -topicreader Microblog \
   -output runs/run.mb11.ql+rm3.topics.microblog2011.txt \
   -searchtweets -qld -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb11/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt \
+  -topicreader Microblog \
   -output runs/run.mb11.ql+rm3.topics.microblog2012.txt \
   -searchtweets -qld -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb11/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2011.txt \
+  -topicreader Microblog \
   -output runs/run.mb11.ql+ax.topics.microblog2011.txt \
   -searchtweets -qld -axiom -axiom.beta 1.0 -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb11/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2012.txt \
+  -topicreader Microblog \
   -output runs/run.mb11.ql+ax.topics.microblog2012.txt \
   -searchtweets -qld -axiom -axiom.beta 1.0 -axiom.deterministic -rerankCutoff 20 &
 ```

--- a/docs/regressions-mb13.md
+++ b/docs/regressions-mb13.md
@@ -44,67 +44,79 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb13/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2013.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2013.txt \
+  -topicreader Microblog \
   -output runs/run.mb13.bm25.topics.microblog2013.txt \
   -searchtweets -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb13/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2014.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2014.txt \
+  -topicreader Microblog \
   -output runs/run.mb13.bm25.topics.microblog2014.txt \
   -searchtweets -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb13/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2013.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2013.txt \
+  -topicreader Microblog \
   -output runs/run.mb13.bm25+rm3.topics.microblog2013.txt \
   -searchtweets -bm25 -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb13/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2014.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2014.txt \
+  -topicreader Microblog \
   -output runs/run.mb13.bm25+rm3.topics.microblog2014.txt \
   -searchtweets -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb13/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2013.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2013.txt \
+  -topicreader Microblog \
   -output runs/run.mb13.bm25+ax.topics.microblog2013.txt \
   -searchtweets -bm25 -axiom -axiom.beta 1.0 -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb13/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2014.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2014.txt \
+  -topicreader Microblog \
   -output runs/run.mb13.bm25+ax.topics.microblog2014.txt \
   -searchtweets -bm25 -axiom -axiom.beta 1.0 -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb13/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2013.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2013.txt \
+  -topicreader Microblog \
   -output runs/run.mb13.ql.topics.microblog2013.txt \
   -searchtweets -qld &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb13/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2014.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2014.txt \
+  -topicreader Microblog \
   -output runs/run.mb13.ql.topics.microblog2014.txt \
   -searchtweets -qld &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb13/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2013.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2013.txt \
+  -topicreader Microblog \
   -output runs/run.mb13.ql+rm3.topics.microblog2013.txt \
   -searchtweets -qld -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb13/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2014.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2014.txt \
+  -topicreader Microblog \
   -output runs/run.mb13.ql+rm3.topics.microblog2014.txt \
   -searchtweets -qld -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb13/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2013.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2013.txt \
+  -topicreader Microblog \
   -output runs/run.mb13.ql+ax.topics.microblog2013.txt \
   -searchtweets -qld -axiom -axiom.beta 1.0 -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mb13/ \
-  -topics src/main/resources/topics-and-qrels/topics.microblog2014.txt -topicreader Microblog \
+  -topics src/main/resources/topics-and-qrels/topics.microblog2014.txt \
+  -topicreader Microblog \
   -output runs/run.mb13.ql+ax.topics.microblog2014.txt \
   -searchtweets -qld -axiom -axiom.beta 1.0 -axiom.deterministic -rerankCutoff 20 &
 ```

--- a/docs/regressions-mrtydi-v1.1-ar.md
+++ b/docs/regressions-mrtydi-v1.1-ar.md
@@ -29,18 +29,21 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-arabic/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ar.train.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-ar.bm25.topics.mrtydi-v1.1-ar.train.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ar.train.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-ar.bm25.topics.mrtydi-v1.1-ar.train.txt \
   -bm25 -hits 100 -language ar &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-arabic/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ar.dev.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-ar.bm25.topics.mrtydi-v1.1-ar.dev.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ar.dev.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-ar.bm25.topics.mrtydi-v1.1-ar.dev.txt \
   -bm25 -hits 100 -language ar &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-arabic/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ar.test.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-ar.bm25.topics.mrtydi-v1.1-ar.test.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ar.test.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-ar.bm25.topics.mrtydi-v1.1-ar.test.txt \
   -bm25 -hits 100 -language ar &
 ```
 

--- a/docs/regressions-mrtydi-v1.1-bn.md
+++ b/docs/regressions-mrtydi-v1.1-bn.md
@@ -29,18 +29,21 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-bengali/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-bn.train.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-bn.bm25.topics.mrtydi-v1.1-bn.train.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-bn.train.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-bn.bm25.topics.mrtydi-v1.1-bn.train.txt \
   -bm25 -hits 100 -language bn &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-bengali/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-bn.dev.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-bn.bm25.topics.mrtydi-v1.1-bn.dev.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-bn.dev.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-bn.bm25.topics.mrtydi-v1.1-bn.dev.txt \
   -bm25 -hits 100 -language bn &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-bengali/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-bn.test.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-bn.bm25.topics.mrtydi-v1.1-bn.test.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-bn.test.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-bn.bm25.topics.mrtydi-v1.1-bn.test.txt \
   -bm25 -hits 100 -language bn &
 ```
 

--- a/docs/regressions-mrtydi-v1.1-en.md
+++ b/docs/regressions-mrtydi-v1.1-en.md
@@ -29,18 +29,21 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-english/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-en.train.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-en.bm25.topics.mrtydi-v1.1-en.train.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-en.train.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-en.bm25.topics.mrtydi-v1.1-en.train.txt \
   -bm25 -hits 100 -language en &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-english/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-en.dev.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-en.bm25.topics.mrtydi-v1.1-en.dev.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-en.dev.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-en.bm25.topics.mrtydi-v1.1-en.dev.txt \
   -bm25 -hits 100 -language en &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-english/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-en.test.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-en.bm25.topics.mrtydi-v1.1-en.test.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-en.test.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-en.bm25.topics.mrtydi-v1.1-en.test.txt \
   -bm25 -hits 100 -language en &
 ```
 

--- a/docs/regressions-mrtydi-v1.1-fi.md
+++ b/docs/regressions-mrtydi-v1.1-fi.md
@@ -29,18 +29,21 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-finnish/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-fi.train.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-fi.bm25.topics.mrtydi-v1.1-fi.train.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-fi.train.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-fi.bm25.topics.mrtydi-v1.1-fi.train.txt \
   -bm25 -hits 100 -language fi &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-finnish/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-fi.dev.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-fi.bm25.topics.mrtydi-v1.1-fi.dev.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-fi.dev.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-fi.bm25.topics.mrtydi-v1.1-fi.dev.txt \
   -bm25 -hits 100 -language fi &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-finnish/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-fi.test.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-fi.bm25.topics.mrtydi-v1.1-fi.test.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-fi.test.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-fi.bm25.topics.mrtydi-v1.1-fi.test.txt \
   -bm25 -hits 100 -language fi &
 ```
 

--- a/docs/regressions-mrtydi-v1.1-id.md
+++ b/docs/regressions-mrtydi-v1.1-id.md
@@ -29,18 +29,21 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-indonesian/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-id.train.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-id.bm25.topics.mrtydi-v1.1-id.train.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-id.train.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-id.bm25.topics.mrtydi-v1.1-id.train.txt \
   -bm25 -hits 100 -language id &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-indonesian/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-id.dev.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-id.bm25.topics.mrtydi-v1.1-id.dev.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-id.dev.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-id.bm25.topics.mrtydi-v1.1-id.dev.txt \
   -bm25 -hits 100 -language id &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-indonesian/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-id.test.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-id.bm25.topics.mrtydi-v1.1-id.test.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-id.test.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-id.bm25.topics.mrtydi-v1.1-id.test.txt \
   -bm25 -hits 100 -language id &
 ```
 

--- a/docs/regressions-mrtydi-v1.1-ja.md
+++ b/docs/regressions-mrtydi-v1.1-ja.md
@@ -29,18 +29,21 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-japanese/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ja.train.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-ja.bm25.topics.mrtydi-v1.1-ja.train.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ja.train.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-ja.bm25.topics.mrtydi-v1.1-ja.train.txt \
   -bm25 -hits 100 -language ja &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-japanese/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ja.dev.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-ja.bm25.topics.mrtydi-v1.1-ja.dev.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ja.dev.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-ja.bm25.topics.mrtydi-v1.1-ja.dev.txt \
   -bm25 -hits 100 -language ja &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-japanese/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ja.test.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-ja.bm25.topics.mrtydi-v1.1-ja.test.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ja.test.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-ja.bm25.topics.mrtydi-v1.1-ja.test.txt \
   -bm25 -hits 100 -language ja &
 ```
 

--- a/docs/regressions-mrtydi-v1.1-ko.md
+++ b/docs/regressions-mrtydi-v1.1-ko.md
@@ -29,18 +29,21 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-korean/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ko.train.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-ko.bm25.topics.mrtydi-v1.1-ko.train.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ko.train.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-ko.bm25.topics.mrtydi-v1.1-ko.train.txt \
   -bm25 -hits 100 -language ko &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-korean/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ko.dev.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-ko.bm25.topics.mrtydi-v1.1-ko.dev.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ko.dev.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-ko.bm25.topics.mrtydi-v1.1-ko.dev.txt \
   -bm25 -hits 100 -language ko &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-korean/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ko.test.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-ko.bm25.topics.mrtydi-v1.1-ko.test.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ko.test.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-ko.bm25.topics.mrtydi-v1.1-ko.test.txt \
   -bm25 -hits 100 -language ko &
 ```
 

--- a/docs/regressions-mrtydi-v1.1-ru.md
+++ b/docs/regressions-mrtydi-v1.1-ru.md
@@ -29,18 +29,21 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-russian/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ru.train.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-ru.bm25.topics.mrtydi-v1.1-ru.train.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ru.train.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-ru.bm25.topics.mrtydi-v1.1-ru.train.txt \
   -bm25 -hits 100 -language ru &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-russian/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ru.dev.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-ru.bm25.topics.mrtydi-v1.1-ru.dev.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ru.dev.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-ru.bm25.topics.mrtydi-v1.1-ru.dev.txt \
   -bm25 -hits 100 -language ru &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-russian/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ru.test.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-ru.bm25.topics.mrtydi-v1.1-ru.test.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-ru.test.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-ru.bm25.topics.mrtydi-v1.1-ru.test.txt \
   -bm25 -hits 100 -language ru &
 ```
 

--- a/docs/regressions-mrtydi-v1.1-sw.md
+++ b/docs/regressions-mrtydi-v1.1-sw.md
@@ -29,18 +29,21 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-swahili/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-sw.train.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-sw.bm25.topics.mrtydi-v1.1-sw.train.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-sw.train.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-sw.bm25.topics.mrtydi-v1.1-sw.train.txt \
   -bm25 -hits 100 -language sw &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-swahili/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-sw.dev.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-sw.bm25.topics.mrtydi-v1.1-sw.dev.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-sw.dev.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-sw.bm25.topics.mrtydi-v1.1-sw.dev.txt \
   -bm25 -hits 100 -language sw &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-swahili/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-sw.test.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-sw.bm25.topics.mrtydi-v1.1-sw.test.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-sw.test.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-sw.bm25.topics.mrtydi-v1.1-sw.test.txt \
   -bm25 -hits 100 -language sw &
 ```
 

--- a/docs/regressions-mrtydi-v1.1-te.md
+++ b/docs/regressions-mrtydi-v1.1-te.md
@@ -29,18 +29,21 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-telugu/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-te.train.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-te.bm25.topics.mrtydi-v1.1-te.train.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-te.train.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-te.bm25.topics.mrtydi-v1.1-te.train.txt \
   -bm25 -hits 100 -language te &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-telugu/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-te.dev.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-te.bm25.topics.mrtydi-v1.1-te.dev.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-te.dev.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-te.bm25.topics.mrtydi-v1.1-te.dev.txt \
   -bm25 -hits 100 -language te &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-telugu/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-te.test.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-te.bm25.topics.mrtydi-v1.1-te.test.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-te.test.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-te.bm25.topics.mrtydi-v1.1-te.test.txt \
   -bm25 -hits 100 -language te &
 ```
 

--- a/docs/regressions-mrtydi-v1.1-th.md
+++ b/docs/regressions-mrtydi-v1.1-th.md
@@ -29,18 +29,21 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-thai/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-th.train.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-th.bm25.topics.mrtydi-v1.1-th.train.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-th.train.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-th.bm25.topics.mrtydi-v1.1-th.train.txt \
   -bm25 -hits 100 -language th &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-thai/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-th.dev.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-th.bm25.topics.mrtydi-v1.1-th.dev.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-th.dev.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-th.bm25.topics.mrtydi-v1.1-th.dev.txt \
   -bm25 -hits 100 -language th &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-thai/ \
-  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-th.test.txt.gz -topicreader TsvInt \
-  -output runs/run.mrtydi-v1.1-th.bm25.topics.mrtydi-v1.1-th.test.txt.gz \
+  -topics src/main/resources/topics-and-qrels/topics.mrtydi-v1.1-th.test.txt.gz \
+  -topicreader TsvInt \
+  -output runs/run.mrtydi-v1.1-th.bm25.topics.mrtydi-v1.1-th.test.txt \
   -bm25 -hits 100 -language th &
 ```
 

--- a/docs/regressions-msmarco-doc-docTTTTTquery.md
+++ b/docs/regressions-msmarco-doc-docTTTTTquery.md
@@ -44,13 +44,15 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-docTTTTTquery.bm25-default.topics.msmarco-doc.dev.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-docTTTTTquery.bm25-tuned.topics.msmarco-doc.dev.txt \
   -bm25 -bm25.k1 4.68 -bm25.b 0.87 &
 ```

--- a/docs/regressions-msmarco-doc-segmented-docTTTTTquery.md
+++ b/docs/regressions-msmarco-doc-segmented-docTTTTTquery.md
@@ -45,13 +45,15 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default.topics.msmarco-doc.dev.txt \
   -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned.topics.msmarco-doc.dev.txt \
   -bm25 -bm25.k1 2.56 -bm25.b 0.59 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```

--- a/docs/regressions-msmarco-doc-segmented-unicoil.md
+++ b/docs/regressions-msmarco-doc-segmented-unicoil.md
@@ -42,8 +42,9 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.unicoil.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.msmarco-doc.dev.unicoil.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.unicoil.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.msmarco-doc.dev.unicoil.txt \
   -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 

--- a/docs/regressions-msmarco-doc-segmented.md
+++ b/docs/regressions-msmarco-doc-segmented.md
@@ -45,49 +45,57 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-default.topics.msmarco-doc.dev.txt \
   -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-default+rm3.topics.msmarco-doc.dev.txt \
   -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-default+ax.topics.msmarco-doc.dev.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-default+prf.topics.msmarco-doc.dev.txt \
   -bm25 -bm25prf -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-tuned.topics.msmarco-doc.dev.txt \
   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-tuned+rm3.topics.msmarco-doc.dev.txt \
   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-tuned+ax.topics.msmarco-doc.dev.txt \
   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -axiom -axiom.deterministic -rerankCutoff 20 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-tuned+prf.topics.msmarco-doc.dev.txt \
   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -bm25prf -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```

--- a/docs/regressions-msmarco-doc.md
+++ b/docs/regressions-msmarco-doc.md
@@ -44,37 +44,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc.bm25-default.topics.msmarco-doc.dev.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc.bm25-default+rm3.topics.msmarco-doc.dev.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc.bm25-tuned.topics.msmarco-doc.dev.txt \
   -bm25 -bm25.k1 3.44 -bm25.b 0.87 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc.bm25-tuned+rm3.topics.msmarco-doc.dev.txt \
   -bm25 -bm25.k1 3.44 -bm25.b 0.87 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc.bm25-tuned2.topics.msmarco-doc.dev.txt \
   -bm25 -bm25.k1 4.46 -bm25.b 0.82 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-doc.bm25-tuned2+rm3.topics.msmarco-doc.dev.txt \
   -bm25 -bm25.k1 4.46 -bm25.b 0.82 -rm3 &
 ```

--- a/docs/regressions-msmarco-passage-deepimpact.md
+++ b/docs/regressions-msmarco-passage-deepimpact.md
@@ -39,8 +39,9 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-deepimpact/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.deepimpact.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-passage-deepimpact.deepimpact.topics.msmarco-passage.dev-subset.deepimpact.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.deepimpact.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-passage-deepimpact.deepimpact.topics.msmarco-passage.dev-subset.deepimpact.txt \
   -impact -pretokenized &
 ```
 

--- a/docs/regressions-msmarco-passage-distill-splade-max.md
+++ b/docs/regressions-msmarco-passage-distill-splade-max.md
@@ -39,8 +39,9 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-distill-splade-max/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.distill-splade-max.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-passage-distill-splade-max.distill-splade-max.topics.msmarco-passage.dev-subset.distill-splade-max.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.distill-splade-max.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-passage-distill-splade-max.distill-splade-max.topics.msmarco-passage.dev-subset.distill-splade-max.txt \
   -impact -pretokenized &
 ```
 

--- a/docs/regressions-msmarco-passage-doc2query.md
+++ b/docs/regressions-msmarco-passage-doc2query.md
@@ -39,25 +39,29 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-doc2query/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-doc2query.bm25-default.topics.msmarco-passage.dev-subset.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-doc2query/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-doc2query.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-doc2query/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-doc2query.bm25-tuned.topics.msmarco-passage.dev-subset.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-doc2query/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-doc2query.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rm3 &
 ```

--- a/docs/regressions-msmarco-passage-docTTTTTquery.md
+++ b/docs/regressions-msmarco-passage-docTTTTTquery.md
@@ -38,37 +38,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-default.topics.msmarco-passage.dev-subset.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned.topics.msmarco-passage.dev-subset.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2.topics.msmarco-passage.dev-subset.txt \
   -bm25 -bm25.k1 2.18 -bm25.b 0.86 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rm3.topics.msmarco-passage.dev-subset.txt \
   -bm25 -bm25.k1 2.18 -bm25.b 0.86 -rm3 &
 ```

--- a/docs/regressions-msmarco-passage-unicoil-tilde-expansion.md
+++ b/docs/regressions-msmarco-passage-unicoil-tilde-expansion.md
@@ -39,8 +39,9 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil-tilde-expansion/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-passage-unicoil-tilde-expansion.unicoil-tilde-expansion.topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-passage-unicoil-tilde-expansion.unicoil-tilde-expansion.topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.txt \
   -impact -pretokenized &
 ```
 

--- a/docs/regressions-msmarco-passage-unicoil.md
+++ b/docs/regressions-msmarco-passage-unicoil.md
@@ -38,8 +38,9 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.unicoil.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.unicoil.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.txt \
   -impact -pretokenized &
 ```
 

--- a/docs/regressions-msmarco-passage.md
+++ b/docs/regressions-msmarco-passage.md
@@ -35,49 +35,57 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-default.topics.msmarco-passage.dev-subset.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-default+ax.topics.msmarco-passage.dev-subset.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-default+prf.topics.msmarco-passage.dev-subset.txt \
   -bm25 -bm25prf &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-tuned.topics.msmarco-passage.dev-subset.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-tuned+ax.topics.msmarco-passage.dev-subset.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-tuned+prf.topics.msmarco-passage.dev-subset.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 -bm25prf &
 ```

--- a/docs/regressions-msmarco-v2-doc-d2q-t5.md
+++ b/docs/regressions-msmarco-v2-doc-d2q-t5.md
@@ -35,12 +35,14 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-d2q-t5.bm25-default.topics.msmarco-v2-doc.dev.txt \
   -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-d2q-t5.bm25-default.topics.msmarco-v2-doc.dev2.txt \
   -bm25 &
 ```

--- a/docs/regressions-msmarco-v2-doc-segmented-d2q-t5.md
+++ b/docs/regressions-msmarco-v2-doc-segmented-d2q-t5.md
@@ -35,12 +35,14 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default.topics.msmarco-v2-doc.dev.txt \
   -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default.topics.msmarco-v2-doc.dev2.txt \
   -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```

--- a/docs/regressions-msmarco-v2-doc-segmented-unicoil-0shot.md
+++ b/docs/regressions-msmarco-v2-doc-segmented-unicoil-0shot.md
@@ -33,13 +33,15 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.unicoil.0shot.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot.unicoil-0shot.topics.msmarco-v2-doc.dev.unicoil.0shot.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.unicoil.0shot.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot.unicoil-0shot.topics.msmarco-v2-doc.dev.unicoil.0shot.txt \
   -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.unicoil.0shot.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot.unicoil-0shot.topics.msmarco-v2-doc.dev2.unicoil.0shot.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.unicoil.0shot.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot.unicoil-0shot.topics.msmarco-v2-doc.dev2.unicoil.0shot.txt \
   -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 

--- a/docs/regressions-msmarco-v2-doc-segmented-unicoil-noexp-0shot.md
+++ b/docs/regressions-msmarco-v2-doc-segmented-unicoil-noexp-0shot.md
@@ -33,13 +33,15 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot.unicoil-noexp-0shot.topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot.unicoil-noexp-0shot.topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.txt \
   -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot.unicoil-noexp-0shot.topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot.unicoil-noexp-0shot.topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.txt \
   -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 

--- a/docs/regressions-msmarco-v2-doc-segmented.md
+++ b/docs/regressions-msmarco-v2-doc-segmented.md
@@ -36,45 +36,53 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default.topics.msmarco-v2-doc.dev.txt \
   -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default.topics.msmarco-v2-doc.dev2.txt \
   -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt \
   -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt \
   -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default+ax.topics.msmarco-v2-doc.dev.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default+ax.topics.msmarco-v2-doc.dev2.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default+prf.topics.msmarco-v2-doc.dev.txt \
   -bm25 -bm25prf -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default+prf.topics.msmarco-v2-doc.dev2.txt \
   -bm25 -bm25prf -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```

--- a/docs/regressions-msmarco-v2-doc.md
+++ b/docs/regressions-msmarco-v2-doc.md
@@ -36,45 +36,53 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default.topics.msmarco-v2-doc.dev.txt \
   -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default.topics.msmarco-v2-doc.dev2.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt \
   -bm25 -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default+ax.topics.msmarco-v2-doc.dev.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default+ax.topics.msmarco-v2-doc.dev2.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default+prf.topics.msmarco-v2-doc.dev.txt \
   -bm25 -bm25prf &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default+prf.topics.msmarco-v2-doc.dev2.txt \
   -bm25 -bm25prf &
 ```

--- a/docs/regressions-msmarco-v2-passage-augmented-d2q-t5.md
+++ b/docs/regressions-msmarco-v2-passage-augmented-d2q-t5.md
@@ -34,12 +34,14 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default.topics.msmarco-v2-passage.dev.txt \
   -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default.topics.msmarco-v2-passage.dev2.txt \
   -bm25 &
 ```

--- a/docs/regressions-msmarco-v2-passage-augmented.md
+++ b/docs/regressions-msmarco-v2-passage-augmented.md
@@ -36,45 +36,53 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default.topics.msmarco-v2-passage.dev.txt \
   -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default.topics.msmarco-v2-passage.dev2.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt \
   -bm25 -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+ax.topics.msmarco-v2-passage.dev.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+ax.topics.msmarco-v2-passage.dev2.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+prf.topics.msmarco-v2-passage.dev.txt \
   -bm25 -bm25prf &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+prf.topics.msmarco-v2-passage.dev2.txt \
   -bm25 -bm25prf &
 ```

--- a/docs/regressions-msmarco-v2-passage-d2q-t5.md
+++ b/docs/regressions-msmarco-v2-passage-d2q-t5.md
@@ -34,12 +34,14 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default.topics.msmarco-v2-passage.dev.txt \
   -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default.topics.msmarco-v2-passage.dev2.txt \
   -bm25 &
 ```

--- a/docs/regressions-msmarco-v2-passage-unicoil-0shot.md
+++ b/docs/regressions-msmarco-v2-passage-unicoil-0shot.md
@@ -33,13 +33,15 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.unicoil.0shot.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot.topics.msmarco-v2-passage.dev.unicoil.0shot.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.unicoil.0shot.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot.topics.msmarco-v2-passage.dev.unicoil.0shot.txt \
   -impact -pretokenized &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.unicoil.0shot.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot.topics.msmarco-v2-passage.dev2.unicoil.0shot.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.unicoil.0shot.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot.topics.msmarco-v2-passage.dev2.unicoil.0shot.txt \
   -impact -pretokenized &
 ```
 

--- a/docs/regressions-msmarco-v2-passage-unicoil-noexp-0shot.md
+++ b/docs/regressions-msmarco-v2-passage-unicoil-noexp-0shot.md
@@ -33,13 +33,15 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot.topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot.topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.txt \
   -impact -pretokenized &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.tsv.gz -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot.topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.tsv.gz \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.tsv.gz \
+  -topicreader TsvInt \
+  -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot.topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.txt \
   -impact -pretokenized &
 ```
 

--- a/docs/regressions-msmarco-v2-passage.md
+++ b/docs/regressions-msmarco-v2-passage.md
@@ -36,45 +36,53 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default.topics.msmarco-v2-passage.dev.txt \
   -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default.topics.msmarco-v2-passage.dev2.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt \
   -bm25 -rm3 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+ax.topics.msmarco-v2-passage.dev.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+ax.topics.msmarco-v2-passage.dev2.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+prf.topics.msmarco-v2-passage.dev.txt \
   -bm25 -bm25prf &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt -topicreader TsvInt \
+  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
+  -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+prf.topics.msmarco-v2-passage.dev2.txt \
   -bm25 -bm25prf &
 ```

--- a/docs/regressions-ntcir8-zh.md
+++ b/docs/regressions-ntcir8-zh.md
@@ -39,7 +39,8 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.ntcir8-zh/ \
-  -topics src/main/resources/topics-and-qrels/topics.ntcir8zh.eval.txt -topicreader TsvString \
+  -topics src/main/resources/topics-and-qrels/topics.ntcir8zh.eval.txt \
+  -topicreader TsvString \
   -output runs/run.ntcir8-zh.bm25.topics.ntcir8zh.eval.txt \
   -bm25 -language zh &
 ```

--- a/docs/regressions-robust05.md
+++ b/docs/regressions-robust05.md
@@ -34,37 +34,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.robust05/ \
-  -topics src/main/resources/topics-and-qrels/topics.robust05.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.robust05.txt \
+  -topicreader Trec \
   -output runs/run.robust05.bm25.topics.robust05.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.robust05/ \
-  -topics src/main/resources/topics-and-qrels/topics.robust05.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.robust05.txt \
+  -topicreader Trec \
   -output runs/run.robust05.bm25+rm3.topics.robust05.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.robust05/ \
-  -topics src/main/resources/topics-and-qrels/topics.robust05.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.robust05.txt \
+  -topicreader Trec \
   -output runs/run.robust05.bm25+ax.topics.robust05.txt \
   -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.robust05/ \
-  -topics src/main/resources/topics-and-qrels/topics.robust05.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.robust05.txt \
+  -topicreader Trec \
   -output runs/run.robust05.ql.topics.robust05.txt \
   -qld &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.robust05/ \
-  -topics src/main/resources/topics-and-qrels/topics.robust05.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.robust05.txt \
+  -topicreader Trec \
   -output runs/run.robust05.ql+rm3.topics.robust05.txt \
   -qld -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.robust05/ \
-  -topics src/main/resources/topics-and-qrels/topics.robust05.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.robust05.txt \
+  -topicreader Trec \
   -output runs/run.robust05.ql+ax.topics.robust05.txt \
   -qld -axiom -axiom.deterministic -rerankCutoff 20 &
 ```

--- a/docs/regressions-trec02-ar.md
+++ b/docs/regressions-trec02-ar.md
@@ -39,7 +39,8 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.trec02-ar/ \
-  -topics src/main/resources/topics-and-qrels/topics.trec02ar-ar.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.trec02ar-ar.txt \
+  -topicreader Trec \
   -output runs/run.trec02-ar.bm25.topics.trec02ar-ar.txt \
   -bm25 -language ar &
 ```

--- a/docs/regressions-wt10g.md
+++ b/docs/regressions-wt10g.md
@@ -34,37 +34,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wt10g/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.451-550.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.451-550.txt \
+  -topicreader Trec \
   -output runs/run.wt10g.bm25.topics.adhoc.451-550.txt \
   -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wt10g/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.451-550.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.451-550.txt \
+  -topicreader Trec \
   -output runs/run.wt10g.bm25+rm3.topics.adhoc.451-550.txt \
   -bm25 -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wt10g/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.451-550.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.451-550.txt \
+  -topicreader Trec \
   -output runs/run.wt10g.bm25+ax.topics.adhoc.451-550.txt \
   -bm25 -axiom -axiom.beta 0.1 -axiom.deterministic -rerankCutoff 20 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wt10g/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.451-550.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.451-550.txt \
+  -topicreader Trec \
   -output runs/run.wt10g.ql.topics.adhoc.451-550.txt \
   -qld &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wt10g/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.451-550.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.451-550.txt \
+  -topicreader Trec \
   -output runs/run.wt10g.ql+rm3.topics.adhoc.451-550.txt \
   -qld -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.wt10g/ \
-  -topics src/main/resources/topics-and-qrels/topics.adhoc.451-550.txt -topicreader Trec \
+  -topics src/main/resources/topics-and-qrels/topics.adhoc.451-550.txt \
+  -topicreader Trec \
   -output runs/run.wt10g.ql+ax.topics.adhoc.451-550.txt \
   -qld -axiom -axiom.beta 0.1 -axiom.deterministic -rerankCutoff 20 &
 ```

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -694,7 +694,13 @@ public final class IndexCollection {
       }
     }
 
-    collectionPath = Paths.get(args.input);
+    // Our documentation uses /path/to/foo as a convention: to make copy and paste of the commands work, we assume
+    // collections/ as the path location.
+    String pathStr = args.input;
+    if (pathStr.startsWith("/path/to")) {
+      pathStr = pathStr.replace("/path/to", "collections");
+    }
+    collectionPath = Paths.get(pathStr);
     if (!Files.exists(collectionPath) || !Files.isReadable(collectionPath) || !Files.isDirectory(collectionPath)) {
       throw new RuntimeException("Document directory " + collectionPath.toString() + " does not exist or is not readable, please check the path");
     }

--- a/src/test/java/io/anserini/doc/DataModel.java
+++ b/src/test/java/io/anserini/doc/DataModel.java
@@ -234,12 +234,23 @@ public class DataModel {
     StringBuilder builder = new StringBuilder();
     for (Model model : getModels()) {
       for (Topic topic : getTopics()) {
+        // Strip suffixes (e.g., gz) to avoid confusion.
+        String modifiedPath = topic.getPath();
+        if (modifiedPath.endsWith(".gz")) {
+          modifiedPath = modifiedPath.substring(0, modifiedPath.lastIndexOf(".gz"));
+        }
+        if (modifiedPath.endsWith(".txt")) {
+          modifiedPath = modifiedPath.substring(0, modifiedPath.lastIndexOf(".txt"));
+        }
+        if (modifiedPath.endsWith(".tsv")) {
+          modifiedPath = modifiedPath.substring(0, modifiedPath.lastIndexOf(".tsv"));
+        }
+
         builder.append(SEARCH_COMMAND).append(" \\\n");
         builder.append("  -index").append(" ").append(getIndex_path()).append(" \\\n");
-        builder
-            .append("  -topics").append(" ").append(Paths.get(getTopic_root(), topic.getPath()).toString())
-            .append(" -topicreader").append(" ").append(getTopic_reader()).append(" \\\n");
-        builder.append("  -output").append(" ").append("runs/run."+collection+"."+model.getName()+"."+topic.getPath()).append(" \\\n");
+        builder.append("  -topics").append(" ").append(Paths.get(getTopic_root(), topic.getPath()).toString()).append(" \\\n");
+        builder.append("  -topicreader").append(" ").append(getTopic_reader()).append(" \\\n");
+        builder.append("  -output").append(" ").append("runs/run."+collection+"."+model.getName()+"."+modifiedPath+ ".txt").append(" \\\n");
         if (model.getParams() != null) {
           builder.append("  ").append(model.getParams());
         }


### PR DESCRIPTION
Puts -topicreader parameter on a separate line; otherwise, it's hidden an easy to miss.