### PR TITLE
Add splade-distill-cocodenser-medium regressions on BEIR_v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ See individual pages for details!
   + DBPedia: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium.md)
   + FEVER: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-fever-splade-distil-cocodenser-medium.md)
   + FiQA-2018: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-fiqa-splade-distil-cocodenser-medium.md)
-  + HotpotQA: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-hotoptqa-splade-distil-cocodenser-medium.md)
+  + HotpotQA: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-hotpotqa-splade-distil-cocodenser-medium.md)
   + NFCorpus: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium.md)
   + NQ: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-nq-splade-distil-cocodenser-medium.md)
   + Quora: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-quora-splade-distil-cocodenser-medium.md)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,19 @@ See individual pages for details!
 + Regressions for FIRE 2012: [Monolingual Bengali](docs/regressions-fire12-bn.md), [Monolingual Hindi](docs/regressions-fire12-hi.md), [Monolingual English](docs/regressions-fire12-en.md)
 + Regressions for Mr. TyDi (v1.1): [ar](docs/regressions-mrtydi-v1.1-ar.md), [bn](docs/regressions-mrtydi-v1.1-bn.md), [en](docs/regressions-mrtydi-v1.1-en.md), [fi](docs/regressions-mrtydi-v1.1-fi.md), [id](docs/regressions-mrtydi-v1.1-id.md), [ja](docs/regressions-mrtydi-v1.1-ja.md), [ko](docs/regressions-mrtydi-v1.1-ko.md), [ru](docs/regressions-mrtydi-v1.1-ru.md), [sw](docs/regressions-mrtydi-v1.1-sw.md), [te](docs/regressions-mrtydi-v1.1-te.md), [th](docs/regressions-mrtydi-v1.1-th.md)
 + Regressions for BEIR (v1.0.0): 
-  + Arguana: [baseline](docs/regressions-beir-v1.0.0-arguana.md), [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-arguana-splade-distil-cocodenser-medium.md)
+  + ArguAna: [baseline](docs/regressions-beir-v1.0.0-arguana.md), [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-arguana-splade-distil-cocodenser-medium.md)
+  + Climate-FEVER: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-climate-fever-splade-distil-cocodenser-medium.md)
+  + DBPedia: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium.md)
+  + FEVER: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-fever-splade-distil-cocodenser-medium.md)
+  + FiQA-2018: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-fiqa-splade-distil-cocodenser-medium.md)
+  + HotpotQA: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-hotoptqa-splade-distil-cocodenser-medium.md)
+  + NFCorpus: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium.md)
+  + NQ: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-nq-splade-distil-cocodenser-medium.md)
+  + Quora: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-quora-splade-distil-cocodenser-medium.md)
+  + SCIDOCS: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-scidocs-splade-distil-cocodenser-medium.md)
+  + SciFact: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-scifact-splade-distil-cocodenser-medium.md)
+  + TREC-COVID: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-trec-covid-splade-distil-cocodenser-medium.md)
+  + Touche2020: [SPLADE-distill CoCodenser-medium](docs/regressions-beir-v1.0.0-webis-touche2020-splade-distil-cocodenser-medium.md)
 
 ## Additional Documentation
 

--- a/docs/regressions-beir-v1.0.0-arguana-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-arguana-splade-distil-cocodenser-medium.md
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; arguana, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; arguana
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/docs/regressions-beir-v1.0.0-arguana-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-arguana-splade-distil-cocodenser-medium.md
@@ -16,7 +16,7 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Corpus
 
-We make available a version of the BEIR-v1.0.0 Arguana corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+We make available a version of the BEIR-v1.0.0 arguana corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
 For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
 
@@ -55,15 +55,15 @@ target/appassembler/bin/IndexCollection \
 
 The path `/path/to/beir-v1.0.0-arguana/` should point to the corpus downloaded above.
 
-The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the uniCOIL tokens.
-Upon completion, we should have an index with 8,841,823 documents.
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+Upon completion, we should have an index with 8,674 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 
 ## Retrieval
 
 Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
-The regression experiments here evaluate on the 6980 dev set questions; see [this page](experiments-msmarco-passage.md) for more details.
+The regression experiments here evaluate on the test set questions.
 
 After indexing has completed, you should be able to perform retrieval as follows:
 

--- a/docs/regressions-beir-v1.0.0-climate-fever-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-climate-fever-splade-distil-cocodenser-medium.md
@@ -1,0 +1,108 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; climate-fever, SPLADE-distil CoCodenser Medium
+
+**Model**: SPLADE-distil CoCodenser Medium
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; climate-fever](http://beir.ai/).
+The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/beir-v1.0.0-climate-fever-splade-distil-cocodenser-medium.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/beir-v1.0.0-climate-fever-splade-distil-cocodenser-medium.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-climate-fever-splade-distil-cocodenser-medium
+```
+
+## Corpus
+
+We make available a version of the BEIR-v1.0.0 climate-fever corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+Thus, no neural inference is involved.
+For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
+
+Download the corpus and unpack into `collections/`:
+
+```
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/climate-fever.tar -P collections/
+
+tar xvf collections/climate-fever.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/climate-fever
+```
+
+To confirm, `climate-fever.tar` is 3.2 GB and has MD5 checksum `a123403f521a95f30c1db4bede45fe0e`.
+
+With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-climate-fever-splade-distil-cocodenser-medium \
+  --corpus-path collections/beir-v1.0.0-climate-fever
+```
+
+Alternatively, you can simply copy/paste from the commands below and obtain the same results.
+
+## Indexing
+
+Sample indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-climate-fever \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-climate-fever/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-climate-fever &
+```
+
+The path `/path/to/beir-v1.0.0-climate-fever/` should point to the corpus downloaded above.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+Upon completion, we should have an index with 5,416,593 documents.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the test set questions.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-climate-fever/ \
+  -topics src/main/resources/topics-and-qrels/topics.beir-v1.0.0-climate-fever.test.splade_distil_cocodenser_medium.tsv.gz \
+  -topicreader TsvString \
+  -output runs/run.beir-v1.0.0-climate-fever.splade_distil_cocodenser_medium.topics.beir-v1.0.0-climate-fever.test.splade_distil_cocodenser_medium.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-climate-fever.test.txt runs/run.beir-v1.0.0-climate-fever.splade_distil_cocodenser_medium.topics.beir-v1.0.0-climate-fever.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-climate-fever.test.txt runs/run.beir-v1.0.0-climate-fever.splade_distil_cocodenser_medium.topics.beir-v1.0.0-climate-fever.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-climate-fever.test.txt runs/run.beir-v1.0.0-climate-fever.splade_distil_cocodenser_medium.topics.beir-v1.0.0-climate-fever.test.splade_distil_cocodenser_medium.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| nDCG@10                                                                                                      | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): climate-fever                                                                                 | 0.2276    |
+
+
+| R@100                                                                                                        | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): climate-fever                                                                                 | 0.5140    |
+
+
+| R@1000                                                                                                       | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): climate-fever                                                                                 | 0.7084    |
+
+
+## Reproduction Log[*](reproducibility.md)
+
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/beir-v1.0.0-climate-fever-splade-distil-cocodenser-medium.template) and run `bin/build.sh` to rebuild the documentation.

--- a/docs/regressions-beir-v1.0.0-climate-fever-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-climate-fever-splade-distil-cocodenser-medium.md
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; climate-fever, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; climate-fever
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/docs/regressions-beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium.md
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; dbpedia-entity, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; dbpedia-entity
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/docs/regressions-beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium.md
@@ -1,0 +1,108 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; dbpedia-entity, SPLADE-distil CoCodenser Medium
+
+**Model**: SPLADE-distil CoCodenser Medium
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; dbpedia-entity](http://beir.ai/).
+The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium
+```
+
+## Corpus
+
+We make available a version of the BEIR-v1.0.0 dbpedia-entity corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+Thus, no neural inference is involved.
+For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
+
+Download the corpus and unpack into `collections/`:
+
+```
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/dbpedia-entity.tar -P collections/
+
+tar xvf collections/dbpedia-entity.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/dbpedia-entity
+```
+
+To confirm, `dbpedia-entity.tar` is 2.5 GB and has MD5 checksum `a52d2752b1b21397cd10b78f7235dcee`.
+
+With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium \
+  --corpus-path collections/beir-v1.0.0-dbpedia-entity
+```
+
+Alternatively, you can simply copy/paste from the commands below and obtain the same results.
+
+## Indexing
+
+Sample indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-dbpedia-entity \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-dbpedia-entity/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-dbpedia-entity &
+```
+
+The path `/path/to/beir-v1.0.0-dbpedia-entity/` should point to the corpus downloaded above.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+Upon completion, we should have an index with 4,635,922 documents.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the test set questions.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-dbpedia-entity/ \
+  -topics src/main/resources/topics-and-qrels/topics.beir-v1.0.0-dbpedia-entity.test.splade_distil_cocodenser_medium.tsv.gz \
+  -topicreader TsvString \
+  -output runs/run.beir-v1.0.0-dbpedia-entity.splade_distil_cocodenser_medium.topics.beir-v1.0.0-dbpedia-entity.test.splade_distil_cocodenser_medium.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-dbpedia-entity.test.txt runs/run.beir-v1.0.0-dbpedia-entity.splade_distil_cocodenser_medium.topics.beir-v1.0.0-dbpedia-entity.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-dbpedia-entity.test.txt runs/run.beir-v1.0.0-dbpedia-entity.splade_distil_cocodenser_medium.topics.beir-v1.0.0-dbpedia-entity.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-dbpedia-entity.test.txt runs/run.beir-v1.0.0-dbpedia-entity.splade_distil_cocodenser_medium.topics.beir-v1.0.0-dbpedia-entity.test.splade_distil_cocodenser_medium.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| nDCG@10                                                                                                      | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): dbpedia-entity                                                                                | 0.4416    |
+
+
+| R@100                                                                                                        | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): dbpedia-entity                                                                                | 0.5636    |
+
+
+| R@1000                                                                                                       | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): dbpedia-entity                                                                                | 0.7774    |
+
+
+## Reproduction Log[*](reproducibility.md)
+
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium.template) and run `bin/build.sh` to rebuild the documentation.

--- a/docs/regressions-beir-v1.0.0-fever-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-fever-splade-distil-cocodenser-medium.md
@@ -1,0 +1,108 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; fever, SPLADE-distil CoCodenser Medium
+
+**Model**: SPLADE-distil CoCodenser Medium
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; fever](http://beir.ai/).
+The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/beir-v1.0.0-fever-splade-distil-cocodenser-medium.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/beir-v1.0.0-fever-splade-distil-cocodenser-medium.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-fever-splade-distil-cocodenser-medium
+```
+
+## Corpus
+
+We make available a version of the BEIR-v1.0.0 fever corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+Thus, no neural inference is involved.
+For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
+
+Download the corpus and unpack into `collections/`:
+
+```
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/fever.tar -P collections/
+
+tar xvf collections/fever.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/fever
+```
+
+To confirm, `fever.tar` is 3.2 GB and has MD5 checksum `dcc9c7e61df122781e872e6e8ded7a3e`.
+
+With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-fever-splade-distil-cocodenser-medium \
+  --corpus-path collections/beir-v1.0.0-fever
+```
+
+Alternatively, you can simply copy/paste from the commands below and obtain the same results.
+
+## Indexing
+
+Sample indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-fever \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-fever/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-fever &
+```
+
+The path `/path/to/beir-v1.0.0-fever/` should point to the corpus downloaded above.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+Upon completion, we should have an index with 5,416,568 documents.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the test set questions.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-fever/ \
+  -topics src/main/resources/topics-and-qrels/topics.beir-v1.0.0-fever.test.splade_distil_cocodenser_medium.tsv.gz \
+  -topicreader TsvString \
+  -output runs/run.beir-v1.0.0-fever.splade_distil_cocodenser_medium.topics.beir-v1.0.0-fever.test.splade_distil_cocodenser_medium.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-fever.test.txt runs/run.beir-v1.0.0-fever.splade_distil_cocodenser_medium.topics.beir-v1.0.0-fever.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-fever.test.txt runs/run.beir-v1.0.0-fever.splade_distil_cocodenser_medium.topics.beir-v1.0.0-fever.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-fever.test.txt runs/run.beir-v1.0.0-fever.splade_distil_cocodenser_medium.topics.beir-v1.0.0-fever.test.splade_distil_cocodenser_medium.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| nDCG@10                                                                                                      | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): fever                                                                                         | 0.7962    |
+
+
+| R@100                                                                                                        | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): fever                                                                                         | 0.9550    |
+
+
+| R@1000                                                                                                       | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): fever                                                                                         | 0.9751    |
+
+
+## Reproduction Log[*](reproducibility.md)
+
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/beir-v1.0.0-fever-splade-distil-cocodenser-medium.template) and run `bin/build.sh` to rebuild the documentation.

--- a/docs/regressions-beir-v1.0.0-fever-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-fever-splade-distil-cocodenser-medium.md
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; fever, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; fever
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/docs/regressions-beir-v1.0.0-fiqa-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-fiqa-splade-distil-cocodenser-medium.md
@@ -1,0 +1,108 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; fiqa, SPLADE-distil CoCodenser Medium
+
+**Model**: SPLADE-distil CoCodenser Medium
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; fiqa](http://beir.ai/).
+The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/beir-v1.0.0-fiqa-splade-distil-cocodenser-medium.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/beir-v1.0.0-fiqa-splade-distil-cocodenser-medium.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-fiqa-splade-distil-cocodenser-medium
+```
+
+## Corpus
+
+We make available a version of the BEIR-v1.0.0 fiqa corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+Thus, no neural inference is involved.
+For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
+
+Download the corpus and unpack into `collections/`:
+
+```
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/fiqa.tar -P collections/
+
+tar xvf collections/fiqa.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/fiqa
+```
+
+To confirm, `fiqa.tar` is 3.2 GB and has MD5 checksum `2e8bba64abfba33c53e9528d20e9a096`.
+
+With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-fiqa-splade-distil-cocodenser-medium \
+  --corpus-path collections/beir-v1.0.0-fiqa
+```
+
+Alternatively, you can simply copy/paste from the commands below and obtain the same results.
+
+## Indexing
+
+Sample indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-fiqa \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-fiqa/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-fiqa &
+```
+
+The path `/path/to/beir-v1.0.0-fiqa/` should point to the corpus downloaded above.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+Upon completion, we should have an index with 57,638 documents.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the test set questions.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-fiqa/ \
+  -topics src/main/resources/topics-and-qrels/topics.beir-v1.0.0-fiqa.test.splade_distil_cocodenser_medium.tsv.gz \
+  -topicreader TsvString \
+  -output runs/run.beir-v1.0.0-fiqa.splade_distil_cocodenser_medium.topics.beir-v1.0.0-fiqa.test.splade_distil_cocodenser_medium.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-fiqa.test.txt runs/run.beir-v1.0.0-fiqa.splade_distil_cocodenser_medium.topics.beir-v1.0.0-fiqa.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-fiqa.test.txt runs/run.beir-v1.0.0-fiqa.splade_distil_cocodenser_medium.topics.beir-v1.0.0-fiqa.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-fiqa.test.txt runs/run.beir-v1.0.0-fiqa.splade_distil_cocodenser_medium.topics.beir-v1.0.0-fiqa.test.splade_distil_cocodenser_medium.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| nDCG@10                                                                                                      | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): fiqa                                                                                          | 0.3514    |
+
+
+| R@100                                                                                                        | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): fiqa                                                                                          | 0.6298    |
+
+
+| R@1000                                                                                                       | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): fiqa                                                                                          | 0.8323    |
+
+
+## Reproduction Log[*](reproducibility.md)
+
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/beir-v1.0.0-fiqa-splade-distil-cocodenser-medium.template) and run `bin/build.sh` to rebuild the documentation.

--- a/docs/regressions-beir-v1.0.0-fiqa-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-fiqa-splade-distil-cocodenser-medium.md
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; fiqa, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; fiqa
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/docs/regressions-beir-v1.0.0-hotpotqa-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-hotpotqa-splade-distil-cocodenser-medium.md
@@ -1,0 +1,108 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; hotpotqa, SPLADE-distil CoCodenser Medium
+
+**Model**: SPLADE-distil CoCodenser Medium
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; hotpotqa](http://beir.ai/).
+The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/beir-v1.0.0-hotpotqa-splade-distil-cocodenser-medium.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa-splade-distil-cocodenser-medium.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-hotpotqa-splade-distil-cocodenser-medium
+```
+
+## Corpus
+
+We make available a version of the BEIR-v1.0.0 hotpotqa corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+Thus, no neural inference is involved.
+For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
+
+Download the corpus and unpack into `collections/`:
+
+```
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/hotpotqa.tar -P collections/
+
+tar xvf collections/hotpotqa.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/hotpotqa
+```
+
+To confirm, `hotpotqa.tar` is 2.6 GB and has MD5 checksum `f20fef3ffbd95c19e9b64e9b4bc93f72`.
+
+With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-hotpotqa-splade-distil-cocodenser-medium \
+  --corpus-path collections/beir-v1.0.0-hotpotqa
+```
+
+Alternatively, you can simply copy/paste from the commands below and obtain the same results.
+
+## Indexing
+
+Sample indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-hotpotqa \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-hotpotqa/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-hotpotqa &
+```
+
+The path `/path/to/beir-v1.0.0-hotpotqa/` should point to the corpus downloaded above.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+Upon completion, we should have an index with 5,233,329 documents.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the test set questions.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-hotpotqa/ \
+  -topics src/main/resources/topics-and-qrels/topics.beir-v1.0.0-hotpotqa.test.splade_distil_cocodenser_medium.tsv.gz \
+  -topicreader TsvString \
+  -output runs/run.beir-v1.0.0-hotpotqa.splade_distil_cocodenser_medium.topics.beir-v1.0.0-hotpotqa.test.splade_distil_cocodenser_medium.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-hotpotqa.test.txt runs/run.beir-v1.0.0-hotpotqa.splade_distil_cocodenser_medium.topics.beir-v1.0.0-hotpotqa.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-hotpotqa.test.txt runs/run.beir-v1.0.0-hotpotqa.splade_distil_cocodenser_medium.topics.beir-v1.0.0-hotpotqa.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-hotpotqa.test.txt runs/run.beir-v1.0.0-hotpotqa.splade_distil_cocodenser_medium.topics.beir-v1.0.0-hotpotqa.test.splade_distil_cocodenser_medium.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| nDCG@10                                                                                                      | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): hotpotqa                                                                                      | 0.6860    |
+
+
+| R@100                                                                                                        | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): hotpotqa                                                                                      | 0.8144    |
+
+
+| R@1000                                                                                                       | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): hotpotqa                                                                                      | 0.8945    |
+
+
+## Reproduction Log[*](reproducibility.md)
+
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa-splade-distil-cocodenser-medium.template) and run `bin/build.sh` to rebuild the documentation.

--- a/docs/regressions-beir-v1.0.0-hotpotqa-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-hotpotqa-splade-distil-cocodenser-medium.md
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; hotpotqa, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; hotpotqa
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/docs/regressions-beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium.md
@@ -1,0 +1,108 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; nfcorpus, SPLADE-distil CoCodenser Medium
+
+**Model**: SPLADE-distil CoCodenser Medium
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; nfcorpus](http://beir.ai/).
+The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium
+```
+
+## Corpus
+
+We make available a version of the BEIR-v1.0.0 nfcorpus corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+Thus, no neural inference is involved.
+For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
+
+Download the corpus and unpack into `collections/`:
+
+```
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/nfcorpus.tar -P collections/
+
+tar xvf collections/nfcorpus.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/nfcorpus
+```
+
+To confirm, `nfcorpus.tar` is 3.2 MB and has MD5 checksum `e77855ca06a96206d97b1d9e3a2ee2a8`.
+
+With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium \
+  --corpus-path collections/beir-v1.0.0-nfcorpus
+```
+
+Alternatively, you can simply copy/paste from the commands below and obtain the same results.
+
+## Indexing
+
+Sample indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-nfcorpus \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-nfcorpus/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-nfcorpus &
+```
+
+The path `/path/to/beir-v1.0.0-nfcorpus/` should point to the corpus downloaded above.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+Upon completion, we should have an index with 3,633 documents.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the test set questions.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-nfcorpus/ \
+  -topics src/main/resources/topics-and-qrels/topics.beir-v1.0.0-nfcorpus.test.splade_distil_cocodenser_medium.tsv.gz \
+  -topicreader TsvString \
+  -output runs/run.beir-v1.0.0-nfcorpus.splade_distil_cocodenser_medium.topics.beir-v1.0.0-nfcorpus.test.splade_distil_cocodenser_medium.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-nfcorpus.test.txt runs/run.beir-v1.0.0-nfcorpus.splade_distil_cocodenser_medium.topics.beir-v1.0.0-nfcorpus.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-nfcorpus.test.txt runs/run.beir-v1.0.0-nfcorpus.splade_distil_cocodenser_medium.topics.beir-v1.0.0-nfcorpus.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-nfcorpus.test.txt runs/run.beir-v1.0.0-nfcorpus.splade_distil_cocodenser_medium.topics.beir-v1.0.0-nfcorpus.test.splade_distil_cocodenser_medium.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| nDCG@10                                                                                                      | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): nfcorpus                                                                                      | 0.3454    |
+
+
+| R@100                                                                                                        | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): nfcorpus                                                                                      | 0.2891    |
+
+
+| R@1000                                                                                                       | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): nfcorpus                                                                                      | 0.5694    |
+
+
+## Reproduction Log[*](reproducibility.md)
+
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium.template) and run `bin/build.sh` to rebuild the documentation.

--- a/docs/regressions-beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium.md
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; nfcorpus, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; nfcorpus
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/docs/regressions-beir-v1.0.0-nq-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-nq-splade-distil-cocodenser-medium.md
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; nq, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; nq
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/docs/regressions-beir-v1.0.0-nq-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-nq-splade-distil-cocodenser-medium.md
@@ -1,0 +1,108 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; nq, SPLADE-distil CoCodenser Medium
+
+**Model**: SPLADE-distil CoCodenser Medium
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; nq](http://beir.ai/).
+The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/beir-v1.0.0-nq-splade-distil-cocodenser-medium.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/beir-v1.0.0-nq-splade-distil-cocodenser-medium.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-nq-splade-distil-cocodenser-medium
+```
+
+## Corpus
+
+We make available a version of the BEIR-v1.0.0 nq corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+Thus, no neural inference is involved.
+For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
+
+Download the corpus and unpack into `collections/`:
+
+```
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/nq.tar -P collections/
+
+tar xvf collections/nq.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/nq
+```
+
+To confirm, `nq.tar` is 1.9 GB and has MD5 checksum `410a3a1ac4bef85b497296b53093cb34`.
+
+With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-nq-splade-distil-cocodenser-medium \
+  --corpus-path collections/beir-v1.0.0-nq
+```
+
+Alternatively, you can simply copy/paste from the commands below and obtain the same results.
+
+## Indexing
+
+Sample indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-nq \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-nq/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-nq &
+```
+
+The path `/path/to/beir-v1.0.0-nq/` should point to the corpus downloaded above.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+Upon completion, we should have an index with 2,681,468 documents.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the test set questions.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-nq/ \
+  -topics src/main/resources/topics-and-qrels/topics.beir-v1.0.0-nq.test.splade_distil_cocodenser_medium.tsv.gz \
+  -topicreader TsvString \
+  -output runs/run.beir-v1.0.0-nq.splade_distil_cocodenser_medium.topics.beir-v1.0.0-nq.test.splade_distil_cocodenser_medium.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-nq.test.txt runs/run.beir-v1.0.0-nq.splade_distil_cocodenser_medium.topics.beir-v1.0.0-nq.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-nq.test.txt runs/run.beir-v1.0.0-nq.splade_distil_cocodenser_medium.topics.beir-v1.0.0-nq.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-nq.test.txt runs/run.beir-v1.0.0-nq.splade_distil_cocodenser_medium.topics.beir-v1.0.0-nq.test.splade_distil_cocodenser_medium.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| nDCG@10                                                                                                      | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): nq                                                                                            | 0.5443    |
+
+
+| R@100                                                                                                        | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): nq                                                                                            | 0.9285    |
+
+
+| R@1000                                                                                                       | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): nq                                                                                            | 0.9812    |
+
+
+## Reproduction Log[*](reproducibility.md)
+
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/beir-v1.0.0-nq-splade-distil-cocodenser-medium.template) and run `bin/build.sh` to rebuild the documentation.

--- a/docs/regressions-beir-v1.0.0-quora-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-quora-splade-distil-cocodenser-medium.md
@@ -1,0 +1,108 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; quora, SPLADE-distil CoCodenser Medium
+
+**Model**: SPLADE-distil CoCodenser Medium
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; quora](http://beir.ai/).
+The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/beir-v1.0.0-quora-splade-distil-cocodenser-medium.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/beir-v1.0.0-quora-splade-distil-cocodenser-medium.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-quora-splade-distil-cocodenser-medium
+```
+
+## Corpus
+
+We make available a version of the BEIR-v1.0.0 quora corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+Thus, no neural inference is involved.
+For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
+
+Download the corpus and unpack into `collections/`:
+
+```
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/quora.tar -P collections/
+
+tar xvf collections/quora.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/quora
+```
+
+To confirm, `quora.tar` is 112 MB and has MD5 checksum `93d6659dedfbf226ce68ad10f28db6e4`.
+
+With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-quora-splade-distil-cocodenser-medium \
+  --corpus-path collections/beir-v1.0.0-quora
+```
+
+Alternatively, you can simply copy/paste from the commands below and obtain the same results.
+
+## Indexing
+
+Sample indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-quora \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-quora/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-quora &
+```
+
+The path `/path/to/beir-v1.0.0-quora/` should point to the corpus downloaded above.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+Upon completion, we should have an index with 522,931 documents.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the test set questions.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-quora/ \
+  -topics src/main/resources/topics-and-qrels/topics.beir-v1.0.0-quora.test.splade_distil_cocodenser_medium.tsv.gz \
+  -topicreader TsvString \
+  -output runs/run.beir-v1.0.0-quora.splade_distil_cocodenser_medium.topics.beir-v1.0.0-quora.test.splade_distil_cocodenser_medium.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-quora.test.txt runs/run.beir-v1.0.0-quora.splade_distil_cocodenser_medium.topics.beir-v1.0.0-quora.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-quora.test.txt runs/run.beir-v1.0.0-quora.splade_distil_cocodenser_medium.topics.beir-v1.0.0-quora.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-quora.test.txt runs/run.beir-v1.0.0-quora.splade_distil_cocodenser_medium.topics.beir-v1.0.0-quora.test.splade_distil_cocodenser_medium.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| nDCG@10                                                                                                      | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): quora                                                                                         | 0.8136    |
+
+
+| R@100                                                                                                        | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): quora                                                                                         | 0.9817    |
+
+
+| R@1000                                                                                                       | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): quora                                                                                         | 0.9979    |
+
+
+## Reproduction Log[*](reproducibility.md)
+
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/beir-v1.0.0-quora-splade-distil-cocodenser-medium.template) and run `bin/build.sh` to rebuild the documentation.

--- a/docs/regressions-beir-v1.0.0-quora-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-quora-splade-distil-cocodenser-medium.md
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; quora, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; quora
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/docs/regressions-beir-v1.0.0-scidocs-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-scidocs-splade-distil-cocodenser-medium.md
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; scidocs, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; scidocs
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/docs/regressions-beir-v1.0.0-scidocs-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-scidocs-splade-distil-cocodenser-medium.md
@@ -1,0 +1,108 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; scidocs, SPLADE-distil CoCodenser Medium
+
+**Model**: SPLADE-distil CoCodenser Medium
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; scidocs](http://beir.ai/).
+The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/beir-v1.0.0-scidocs-splade-distil-cocodenser-medium.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/beir-v1.0.0-scidocs-splade-distil-cocodenser-medium.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-scidocs-splade-distil-cocodenser-medium
+```
+
+## Corpus
+
+We make available a version of the BEIR-v1.0.0 scidocs corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+Thus, no neural inference is involved.
+For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
+
+Download the corpus and unpack into `collections/`:
+
+```
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/scidocs.tar -P collections/
+
+tar xvf collections/scidocs.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/scidocs
+```
+
+To confirm, `scidocs.tar` is 24 MB and has MD5 checksum `1cc218ecc94473fafa98881ebbfa24b9`.
+
+With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-scidocs-splade-distil-cocodenser-medium \
+  --corpus-path collections/beir-v1.0.0-scidocs
+```
+
+Alternatively, you can simply copy/paste from the commands below and obtain the same results.
+
+## Indexing
+
+Sample indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-scidocs \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-scidocs/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-scidocs &
+```
+
+The path `/path/to/beir-v1.0.0-scidocs/` should point to the corpus downloaded above.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+Upon completion, we should have an index with 25,657 documents.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the test set questions.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-scidocs/ \
+  -topics src/main/resources/topics-and-qrels/topics.beir-v1.0.0-scidocs.test.splade_distil_cocodenser_medium.tsv.gz \
+  -topicreader TsvString \
+  -output runs/run.beir-v1.0.0-scidocs.splade_distil_cocodenser_medium.topics.beir-v1.0.0-scidocs.test.splade_distil_cocodenser_medium.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-scidocs.test.txt runs/run.beir-v1.0.0-scidocs.splade_distil_cocodenser_medium.topics.beir-v1.0.0-scidocs.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-scidocs.test.txt runs/run.beir-v1.0.0-scidocs.splade_distil_cocodenser_medium.topics.beir-v1.0.0-scidocs.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-scidocs.test.txt runs/run.beir-v1.0.0-scidocs.splade_distil_cocodenser_medium.topics.beir-v1.0.0-scidocs.test.splade_distil_cocodenser_medium.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| nDCG@10                                                                                                      | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): scidocs                                                                                       | 0.1590    |
+
+
+| R@100                                                                                                        | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): scidocs                                                                                       | 0.3671    |
+
+
+| R@1000                                                                                                       | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): scidocs                                                                                       | 0.5891    |
+
+
+## Reproduction Log[*](reproducibility.md)
+
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/beir-v1.0.0-scidocs-splade-distil-cocodenser-medium.template) and run `bin/build.sh` to rebuild the documentation.

--- a/docs/regressions-beir-v1.0.0-scifact-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-scifact-splade-distil-cocodenser-medium.md
@@ -1,0 +1,108 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; scifact, SPLADE-distil CoCodenser Medium
+
+**Model**: SPLADE-distil CoCodenser Medium
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; scifact](http://beir.ai/).
+The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/beir-v1.0.0-scifact-splade-distil-cocodenser-medium.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/beir-v1.0.0-scifact-splade-distil-cocodenser-medium.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-scifact-splade-distil-cocodenser-medium
+```
+
+## Corpus
+
+We make available a version of the BEIR-v1.0.0 scifact corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+Thus, no neural inference is involved.
+For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
+
+Download the corpus and unpack into `collections/`:
+
+```
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/scifact.tar -P collections/
+
+tar xvf collections/scifact.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/scifact
+```
+
+To confirm, `scifact.tar` is 4.8 MB and has MD5 checksum `4ac1e39fef272755a06e770c886d5bb6`.
+
+With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-scifact-splade-distil-cocodenser-medium \
+  --corpus-path collections/beir-v1.0.0-scifact
+```
+
+Alternatively, you can simply copy/paste from the commands below and obtain the same results.
+
+## Indexing
+
+Sample indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-scifact \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-scifact/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-scifact &
+```
+
+The path `/path/to/beir-v1.0.0-scifact/` should point to the corpus downloaded above.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+Upon completion, we should have an index with 5,183 documents.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the test set questions.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-scifact/ \
+  -topics src/main/resources/topics-and-qrels/topics.beir-v1.0.0-scifact.test.splade_distil_cocodenser_medium.tsv.gz \
+  -topicreader TsvString \
+  -output runs/run.beir-v1.0.0-scifact.splade_distil_cocodenser_medium.topics.beir-v1.0.0-scifact.test.splade_distil_cocodenser_medium.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-scifact.test.txt runs/run.beir-v1.0.0-scifact.splade_distil_cocodenser_medium.topics.beir-v1.0.0-scifact.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-scifact.test.txt runs/run.beir-v1.0.0-scifact.splade_distil_cocodenser_medium.topics.beir-v1.0.0-scifact.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-scifact.test.txt runs/run.beir-v1.0.0-scifact.splade_distil_cocodenser_medium.topics.beir-v1.0.0-scifact.test.splade_distil_cocodenser_medium.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| nDCG@10                                                                                                      | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): scifact                                                                                       | 0.6992    |
+
+
+| R@100                                                                                                        | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): scifact                                                                                       | 0.9270    |
+
+
+| R@1000                                                                                                       | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): scifact                                                                                       | 0.9767    |
+
+
+## Reproduction Log[*](reproducibility.md)
+
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/beir-v1.0.0-scifact-splade-distil-cocodenser-medium.template) and run `bin/build.sh` to rebuild the documentation.

--- a/docs/regressions-beir-v1.0.0-scifact-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-scifact-splade-distil-cocodenser-medium.md
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; scifact, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; scifact
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/docs/regressions-beir-v1.0.0-trec-covid-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-trec-covid-splade-distil-cocodenser-medium.md
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; trec-covid, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; trec-covid
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/docs/regressions-beir-v1.0.0-trec-covid-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-trec-covid-splade-distil-cocodenser-medium.md
@@ -1,0 +1,108 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; trec-covid, SPLADE-distil CoCodenser Medium
+
+**Model**: SPLADE-distil CoCodenser Medium
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; trec-covid](http://beir.ai/).
+The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/beir-v1.0.0-trec-covid-splade-distil-cocodenser-medium.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/beir-v1.0.0-trec-covid-splade-distil-cocodenser-medium.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-trec-covid-splade-distil-cocodenser-medium
+```
+
+## Corpus
+
+We make available a version of the BEIR-v1.0.0 trec-covid corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+Thus, no neural inference is involved.
+For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
+
+Download the corpus and unpack into `collections/`:
+
+```
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/trec-covid.tar -P collections/
+
+tar xvf collections/trec-covid.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/trec-covid
+```
+
+To confirm, `trec-covid.tar` is 133 MB and has MD5 checksum `6819744082e545203c07c03446484f81`.
+
+With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-trec-covid-splade-distil-cocodenser-medium \
+  --corpus-path collections/beir-v1.0.0-trec-covid
+```
+
+Alternatively, you can simply copy/paste from the commands below and obtain the same results.
+
+## Indexing
+
+Sample indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-trec-covid \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-trec-covid/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-trec-covid &
+```
+
+The path `/path/to/beir-v1.0.0-trec-covid/` should point to the corpus downloaded above.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+Upon completion, we should have an index with 171,332 documents.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the test set questions.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-trec-covid/ \
+  -topics src/main/resources/topics-and-qrels/topics.beir-v1.0.0-trec-covid.test.splade_distil_cocodenser_medium.tsv.gz \
+  -topicreader TsvString \
+  -output runs/run.beir-v1.0.0-trec-covid.splade_distil_cocodenser_medium.topics.beir-v1.0.0-trec-covid.test.splade_distil_cocodenser_medium.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-trec-covid.test.txt runs/run.beir-v1.0.0-trec-covid.splade_distil_cocodenser_medium.topics.beir-v1.0.0-trec-covid.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-trec-covid.test.txt runs/run.beir-v1.0.0-trec-covid.splade_distil_cocodenser_medium.topics.beir-v1.0.0-trec-covid.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-trec-covid.test.txt runs/run.beir-v1.0.0-trec-covid.splade_distil_cocodenser_medium.topics.beir-v1.0.0-trec-covid.test.splade_distil_cocodenser_medium.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| nDCG@10                                                                                                      | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): trec-covid                                                                                    | 0.7109    |
+
+
+| R@100                                                                                                        | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): trec-covid                                                                                    | 0.1308    |
+
+
+| R@1000                                                                                                       | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): trec-covid                                                                                    | 0.4433    |
+
+
+## Reproduction Log[*](reproducibility.md)
+
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/beir-v1.0.0-trec-covid-splade-distil-cocodenser-medium.template) and run `bin/build.sh` to rebuild the documentation.

--- a/docs/regressions-beir-v1.0.0-webis-touche2020-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-webis-touche2020-splade-distil-cocodenser-medium.md
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; webis-touche2020, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; webis-touche2020
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/docs/regressions-beir-v1.0.0-webis-touche2020-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-webis-touche2020-splade-distil-cocodenser-medium.md
@@ -1,0 +1,108 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; webis-touche2020, SPLADE-distil CoCodenser Medium
+
+**Model**: SPLADE-distil CoCodenser Medium
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; webis-touche2020](http://beir.ai/).
+The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
+
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/beir-v1.0.0-webis-touche2020-splade-distil-cocodenser-medium.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020-splade-distil-cocodenser-medium.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-webis-touche2020-splade-distil-cocodenser-medium
+```
+
+## Corpus
+
+We make available a version of the BEIR-v1.0.0 webis-touche2020 corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+Thus, no neural inference is involved.
+For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
+
+Download the corpus and unpack into `collections/`:
+
+```
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/webis-touche2020.tar -P collections/
+
+tar xvf collections/webis-touche2020.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/webis-touche2020
+```
+
+To confirm, `webis-touche2020.tar` is 293 MB and has MD5 checksum `526ade9107d188bbd912ebd0f8313aec`.
+
+With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-webis-touche2020-splade-distil-cocodenser-medium \
+  --corpus-path collections/beir-v1.0.0-webis-touche2020
+```
+
+Alternatively, you can simply copy/paste from the commands below and obtain the same results.
+
+## Indexing
+
+Sample indexing command:
+
+```
+target/appassembler/bin/IndexCollection \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-webis-touche2020 \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-webis-touche2020/ \
+  -generator DefaultLuceneDocumentGenerator \
+  -threads 16 -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-webis-touche2020 &
+```
+
+The path `/path/to/beir-v1.0.0-webis-touche2020/` should point to the corpus downloaded above.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+Upon completion, we should have an index with 382,545 documents.
+
+For additional details, see explanation of [common indexing options](common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored in [`src/main/resources/topics-and-qrels/`](../src/main/resources/topics-and-qrels/).
+The regression experiments here evaluate on the test set questions.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+target/appassembler/bin/SearchCollection \
+  -index indexes/lucene-index.splade_distil_cocodenser_medium-webis-touche2020/ \
+  -topics src/main/resources/topics-and-qrels/topics.beir-v1.0.0-webis-touche2020.test.splade_distil_cocodenser_medium.tsv.gz \
+  -topicreader TsvString \
+  -output runs/run.beir-v1.0.0-webis-touche2020.splade_distil_cocodenser_medium.topics.beir-v1.0.0-webis-touche2020.test.splade_distil_cocodenser_medium.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-webis-touche2020.test.txt runs/run.beir-v1.0.0-webis-touche2020.splade_distil_cocodenser_medium.topics.beir-v1.0.0-webis-touche2020.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-webis-touche2020.test.txt runs/run.beir-v1.0.0-webis-touche2020.splade_distil_cocodenser_medium.topics.beir-v1.0.0-webis-touche2020.test.splade_distil_cocodenser_medium.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.beir-v1.0.0-webis-touche2020.test.txt runs/run.beir-v1.0.0-webis-touche2020.splade_distil_cocodenser_medium.topics.beir-v1.0.0-webis-touche2020.test.splade_distil_cocodenser_medium.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| nDCG@10                                                                                                      | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): webis-touche2020                                                                              | 0.2435    |
+
+
+| R@100                                                                                                        | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): webis-touche2020                                                                              | 0.4723    |
+
+
+| R@1000                                                                                                       | SPLADE-distill CoCodenser Medium|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): webis-touche2020                                                                              | 0.8116    |
+
+
+## Reproduction Log[*](reproducibility.md)
+
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020-splade-distil-cocodenser-medium.template) and run `bin/build.sh` to rebuild the documentation.

--- a/src/main/resources/docgen/templates/beir-v1.0.0-arguana-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-arguana-splade-distil-cocodenser-medium.template
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; arguana, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; arguana
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever-splade-distil-cocodenser-medium.template
@@ -1,8 +1,8 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; arguana, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; climate-fever, SPLADE-distil CoCodenser Medium
 
 **Model**: SPLADE-distil CoCodenser Medium
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; arguana](http://beir.ai/).
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; climate-fever](http://beir.ai/).
 The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
@@ -16,19 +16,19 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Corpus
 
-We make available a version of the BEIR-v1.0.0 arguana corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+We make available a version of the BEIR-v1.0.0 climate-fever corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
 For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
 
 Download the corpus and unpack into `collections/`:
 
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana.tar -P collections/
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/climate-fever.tar -P collections/
 
-tar xvf collections/arguana.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
+tar xvf collections/climate-fever.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/climate-fever
 ```
 
-To confirm, `arguana.tar` is 8.9 MB and has MD5 checksum `cbc95edcaf1d7306d780aa913d2e9018`.
+To confirm, `climate-fever.tar` is 3.2 GB and has MD5 checksum `a123403f521a95f30c1db4bede45fe0e`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
@@ -50,7 +50,7 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
-Upon completion, we should have an index with 8,674 documents.
+Upon completion, we should have an index with 5,416,593 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever-splade-distil-cocodenser-medium.template
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; climate-fever, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; climate-fever
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium.template
@@ -1,8 +1,8 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; arguana, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; dbpedia-entity, SPLADE-distil CoCodenser Medium
 
 **Model**: SPLADE-distil CoCodenser Medium
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; arguana](http://beir.ai/).
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; dbpedia-entity](http://beir.ai/).
 The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
@@ -16,19 +16,19 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Corpus
 
-We make available a version of the BEIR-v1.0.0 arguana corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+We make available a version of the BEIR-v1.0.0 dbpedia-entity corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
 For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
 
 Download the corpus and unpack into `collections/`:
 
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana.tar -P collections/
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/dbpedia-entity.tar -P collections/
 
-tar xvf collections/arguana.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
+tar xvf collections/dbpedia-entity.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/dbpedia-entity
 ```
 
-To confirm, `arguana.tar` is 8.9 MB and has MD5 checksum `cbc95edcaf1d7306d780aa913d2e9018`.
+To confirm, `dbpedia-entity.tar` is 2.5 GB and has MD5 checksum `a52d2752b1b21397cd10b78f7235dcee`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
@@ -50,7 +50,7 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
-Upon completion, we should have an index with 8,674 documents.
+Upon completion, we should have an index with 4,635,922 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium.template
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; dbpedia-entity, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; dbpedia-entity
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fever-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fever-splade-distil-cocodenser-medium.template
@@ -1,8 +1,8 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; arguana, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; fever, SPLADE-distil CoCodenser Medium
 
 **Model**: SPLADE-distil CoCodenser Medium
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; arguana](http://beir.ai/).
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; fever](http://beir.ai/).
 The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
@@ -16,19 +16,19 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Corpus
 
-We make available a version of the BEIR-v1.0.0 arguana corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+We make available a version of the BEIR-v1.0.0 fever corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
 For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
 
 Download the corpus and unpack into `collections/`:
 
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana.tar -P collections/
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/fever.tar -P collections/
 
-tar xvf collections/arguana.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
+tar xvf collections/fever.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/fever
 ```
 
-To confirm, `arguana.tar` is 8.9 MB and has MD5 checksum `cbc95edcaf1d7306d780aa913d2e9018`.
+To confirm, `fever.tar` is 3.2 GB and has MD5 checksum `dcc9c7e61df122781e872e6e8ded7a3e`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
@@ -50,7 +50,7 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
-Upon completion, we should have an index with 8,674 documents.
+Upon completion, we should have an index with 5,416,568 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fever-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fever-splade-distil-cocodenser-medium.template
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; fever, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; fever
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fiqa-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fiqa-splade-distil-cocodenser-medium.template
@@ -1,8 +1,8 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; arguana, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; fiqa, SPLADE-distil CoCodenser Medium
 
 **Model**: SPLADE-distil CoCodenser Medium
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; arguana](http://beir.ai/).
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; fiqa](http://beir.ai/).
 The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
@@ -16,19 +16,19 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Corpus
 
-We make available a version of the BEIR-v1.0.0 arguana corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+We make available a version of the BEIR-v1.0.0 fiqa corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
 For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
 
 Download the corpus and unpack into `collections/`:
 
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana.tar -P collections/
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/fiqa.tar -P collections/
 
-tar xvf collections/arguana.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
+tar xvf collections/fiqa.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/fiqa
 ```
 
-To confirm, `arguana.tar` is 8.9 MB and has MD5 checksum `cbc95edcaf1d7306d780aa913d2e9018`.
+To confirm, `fiqa.tar` is 3.2 GB and has MD5 checksum `2e8bba64abfba33c53e9528d20e9a096`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
@@ -50,7 +50,7 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
-Upon completion, we should have an index with 8,674 documents.
+Upon completion, we should have an index with 57,638 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fiqa-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fiqa-splade-distil-cocodenser-medium.template
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; fiqa, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; fiqa
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa-splade-distil-cocodenser-medium.template
@@ -1,8 +1,8 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; arguana, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; hotpotqa, SPLADE-distil CoCodenser Medium
 
 **Model**: SPLADE-distil CoCodenser Medium
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; arguana](http://beir.ai/).
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; hotpotqa](http://beir.ai/).
 The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
@@ -16,19 +16,19 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Corpus
 
-We make available a version of the BEIR-v1.0.0 arguana corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+We make available a version of the BEIR-v1.0.0 hotpotqa corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
 For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
 
 Download the corpus and unpack into `collections/`:
 
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana.tar -P collections/
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/hotpotqa.tar -P collections/
 
-tar xvf collections/arguana.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
+tar xvf collections/hotpotqa.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/hotpotqa
 ```
 
-To confirm, `arguana.tar` is 8.9 MB and has MD5 checksum `cbc95edcaf1d7306d780aa913d2e9018`.
+To confirm, `hotpotqa.tar` is 2.6 GB and has MD5 checksum `f20fef3ffbd95c19e9b64e9b4bc93f72`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
@@ -50,7 +50,7 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
-Upon completion, we should have an index with 8,674 documents.
+Upon completion, we should have an index with 5,233,329 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa-splade-distil-cocodenser-medium.template
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; hotpotqa, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; hotpotqa
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium.template
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; nfcorpus, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; nfcorpus
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium.template
@@ -1,8 +1,8 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; arguana, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; nfcorpus, SPLADE-distil CoCodenser Medium
 
 **Model**: SPLADE-distil CoCodenser Medium
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; arguana](http://beir.ai/).
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; nfcorpus](http://beir.ai/).
 The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
@@ -16,19 +16,19 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Corpus
 
-We make available a version of the BEIR-v1.0.0 arguana corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+We make available a version of the BEIR-v1.0.0 nfcorpus corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
 For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
 
 Download the corpus and unpack into `collections/`:
 
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana.tar -P collections/
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/nfcorpus.tar -P collections/
 
-tar xvf collections/arguana.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
+tar xvf collections/nfcorpus.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/nfcorpus
 ```
 
-To confirm, `arguana.tar` is 8.9 MB and has MD5 checksum `cbc95edcaf1d7306d780aa913d2e9018`.
+To confirm, `nfcorpus.tar` is 3.2 MB and has MD5 checksum `e77855ca06a96206d97b1d9e3a2ee2a8`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
@@ -50,7 +50,7 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
-Upon completion, we should have an index with 8,674 documents.
+Upon completion, we should have an index with 3,633 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nq-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nq-splade-distil-cocodenser-medium.template
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; nq, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; nq
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nq-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nq-splade-distil-cocodenser-medium.template
@@ -1,8 +1,8 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; arguana, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; nq, SPLADE-distil CoCodenser Medium
 
 **Model**: SPLADE-distil CoCodenser Medium
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; arguana](http://beir.ai/).
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; nq](http://beir.ai/).
 The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
@@ -16,19 +16,19 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Corpus
 
-We make available a version of the BEIR-v1.0.0 arguana corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+We make available a version of the BEIR-v1.0.0 nq corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
 For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
 
 Download the corpus and unpack into `collections/`:
 
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana.tar -P collections/
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/nq.tar -P collections/
 
-tar xvf collections/arguana.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
+tar xvf collections/nq.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/nq
 ```
 
-To confirm, `arguana.tar` is 8.9 MB and has MD5 checksum `cbc95edcaf1d7306d780aa913d2e9018`.
+To confirm, `nq.tar` is 1.9 GB and has MD5 checksum `410a3a1ac4bef85b497296b53093cb34`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
@@ -50,7 +50,7 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
-Upon completion, we should have an index with 8,674 documents.
+Upon completion, we should have an index with 2,681,468 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-quora-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-quora-splade-distil-cocodenser-medium.template
@@ -1,8 +1,8 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; arguana, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; quora, SPLADE-distil CoCodenser Medium
 
 **Model**: SPLADE-distil CoCodenser Medium
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; arguana](http://beir.ai/).
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; quora](http://beir.ai/).
 The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
@@ -16,19 +16,19 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Corpus
 
-We make available a version of the BEIR-v1.0.0 arguana corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+We make available a version of the BEIR-v1.0.0 quora corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
 For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
 
 Download the corpus and unpack into `collections/`:
 
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana.tar -P collections/
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/quora.tar -P collections/
 
-tar xvf collections/arguana.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
+tar xvf collections/quora.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/quora
 ```
 
-To confirm, `arguana.tar` is 8.9 MB and has MD5 checksum `cbc95edcaf1d7306d780aa913d2e9018`.
+To confirm, `quora.tar` is 112 MB and has MD5 checksum `93d6659dedfbf226ce68ad10f28db6e4`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
@@ -50,7 +50,7 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
-Upon completion, we should have an index with 8,674 documents.
+Upon completion, we should have an index with 522,931 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-quora-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-quora-splade-distil-cocodenser-medium.template
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; quora, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; quora
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scidocs-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scidocs-splade-distil-cocodenser-medium.template
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; scidocs, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; scidocs
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scidocs-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scidocs-splade-distil-cocodenser-medium.template
@@ -1,8 +1,8 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; arguana, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; scidocs, SPLADE-distil CoCodenser Medium
 
 **Model**: SPLADE-distil CoCodenser Medium
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; arguana](http://beir.ai/).
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; scidocs](http://beir.ai/).
 The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
@@ -16,19 +16,19 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Corpus
 
-We make available a version of the BEIR-v1.0.0 arguana corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+We make available a version of the BEIR-v1.0.0 scidocs corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
 For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
 
 Download the corpus and unpack into `collections/`:
 
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana.tar -P collections/
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/scidocs.tar -P collections/
 
-tar xvf collections/arguana.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
+tar xvf collections/scidocs.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/scidocs
 ```
 
-To confirm, `arguana.tar` is 8.9 MB and has MD5 checksum `cbc95edcaf1d7306d780aa913d2e9018`.
+To confirm, `scidocs.tar` is 24 MB and has MD5 checksum `1cc218ecc94473fafa98881ebbfa24b9`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
@@ -50,7 +50,7 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
-Upon completion, we should have an index with 8,674 documents.
+Upon completion, we should have an index with 25,657 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scifact-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scifact-splade-distil-cocodenser-medium.template
@@ -1,8 +1,8 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; arguana, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; scifact, SPLADE-distil CoCodenser Medium
 
 **Model**: SPLADE-distil CoCodenser Medium
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; arguana](http://beir.ai/).
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; scifact](http://beir.ai/).
 The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
@@ -16,19 +16,19 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Corpus
 
-We make available a version of the BEIR-v1.0.0 arguana corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+We make available a version of the BEIR-v1.0.0 scifact corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
 For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
 
 Download the corpus and unpack into `collections/`:
 
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana.tar -P collections/
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/scifact.tar -P collections/
 
-tar xvf collections/arguana.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
+tar xvf collections/scifact.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/scifact
 ```
 
-To confirm, `arguana.tar` is 8.9 MB and has MD5 checksum `cbc95edcaf1d7306d780aa913d2e9018`.
+To confirm, `scifact.tar` is 4.8 MB and has MD5 checksum `4ac1e39fef272755a06e770c886d5bb6`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
@@ -50,7 +50,7 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
-Upon completion, we should have an index with 8,674 documents.
+Upon completion, we should have an index with 5,183 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scifact-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scifact-splade-distil-cocodenser-medium.template
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; scifact, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; scifact
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid-splade-distil-cocodenser-medium.template
@@ -1,8 +1,8 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; arguana, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; trec-covid, SPLADE-distil CoCodenser Medium
 
 **Model**: SPLADE-distil CoCodenser Medium
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; arguana](http://beir.ai/).
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; trec-covid](http://beir.ai/).
 The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
@@ -16,19 +16,19 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Corpus
 
-We make available a version of the BEIR-v1.0.0 arguana corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+We make available a version of the BEIR-v1.0.0 trec-covid corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
 For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
 
 Download the corpus and unpack into `collections/`:
 
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana.tar -P collections/
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/trec-covid.tar -P collections/
 
-tar xvf collections/arguana.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
+tar xvf collections/trec-covid.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/trec-covid
 ```
 
-To confirm, `arguana.tar` is 8.9 MB and has MD5 checksum `cbc95edcaf1d7306d780aa913d2e9018`.
+To confirm, `trec-covid.tar` is 133 MB and has MD5 checksum `6819744082e545203c07c03446484f81`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
@@ -50,7 +50,7 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
-Upon completion, we should have an index with 8,674 documents.
+Upon completion, we should have an index with 171,332 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid-splade-distil-cocodenser-medium.template
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; trec-covid, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; trec-covid
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020-splade-distil-cocodenser-medium.template
@@ -1,4 +1,4 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; webis-touche2020, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; webis-touche2020
 
 **Model**: SPLADE-distil CoCodenser Medium
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020-splade-distil-cocodenser-medium.template
@@ -1,8 +1,8 @@
-# Anserini Regressions: BEIR (v1.0.0) &mdash; arguana, SPLADE-distil CoCodenser Medium
+# Anserini Regressions: BEIR (v1.0.0) &mdash; webis-touche2020, SPLADE-distil CoCodenser Medium
 
 **Model**: SPLADE-distil CoCodenser Medium
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; arguana](http://beir.ai/).
+This page describes regression experiments, integrated into Anserini's regression testing framework, using SPLADE-distil CoCodenser Medium on the [BEIR (v1.0.0) &mdash; webis-touche2020](http://beir.ai/).
 The SPLADE-distil CoCodenser Medium model is open-sourced by [Naver Labs Europe](https://europe.naverlabs.com/research/machine-learning-and-optimization/splade-models)
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
@@ -16,19 +16,19 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Corpus
 
-We make available a version of the BEIR-v1.0.0 arguana corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
+We make available a version of the BEIR-v1.0.0 webis-touche2020 corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
 For details on how to train SPLADE-distil CoCodenser Medium and perform inference, please see [guide provided by Naver Labs Europe](https://github.com/naver/splade/tree/main/anserini_evaluation).
 
 Download the corpus and unpack into `collections/`:
 
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana.tar -P collections/
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/collections/beir-v1.0.0/splade_distil_cocodenser_medium/webis-touche2020.tar -P collections/
 
-tar xvf collections/arguana.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
+tar xvf collections/webis-touche2020.tar -C collections/beir-v1.0.0/splade_distil_cocodenser_medium/webis-touche2020
 ```
 
-To confirm, `arguana.tar` is 8.9 MB and has MD5 checksum `cbc95edcaf1d7306d780aa913d2e9018`.
+To confirm, `webis-touche2020.tar` is 293 MB and has MD5 checksum `526ade9107d188bbd912ebd0f8313aec`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
@@ -50,7 +50,7 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
-Upon completion, we should have an index with 8,674 documents.
+Upon completion, we should have an index with 382,545 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
 

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever-splade-distil-cocodenser-medium.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever-splade-distil-cocodenser-medium.yaml
@@ -1,14 +1,14 @@
-corpus: beir-v1.0.0-arguana
-corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
-index_path: indexes/lucene-index.splade_distil_cocodenser_medium-arguana/
+corpus: beir-v1.0.0-climate-fever
+corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/climate-fever
+index_path: indexes/lucene-index.splade_distil_cocodenser_medium-climate-fever/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 16
 index_options: -impact -pretokenized
 index_stats:
-  documents: 8674
-  documents (non-empty): 8674
-  total terms: 96421121
+  documents: 5416593
+  documents (non-empty): 5416593
+  total terms: 38845226073
 metrics:
 - metric: nDCG@10
   command: tools/eval/trec_eval.9.0.4/trec_eval
@@ -35,18 +35,18 @@ topic_reader: TsvString
 topic_root: src/main/resources/topics-and-qrels/
 qrels_root: src/main/resources/topics-and-qrels/
 topics:
-- name: 'BEIR (v1.0.0): arguana'
+- name: 'BEIR (v1.0.0): climate-fever'
   id: test
-  path: topics.beir-v1.0.0-arguana.test.splade_distil_cocodenser_medium.tsv.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  path: topics.beir-v1.0.0-climate-fever.test.splade_distil_cocodenser_medium.tsv.gz
+  qrel: qrels.beir-v1.0.0-climate-fever.test.txt
 models:
 - name: splade_distil_cocodenser_medium
   display: SPLADE-distill CoCodenser Medium
   params: -impact -pretokenized -removeQuery -hits 1000
   results:
     nDCG@10:
-    - 0.5210
+    - 0.2276
     R@100:
-    - 0.9822
+    - 0.5140
     R@1000:
-    - 0.9950
+    - 0.7084

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity-splade-distil-cocodenser-medium.yaml
@@ -1,14 +1,14 @@
-corpus: beir-v1.0.0-arguana
-corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
-index_path: indexes/lucene-index.splade_distil_cocodenser_medium-arguana/
+corpus: beir-v1.0.0-dbpedia-entity
+corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/dbpedia-entity
+index_path: indexes/lucene-index.splade_distil_cocodenser_medium-dbpedia-entity/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 16
 index_options: -impact -pretokenized
 index_stats:
-  documents: 8674
-  documents (non-empty): 8674
-  total terms: 96421121
+  documents: 4635922
+  documents (non-empty): 4635922
+  total terms: 30490098411
 metrics:
 - metric: nDCG@10
   command: tools/eval/trec_eval.9.0.4/trec_eval
@@ -35,18 +35,18 @@ topic_reader: TsvString
 topic_root: src/main/resources/topics-and-qrels/
 qrels_root: src/main/resources/topics-and-qrels/
 topics:
-- name: 'BEIR (v1.0.0): arguana'
+- name: 'BEIR (v1.0.0): dbpedia-entity'
   id: test
-  path: topics.beir-v1.0.0-arguana.test.splade_distil_cocodenser_medium.tsv.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  path: topics.beir-v1.0.0-dbpedia-entity.test.splade_distil_cocodenser_medium.tsv.gz
+  qrel: qrels.beir-v1.0.0-dbpedia-entity.test.txt
 models:
 - name: splade_distil_cocodenser_medium
   display: SPLADE-distill CoCodenser Medium
   params: -impact -pretokenized -removeQuery -hits 1000
   results:
     nDCG@10:
-    - 0.5210
+    - 0.4416
     R@100:
-    - 0.9822
+    - 0.5636
     R@1000:
-    - 0.9950
+    - 0.7774

--- a/src/main/resources/regression/beir-v1.0.0-fever-splade-distil-cocodenser-medium.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever-splade-distil-cocodenser-medium.yaml
@@ -1,14 +1,14 @@
-corpus: beir-v1.0.0-arguana
-corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
-index_path: indexes/lucene-index.splade_distil_cocodenser_medium-arguana/
+corpus: beir-v1.0.0-fever
+corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/fever
+index_path: indexes/lucene-index.splade_distil_cocodenser_medium-fever/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 16
 index_options: -impact -pretokenized
 index_stats:
-  documents: 8674
-  documents (non-empty): 8674
-  total terms: 96421121
+  documents: 5416568
+  documents (non-empty): 5416568
+  total terms: 38844967407
 metrics:
 - metric: nDCG@10
   command: tools/eval/trec_eval.9.0.4/trec_eval
@@ -35,18 +35,18 @@ topic_reader: TsvString
 topic_root: src/main/resources/topics-and-qrels/
 qrels_root: src/main/resources/topics-and-qrels/
 topics:
-- name: 'BEIR (v1.0.0): arguana'
+- name: 'BEIR (v1.0.0): fever'
   id: test
-  path: topics.beir-v1.0.0-arguana.test.splade_distil_cocodenser_medium.tsv.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  path: topics.beir-v1.0.0-fever.test.splade_distil_cocodenser_medium.tsv.gz
+  qrel: qrels.beir-v1.0.0-fever.test.txt
 models:
 - name: splade_distil_cocodenser_medium
   display: SPLADE-distill CoCodenser Medium
   params: -impact -pretokenized -removeQuery -hits 1000
   results:
     nDCG@10:
-    - 0.5210
+    - 0.7962
     R@100:
-    - 0.9822
+    - 0.9550
     R@1000:
-    - 0.9950
+    - 0.9751

--- a/src/main/resources/regression/beir-v1.0.0-fiqa-splade-distil-cocodenser-medium.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa-splade-distil-cocodenser-medium.yaml
@@ -1,14 +1,14 @@
-corpus: beir-v1.0.0-arguana
-corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
-index_path: indexes/lucene-index.splade_distil_cocodenser_medium-arguana/
+corpus: beir-v1.0.0-fiqa
+corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/fiqa
+index_path: indexes/lucene-index.splade_distil_cocodenser_medium-fiqa/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 16
 index_options: -impact -pretokenized
 index_stats:
-  documents: 8674
-  documents (non-empty): 8674
-  total terms: 96421121
+  documents: 57638
+  documents (non-empty): 57638
+  total terms: 487502241
 metrics:
 - metric: nDCG@10
   command: tools/eval/trec_eval.9.0.4/trec_eval
@@ -35,18 +35,18 @@ topic_reader: TsvString
 topic_root: src/main/resources/topics-and-qrels/
 qrels_root: src/main/resources/topics-and-qrels/
 topics:
-- name: 'BEIR (v1.0.0): arguana'
+- name: 'BEIR (v1.0.0): fiqa'
   id: test
-  path: topics.beir-v1.0.0-arguana.test.splade_distil_cocodenser_medium.tsv.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  path: topics.beir-v1.0.0-fiqa.test.splade_distil_cocodenser_medium.tsv.gz
+  qrel: qrels.beir-v1.0.0-fiqa.test.txt
 models:
 - name: splade_distil_cocodenser_medium
   display: SPLADE-distill CoCodenser Medium
   params: -impact -pretokenized -removeQuery -hits 1000
   results:
     nDCG@10:
-    - 0.5210
+    - 0.3514
     R@100:
-    - 0.9822
+    - 0.6298
     R@1000:
-    - 0.9950
+    - 0.8323

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa-splade-distil-cocodenser-medium.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa-splade-distil-cocodenser-medium.yaml
@@ -1,14 +1,14 @@
-corpus: beir-v1.0.0-arguana
-corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
-index_path: indexes/lucene-index.splade_distil_cocodenser_medium-arguana/
+corpus: beir-v1.0.0-hotpotqa
+corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/hotpotqa
+index_path: indexes/lucene-index.splade_distil_cocodenser_medium-hotpotqa/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 16
 index_options: -impact -pretokenized
 index_stats:
-  documents: 8674
-  documents (non-empty): 8674
-  total terms: 96421121
+  documents: 5233329
+  documents (non-empty): 5233329
+  total terms: 32565190895
 metrics:
 - metric: nDCG@10
   command: tools/eval/trec_eval.9.0.4/trec_eval
@@ -35,18 +35,18 @@ topic_reader: TsvString
 topic_root: src/main/resources/topics-and-qrels/
 qrels_root: src/main/resources/topics-and-qrels/
 topics:
-- name: 'BEIR (v1.0.0): arguana'
+- name: 'BEIR (v1.0.0): hotpotqa'
   id: test
-  path: topics.beir-v1.0.0-arguana.test.splade_distil_cocodenser_medium.tsv.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  path: topics.beir-v1.0.0-hotpotqa.test.splade_distil_cocodenser_medium.tsv.gz
+  qrel: qrels.beir-v1.0.0-hotpotqa.test.txt
 models:
 - name: splade_distil_cocodenser_medium
   display: SPLADE-distill CoCodenser Medium
   params: -impact -pretokenized -removeQuery -hits 1000
   results:
     nDCG@10:
-    - 0.5210
+    - 0.6860
     R@100:
-    - 0.9822
+    - 0.8144
     R@1000:
-    - 0.9950
+    - 0.8945

--- a/src/main/resources/regression/beir-v1.0.0-msmarco-splade-distil-cocodenser-medium.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-msmarco-splade-distil-cocodenser-medium.yaml
@@ -1,14 +1,14 @@
-corpus: beir-v1.0.0-arguana
-corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
-index_path: indexes/lucene-index.splade_distil_cocodenser_medium-arguana/
+corpus: beir-v1.0.0-msmarco
+corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/msmarco
+index_path: indexes/lucene-index.splade_distil_cocodenser_medium-msmarco/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 16
 index_options: -impact -pretokenized
 index_stats:
-  documents: 8674
-  documents (non-empty): 8674
-  total terms: 96421121
+  documents: 8841823
+  documents (non-empty): 8841823
+  total terms: 54967294608
 metrics:
 - metric: nDCG@10
   command: tools/eval/trec_eval.9.0.4/trec_eval
@@ -35,18 +35,18 @@ topic_reader: TsvString
 topic_root: src/main/resources/topics-and-qrels/
 qrels_root: src/main/resources/topics-and-qrels/
 topics:
-- name: 'BEIR (v1.0.0): arguana'
+- name: 'BEIR (v1.0.0): msmarco'
   id: test
-  path: topics.beir-v1.0.0-arguana.test.splade_distil_cocodenser_medium.tsv.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  path: topics.beir-v1.0.0-msmarco.test.splade_distil_cocodenser_medium.tsv.gz
+  qrel: qrels.beir-v1.0.0-msmarco.test.txt
 models:
 - name: splade_distil_cocodenser_medium
   display: SPLADE-distill CoCodenser Medium
   params: -impact -pretokenized -removeQuery -hits 1000
   results:
     nDCG@10:
-    - 0.5210
+    - 0.521
     R@100:
     - 0.9822
     R@1000:
-    - 0.9950
+    - 0.995

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus-splade-distil-cocodenser-medium.yaml
@@ -1,14 +1,14 @@
-corpus: beir-v1.0.0-arguana
-corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
-index_path: indexes/lucene-index.splade_distil_cocodenser_medium-arguana/
+corpus: beir-v1.0.0-nfcorpus
+corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/nfcorpus
+index_path: indexes/lucene-index.splade_distil_cocodenser_medium-nfcorpus/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 16
 index_options: -impact -pretokenized
 index_stats:
-  documents: 8674
-  documents (non-empty): 8674
-  total terms: 96421121
+  documents: 3633
+  documents (non-empty): 3633
+  total terms: 41582222
 metrics:
 - metric: nDCG@10
   command: tools/eval/trec_eval.9.0.4/trec_eval
@@ -35,18 +35,18 @@ topic_reader: TsvString
 topic_root: src/main/resources/topics-and-qrels/
 qrels_root: src/main/resources/topics-and-qrels/
 topics:
-- name: 'BEIR (v1.0.0): arguana'
+- name: 'BEIR (v1.0.0): nfcorpus'
   id: test
-  path: topics.beir-v1.0.0-arguana.test.splade_distil_cocodenser_medium.tsv.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  path: topics.beir-v1.0.0-nfcorpus.test.splade_distil_cocodenser_medium.tsv.gz
+  qrel: qrels.beir-v1.0.0-nfcorpus.test.txt
 models:
 - name: splade_distil_cocodenser_medium
   display: SPLADE-distill CoCodenser Medium
   params: -impact -pretokenized -removeQuery -hits 1000
   results:
     nDCG@10:
-    - 0.5210
+    - 0.3454
     R@100:
-    - 0.9822
+    - 0.2891
     R@1000:
-    - 0.9950
+    - 0.5694

--- a/src/main/resources/regression/beir-v1.0.0-nq-splade-distil-cocodenser-medium.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq-splade-distil-cocodenser-medium.yaml
@@ -1,14 +1,14 @@
-corpus: beir-v1.0.0-arguana
-corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
-index_path: indexes/lucene-index.splade_distil_cocodenser_medium-arguana/
+corpus: beir-v1.0.0-nq
+corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/nq
+index_path: indexes/lucene-index.splade_distil_cocodenser_medium-nq/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 16
 index_options: -impact -pretokenized
 index_stats:
-  documents: 8674
-  documents (non-empty): 8674
-  total terms: 96421121
+  documents: 2681468
+  documents (non-empty): 2681468
+  total terms: 21901570532
 metrics:
 - metric: nDCG@10
   command: tools/eval/trec_eval.9.0.4/trec_eval
@@ -35,18 +35,18 @@ topic_reader: TsvString
 topic_root: src/main/resources/topics-and-qrels/
 qrels_root: src/main/resources/topics-and-qrels/
 topics:
-- name: 'BEIR (v1.0.0): arguana'
+- name: 'BEIR (v1.0.0): nq'
   id: test
-  path: topics.beir-v1.0.0-arguana.test.splade_distil_cocodenser_medium.tsv.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  path: topics.beir-v1.0.0-nq.test.splade_distil_cocodenser_medium.tsv.gz
+  qrel: qrels.beir-v1.0.0-nq.test.txt
 models:
 - name: splade_distil_cocodenser_medium
   display: SPLADE-distill CoCodenser Medium
   params: -impact -pretokenized -removeQuery -hits 1000
   results:
     nDCG@10:
-    - 0.5210
+    - 0.5443
     R@100:
-    - 0.9822
+    - 0.9285
     R@1000:
-    - 0.9950
+    - 0.9812

--- a/src/main/resources/regression/beir-v1.0.0-quora-splade-distil-cocodenser-medium.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora-splade-distil-cocodenser-medium.yaml
@@ -1,14 +1,14 @@
-corpus: beir-v1.0.0-arguana
-corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
-index_path: indexes/lucene-index.splade_distil_cocodenser_medium-arguana/
+corpus: beir-v1.0.0-quora
+corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/quora
+index_path: indexes/lucene-index.splade_distil_cocodenser_medium-quora/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 16
 index_options: -impact -pretokenized
 index_stats:
-  documents: 8674
-  documents (non-empty): 8674
-  total terms: 96421121
+  documents: 522931
+  documents (non-empty): 522931
+  total terms: 1322737004
 metrics:
 - metric: nDCG@10
   command: tools/eval/trec_eval.9.0.4/trec_eval
@@ -35,18 +35,18 @@ topic_reader: TsvString
 topic_root: src/main/resources/topics-and-qrels/
 qrels_root: src/main/resources/topics-and-qrels/
 topics:
-- name: 'BEIR (v1.0.0): arguana'
+- name: 'BEIR (v1.0.0): quora'
   id: test
-  path: topics.beir-v1.0.0-arguana.test.splade_distil_cocodenser_medium.tsv.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  path: topics.beir-v1.0.0-quora.test.splade_distil_cocodenser_medium.tsv.gz
+  qrel: qrels.beir-v1.0.0-quora.test.txt
 models:
 - name: splade_distil_cocodenser_medium
   display: SPLADE-distill CoCodenser Medium
   params: -impact -pretokenized -removeQuery -hits 1000
   results:
     nDCG@10:
-    - 0.5210
+    - 0.8136
     R@100:
-    - 0.9822
+    - 0.9817
     R@1000:
-    - 0.9950
+    - 0.9979

--- a/src/main/resources/regression/beir-v1.0.0-scidocs-splade-distil-cocodenser-medium.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs-splade-distil-cocodenser-medium.yaml
@@ -1,14 +1,14 @@
-corpus: beir-v1.0.0-arguana
-corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
-index_path: indexes/lucene-index.splade_distil_cocodenser_medium-arguana/
+corpus: beir-v1.0.0-scidocs
+corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/scidocs
+index_path: indexes/lucene-index.splade_distil_cocodenser_medium-scidocs/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 16
 index_options: -impact -pretokenized
 index_stats:
-  documents: 8674
-  documents (non-empty): 8674
-  total terms: 96421121
+  documents: 25657
+  documents (non-empty): 25657
+  total terms: 273175826
 metrics:
 - metric: nDCG@10
   command: tools/eval/trec_eval.9.0.4/trec_eval
@@ -35,18 +35,18 @@ topic_reader: TsvString
 topic_root: src/main/resources/topics-and-qrels/
 qrels_root: src/main/resources/topics-and-qrels/
 topics:
-- name: 'BEIR (v1.0.0): arguana'
+- name: 'BEIR (v1.0.0): scidocs'
   id: test
-  path: topics.beir-v1.0.0-arguana.test.splade_distil_cocodenser_medium.tsv.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  path: topics.beir-v1.0.0-scidocs.test.splade_distil_cocodenser_medium.tsv.gz
+  qrel: qrels.beir-v1.0.0-scidocs.test.txt
 models:
 - name: splade_distil_cocodenser_medium
   display: SPLADE-distill CoCodenser Medium
   params: -impact -pretokenized -removeQuery -hits 1000
   results:
     nDCG@10:
-    - 0.5210
+    - 0.1590
     R@100:
-    - 0.9822
+    - 0.3671
     R@1000:
-    - 0.9950
+    - 0.5891

--- a/src/main/resources/regression/beir-v1.0.0-scifact-splade-distil-cocodenser-medium.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact-splade-distil-cocodenser-medium.yaml
@@ -1,14 +1,14 @@
-corpus: beir-v1.0.0-arguana
-corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
-index_path: indexes/lucene-index.splade_distil_cocodenser_medium-arguana/
+corpus: beir-v1.0.0-scifact
+corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/scifact
+index_path: indexes/lucene-index.splade_distil_cocodenser_medium-scifact/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 16
 index_options: -impact -pretokenized
 index_stats:
-  documents: 8674
-  documents (non-empty): 8674
-  total terms: 96421121
+  documents: 5183
+  documents (non-empty): 5183
+  total terms: 65836037
 metrics:
 - metric: nDCG@10
   command: tools/eval/trec_eval.9.0.4/trec_eval
@@ -35,18 +35,18 @@ topic_reader: TsvString
 topic_root: src/main/resources/topics-and-qrels/
 qrels_root: src/main/resources/topics-and-qrels/
 topics:
-- name: 'BEIR (v1.0.0): arguana'
+- name: 'BEIR (v1.0.0): scifact'
   id: test
-  path: topics.beir-v1.0.0-arguana.test.splade_distil_cocodenser_medium.tsv.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  path: topics.beir-v1.0.0-scifact.test.splade_distil_cocodenser_medium.tsv.gz
+  qrel: qrels.beir-v1.0.0-scifact.test.txt
 models:
 - name: splade_distil_cocodenser_medium
   display: SPLADE-distill CoCodenser Medium
   params: -impact -pretokenized -removeQuery -hits 1000
   results:
     nDCG@10:
-    - 0.5210
+    - 0.6992
     R@100:
-    - 0.9822
+    - 0.9270
     R@1000:
-    - 0.9950
+    - 0.9767

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid-splade-distil-cocodenser-medium.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid-splade-distil-cocodenser-medium.yaml
@@ -1,14 +1,14 @@
-corpus: beir-v1.0.0-arguana
-corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
-index_path: indexes/lucene-index.splade_distil_cocodenser_medium-arguana/
+corpus: beir-v1.0.0-trec-covid
+corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/trec-covid
+index_path: indexes/lucene-index.splade_distil_cocodenser_medium-trec-covid/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 16
 index_options: -impact -pretokenized
 index_stats:
-  documents: 8674
-  documents (non-empty): 8674
-  total terms: 96421121
+  documents: 171332
+  documents (non-empty): 171332
+  total terms: 1697942549
 metrics:
 - metric: nDCG@10
   command: tools/eval/trec_eval.9.0.4/trec_eval
@@ -35,18 +35,18 @@ topic_reader: TsvString
 topic_root: src/main/resources/topics-and-qrels/
 qrels_root: src/main/resources/topics-and-qrels/
 topics:
-- name: 'BEIR (v1.0.0): arguana'
+- name: 'BEIR (v1.0.0): trec-covid'
   id: test
-  path: topics.beir-v1.0.0-arguana.test.splade_distil_cocodenser_medium.tsv.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  path: topics.beir-v1.0.0-trec-covid.test.splade_distil_cocodenser_medium.tsv.gz
+  qrel: qrels.beir-v1.0.0-trec-covid.test.txt
 models:
 - name: splade_distil_cocodenser_medium
   display: SPLADE-distill CoCodenser Medium
   params: -impact -pretokenized -removeQuery -hits 1000
   results:
     nDCG@10:
-    - 0.5210
+    - 0.7109
     R@100:
-    - 0.9822
+    - 0.1308
     R@1000:
-    - 0.9950
+    - 0.4433

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020-splade-distil-cocodenser-medium.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020-splade-distil-cocodenser-medium.yaml
@@ -1,14 +1,14 @@
-corpus: beir-v1.0.0-arguana
-corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/arguana
-index_path: indexes/lucene-index.splade_distil_cocodenser_medium-arguana/
+corpus: beir-v1.0.0-webis-touche2020
+corpus_path: collections/beir-v1.0.0/splade_distil_cocodenser_medium/webis-touche2020
+index_path: indexes/lucene-index.splade_distil_cocodenser_medium-webis-touche2020/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 16
 index_options: -impact -pretokenized
 index_stats:
-  documents: 8674
-  documents (non-empty): 8674
-  total terms: 96421121
+  documents: 382545
+  documents (non-empty): 382545
+  total terms: 3229042324
 metrics:
 - metric: nDCG@10
   command: tools/eval/trec_eval.9.0.4/trec_eval
@@ -35,18 +35,18 @@ topic_reader: TsvString
 topic_root: src/main/resources/topics-and-qrels/
 qrels_root: src/main/resources/topics-and-qrels/
 topics:
-- name: 'BEIR (v1.0.0): arguana'
+- name: 'BEIR (v1.0.0): webis-touche2020'
   id: test
-  path: topics.beir-v1.0.0-arguana.test.splade_distil_cocodenser_medium.tsv.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  path: topics.beir-v1.0.0-webis-touche2020.test.splade_distil_cocodenser_medium.tsv.gz
+  qrel: qrels.beir-v1.0.0-webis-touche2020.test.txt
 models:
 - name: splade_distil_cocodenser_medium
   display: SPLADE-distill CoCodenser Medium
   params: -impact -pretokenized -removeQuery -hits 1000
   results:
     nDCG@10:
-    - 0.5210
+    - 0.2435
     R@100:
-    - 0.9822
+    - 0.4723
     R@1000:
-    - 0.9950
+    - 0.8116


### PR DESCRIPTION
# What does this PR do?
Add BEIR_v1.0.0 regressions for `splade-distill-cocodenser-medium` model
Now we can run
`python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-<task_name>-splade-distil-cocodenser-medium`  on `orca`