### PR TITLE
Add script to programmatically gather BEIR results

### DIFF
--- a/src/main/python/beir/gather_beir_results.py
+++ b/src/main/python/beir/gather_beir_results.py
@@ -1,0 +1,96 @@
+#
+# Anserini: A Lucene toolkit for reproducible information retrieval research
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import yaml
+
+from collections import defaultdict
+
+
+beir_keys = ['trec-covid',
+             'bioasq',
+             'nfcorpus',
+             'nq',
+             'hotpotqa',
+             'fiqa',
+             'signal1m',
+             'trec-news',
+             'robust04',
+             'arguana',
+             'webis-touche2020',
+             'cqadupstack-android',
+             'cqadupstack-english',
+             'cqadupstack-gaming',
+             'cqadupstack-gis',
+             'cqadupstack-mathematica',
+             'cqadupstack-physics',
+             'cqadupstack-programmers',
+             'cqadupstack-stats',
+             'cqadupstack-tex',
+             'cqadupstack-unix',
+             'cqadupstack-webmasters',
+             'cqadupstack-wordpress',
+             'quora',
+             'dbpedia-entity',
+             'scidocs',
+             'fever',
+             'climate-fever',
+             'scifact'
+             ]
+
+models = ['flat', 'multifield', 'splade-distil-cocodenser-medium']
+metrics = ['nDCG@10', 'R@100', 'R@1000']
+
+table = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: 0.0)))
+top_level_sums = defaultdict(lambda: defaultdict(float))
+cqadupstack_sums = defaultdict(lambda: defaultdict(float))
+final_scores = defaultdict(lambda: defaultdict(float))
+
+for key in beir_keys:
+    for model in models:
+        yaml_file = f'src/main/resources/regression/beir-v1.0.0-{key}-{model}.yaml'
+        with open(yaml_file) as f:
+            yaml_data = yaml.safe_load(f)
+            for metric in metrics:
+                table[key][model][metric] = float(yaml_data['models'][0]['results'][metric][0])
+
+# Compute the running sums to compute the final mean scores
+for key in beir_keys:
+    for model in models:
+        for metric in metrics:
+            if key.startswith('cqa'):
+                cqadupstack_sums[model][metric] += table[key][model][metric]
+            else:
+                top_level_sums[model][metric] += table[key][model][metric]
+
+# Compute the final mean
+for model in models:
+    for metric in metrics:
+        cqa_score = cqadupstack_sums[model][metric] / 12
+        final_score = (top_level_sums[model][metric] + cqa_score) / 18
+        print(f'{model} {cqa_score:.4f} {final_score:.4f}')
+        final_scores[model][metric] = final_score
+
+for metric in metrics:
+    print(f'{metric:25}flat    multi   SPLADE')
+    print(' ' * 25 + '-' * 6 + '  ' + '-' * 6 + '  ' + '-' * 6)
+    for key in beir_keys:
+        print(f'{key:25}{table[key]["flat"][metric]:.4f}  ' +
+              f'{table[key]["multifield"][metric]:.4f}  ' +
+              f'{table[key]["splade-distil-cocodenser-medium"][metric]:.4f}')
+
+    print(' ' * 25 + '-' * 6 + '  ' + '-' * 6 + '  ' + '-' * 6)
+    print(' ' * 25 + f'{final_scores["flat"][metric]:0.4f}  {final_scores["multifield"][metric]:0.4f}  {final_scores["splade-distil-cocodenser-medium"][metric]:0.4f}')
+    print('\n')

--- a/src/main/python/beir/gather_beir_results.py
+++ b/src/main/python/beir/gather_beir_results.py
@@ -71,6 +71,7 @@ for key in beir_keys:
     for model in models:
         for metric in metrics:
             if key.startswith('cqa'):
+                # The running sum for cqa needs to be kept separately.
                 cqadupstack_sums[model][metric] += table[key][model][metric]
             else:
                 top_level_sums[model][metric] += table[key][model][metric]
@@ -78,9 +79,10 @@ for key in beir_keys:
 # Compute the final mean
 for model in models:
     for metric in metrics:
+        # Compute mean over cqa sub-collections first
         cqa_score = cqadupstack_sums[model][metric] / 12
+        # Roll cqa scores into final overall mean
         final_score = (top_level_sums[model][metric] + cqa_score) / 18
-        print(f'{model} {cqa_score:.4f} {final_score:.4f}')
         final_scores[model][metric] = final_score
 
 for metric in metrics:
@@ -92,5 +94,7 @@ for metric in metrics:
               f'{table[key]["splade-distil-cocodenser-medium"][metric]:.4f}')
 
     print(' ' * 25 + '-' * 6 + '  ' + '-' * 6 + '  ' + '-' * 6)
-    print(' ' * 25 + f'{final_scores["flat"][metric]:0.4f}  {final_scores["multifield"][metric]:0.4f}  {final_scores["splade-distil-cocodenser-medium"][metric]:0.4f}')
+    print(' ' * 25 + f'{final_scores["flat"][metric]:0.4f}  ' +
+          f'{final_scores["multifield"][metric]:0.4f}  ' +
+          f'{final_scores["splade-distil-cocodenser-medium"][metric]:0.4f}')
     print('\n')


### PR DESCRIPTION
```
% python src/main/python/beir/gather_beir_results.py                
nDCG@10                  flat    multi   SPLADE
                         ------  ------  ------
trec-covid               0.5947  0.6559  0.7109
bioasq                   0.5225  0.4646  0.5035
nfcorpus                 0.3218  0.3254  0.3454
nq                       0.3055  0.3285  0.5442
hotpotqa                 0.6330  0.6027  0.6860
fiqa                     0.2361  0.2361  0.3514
signal1m                 0.3304  0.3304  0.2957
trec-news                0.3952  0.3977  0.3936
robust04                 0.4070  0.4070  0.4581
arguana                  0.3970  0.4142  0.5210
webis-touche2020         0.4422  0.3673  0.2435
cqadupstack-android      0.3801  0.3709  0.3954
cqadupstack-english      0.3453  0.3321  0.4026
cqadupstack-gaming       0.4822  0.4418  0.5061
cqadupstack-gis          0.2901  0.2904  0.3223
cqadupstack-mathematica  0.2015  0.2046  0.2423
cqadupstack-physics      0.3214  0.3248  0.3668
cqadupstack-programmers  0.2802  0.2963  0.3412
cqadupstack-stats        0.2711  0.2790  0.3142
cqadupstack-tex          0.2244  0.2086  0.2575
cqadupstack-unix         0.2749  0.2788  0.3292
cqadupstack-webmasters   0.3059  0.3008  0.3343
cqadupstack-wordpress    0.2483  0.2562  0.2839
quora                    0.7886  0.7886  0.8136
dbpedia-entity           0.3180  0.3128  0.4416
scidocs                  0.1490  0.1581  0.1590
fever                    0.6513  0.7530  0.7962
climate-fever            0.1651  0.2129  0.2276
scifact                  0.6789  0.6647  0.6992
                         ------  ------  ------
                         0.4244  0.4288  0.4740


R@100                    flat    multi   SPLADE
                         ------  ------  ------
trec-covid               0.1091  0.1141  0.1308
bioasq                   0.7687  0.7145  0.7422
nfcorpus                 0.2457  0.2500  0.2891
nq                       0.7513  0.7597  0.9285
hotpotqa                 0.7957  0.7400  0.8144
fiqa                     0.5395  0.5395  0.6298
signal1m                 0.3703  0.3703  0.3311
trec-news                0.4469  0.4216  0.4323
robust04                 0.3746  0.3746  0.3773
arguana                  0.9324  0.9431  0.9822
webis-touche2020         0.5822  0.5376  0.4723
cqadupstack-android      0.6829  0.6889  0.7405
cqadupstack-english      0.5757  0.5842  0.6768
cqadupstack-gaming       0.7651  0.7571  0.8138
cqadupstack-gis          0.6119  0.6458  0.6419
cqadupstack-mathematica  0.4877  0.5215  0.5732
cqadupstack-physics      0.6326  0.6486  0.7286
cqadupstack-programmers  0.5588  0.6194  0.6653
cqadupstack-stats        0.5338  0.5719  0.5889
cqadupstack-tex          0.4686  0.4954  0.5231
cqadupstack-unix         0.5417  0.5721  0.6192
cqadupstack-webmasters   0.5820  0.6100  0.6404
cqadupstack-wordpress    0.5152  0.5526  0.5974
quora                    0.9733  0.9733  0.9817
dbpedia-entity           0.4682  0.3981  0.5636
scidocs                  0.3477  0.3561  0.3671
fever                    0.9185  0.9309  0.9550
climate-fever            0.4249  0.4357  0.5140
scifact                  0.9253  0.9076  0.9270
                         ------  ------  ------
                         0.5863  0.5762  0.6161


R@1000                   flat    multi   SPLADE
                         ------  ------  ------
trec-covid               0.3955  0.3891  0.4433
bioasq                   0.9030  0.8428  0.8904
nfcorpus                 0.3704  0.3718  0.5694
nq                       0.8958  0.9019  0.9812
hotpotqa                 0.8820  0.8405  0.8945
fiqa                     0.7393  0.7393  0.8323
signal1m                 0.5642  0.5642  0.5514
trec-news                0.7051  0.6993  0.6977
robust04                 0.6345  0.6345  0.6099
arguana                  0.9872  0.9893  0.9950
webis-touche2020         0.8621  0.8668  0.8116
cqadupstack-android      0.8632  0.8712  0.9035
cqadupstack-english      0.7323  0.7574  0.8346
cqadupstack-gaming       0.8945  0.8882  0.9253
cqadupstack-gis          0.8174  0.8248  0.8385
cqadupstack-mathematica  0.7221  0.7559  0.7848
cqadupstack-physics      0.8340  0.8506  0.8931
cqadupstack-programmers  0.7734  0.8096  0.8451
cqadupstack-stats        0.7310  0.7619  0.7823
cqadupstack-tex          0.6907  0.7222  0.7372
cqadupstack-unix         0.7616  0.7783  0.8225
cqadupstack-webmasters   0.8066  0.8226  0.8767
cqadupstack-wordpress    0.7552  0.7848  0.8036
quora                    0.9950  0.9950  0.9979
dbpedia-entity           0.6760  0.5848  0.7774
scidocs                  0.5638  0.5599  0.5891
fever                    0.9589  0.9599  0.9751
climate-fever            0.6324  0.6099  0.7084
scifact                  0.9767  0.9800  0.9767
                         ------  ------  ------
                         0.7513  0.7406  0.7855
```