### PR TITLE
Rename BeirCollection -> BeirFlatCollection

### DIFF
--- a/docs/regressions-beir-v1.0.0-arguana-flat.md
+++ b/docs/regressions-beir-v1.0.0-arguana-flat.md
@@ -17,7 +17,7 @@ Typical indexing command:
 
 ```
 target/appassembler/bin/IndexCollection \
-  -collection BeirCollection \
+  -collection BeirFlatCollection \
   -input /path/to/beir-v1.0.0-arguana \
   -index indexes/lucene-index.beir-v1.0.0-arguana-flat/ \
   -generator DefaultLuceneDocumentGenerator \

--- a/docs/regressions-beir-v1.0.0-climate-fever-flat.md
+++ b/docs/regressions-beir-v1.0.0-climate-fever-flat.md
@@ -17,7 +17,7 @@ Typical indexing command:
 
 ```
 target/appassembler/bin/IndexCollection \
-  -collection BeirCollection \
+  -collection BeirFlatCollection \
   -input /path/to/beir-v1.0.0-climate-fever \
   -index indexes/lucene-index.beir-v1.0.0-climate-fever-flat/ \
   -generator DefaultLuceneDocumentGenerator \

--- a/docs/regressions-beir-v1.0.0-dbpedia-entity-flat.md
+++ b/docs/regressions-beir-v1.0.0-dbpedia-entity-flat.md
@@ -17,7 +17,7 @@ Typical indexing command:
 
 ```
 target/appassembler/bin/IndexCollection \
-  -collection BeirCollection \
+  -collection BeirFlatCollection \
   -input /path/to/beir-v1.0.0-dbpedia-entity \
   -index indexes/lucene-index.beir-v1.0.0-dbpedia-entity-flat/ \
   -generator DefaultLuceneDocumentGenerator \

--- a/docs/regressions-beir-v1.0.0-fever-flat.md
+++ b/docs/regressions-beir-v1.0.0-fever-flat.md
@@ -17,7 +17,7 @@ Typical indexing command:
 
 ```
 target/appassembler/bin/IndexCollection \
-  -collection BeirCollection \
+  -collection BeirFlatCollection \
   -input /path/to/beir-v1.0.0-fever \
   -index indexes/lucene-index.beir-v1.0.0-fever-flat/ \
   -generator DefaultLuceneDocumentGenerator \

--- a/docs/regressions-beir-v1.0.0-fiqa-flat.md
+++ b/docs/regressions-beir-v1.0.0-fiqa-flat.md
@@ -17,7 +17,7 @@ Typical indexing command:
 
 ```
 target/appassembler/bin/IndexCollection \
-  -collection BeirCollection \
+  -collection BeirFlatCollection \
   -input /path/to/beir-v1.0.0-fiqa \
   -index indexes/lucene-index.beir-v1.0.0-fiqa-flat/ \
   -generator DefaultLuceneDocumentGenerator \

--- a/docs/regressions-beir-v1.0.0-hotpotqa-flat.md
+++ b/docs/regressions-beir-v1.0.0-hotpotqa-flat.md
@@ -17,7 +17,7 @@ Typical indexing command:
 
 ```
 target/appassembler/bin/IndexCollection \
-  -collection BeirCollection \
+  -collection BeirFlatCollection \
   -input /path/to/beir-v1.0.0-hotpotqa \
   -index indexes/lucene-index.beir-v1.0.0-hotpotqa-flat/ \
   -generator DefaultLuceneDocumentGenerator \

--- a/docs/regressions-beir-v1.0.0-nfcorpus-flat.md
+++ b/docs/regressions-beir-v1.0.0-nfcorpus-flat.md
@@ -17,7 +17,7 @@ Typical indexing command:
 
 ```
 target/appassembler/bin/IndexCollection \
-  -collection BeirCollection \
+  -collection BeirFlatCollection \
   -input /path/to/beir-v1.0.0-nfcorpus \
   -index indexes/lucene-index.beir-v1.0.0-nfcorpus-flat/ \
   -generator DefaultLuceneDocumentGenerator \

--- a/docs/regressions-beir-v1.0.0-nq-flat.md
+++ b/docs/regressions-beir-v1.0.0-nq-flat.md
@@ -17,7 +17,7 @@ Typical indexing command:
 
 ```
 target/appassembler/bin/IndexCollection \
-  -collection BeirCollection \
+  -collection BeirFlatCollection \
   -input /path/to/beir-v1.0.0-nq \
   -index indexes/lucene-index.beir-v1.0.0-nq-flat/ \
   -generator DefaultLuceneDocumentGenerator \

--- a/docs/regressions-beir-v1.0.0-quora-flat.md
+++ b/docs/regressions-beir-v1.0.0-quora-flat.md
@@ -17,7 +17,7 @@ Typical indexing command:
 
 ```
 target/appassembler/bin/IndexCollection \
-  -collection BeirCollection \
+  -collection BeirFlatCollection \
   -input /path/to/beir-v1.0.0-quora \
   -index indexes/lucene-index.beir-v1.0.0-quora-flat/ \
   -generator DefaultLuceneDocumentGenerator \

--- a/docs/regressions-beir-v1.0.0-scidocs-flat.md
+++ b/docs/regressions-beir-v1.0.0-scidocs-flat.md
@@ -17,7 +17,7 @@ Typical indexing command:
 
 ```
 target/appassembler/bin/IndexCollection \
-  -collection BeirCollection \
+  -collection BeirFlatCollection \
   -input /path/to/beir-v1.0.0-scidocs \
   -index indexes/lucene-index.beir-v1.0.0-scidocs-flat/ \
   -generator DefaultLuceneDocumentGenerator \

--- a/docs/regressions-beir-v1.0.0-scifact-flat.md
+++ b/docs/regressions-beir-v1.0.0-scifact-flat.md
@@ -17,7 +17,7 @@ Typical indexing command:
 
 ```
 target/appassembler/bin/IndexCollection \
-  -collection BeirCollection \
+  -collection BeirFlatCollection \
   -input /path/to/beir-v1.0.0-scifact \
   -index indexes/lucene-index.beir-v1.0.0-scifact-flat/ \
   -generator DefaultLuceneDocumentGenerator \

--- a/docs/regressions-beir-v1.0.0-trec-covid-flat.md
+++ b/docs/regressions-beir-v1.0.0-trec-covid-flat.md
@@ -17,7 +17,7 @@ Typical indexing command:
 
 ```
 target/appassembler/bin/IndexCollection \
-  -collection BeirCollection \
+  -collection BeirFlatCollection \
   -input /path/to/beir-v1.0.0-trec-covid \
   -index indexes/lucene-index.beir-v1.0.0-trec-covid-flat/ \
   -generator DefaultLuceneDocumentGenerator \

--- a/docs/regressions-beir-v1.0.0-webis-touche2020-flat.md
+++ b/docs/regressions-beir-v1.0.0-webis-touche2020-flat.md
@@ -17,7 +17,7 @@ Typical indexing command:
 
 ```
 target/appassembler/bin/IndexCollection \
-  -collection BeirCollection \
+  -collection BeirFlatCollection \
   -input /path/to/beir-v1.0.0-webis-touche2020 \
   -index indexes/lucene-index.beir-v1.0.0-webis-touche2020-flat/ \
   -generator DefaultLuceneDocumentGenerator \

--- a/src/main/java/io/anserini/collection/BeirFlatCollection.java
+++ b/src/main/java/io/anserini/collection/BeirFlatCollection.java
@@ -26,17 +26,17 @@ import java.util.Map;
 /**
  * A document collection for BEIR corpora.
  */
-public class BeirCollection extends DocumentCollection<BeirCollection.Document> {
-  public BeirCollection(Path path) {
+public class BeirFlatCollection extends DocumentCollection<BeirFlatCollection.Document> {
+  public BeirFlatCollection(Path path) {
     this.path = path;
   }
 
   @Override
-  public FileSegment<BeirCollection.Document> createFileSegment(Path p) throws IOException {
-    return new BeirCollection.Segment<>(p);
+  public FileSegment<BeirFlatCollection.Document> createFileSegment(Path p) throws IOException {
+    return new BeirFlatCollection.Segment<>(p);
   }
 
-  public static class Segment<T extends BeirCollection.Document> extends JsonCollection.Segment<T> {
+  public static class Segment<T extends BeirFlatCollection.Document> extends JsonCollection.Segment<T> {
     public Segment(Path path) throws IOException {
       super(path);
     }

--- a/src/main/resources/regression/beir-v1.0.0-arguana-flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana-flat.yaml
@@ -3,7 +3,7 @@ corpus: beir-v1.0.0-arguana
 corpus_path: collections/beir-v1.0.0/corpus/arguana/
 
 index_path: indexes/lucene-index.beir-v1.0.0-arguana-flat/
-collection_class: BeirCollection
+collection_class: BeirFlatCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 1
 index_options: -storePositions -storeDocvectors -storeRaw

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever-flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever-flat.yaml
@@ -3,7 +3,7 @@ corpus: beir-v1.0.0-climate-fever
 corpus_path: collections/beir-v1.0.0/corpus/climate-fever/
 
 index_path: indexes/lucene-index.beir-v1.0.0-climate-fever-flat/
-collection_class: BeirCollection
+collection_class: BeirFlatCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 1
 index_options: -storePositions -storeDocvectors -storeRaw

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity-flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity-flat.yaml
@@ -3,7 +3,7 @@ corpus: beir-v1.0.0-dbpedia-entity
 corpus_path: collections/beir-v1.0.0/corpus/dbpedia-entity/
 
 index_path: indexes/lucene-index.beir-v1.0.0-dbpedia-entity-flat/
-collection_class: BeirCollection
+collection_class: BeirFlatCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 1
 index_options: -storePositions -storeDocvectors -storeRaw

--- a/src/main/resources/regression/beir-v1.0.0-fever-flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever-flat.yaml
@@ -3,7 +3,7 @@ corpus: beir-v1.0.0-fever
 corpus_path: collections/beir-v1.0.0/corpus/fever/
 
 index_path: indexes/lucene-index.beir-v1.0.0-fever-flat/
-collection_class: BeirCollection
+collection_class: BeirFlatCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 1
 index_options: -storePositions -storeDocvectors -storeRaw

--- a/src/main/resources/regression/beir-v1.0.0-fiqa-flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa-flat.yaml
@@ -3,7 +3,7 @@ corpus: beir-v1.0.0-fiqa
 corpus_path: collections/beir-v1.0.0/corpus/fiqa/
 
 index_path: indexes/lucene-index.beir-v1.0.0-fiqa-flat/
-collection_class: BeirCollection
+collection_class: BeirFlatCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 1
 index_options: -storePositions -storeDocvectors -storeRaw

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa-flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa-flat.yaml
@@ -3,7 +3,7 @@ corpus: beir-v1.0.0-hotpotqa
 corpus_path: collections/beir-v1.0.0/corpus/hotpotqa/
 
 index_path: indexes/lucene-index.beir-v1.0.0-hotpotqa-flat/
-collection_class: BeirCollection
+collection_class: BeirFlatCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 1
 index_options: -storePositions -storeDocvectors -storeRaw

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus-flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus-flat.yaml
@@ -3,7 +3,7 @@ corpus: beir-v1.0.0-nfcorpus
 corpus_path: collections/beir-v1.0.0/corpus/nfcorpus/
 
 index_path: indexes/lucene-index.beir-v1.0.0-nfcorpus-flat/
-collection_class: BeirCollection
+collection_class: BeirFlatCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 1
 index_options: -storePositions -storeDocvectors -storeRaw

--- a/src/main/resources/regression/beir-v1.0.0-nq-flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq-flat.yaml
@@ -3,7 +3,7 @@ corpus: beir-v1.0.0-nq
 corpus_path: collections/beir-v1.0.0/corpus/nq/
 
 index_path: indexes/lucene-index.beir-v1.0.0-nq-flat/
-collection_class: BeirCollection
+collection_class: BeirFlatCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 1
 index_options: -storePositions -storeDocvectors -storeRaw

--- a/src/main/resources/regression/beir-v1.0.0-quora-flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora-flat.yaml
@@ -3,7 +3,7 @@ corpus: beir-v1.0.0-quora
 corpus_path: collections/beir-v1.0.0/corpus/quora/
 
 index_path: indexes/lucene-index.beir-v1.0.0-quora-flat/
-collection_class: BeirCollection
+collection_class: BeirFlatCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 1
 index_options: -storePositions -storeDocvectors -storeRaw

--- a/src/main/resources/regression/beir-v1.0.0-scidocs-flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs-flat.yaml
@@ -3,7 +3,7 @@ corpus: beir-v1.0.0-scidocs
 corpus_path: collections/beir-v1.0.0/corpus/scidocs/
 
 index_path: indexes/lucene-index.beir-v1.0.0-scidocs-flat/
-collection_class: BeirCollection
+collection_class: BeirFlatCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 1
 index_options: -storePositions -storeDocvectors -storeRaw

--- a/src/main/resources/regression/beir-v1.0.0-scifact-flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact-flat.yaml
@@ -3,7 +3,7 @@ corpus: beir-v1.0.0-scifact
 corpus_path: collections/beir-v1.0.0/corpus/scifact/
 
 index_path: indexes/lucene-index.beir-v1.0.0-scifact-flat/
-collection_class: BeirCollection
+collection_class: BeirFlatCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 1
 index_options: -storePositions -storeDocvectors -storeRaw

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid-flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid-flat.yaml
@@ -3,7 +3,7 @@ corpus: beir-v1.0.0-trec-covid
 corpus_path: collections/beir-v1.0.0/corpus/trec-covid/
 
 index_path: indexes/lucene-index.beir-v1.0.0-trec-covid-flat/
-collection_class: BeirCollection
+collection_class: BeirFlatCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 1
 index_options: -storePositions -storeDocvectors -storeRaw

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020-flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020-flat.yaml
@@ -3,7 +3,7 @@ corpus: beir-v1.0.0-webis-touche2020
 corpus_path: collections/beir-v1.0.0/corpus/webis-touche2020/
 
 index_path: indexes/lucene-index.beir-v1.0.0-webis-touche2020-flat/
-collection_class: BeirCollection
+collection_class: BeirFlatCollection
 generator_class: DefaultLuceneDocumentGenerator
 index_threads: 1
 index_options: -storePositions -storeDocvectors -storeRaw

--- a/src/test/java/io/anserini/collection/BeirFlatCollectionCompressedTest.java
+++ b/src/test/java/io/anserini/collection/BeirFlatCollectionCompressedTest.java
@@ -22,17 +22,17 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 
-public class BeirCollectionTest extends DocumentCollectionTest<BeirCollection.Document> {
+public class BeirFlatCollectionCompressedTest extends DocumentCollectionTest<BeirFlatCollection.Document> {
 
   @Before
   public void setUp() throws Exception {
     super.setUp();
 
-    collectionPath = Paths.get("src/test/resources/sample_docs/beir/collection1");
-    collection = new BeirCollection(collectionPath);
+    collectionPath = Paths.get("src/test/resources/sample_docs/beir/collection2");
+    collection = new BeirFlatCollection(collectionPath);
 
-    Path segment1 = Paths.get("src/test/resources/sample_docs/beir/collection1/segment1.jsonl");
-    Path segment2 = Paths.get("src/test/resources/sample_docs/beir/collection1/segment2.jsonl");
+    Path segment1 = Paths.get("src/test/resources/sample_docs/beir/collection2/segment1.jsonl.gz");
+    Path segment2 = Paths.get("src/test/resources/sample_docs/beir/collection2/segment2.jsonl.gz");
 
     segmentPaths.add(segment1);
     segmentPaths.add(segment2);
@@ -54,6 +54,6 @@ public class BeirCollectionTest extends DocumentCollectionTest<BeirCollection.Do
     assertEquals(expected.get("id"), doc.id());
     assertEquals(expected.get("contents"), doc.contents());
     // fields() should return a Map that contains all three of the original fields.
-    assertEquals(3, ((BeirCollection.Document) doc).fields().size());
+    assertEquals(3, ((BeirFlatCollection.Document) doc).fields().size());
   }
 }

--- a/src/test/java/io/anserini/collection/BeirFlatCollectionTest.java
+++ b/src/test/java/io/anserini/collection/BeirFlatCollectionTest.java
@@ -22,17 +22,17 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 
-public class BeirCollectionCompressedTest extends DocumentCollectionTest<BeirCollection.Document> {
+public class BeirFlatCollectionTest extends DocumentCollectionTest<BeirFlatCollection.Document> {
 
   @Before
   public void setUp() throws Exception {
     super.setUp();
 
-    collectionPath = Paths.get("src/test/resources/sample_docs/beir/collection2");
-    collection = new BeirCollection(collectionPath);
+    collectionPath = Paths.get("src/test/resources/sample_docs/beir/collection1");
+    collection = new BeirFlatCollection(collectionPath);
 
-    Path segment1 = Paths.get("src/test/resources/sample_docs/beir/collection2/segment1.jsonl.gz");
-    Path segment2 = Paths.get("src/test/resources/sample_docs/beir/collection2/segment2.jsonl.gz");
+    Path segment1 = Paths.get("src/test/resources/sample_docs/beir/collection1/segment1.jsonl");
+    Path segment2 = Paths.get("src/test/resources/sample_docs/beir/collection1/segment2.jsonl");
 
     segmentPaths.add(segment1);
     segmentPaths.add(segment2);
@@ -54,6 +54,6 @@ public class BeirCollectionCompressedTest extends DocumentCollectionTest<BeirCol
     assertEquals(expected.get("id"), doc.id());
     assertEquals(expected.get("contents"), doc.contents());
     // fields() should return a Map that contains all three of the original fields.
-    assertEquals(3, ((BeirCollection.Document) doc).fields().size());
+    assertEquals(3, ((BeirFlatCollection.Document) doc).fields().size());
   }
 }


### PR DESCRIPTION
To reduce confusion, I'm renaming `BeirCollection` to `BeirFlatCollection`. I'll then implement `BeirMultiFieldCollection` (separate PR) that will separately index the BEIR fields.