### PR TITLE
fix typo: reset ndcg@10 criteria of splade-distil-cocodenser

### DIFF
--- a/docs/regressions-beir-v1.0.0-nq-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-beir-v1.0.0-nq-splade-distil-cocodenser-medium.md
@@ -90,7 +90,7 @@ With the above commands, you should be able to reproduce the following results:
 
 | nDCG@10                                                                                                      | SPLADE-distill CoCodenser Medium|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| BEIR (v1.0.0): nq                                                                                            | 0.5443    |
+| BEIR (v1.0.0): nq                                                                                            | 0.5442    |
 
 
 | R@100                                                                                                        | SPLADE-distill CoCodenser Medium|

--- a/src/main/resources/regression/beir-v1.0.0-nq-splade-distil-cocodenser-medium.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq-splade-distil-cocodenser-medium.yaml
@@ -45,7 +45,7 @@ models:
   params: -impact -pretokenized -removeQuery -hits 1000
   results:
     nDCG@10:
-    - 0.5443
+    - 0.5442
     R@100:
     - 0.9285
     R@1000:


### PR DESCRIPTION
This patch fixes the typo of the ndcg@10 criteria for beir_v1.0.0-nq regression.