### PR TITLE
fix typo: beir-v1.0.0-hotpotqa-bm25-flat.yaml

### DIFF
--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa-bm25-flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa-bm25-flat.yaml
@@ -8,7 +8,7 @@ index_threads: 1
 index_options: -storePositions -storeDocvectors -storeRaw
 index_stats:
   documents: 5233329
-  documents (non-empty): 5233329
+  documents (non-empty): 5233328
   total terms: 172477063
 metrics:
   - metric: nDCG@10


### PR DESCRIPTION
fix typo:
 document (non-empty) in regression beir-v1.0.0-hotpotqa-bm25-flat.yaml