### PR TITLE
Clean up MS MARCO V1 passage/doc repro guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,19 @@ See individual pages for details!
 + Regressions for FIRE 2012: [Monolingual Bengali](docs/regressions-fire12-bn.md), [Monolingual Hindi](docs/regressions-fire12-hi.md), [Monolingual English](docs/regressions-fire12-en.md)
 + Regressions for Mr. TyDi (v1.1) baselines : [ar](docs/regressions-mrtydi-v1.1-ar.md), [bn](docs/regressions-mrtydi-v1.1-bn.md), [en](docs/regressions-mrtydi-v1.1-en.md), [fi](docs/regressions-mrtydi-v1.1-fi.md), [id](docs/regressions-mrtydi-v1.1-id.md), [ja](docs/regressions-mrtydi-v1.1-ja.md), [ko](docs/regressions-mrtydi-v1.1-ko.md), [ru](docs/regressions-mrtydi-v1.1-ru.md), [sw](docs/regressions-mrtydi-v1.1-sw.md), [te](docs/regressions-mrtydi-v1.1-te.md), [th](docs/regressions-mrtydi-v1.1-th.md)
 
+### Available Corpora
+
+| Corpora | Size | Checksum |
+|:--------|-----:|:---------|
+| [MS MARCO V1 passage: uniCOIL (noexp)](https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil-noexp.tar) | 2.7 GB | `f17ddd8c7c00ff121c3c3b147d2e17d8` |
+| [MS MARCO V1 passage: uniCOIL (d2q-T5)](https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil.tar) | 3.4 GB | `78eef752c78c8691f7d61600ceed306f` |
+| [MS MARCO V1 doc: uniCOIL (noexp)](https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil-noexp.tar) | 11 GB | `11b226e1cacd9c8ae0a660fd14cdd710` |
+| [MS MARCO V1 doc: uniCOIL (d2q-T5)](https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil.tar) | 19 GB | `6a00e2c0c375cb1e52c83ae5ac377ebb` |
+| [MS MARCO V2 passage: uniCOIL (noexp)](https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco_v2_passage_unicoil_noexp_0shot.tar) | 24 GB | `d9cc1ed3049746e68a2c91bf90e5212d` |
+| [MS MARCO V2 passage: uniCOIL (d2q-T5)](https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco_v2_passage_unicoil_0shot.tar) | 41 GB | `1949a00bfd5e1f1a230a04bbc1f01539` |
+| [MS MARCO V2 doc: uniCOIL (noexp)](https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco_v2_doc_segmented_unicoil_noexp_0shot_v2.tar) | 55 GB | `97ba262c497164de1054f357caea0c63` |
+| [MS MARCO V2 doc: uniCOIL (d2q-T5)](https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco_v2_doc_segmented_unicoil_0shot_v2.tar) | 72 GB | `c5639748c2cbad0152e10b0ebde3b804` |
+
 ## Additional Documentation
 
 The experiments described below are not associated with rigorous end-to-end regression testing and thus provide a lower standard of reproducibility.

--- a/README.md
+++ b/README.md
@@ -53,66 +53,66 @@ See individual pages for details!
 
 ### MS MARCO V1 Passage Corpus
 
-|  | dev | DL19 | DL20 |
-|--|:---:|:----:|:----:|
+|   | dev | DL19 | DL20 |
+|---|:---:|:----:|:----:|
 | **Unsupervised Lexical** |
 | BoW baselines | [+](docs/regressions-msmarco-passage.md) | [+](docs/regressions-dl19-passage.md) | [+](docs/regressions-dl20-passage.md) |
 | Quantized BM25 | [+](docs/regressions-msmarco-passage-bm25-b8.md) | [+](docs/regressions-dl19-passage-bm25-b8.md) | [+](docs/regressions-dl20-passage-bm25-b8.md) |
 | WP baselines | [+](docs/regressions-msmarco-passage-wp.md) | [+](docs/regressions-dl19-passage-wp.md) | [+](docs/regressions-dl20-passage-wp.md) |
-| doc2query | [+](docs/regressions-msmarco-passage-doc2query.md)
+| doc2query | [+](docs/regressions-msmarco-passage-doc2query.md) |
 | doc2query-T5 | [+](docs/regressions-msmarco-passage-docTTTTTquery.md) | [+](docs/regressions-dl19-passage-docTTTTTquery.md) | [+](docs/regressions-dl20-passage-docTTTTTquery.md) |
 | **Learned sparse lexical (uniCOIL family)** |
-| uniCOIL noexp | [+](docs/regressions-msmarco-passage-unicoil-noexp.md) | [+](docs/regressions-dl19-passage-unicoil-noexp.md) | [+](docs/regressions-dl20-passage-unicoil-noexp.md)
-| uniCOIL with d2q-T5 | [+](docs/regressions-msmarco-passage-unicoil.md) | [+](docs/regressions-dl19-passage-unicoil.md) | [+](docs/regressions-dl20-passage-unicoil.md)
-| uniCOIL with TILDE | [+](docs/regressions-msmarco-passage-unicoil-tilde-expansion.md)
+| uniCOIL noexp | [+](docs/regressions-msmarco-passage-unicoil-noexp.md) | [+](docs/regressions-dl19-passage-unicoil-noexp.md) | [+](docs/regressions-dl20-passage-unicoil-noexp.md) |
+| uniCOIL with doc2query-T5 | [+](docs/regressions-msmarco-passage-unicoil.md) | [+](docs/regressions-dl19-passage-unicoil.md) | [+](docs/regressions-dl20-passage-unicoil.md) |
+| uniCOIL with TILDE | [+](docs/regressions-msmarco-passage-unicoil-tilde-expansion.md) |
 | **Learned sparse lexical (other)** |
-| DeepImpact | [+](docs/regressions-msmarco-passage-deepimpact.md)
-| SPLADEv2 | [+](docs/regressions-msmarco-passage-distill-splade-max.md)
-| SPLADE-distill CoCodenser-medium | [+](docs/regressions-msmarco-passage-splade-distil-cocodenser-medium.md) | [+](docs/regressions-dl19-passage-splade-distil-cocodenser-medium.md) | [+](docs/regressions-dl20-passage-splade-distil-cocodenser-medium.md)
+| DeepImpact | [+](docs/regressions-msmarco-passage-deepimpact.md) |
+| SPLADEv2 | [+](docs/regressions-msmarco-passage-distill-splade-max.md) |
+| SPLADE-distill CoCodenser-medium | [+](docs/regressions-msmarco-passage-splade-distil-cocodenser-medium.md) | [+](docs/regressions-dl19-passage-splade-distil-cocodenser-medium.md) | [+](docs/regressions-dl20-passage-splade-distil-cocodenser-medium.md) |
 
 ### MS MARCO V1 Document Corpus
 
-|  | dev | DL19 | DL20 |
-|--|:---:|:----:|:----:|
+|   | dev | DL19 | DL20 |
+|---|:---:|:----:|:----:|
 | **Unsupervised lexical, complete doc**[*](docs/experiments-msmarco-doc-doc2query-details.md) |
-| BoW baselines | [+](docs/regressions-msmarco-doc.md) | [+](docs/regressions-dl19-doc.md) | [+](docs/regressions-dl20-doc.md)
-| WP baselines | [+](docs/regressions-msmarco-doc-wp.md) | [+](docs/regressions-dl19-doc-wp.md) | [+](docs/regressions-dl20-doc-wp.md)
-| doc2query-T5 | [+](docs/regressions-msmarco-doc-docTTTTTquery.md) | [+](docs/regressions-dl19-doc-docTTTTTquery.md) | [+](docs/regressions-dl20-doc-docTTTTTquery.md)
-| **Unsupervised lexical, segmented doc**[*](docs/experiments-msmarco-doc-doc2query-details.md)
-| BoW baselines | [+](docs/regressions-msmarco-doc-segmented.md) | [+](docs/regressions-dl19-doc-segmented.md) | [+](docs/regressions-dl20-doc-segmented.md)
-| WP baselines | [+](docs/regressions-msmarco-doc-segmented-wp.md) | [+](docs/regressions-dl19-doc-segmented-wp.md) | [+](docs/regressions-dl20-doc-segmented-wp.md)
-| doc2query-T5 | [+](docs/regressions-msmarco-doc-segmented-docTTTTTquery.md) | [+](docs/regressions-dl19-doc-segmented-docTTTTTquery.md) | [+](docs/regressions-dl20-doc-segmented-docTTTTTquery.md)
-| **Learned sparse lexical**
-| uniCOIL noexp | [+](docs/regressions-msmarco-doc-segmented-unicoil-noexp.md) | [+](docs/regressions-dl19-doc-segmented-unicoil-noexp.md) | [+](docs/regressions-dl20-doc-segmented-unicoil-noexp.md)
-| uniCOIL with d2q-T5 | [+](docs/regressions-msmarco-doc-segmented-unicoil.md) | [+](docs/regressions-dl19-doc-segmented-unicoil.md) | [+](docs/regressions-dl20-doc-segmented-unicoil.md)
+| BoW baselines | [+](docs/regressions-msmarco-doc.md) | [+](docs/regressions-dl19-doc.md) | [+](docs/regressions-dl20-doc.md) |
+| WP baselines | [+](docs/regressions-msmarco-doc-wp.md) | [+](docs/regressions-dl19-doc-wp.md) | [+](docs/regressions-dl20-doc-wp.md) |
+| doc2query-T5 | [+](docs/regressions-msmarco-doc-docTTTTTquery.md) | [+](docs/regressions-dl19-doc-docTTTTTquery.md) | [+](docs/regressions-dl20-doc-docTTTTTquery.md) |
+| **Unsupervised lexical, segmented doc**[*](docs/experiments-msmarco-doc-doc2query-details.md) |
+| BoW baselines | [+](docs/regressions-msmarco-doc-segmented.md) | [+](docs/regressions-dl19-doc-segmented.md) | [+](docs/regressions-dl20-doc-segmented.md) |
+| WP baselines | [+](docs/regressions-msmarco-doc-segmented-wp.md) | [+](docs/regressions-dl19-doc-segmented-wp.md) | [+](docs/regressions-dl20-doc-segmented-wp.md) |
+| doc2query-T5 | [+](docs/regressions-msmarco-doc-segmented-docTTTTTquery.md) | [+](docs/regressions-dl19-doc-segmented-docTTTTTquery.md) | [+](docs/regressions-dl20-doc-segmented-docTTTTTquery.md) |
+| **Learned sparse lexical** |
+| uniCOIL noexp | [+](docs/regressions-msmarco-doc-segmented-unicoil-noexp.md) | [+](docs/regressions-dl19-doc-segmented-unicoil-noexp.md) | [+](docs/regressions-dl20-doc-segmented-unicoil-noexp.md) |
+| uniCOIL with doc2query-T5 | [+](docs/regressions-msmarco-doc-segmented-unicoil.md) | [+](docs/regressions-dl19-doc-segmented-unicoil.md) | [+](docs/regressions-dl20-doc-segmented-unicoil.md) |
 
 ### MS MARCO V2 Passage Corpus
 
-|  | dev | DL21 |
-|--|:---:|:----:|
-| **Unsupervised lexical, original corpus**
-| baselines | [+](docs/regressions-msmarco-v2-passage.md) | [+](docs/regressions-dl21-passage.md)
-| doc2query-T5 | [+](docs/regressions-msmarco-v2-passage-d2q-t5.md) | [+](docs/regressions-dl21-passage-d2q-t5.md)
-| **Unsupervised lexical, augmented corpus**
-| baselines | [+](docs/regressions-msmarco-v2-passage-augmented.md) | [+](docs/regressions-dl21-passage-augmented.md)
-| doc2query-T5 | [+](docs/regressions-msmarco-v2-passage-augmented-d2q-t5.md) | [+](docs/regressions-dl21-passage-augmented-d2q-t5.md)
-| **Learned sparse lexical**
-| uniCOIL noexp zero-shot | [+](docs/regressions-msmarco-v2-passage-unicoil-noexp-0shot.md) | [+](docs/regressions-dl21-passage-unicoil-noexp-0shot.md)
-| uniCOIL with d2q-T5 zero-shot | [+](docs/regressions-msmarco-v2-passage-unicoil-0shot.md) | [+](docs/regressions-dl21-passage-unicoil-0shot.md)
+|   | dev | DL21 |
+|---|:---:|:----:|
+| **Unsupervised lexical, original corpus** |
+| baselines | [+](docs/regressions-msmarco-v2-passage.md) | [+](docs/regressions-dl21-passage.md) |
+| doc2query-T5 | [+](docs/regressions-msmarco-v2-passage-d2q-t5.md) | [+](docs/regressions-dl21-passage-d2q-t5.md) |
+| **Unsupervised lexical, augmented corpus** |
+| baselines | [+](docs/regressions-msmarco-v2-passage-augmented.md) | [+](docs/regressions-dl21-passage-augmented.md) |
+| doc2query-T5 | [+](docs/regressions-msmarco-v2-passage-augmented-d2q-t5.md) | [+](docs/regressions-dl21-passage-augmented-d2q-t5.md) |
+| **Learned sparse lexical** |
+| uniCOIL noexp zero-shot | [+](docs/regressions-msmarco-v2-passage-unicoil-noexp-0shot.md) | [+](docs/regressions-dl21-passage-unicoil-noexp-0shot.md) |
+| uniCOIL with doc2query-T5 zero-shot | [+](docs/regressions-msmarco-v2-passage-unicoil-0shot.md) | [+](docs/regressions-dl21-passage-unicoil-0shot.md) |
 
 ### MS MARCO V2 Document Corpus
 
-|  | dev | DL21 |
-|--|:---:|:----:|
-| **Unsupervised lexical, complete doc**
-| baselines | [+](docs/regressions-msmarco-v2-doc.md) | [+](docs/regressions-dl21-doc.md)
-| doc2query-T5 | [+](docs/regressions-msmarco-v2-doc-d2q-t5.md) | [+](docs/regressions-dl21-doc-d2q-t5.md)
-| **Unsupervised lexical, segmented doc**
-| baselines | [+](docs/regressions-msmarco-v2-doc-segmented.md) | [+](docs/regressions-dl21-doc-segmented.md)
-| doc2query-T5 | [+](docs/regressions-msmarco-v2-doc-segmented-d2q-t5.md) | [+](docs/regressions-dl21-doc-segmented-d2q-t5.md)
-| **Learned sparse lexical**
-| uniCOIL noexp zero-shot | [+](docs/regressions-msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.md) | [+](docs/regressions-dl21-doc-segmented-unicoil-noexp-0shot-v2.md)
-| uniCOIL with d2q-T5 zero-shot | [+](docs/regressions-msmarco-v2-doc-segmented-unicoil-0shot-v2.md) | [+](docs/regressions-dl21-doc-segmented-unicoil-0shot-v2.md)
+|   | dev | DL21 |
+|---|:---:|:----:|
+| **Unsupervised lexical, complete doc** |
+| baselines | [+](docs/regressions-msmarco-v2-doc.md) | [+](docs/regressions-dl21-doc.md) |
+| doc2query-T5 | [+](docs/regressions-msmarco-v2-doc-d2q-t5.md) | [+](docs/regressions-dl21-doc-d2q-t5.md) |
+| **Unsupervised lexical, segmented doc** |
+| baselines | [+](docs/regressions-msmarco-v2-doc-segmented.md) | [+](docs/regressions-dl21-doc-segmented.md) |
+| doc2query-T5 | [+](docs/regressions-msmarco-v2-doc-segmented-d2q-t5.md) | [+](docs/regressions-dl21-doc-segmented-d2q-t5.md) |
+| **Learned sparse lexical** |
+| uniCOIL noexp zero-shot | [+](docs/regressions-msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.md) | [+](docs/regressions-dl21-doc-segmented-unicoil-noexp-0shot-v2.md) |
+| uniCOIL with doc2query-T5 zero-shot | [+](docs/regressions-msmarco-v2-doc-segmented-unicoil-0shot-v2.md) | [+](docs/regressions-dl21-doc-segmented-unicoil-0shot-v2.md) |
 
 ### Regressions for BEIR (v1.0.0)
 

--- a/docs/regressions-dl19-doc-segmented-unicoil-noexp.md
+++ b/docs/regressions-dl19-doc-segmented-unicoil-noexp.md
@@ -16,11 +16,11 @@ Note that this page is automatically generated from [this template](../src/main/
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression dl19-doc-segmented-unicoil-noexp
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO segmented document corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -28,9 +28,8 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil-noexp.tar -P collections/
-
 tar xvf collections/msmarco-doc-segmented-unicoil-noexp.tar -C collections/
 ```
 
@@ -38,7 +37,7 @@ To confirm, `msmarco-doc-segmented-unicoil-noexp.tar` is 11 GB and has MD5 check
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression dl19-doc-segmented-unicoil-noexp \
   --corpus-path collections/msmarco-doc-segmented-unicoil-noexp
 ```
@@ -49,7 +48,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 target/appassembler/bin/IndexCollection \
   -collection JsonVectorCollection \
   -input /path/to/msmarco-doc-segmented-unicoil-noexp \
@@ -74,7 +73,7 @@ The original data can be found [here](https://trec.nist.gov/data/deep2019.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil-noexp/ \
   -topics src/main/resources/topics-and-qrels/topics.dl19-doc.unicoil-noexp.0shot.tsv.gz \
@@ -85,7 +84,7 @@ target/appassembler/bin/SearchCollection \
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map src/main/resources/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.dl19-doc.unicoil-noexp.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.dl19-doc.unicoil-noexp.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.dl19-doc.unicoil-noexp.0shot.txt
@@ -120,6 +119,17 @@ Thus, average precision is computed to depth 100 (i.e., AP@100); nDCG@10 remains
 Remember that we keep qrels of _all_ relevance grades, unlike the case for passage ranking, where relevance grade 1 needs to be discarded when computing certain metrics.
 Here, we retrieve 1000 hits per query, but measure AP at cutoff 100 (e.g., AP@100).
 Thus, the experimental results reported here are directly comparable to the results reported in the [track overview paper](https://arxiv.org/abs/2003.07820).
+
+## Additional Notes
+
+Note that due to MaxP and the need to generate runs to different depths, we can set `-hits` and `-selectMaxPassage.hits` differently.
+The reasonable settings are:
+
++ `-hits 10000 -selectMaxPassage.hits 1000` (as above)
++ `-hits 10000 -selectMaxPassage.hits 100`
++ `-hits 1000 -selectMaxPassage.hits 100`
+
+However, for these topics, we get the same effectiveness results; that is, the tie-breaking affects do not manifest in different scores.
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-dl19-doc-segmented-unicoil.md
+++ b/docs/regressions-dl19-doc-segmented-unicoil.md
@@ -130,8 +130,7 @@ The reasonable settings are:
 + `-hits 10000 -selectMaxPassage.hits 100`
 + `-hits 1000 -selectMaxPassage.hits 100`
 
-Due to tie-breaking effects, we get slightly different results on the dev queries.
-However, for these topics, we get the same results (that is, the tie-breaking affects do not manifest in different scores).
+However, for these topics, we get the same results; that is, the tie-breaking affects do not manifest in different scores.
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-dl19-doc-segmented-unicoil.md
+++ b/docs/regressions-dl19-doc-segmented-unicoil.md
@@ -121,6 +121,18 @@ Remember that we keep qrels of _all_ relevance grades, unlike the case for passa
 Here, we retrieve 1000 hits per query, but measure AP at cutoff 100 (e.g., AP@100).
 Thus, the experimental results reported here are directly comparable to the results reported in the [track overview paper](https://arxiv.org/abs/2003.07820).
 
+## Additional Notes
+
+Note that due to MaxP and the need to generate runs to different depths, we can set `-hits` and `-selectMaxPassage.hits` differently.
+The reasonable settings are:
+
++ `-hits 10000 -selectMaxPassage.hits 1000` (as above)
++ `-hits 10000 -selectMaxPassage.hits 100`
++ `-hits 1000 -selectMaxPassage.hits 100`
+
+Due to tie-breaking effects, we get slightly different results on the dev queries.
+However, for these topics, we get the same results (that is, the tie-breaking affects do not manifest in different scores).
+
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl19-doc-segmented-unicoil.template) and run `bin/build.sh` to rebuild the documentation.

--- a/docs/regressions-dl19-doc-segmented-unicoil.md
+++ b/docs/regressions-dl19-doc-segmented-unicoil.md
@@ -16,11 +16,11 @@ Note that this page is automatically generated from [this template](../src/main/
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression dl19-doc-segmented-unicoil
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO segmented document corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -28,17 +28,16 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil.tar -P collections/
-
 tar xvf collections/msmarco-doc-segmented-unicoil.tar -C collections/
 ```
 
-To confirm, `msmarco-doc-segmented-unicoil.tar` is 18 GB and has MD5 checksum `6a00e2c0c375cb1e52c83ae5ac377ebb`.
+To confirm, `msmarco-doc-segmented-unicoil.tar` is 19 GB and has MD5 checksum `6a00e2c0c375cb1e52c83ae5ac377ebb`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression dl19-doc-segmented-unicoil \
   --corpus-path collections/msmarco-doc-segmented-unicoil
 ```
@@ -49,7 +48,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 target/appassembler/bin/IndexCollection \
   -collection JsonVectorCollection \
   -input /path/to/msmarco-doc-segmented-unicoil \
@@ -74,7 +73,7 @@ The original data can be found [here](https://trec.nist.gov/data/deep2019.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
   -topics src/main/resources/topics-and-qrels/topics.dl19-doc.unicoil.0shot.tsv.gz \
@@ -85,7 +84,7 @@ target/appassembler/bin/SearchCollection \
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map src/main/resources/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl19-doc.unicoil.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl19-doc.unicoil.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl19-doc.unicoil.0shot.txt
@@ -130,7 +129,7 @@ The reasonable settings are:
 + `-hits 10000 -selectMaxPassage.hits 100`
 + `-hits 1000 -selectMaxPassage.hits 100`
 
-However, for these topics, we get the same results; that is, the tie-breaking affects do not manifest in different scores.
+However, for these topics, we get the same effectiveness results; that is, the tie-breaking affects do not manifest in different scores.
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-dl19-passage-unicoil-noexp.md
+++ b/docs/regressions-dl19-passage-unicoil-noexp.md
@@ -18,11 +18,11 @@ Note that this page is automatically generated from [this template](../src/main/
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-unicoil-noexp
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -30,17 +30,16 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
+```bash
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil-noexp.tar -P collections/
+tar xvf collections/msmarco-passage-unicoil-noexp.tar -C collections/
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil.tar -P collections/
 
-tar xvf collections/msmarco-passage-unicoil.tar -C collections/
-```
-
-To confirm, `msmarco-passage-unicoil.tar` is 3.3 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
+To confirm, `msmarco-passage-unicoil-noexp.tar` is 2.7 GB and has MD5 checksum `f17ddd8c7c00ff121c3c3b147d2e17d8`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-unicoil-noexp \
   --corpus-path collections/msmarco-passage-unicoil-noexp
 ```
@@ -51,7 +50,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 target/appassembler/bin/IndexCollection \
   -collection JsonVectorCollection \
   -input /path/to/msmarco-passage-unicoil-noexp \
@@ -76,7 +75,7 @@ The original data can be found [here](https://trec.nist.gov/data/deep2019.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil-noexp/ \
   -topics src/main/resources/topics-and-qrels/topics.dl19-passage.unicoil-noexp.0shot.tsv.gz \
@@ -87,7 +86,7 @@ target/appassembler/bin/SearchCollection \
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 src/main/resources/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.dl19-passage.unicoil-noexp.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c src/main/resources/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.dl19-passage.unicoil-noexp.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 src/main/resources/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.dl19-passage.unicoil-noexp.0shot.txt

--- a/docs/regressions-dl19-passage-unicoil.md
+++ b/docs/regressions-dl19-passage-unicoil.md
@@ -18,11 +18,11 @@ Note that this page is automatically generated from [this template](../src/main/
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-unicoil
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -30,17 +30,16 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil.tar -P collections/
-
 tar xvf collections/msmarco-passage-unicoil.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-unicoil.tar` is 3.3 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
+To confirm, `msmarco-passage-unicoil.tar` is 3.4 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-unicoil \
   --corpus-path collections/msmarco-passage-unicoil
 ```
@@ -51,7 +50,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 target/appassembler/bin/IndexCollection \
   -collection JsonVectorCollection \
   -input /path/to/msmarco-passage-unicoil \
@@ -76,7 +75,7 @@ The original data can be found [here](https://trec.nist.gov/data/deep2019.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil/ \
   -topics src/main/resources/topics-and-qrels/topics.dl19-passage.unicoil.0shot.tsv.gz \
@@ -87,7 +86,7 @@ target/appassembler/bin/SearchCollection \
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 src/main/resources/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl19-passage.unicoil.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c src/main/resources/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl19-passage.unicoil.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 src/main/resources/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl19-passage.unicoil.0shot.txt

--- a/docs/regressions-dl20-doc-segmented-unicoil-noexp.md
+++ b/docs/regressions-dl20-doc-segmented-unicoil-noexp.md
@@ -16,11 +16,11 @@ Note that this page is automatically generated from [this template](../src/main/
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression dl20-doc-segmented-unicoil-noexp
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO segmented document corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -28,9 +28,8 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil-noexp.tar -P collections/
-
 tar xvf collections/msmarco-doc-segmented-unicoil-noexp.tar -C collections/
 ```
 
@@ -38,7 +37,7 @@ To confirm, `msmarco-doc-segmented-unicoil-noexp.tar` is 11 GB and has MD5 check
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression dl20-doc-segmented-unicoil-noexp \
   --corpus-path collections/msmarco-doc-segmented-unicoil-noexp
 ```
@@ -49,7 +48,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 target/appassembler/bin/IndexCollection \
   -collection JsonVectorCollection \
   -input /path/to/msmarco-doc-segmented-unicoil-noexp \
@@ -74,7 +73,7 @@ The original data can be found [here](https://trec.nist.gov/data/deep2020.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil-noexp/ \
   -topics src/main/resources/topics-and-qrels/topics.dl20.unicoil-noexp.0shot.tsv.gz \
@@ -85,7 +84,7 @@ target/appassembler/bin/SearchCollection \
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map src/main/resources/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.dl20.unicoil-noexp.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.dl20.unicoil-noexp.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.dl20.unicoil-noexp.0shot.txt
@@ -120,6 +119,17 @@ Thus, average precision is computed to depth 100 (i.e., AP@100); nDCG@10 remains
 Remember that we keep qrels of _all_ relevance grades, unlike the case for passage ranking, where relevance grade 1 needs to be discarded when computing certain metrics.
 Here, we retrieve 1000 hits per query, but measure AP at cutoff 100 (e.g., AP@100).
 Thus, the experimental results reported here are directly comparable to the results reported in the [track overview paper](https://arxiv.org/abs/2102.07662).
+
+## Additional Notes
+
+Note that due to MaxP and the need to generate runs to different depths, we can set `-hits` and `-selectMaxPassage.hits` differently.
+The reasonable settings are:
+
++ `-hits 10000 -selectMaxPassage.hits 1000` (as above)
++ `-hits 10000 -selectMaxPassage.hits 100`
++ `-hits 1000 -selectMaxPassage.hits 100`
+
+However, for these topics, we get the same effectiveness results; that is, the tie-breaking affects do not manifest in different scores.
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-dl20-doc-segmented-unicoil.md
+++ b/docs/regressions-dl20-doc-segmented-unicoil.md
@@ -130,8 +130,7 @@ The reasonable settings are:
 + `-hits 10000 -selectMaxPassage.hits 100`
 + `-hits 1000 -selectMaxPassage.hits 100`
 
-Due to tie-breaking effects, we get slightly different results on the dev queries.
-However, for these topics, we get the same results (that is, the tie-breaking affects do not manifest in different scores).
+However, for these topics, we get the same results; that is, the tie-breaking affects do not manifest in different scores.
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-dl20-doc-segmented-unicoil.md
+++ b/docs/regressions-dl20-doc-segmented-unicoil.md
@@ -16,11 +16,11 @@ Note that this page is automatically generated from [this template](../src/main/
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression dl20-doc-segmented-unicoil
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO segmented document corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -28,17 +28,16 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil.tar -P collections/
-
 tar xvf collections/msmarco-doc-segmented-unicoil.tar -C collections/
 ```
 
-To confirm, `msmarco-doc-segmented-unicoil.tar` is 18 GB and has MD5 checksum `6a00e2c0c375cb1e52c83ae5ac377ebb`.
+To confirm, `msmarco-doc-segmented-unicoil.tar` is 19 GB and has MD5 checksum `6a00e2c0c375cb1e52c83ae5ac377ebb`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression dl20-doc-segmented-unicoil \
   --corpus-path collections/msmarco-doc-segmented-unicoil
 ```
@@ -49,7 +48,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 target/appassembler/bin/IndexCollection \
   -collection JsonVectorCollection \
   -input /path/to/msmarco-doc-segmented-unicoil \
@@ -74,7 +73,7 @@ The original data can be found [here](https://trec.nist.gov/data/deep2020.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
   -topics src/main/resources/topics-and-qrels/topics.dl20.unicoil.0shot.tsv.gz \
@@ -85,7 +84,7 @@ target/appassembler/bin/SearchCollection \
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map src/main/resources/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl20.unicoil.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 src/main/resources/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl20.unicoil.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl20.unicoil.0shot.txt
@@ -130,7 +129,7 @@ The reasonable settings are:
 + `-hits 10000 -selectMaxPassage.hits 100`
 + `-hits 1000 -selectMaxPassage.hits 100`
 
-However, for these topics, we get the same results; that is, the tie-breaking affects do not manifest in different scores.
+However, for these topics, we get the same effectiveness results; that is, the tie-breaking affects do not manifest in different scores.
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-dl20-doc-segmented-unicoil.md
+++ b/docs/regressions-dl20-doc-segmented-unicoil.md
@@ -121,6 +121,18 @@ Remember that we keep qrels of _all_ relevance grades, unlike the case for passa
 Here, we retrieve 1000 hits per query, but measure AP at cutoff 100 (e.g., AP@100).
 Thus, the experimental results reported here are directly comparable to the results reported in the [track overview paper](https://arxiv.org/abs/2102.07662).
 
+## Additional Notes
+
+Note that due to MaxP and the need to generate runs to different depths, we can set `-hits` and `-selectMaxPassage.hits` differently.
+The reasonable settings are:
+
++ `-hits 10000 -selectMaxPassage.hits 1000` (as above)
++ `-hits 10000 -selectMaxPassage.hits 100`
++ `-hits 1000 -selectMaxPassage.hits 100`
+
+Due to tie-breaking effects, we get slightly different results on the dev queries.
+However, for these topics, we get the same results (that is, the tie-breaking affects do not manifest in different scores).
+
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl20-doc-segmented-unicoil.template) and run `bin/build.sh` to rebuild the documentation.

--- a/docs/regressions-dl20-passage-unicoil-noexp.md
+++ b/docs/regressions-dl20-passage-unicoil-noexp.md
@@ -18,11 +18,11 @@ Note that this page is automatically generated from [this template](../src/main/
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-unicoil-noexp
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -30,17 +30,16 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
+```bash
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil-noexp.tar -P collections/
+tar xvf collections/msmarco-passage-unicoil-noexp.tar -C collections/
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil.tar -P collections/
 
-tar xvf collections/msmarco-passage-unicoil.tar -C collections/
-```
-
-To confirm, `msmarco-passage-unicoil.tar` is 3.3 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
+To confirm, `msmarco-passage-unicoil-noexp.tar` is 2.7 GB and has MD5 checksum `f17ddd8c7c00ff121c3c3b147d2e17d8`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-unicoil-noexp \
   --corpus-path collections/msmarco-passage-unicoil-noexp
 ```
@@ -51,7 +50,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 target/appassembler/bin/IndexCollection \
   -collection JsonVectorCollection \
   -input /path/to/msmarco-passage-unicoil-noexp \
@@ -76,7 +75,7 @@ The original data can be found [here](https://trec.nist.gov/data/deep2020.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil-noexp/ \
   -topics src/main/resources/topics-and-qrels/topics.dl20.unicoil-noexp.0shot.tsv.gz \
@@ -87,7 +86,7 @@ target/appassembler/bin/SearchCollection \
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 src/main/resources/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.dl20.unicoil-noexp.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c src/main/resources/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.dl20.unicoil-noexp.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 src/main/resources/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.dl20.unicoil-noexp.0shot.txt

--- a/docs/regressions-dl20-passage-unicoil.md
+++ b/docs/regressions-dl20-passage-unicoil.md
@@ -18,11 +18,11 @@ Note that this page is automatically generated from [this template](../src/main/
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-unicoil
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -30,17 +30,16 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil.tar -P collections/
-
 tar xvf collections/msmarco-passage-unicoil.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-unicoil.tar` is 3.3 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
+To confirm, `msmarco-passage-unicoil.tar` is 3.4 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-unicoil \
   --corpus-path collections/msmarco-passage-unicoil
 ```
@@ -51,7 +50,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 target/appassembler/bin/IndexCollection \
   -collection JsonVectorCollection \
   -input /path/to/msmarco-passage-unicoil \
@@ -76,7 +75,7 @@ The original data can be found [here](https://trec.nist.gov/data/deep2020.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil/ \
   -topics src/main/resources/topics-and-qrels/topics.dl20.unicoil.0shot.tsv.gz \
@@ -87,7 +86,7 @@ target/appassembler/bin/SearchCollection \
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 src/main/resources/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl20.unicoil.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c src/main/resources/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl20.unicoil.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 src/main/resources/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl20.unicoil.0shot.txt

--- a/docs/regressions-msmarco-doc-segmented-unicoil-noexp.md
+++ b/docs/regressions-msmarco-doc-segmented-unicoil-noexp.md
@@ -115,37 +115,6 @@ With the above commands, you should be able to reproduce the following results:
 
 ## Additional Notes
 
-This model corresponds to the run named "uniCOIL-d2q" on the official MS MARCO Document Ranking Leaderboard, submitted 2021/09/16.
-The following command generates a comparable run:
-
-```bash
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.unicoil.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil.msmarco-doc.dev.txt \
-  -format msmarco \
-  -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
-```
-
-Note that the above command uses `-format msmarco` to directly generate a run in the MS MARCO output format.
-And to evaluate:
-
-```bash
-python tools/scripts/msmarco/msmarco_doc_eval.py \
-  --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
-  --run runs/run.msmarco-doc-segmented-unicoil.msmarco-doc.dev.txt
-```
-
-The results should be as follows:
-
-```
-#####################
-MRR @100: 0.352997702662614
-QueriesRanked: 5193
-#####################
-```
-
 Note that due to MaxP and the need to generate runs to different depths, we can set `-hits` and `-selectMaxPassage.hits` differently.
 Because of tie-breaking effects, we get slightly different results:
 

--- a/docs/regressions-msmarco-doc-segmented-unicoil-noexp.md
+++ b/docs/regressions-msmarco-doc-segmented-unicoil-noexp.md
@@ -16,11 +16,11 @@ Note that this page is automatically generated from [this template](../src/main/
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc-segmented-unicoil-noexp
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO segmented document corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -28,9 +28,8 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil-noexp.tar -P collections/
-
 tar xvf collections/msmarco-doc-segmented-unicoil-noexp.tar -C collections/
 ```
 
@@ -38,7 +37,7 @@ To confirm, `msmarco-doc-segmented-unicoil-noexp.tar` is 11 GB and has MD5 check
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc-segmented-unicoil-noexp \
   --corpus-path collections/msmarco-doc-segmented-unicoil-noexp
 ```
@@ -49,7 +48,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 target/appassembler/bin/IndexCollection \
   -collection JsonVectorCollection \
   -input /path/to/msmarco-doc-segmented-unicoil-noexp \
@@ -73,7 +72,7 @@ The regression experiments here evaluate on the 6980 dev set questions; see [thi
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil-noexp/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.unicoil-noexp.tsv.gz \
@@ -84,7 +83,7 @@ target/appassembler/bin/SearchCollection \
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.msmarco-doc.dev.unicoil-noexp.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.msmarco-doc.dev.unicoil-noexp.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.msmarco-doc.dev.unicoil-noexp.txt
@@ -114,10 +113,12 @@ With the above commands, you should be able to reproduce the following results:
 |:-------------------------------------------------------------------------------------------------------------|-----------|
 | [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9420    |
 
+## Additional Notes
+
 This model corresponds to the run named "uniCOIL-d2q" on the official MS MARCO Document Ranking Leaderboard, submitted 2021/09/16.
 The following command generates a comparable run:
 
-```
+```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.unicoil.tsv.gz \
@@ -144,6 +145,15 @@ MRR @100: 0.352997702662614
 QueriesRanked: 5193
 #####################
 ```
+
+Note that due to MaxP and the need to generate runs to different depths, we can set `-hits` and `-selectMaxPassage.hits` differently.
+Because of tie-breaking effects, we get slightly different results:
+
+| Condition                                            | AP@1000 | RR@100 | R@100  | R@1000 | MS MARCO MRR @100   |
+|:-----------------------------------------------------|:--------|:-------|:-------|:-------|:--------------------|
+| `-hits 10000 -selectMaxPassage.hits 1000` (as above) | 0.3413  | 0.3409 | 0.8639 | 0.9420 | 0.34138671941993426 |
+| `-hits 10000 -selectMaxPassage.hits 100`             | 0.3409  | 0.3409 | 0.8639 | -      | 0.3410112121151749  |
+| `-hits 1000 -selectMaxPassage.hits 100`              | 0.3409  | 0.3409 | 0.8639 | -      | 0.3410112121151749  |
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-msmarco-doc-segmented-unicoil.md
+++ b/docs/regressions-msmarco-doc-segmented-unicoil.md
@@ -34,7 +34,7 @@ wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-uni
 tar xvf collections/msmarco-doc-segmented-unicoil.tar -C collections/
 ```
 
-To confirm, `msmarco-doc-segmented-unicoil.tar` is 18 GB and has MD5 checksum `6a00e2c0c375cb1e52c83ae5ac377ebb`.
+To confirm, `msmarco-doc-segmented-unicoil.tar` is 19 GB and has MD5 checksum `6a00e2c0c375cb1e52c83ae5ac377ebb`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
@@ -114,6 +114,8 @@ With the above commands, you should be able to reproduce the following results:
 |:-------------------------------------------------------------------------------------------------------------|-----------|
 | [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9546    |
 
+## Additional Notes
+
 This model corresponds to the run named "uniCOIL-d2q" on the official MS MARCO Document Ranking Leaderboard, submitted 2021/09/16.
 The following command generates a comparable run:
 
@@ -144,6 +146,16 @@ MRR @100: 0.352997702662614
 QueriesRanked: 5193
 #####################
 ```
+
+Note that due to MaxP and the need to generate runs to different depths, we can set `-hits` and `-selectMaxPassage.hits` differently.
+Due to tie-breaking effects, we get slightly different results:
+
+| Condition                                            | AP@1000 | RR@100 | R@100  | R@1000 | MS MARCO MRR @100  |
+|:-----------------------------------------------------|:--------|:-------|:-------|:-------|:-------------------|
+| `-hits 10000 -selectMaxPassage.hits 1000` (as above) | 0.3535  | 0.3531 | 0.8858 | 0.9546 | 0.3533301973179882 |
+| `-hits 10000 -selectMaxPassage.hits 100`             | 0.3531  | 0.3531 | 0.8860 | -      | 0.352997702662614  |
+| `-hits 1000 -selectMaxPassage.hits 100`              | 0.3531  | 0.3531 | 0.8860 | -      | 0.352997702662614  |
+
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-msmarco-doc-segmented-unicoil.md
+++ b/docs/regressions-msmarco-doc-segmented-unicoil.md
@@ -148,7 +148,7 @@ QueriesRanked: 5193
 ```
 
 Note that due to MaxP and the need to generate runs to different depths, we can set `-hits` and `-selectMaxPassage.hits` differently.
-Due to tie-breaking effects, we get slightly different results:
+Because of tie-breaking effects, we get slightly different results:
 
 | Condition                                            | AP@1000 | RR@100 | R@100  | R@1000 | MS MARCO MRR @100  |
 |:-----------------------------------------------------|:--------|:-------|:-------|:-------|:-------------------|

--- a/docs/regressions-msmarco-doc-segmented-unicoil.md
+++ b/docs/regressions-msmarco-doc-segmented-unicoil.md
@@ -16,11 +16,11 @@ Note that this page is automatically generated from [this template](../src/main/
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc-segmented-unicoil
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO segmented document corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -28,9 +28,8 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil.tar -P collections/
-
 tar xvf collections/msmarco-doc-segmented-unicoil.tar -C collections/
 ```
 
@@ -38,7 +37,7 @@ To confirm, `msmarco-doc-segmented-unicoil.tar` is 19 GB and has MD5 checksum `6
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc-segmented-unicoil \
   --corpus-path collections/msmarco-doc-segmented-unicoil
 ```
@@ -49,7 +48,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 target/appassembler/bin/IndexCollection \
   -collection JsonVectorCollection \
   -input /path/to/msmarco-doc-segmented-unicoil \
@@ -73,7 +72,7 @@ The regression experiments here evaluate on the 6980 dev set questions; see [thi
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.unicoil.tsv.gz \
@@ -84,7 +83,7 @@ target/appassembler/bin/SearchCollection \
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.msmarco-doc.dev.unicoil.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.msmarco-doc.dev.unicoil.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.msmarco-doc.dev.unicoil.txt
@@ -119,7 +118,7 @@ With the above commands, you should be able to reproduce the following results:
 This model corresponds to the run named "uniCOIL-d2q" on the official MS MARCO Document Ranking Leaderboard, submitted 2021/09/16.
 The following command generates a comparable run:
 
-```
+```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.unicoil.tsv.gz \
@@ -155,7 +154,6 @@ Because of tie-breaking effects, we get slightly different results:
 | `-hits 10000 -selectMaxPassage.hits 1000` (as above) | 0.3535  | 0.3531 | 0.8858 | 0.9546 | 0.3533301973179882 |
 | `-hits 10000 -selectMaxPassage.hits 100`             | 0.3531  | 0.3531 | 0.8860 | -      | 0.352997702662614  |
 | `-hits 1000 -selectMaxPassage.hits 100`              | 0.3531  | 0.3531 | 0.8860 | -      | 0.352997702662614  |
-
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-msmarco-passage-unicoil-noexp.md
+++ b/docs/regressions-msmarco-passage-unicoil-noexp.md
@@ -112,30 +112,6 @@ With the above commands, you should be able to reproduce the following results:
 |:-------------------------------------------------------------------------------------------------------------|-----------|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9239    |
 
-The above runs are in TREC output format and evaluated with `trec_eval`.
-In order to reproduce results reported in the paper, we need to convert to MS MARCO output format and then evaluate:
-
-```bash
-python tools/scripts/msmarco/convert_trec_to_msmarco_run.py \
-   --input runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.txt \
-   --output runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.tsv --quiet
-
-python tools/scripts/msmarco/msmarco_passage_eval.py \
-   tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt \
-   runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.tsv
-```
-
-The results should be as follows:
-
-```
-#####################
-MRR @10: 0.35155222404147896
-QueriesRanked: 6980
-#####################
-```
-
-This corresponds to the effectiveness reported in the paper and also the run named "uniCOIL-d2q" on the official MS MARCO Passage Ranking Leaderboard, submitted 2021/09/22.
-
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/msmarco-passage-unicoil-noexp.template) and run `bin/build.sh` to rebuild the documentation.

--- a/docs/regressions-msmarco-passage-unicoil-noexp.md
+++ b/docs/regressions-msmarco-passage-unicoil-noexp.md
@@ -15,11 +15,11 @@ Note that this page is automatically generated from [this template](../src/main/
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-unicoil-noexp
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -27,17 +27,16 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
+```bash
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil-noexp.tar -P collections/
+tar xvf collections/msmarco-passage-unicoil-noexp.tar -C collections/
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil.tar -P collections/
 
-tar xvf collections/msmarco-passage-unicoil.tar -C collections/
-```
-
-To confirm, `msmarco-passage-unicoil.tar` is 3.3 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
+To confirm, `msmarco-passage-unicoil-noexp.tar` is 2.7 GB and has MD5 checksum `f17ddd8c7c00ff121c3c3b147d2e17d8`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-unicoil-noexp \
   --corpus-path collections/msmarco-passage-unicoil-noexp
 ```
@@ -48,7 +47,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 target/appassembler/bin/IndexCollection \
   -collection JsonVectorCollection \
   -input /path/to/msmarco-passage-unicoil-noexp \
@@ -72,7 +71,7 @@ The regression experiments here evaluate on the 6980 dev set questions; see [thi
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil-noexp/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.unicoil-noexp.tsv.gz \
@@ -83,7 +82,7 @@ target/appassembler/bin/SearchCollection \
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.msmarco-passage.dev-subset.unicoil-noexp.txt

--- a/docs/regressions-msmarco-passage-unicoil.md
+++ b/docs/regressions-msmarco-passage-unicoil.md
@@ -12,11 +12,11 @@ Note that this page is automatically generated from [this template](../src/main/
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-unicoil
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -24,17 +24,16 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil.tar -P collections/
-
 tar xvf collections/msmarco-passage-unicoil.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-unicoil.tar` is 3.3 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
+To confirm, `msmarco-passage-unicoil.tar` is 3.4 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-unicoil \
   --corpus-path collections/msmarco-passage-unicoil
 ```
@@ -45,7 +44,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 target/appassembler/bin/IndexCollection \
   -collection JsonVectorCollection \
   -input /path/to/msmarco-passage-unicoil \
@@ -69,7 +68,7 @@ The regression experiments here evaluate on the 6980 dev set questions; see [thi
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.unicoil.tsv.gz \
@@ -80,7 +79,7 @@ target/appassembler/bin/SearchCollection \
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.txt

--- a/src/main/resources/docgen/templates/dl19-doc-segmented-unicoil-noexp.template
+++ b/src/main/resources/docgen/templates/dl19-doc-segmented-unicoil-noexp.template
@@ -16,11 +16,11 @@ Note that this page is automatically generated from [this template](${template})
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO segmented document corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -28,9 +28,8 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil-noexp.tar -P collections/
-
 tar xvf collections/msmarco-doc-segmented-unicoil-noexp.tar -C collections/
 ```
 
@@ -38,7 +37,7 @@ To confirm, `msmarco-doc-segmented-unicoil-noexp.tar` is 11 GB and has MD5 check
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
   --corpus-path collections/${corpus}
 ```
@@ -49,7 +48,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 ${index_cmds}
 ```
 
@@ -68,13 +67,13 @@ The original data can be found [here](https://trec.nist.gov/data/deep2019.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 ${ranking_cmds}
 ```
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 ${eval_cmds}
 ```
 
@@ -89,6 +88,17 @@ Thus, average precision is computed to depth 100 (i.e., AP@100); nDCG@10 remains
 Remember that we keep qrels of _all_ relevance grades, unlike the case for passage ranking, where relevance grade 1 needs to be discarded when computing certain metrics.
 Here, we retrieve 1000 hits per query, but measure AP at cutoff 100 (e.g., AP@100).
 Thus, the experimental results reported here are directly comparable to the results reported in the [track overview paper](https://arxiv.org/abs/2003.07820).
+
+## Additional Notes
+
+Note that due to MaxP and the need to generate runs to different depths, we can set `-hits` and `-selectMaxPassage.hits` differently.
+The reasonable settings are:
+
++ `-hits 10000 -selectMaxPassage.hits 1000` (as above)
++ `-hits 10000 -selectMaxPassage.hits 100`
++ `-hits 1000 -selectMaxPassage.hits 100`
+
+However, for these topics, we get the same effectiveness results; that is, the tie-breaking affects do not manifest in different scores.
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/src/main/resources/docgen/templates/dl19-doc-segmented-unicoil.template
+++ b/src/main/resources/docgen/templates/dl19-doc-segmented-unicoil.template
@@ -99,8 +99,7 @@ The reasonable settings are:
 + `-hits 10000 -selectMaxPassage.hits 100`
 + `-hits 1000 -selectMaxPassage.hits 100`
 
-Due to tie-breaking effects, we get slightly different results on the dev queries.
-However, for these topics, we get the same results (that is, the tie-breaking affects do not manifest in different scores).
+However, for these topics, we get the same results; that is, the tie-breaking affects do not manifest in different scores.
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/src/main/resources/docgen/templates/dl19-doc-segmented-unicoil.template
+++ b/src/main/resources/docgen/templates/dl19-doc-segmented-unicoil.template
@@ -16,11 +16,11 @@ Note that this page is automatically generated from [this template](${template})
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO segmented document corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -28,17 +28,16 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil.tar -P collections/
-
 tar xvf collections/msmarco-doc-segmented-unicoil.tar -C collections/
 ```
 
-To confirm, `msmarco-doc-segmented-unicoil.tar` is 18 GB and has MD5 checksum `6a00e2c0c375cb1e52c83ae5ac377ebb`.
+To confirm, `msmarco-doc-segmented-unicoil.tar` is 19 GB and has MD5 checksum `6a00e2c0c375cb1e52c83ae5ac377ebb`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
   --corpus-path collections/${corpus}
 ```
@@ -49,7 +48,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 ${index_cmds}
 ```
 
@@ -68,13 +67,13 @@ The original data can be found [here](https://trec.nist.gov/data/deep2019.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 ${ranking_cmds}
 ```
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 ${eval_cmds}
 ```
 
@@ -99,7 +98,7 @@ The reasonable settings are:
 + `-hits 10000 -selectMaxPassage.hits 100`
 + `-hits 1000 -selectMaxPassage.hits 100`
 
-However, for these topics, we get the same results; that is, the tie-breaking affects do not manifest in different scores.
+However, for these topics, we get the same effectiveness results; that is, the tie-breaking affects do not manifest in different scores.
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/src/main/resources/docgen/templates/dl19-doc-segmented-unicoil.template
+++ b/src/main/resources/docgen/templates/dl19-doc-segmented-unicoil.template
@@ -90,6 +90,18 @@ Remember that we keep qrels of _all_ relevance grades, unlike the case for passa
 Here, we retrieve 1000 hits per query, but measure AP at cutoff 100 (e.g., AP@100).
 Thus, the experimental results reported here are directly comparable to the results reported in the [track overview paper](https://arxiv.org/abs/2003.07820).
 
+## Additional Notes
+
+Note that due to MaxP and the need to generate runs to different depths, we can set `-hits` and `-selectMaxPassage.hits` differently.
+The reasonable settings are:
+
++ `-hits 10000 -selectMaxPassage.hits 1000` (as above)
++ `-hits 10000 -selectMaxPassage.hits 100`
++ `-hits 1000 -selectMaxPassage.hits 100`
+
+Due to tie-breaking effects, we get slightly different results on the dev queries.
+However, for these topics, we get the same results (that is, the tie-breaking affects do not manifest in different scores).
+
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.

--- a/src/main/resources/docgen/templates/dl19-passage-unicoil-noexp.template
+++ b/src/main/resources/docgen/templates/dl19-passage-unicoil-noexp.template
@@ -18,11 +18,11 @@ Note that this page is automatically generated from [this template](${template})
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -30,17 +30,16 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
+```bash
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil-noexp.tar -P collections/
+tar xvf collections/msmarco-passage-unicoil-noexp.tar -C collections/
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil.tar -P collections/
 
-tar xvf collections/msmarco-passage-unicoil.tar -C collections/
-```
-
-To confirm, `msmarco-passage-unicoil.tar` is 3.3 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
+To confirm, `msmarco-passage-unicoil-noexp.tar` is 2.7 GB and has MD5 checksum `f17ddd8c7c00ff121c3c3b147d2e17d8`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
   --corpus-path collections/${corpus}
 ```
@@ -51,7 +50,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 ${index_cmds}
 ```
 
@@ -70,13 +69,13 @@ The original data can be found [here](https://trec.nist.gov/data/deep2019.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 ${ranking_cmds}
 ```
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 ${eval_cmds}
 ```
 

--- a/src/main/resources/docgen/templates/dl19-passage-unicoil.template
+++ b/src/main/resources/docgen/templates/dl19-passage-unicoil.template
@@ -18,11 +18,11 @@ Note that this page is automatically generated from [this template](${template})
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -30,17 +30,16 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil.tar -P collections/
-
 tar xvf collections/msmarco-passage-unicoil.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-unicoil.tar` is 3.3 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
+To confirm, `msmarco-passage-unicoil.tar` is 3.4 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
   --corpus-path collections/${corpus}
 ```
@@ -51,7 +50,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 ${index_cmds}
 ```
 
@@ -70,13 +69,13 @@ The original data can be found [here](https://trec.nist.gov/data/deep2019.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 ${ranking_cmds}
 ```
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 ${eval_cmds}
 ```
 

--- a/src/main/resources/docgen/templates/dl20-doc-segmented-unicoil-noexp.template
+++ b/src/main/resources/docgen/templates/dl20-doc-segmented-unicoil-noexp.template
@@ -16,11 +16,11 @@ Note that this page is automatically generated from [this template](${template})
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO segmented document corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -28,9 +28,8 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil-noexp.tar -P collections/
-
 tar xvf collections/msmarco-doc-segmented-unicoil-noexp.tar -C collections/
 ```
 
@@ -38,7 +37,7 @@ To confirm, `msmarco-doc-segmented-unicoil-noexp.tar` is 11 GB and has MD5 check
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
   --corpus-path collections/${corpus}
 ```
@@ -49,7 +48,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 ${index_cmds}
 ```
 
@@ -68,13 +67,13 @@ The original data can be found [here](https://trec.nist.gov/data/deep2020.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 ${ranking_cmds}
 ```
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 ${eval_cmds}
 ```
 
@@ -89,6 +88,17 @@ Thus, average precision is computed to depth 100 (i.e., AP@100); nDCG@10 remains
 Remember that we keep qrels of _all_ relevance grades, unlike the case for passage ranking, where relevance grade 1 needs to be discarded when computing certain metrics.
 Here, we retrieve 1000 hits per query, but measure AP at cutoff 100 (e.g., AP@100).
 Thus, the experimental results reported here are directly comparable to the results reported in the [track overview paper](https://arxiv.org/abs/2102.07662).
+
+## Additional Notes
+
+Note that due to MaxP and the need to generate runs to different depths, we can set `-hits` and `-selectMaxPassage.hits` differently.
+The reasonable settings are:
+
++ `-hits 10000 -selectMaxPassage.hits 1000` (as above)
++ `-hits 10000 -selectMaxPassage.hits 100`
++ `-hits 1000 -selectMaxPassage.hits 100`
+
+However, for these topics, we get the same effectiveness results; that is, the tie-breaking affects do not manifest in different scores.
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/src/main/resources/docgen/templates/dl20-doc-segmented-unicoil.template
+++ b/src/main/resources/docgen/templates/dl20-doc-segmented-unicoil.template
@@ -99,8 +99,7 @@ The reasonable settings are:
 + `-hits 10000 -selectMaxPassage.hits 100`
 + `-hits 1000 -selectMaxPassage.hits 100`
 
-Due to tie-breaking effects, we get slightly different results on the dev queries.
-However, for these topics, we get the same results (that is, the tie-breaking affects do not manifest in different scores).
+However, for these topics, we get the same results; that is, the tie-breaking affects do not manifest in different scores.
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/src/main/resources/docgen/templates/dl20-doc-segmented-unicoil.template
+++ b/src/main/resources/docgen/templates/dl20-doc-segmented-unicoil.template
@@ -90,6 +90,18 @@ Remember that we keep qrels of _all_ relevance grades, unlike the case for passa
 Here, we retrieve 1000 hits per query, but measure AP at cutoff 100 (e.g., AP@100).
 Thus, the experimental results reported here are directly comparable to the results reported in the [track overview paper](https://arxiv.org/abs/2102.07662).
 
+## Additional Notes
+
+Note that due to MaxP and the need to generate runs to different depths, we can set `-hits` and `-selectMaxPassage.hits` differently.
+The reasonable settings are:
+
++ `-hits 10000 -selectMaxPassage.hits 1000` (as above)
++ `-hits 10000 -selectMaxPassage.hits 100`
++ `-hits 1000 -selectMaxPassage.hits 100`
+
+Due to tie-breaking effects, we get slightly different results on the dev queries.
+However, for these topics, we get the same results (that is, the tie-breaking affects do not manifest in different scores).
+
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.

--- a/src/main/resources/docgen/templates/dl20-doc-segmented-unicoil.template
+++ b/src/main/resources/docgen/templates/dl20-doc-segmented-unicoil.template
@@ -16,11 +16,11 @@ Note that this page is automatically generated from [this template](${template})
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO segmented document corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -28,17 +28,16 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil.tar -P collections/
-
 tar xvf collections/msmarco-doc-segmented-unicoil.tar -C collections/
 ```
 
-To confirm, `msmarco-doc-segmented-unicoil.tar` is 18 GB and has MD5 checksum `6a00e2c0c375cb1e52c83ae5ac377ebb`.
+To confirm, `msmarco-doc-segmented-unicoil.tar` is 19 GB and has MD5 checksum `6a00e2c0c375cb1e52c83ae5ac377ebb`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
   --corpus-path collections/${corpus}
 ```
@@ -49,7 +48,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 ${index_cmds}
 ```
 
@@ -68,13 +67,13 @@ The original data can be found [here](https://trec.nist.gov/data/deep2020.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 ${ranking_cmds}
 ```
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 ${eval_cmds}
 ```
 
@@ -99,7 +98,7 @@ The reasonable settings are:
 + `-hits 10000 -selectMaxPassage.hits 100`
 + `-hits 1000 -selectMaxPassage.hits 100`
 
-However, for these topics, we get the same results; that is, the tie-breaking affects do not manifest in different scores.
+However, for these topics, we get the same effectiveness results; that is, the tie-breaking affects do not manifest in different scores.
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/src/main/resources/docgen/templates/dl20-passage-unicoil-noexp.template
+++ b/src/main/resources/docgen/templates/dl20-passage-unicoil-noexp.template
@@ -18,11 +18,11 @@ Note that this page is automatically generated from [this template](${template})
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -30,17 +30,16 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
+```bash
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil-noexp.tar -P collections/
+tar xvf collections/msmarco-passage-unicoil-noexp.tar -C collections/
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil.tar -P collections/
 
-tar xvf collections/msmarco-passage-unicoil.tar -C collections/
-```
-
-To confirm, `msmarco-passage-unicoil.tar` is 3.3 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
+To confirm, `msmarco-passage-unicoil-noexp.tar` is 2.7 GB and has MD5 checksum `f17ddd8c7c00ff121c3c3b147d2e17d8`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
   --corpus-path collections/${corpus}
 ```
@@ -51,7 +50,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 ${index_cmds}
 ```
 
@@ -70,13 +69,13 @@ The original data can be found [here](https://trec.nist.gov/data/deep2020.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 ${ranking_cmds}
 ```
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 ${eval_cmds}
 ```
 

--- a/src/main/resources/docgen/templates/dl20-passage-unicoil.template
+++ b/src/main/resources/docgen/templates/dl20-passage-unicoil.template
@@ -18,11 +18,11 @@ Note that this page is automatically generated from [this template](${template})
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -30,17 +30,16 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil.tar -P collections/
-
 tar xvf collections/msmarco-passage-unicoil.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-unicoil.tar` is 3.3 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
+To confirm, `msmarco-passage-unicoil.tar` is 3.4 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
   --corpus-path collections/${corpus}
 ```
@@ -51,7 +50,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 ${index_cmds}
 ```
 
@@ -70,13 +69,13 @@ The original data can be found [here](https://trec.nist.gov/data/deep2020.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 ${ranking_cmds}
 ```
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 ${eval_cmds}
 ```
 

--- a/src/main/resources/docgen/templates/msmarco-doc-segmented-unicoil-noexp.template
+++ b/src/main/resources/docgen/templates/msmarco-doc-segmented-unicoil-noexp.template
@@ -84,37 +84,6 @@ ${effectiveness}
 
 ## Additional Notes
 
-This model corresponds to the run named "uniCOIL-d2q" on the official MS MARCO Document Ranking Leaderboard, submitted 2021/09/16.
-The following command generates a comparable run:
-
-```bash
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.unicoil.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil.msmarco-doc.dev.txt \
-  -format msmarco \
-  -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 100
-```
-
-Note that the above command uses `-format msmarco` to directly generate a run in the MS MARCO output format.
-And to evaluate:
-
-```bash
-python tools/scripts/msmarco/msmarco_doc_eval.py \
-  --judgments src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt \
-  --run runs/run.msmarco-doc-segmented-unicoil.msmarco-doc.dev.txt
-```
-
-The results should be as follows:
-
-```
-#####################
-MRR @100: 0.352997702662614
-QueriesRanked: 5193
-#####################
-```
-
 Note that due to MaxP and the need to generate runs to different depths, we can set `-hits` and `-selectMaxPassage.hits` differently.
 Because of tie-breaking effects, we get slightly different results:
 

--- a/src/main/resources/docgen/templates/msmarco-doc-segmented-unicoil-noexp.template
+++ b/src/main/resources/docgen/templates/msmarco-doc-segmented-unicoil-noexp.template
@@ -16,11 +16,11 @@ Note that this page is automatically generated from [this template](${template})
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO segmented document corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -28,9 +28,8 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil-noexp.tar -P collections/
-
 tar xvf collections/msmarco-doc-segmented-unicoil-noexp.tar -C collections/
 ```
 
@@ -38,7 +37,7 @@ To confirm, `msmarco-doc-segmented-unicoil-noexp.tar` is 11 GB and has MD5 check
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
   --corpus-path collections/${corpus}
 ```
@@ -49,7 +48,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 ${index_cmds}
 ```
 
@@ -67,13 +66,13 @@ The regression experiments here evaluate on the 6980 dev set questions; see [thi
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 ${ranking_cmds}
 ```
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 ${eval_cmds}
 ```
 
@@ -83,10 +82,12 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
+## Additional Notes
+
 This model corresponds to the run named "uniCOIL-d2q" on the official MS MARCO Document Ranking Leaderboard, submitted 2021/09/16.
 The following command generates a comparable run:
 
-```
+```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.unicoil.tsv.gz \
@@ -113,6 +114,15 @@ MRR @100: 0.352997702662614
 QueriesRanked: 5193
 #####################
 ```
+
+Note that due to MaxP and the need to generate runs to different depths, we can set `-hits` and `-selectMaxPassage.hits` differently.
+Because of tie-breaking effects, we get slightly different results:
+
+| Condition                                            | AP@1000 | RR@100 | R@100  | R@1000 | MS MARCO MRR @100   |
+|:-----------------------------------------------------|:--------|:-------|:-------|:-------|:--------------------|
+| `-hits 10000 -selectMaxPassage.hits 1000` (as above) | 0.3413  | 0.3409 | 0.8639 | 0.9420 | 0.34138671941993426 |
+| `-hits 10000 -selectMaxPassage.hits 100`             | 0.3409  | 0.3409 | 0.8639 | -      | 0.3410112121151749  |
+| `-hits 1000 -selectMaxPassage.hits 100`              | 0.3409  | 0.3409 | 0.8639 | -      | 0.3410112121151749  |
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/src/main/resources/docgen/templates/msmarco-doc-segmented-unicoil.template
+++ b/src/main/resources/docgen/templates/msmarco-doc-segmented-unicoil.template
@@ -16,11 +16,11 @@ Note that this page is automatically generated from [this template](${template})
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO segmented document corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -28,9 +28,8 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil.tar -P collections/
-
 tar xvf collections/msmarco-doc-segmented-unicoil.tar -C collections/
 ```
 
@@ -38,7 +37,7 @@ To confirm, `msmarco-doc-segmented-unicoil.tar` is 19 GB and has MD5 checksum `6
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
   --corpus-path collections/${corpus}
 ```
@@ -49,7 +48,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 ${index_cmds}
 ```
 
@@ -67,13 +66,13 @@ The regression experiments here evaluate on the 6980 dev set questions; see [thi
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 ${ranking_cmds}
 ```
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 ${eval_cmds}
 ```
 
@@ -88,7 +87,7 @@ ${effectiveness}
 This model corresponds to the run named "uniCOIL-d2q" on the official MS MARCO Document Ranking Leaderboard, submitted 2021/09/16.
 The following command generates a comparable run:
 
-```
+```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.unicoil.tsv.gz \
@@ -124,7 +123,6 @@ Because of tie-breaking effects, we get slightly different results:
 | `-hits 10000 -selectMaxPassage.hits 1000` (as above) | 0.3535  | 0.3531 | 0.8858 | 0.9546 | 0.3533301973179882 |
 | `-hits 10000 -selectMaxPassage.hits 100`             | 0.3531  | 0.3531 | 0.8860 | -      | 0.352997702662614  |
 | `-hits 1000 -selectMaxPassage.hits 100`              | 0.3531  | 0.3531 | 0.8860 | -      | 0.352997702662614  |
-
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/src/main/resources/docgen/templates/msmarco-doc-segmented-unicoil.template
+++ b/src/main/resources/docgen/templates/msmarco-doc-segmented-unicoil.template
@@ -117,7 +117,7 @@ QueriesRanked: 5193
 ```
 
 Note that due to MaxP and the need to generate runs to different depths, we can set `-hits` and `-selectMaxPassage.hits` differently.
-Due to tie-breaking effects, we get slightly different results:
+Because of tie-breaking effects, we get slightly different results:
 
 | Condition                                            | AP@1000 | RR@100 | R@100  | R@1000 | MS MARCO MRR @100  |
 |:-----------------------------------------------------|:--------|:-------|:-------|:-------|:-------------------|

--- a/src/main/resources/docgen/templates/msmarco-doc-segmented-unicoil.template
+++ b/src/main/resources/docgen/templates/msmarco-doc-segmented-unicoil.template
@@ -34,7 +34,7 @@ wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-uni
 tar xvf collections/msmarco-doc-segmented-unicoil.tar -C collections/
 ```
 
-To confirm, `msmarco-doc-segmented-unicoil.tar` is 18 GB and has MD5 checksum `6a00e2c0c375cb1e52c83ae5ac377ebb`.
+To confirm, `msmarco-doc-segmented-unicoil.tar` is 19 GB and has MD5 checksum `6a00e2c0c375cb1e52c83ae5ac377ebb`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
@@ -83,6 +83,8 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
+## Additional Notes
+
 This model corresponds to the run named "uniCOIL-d2q" on the official MS MARCO Document Ranking Leaderboard, submitted 2021/09/16.
 The following command generates a comparable run:
 
@@ -113,6 +115,16 @@ MRR @100: 0.352997702662614
 QueriesRanked: 5193
 #####################
 ```
+
+Note that due to MaxP and the need to generate runs to different depths, we can set `-hits` and `-selectMaxPassage.hits` differently.
+Due to tie-breaking effects, we get slightly different results:
+
+| Condition                                            | AP@1000 | RR@100 | R@100  | R@1000 | MS MARCO MRR @100  |
+|:-----------------------------------------------------|:--------|:-------|:-------|:-------|:-------------------|
+| `-hits 10000 -selectMaxPassage.hits 1000` (as above) | 0.3535  | 0.3531 | 0.8858 | 0.9546 | 0.3533301973179882 |
+| `-hits 10000 -selectMaxPassage.hits 100`             | 0.3531  | 0.3531 | 0.8860 | -      | 0.352997702662614  |
+| `-hits 1000 -selectMaxPassage.hits 100`              | 0.3531  | 0.3531 | 0.8860 | -      | 0.352997702662614  |
+
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/src/main/resources/docgen/templates/msmarco-passage-unicoil-noexp.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-unicoil-noexp.template
@@ -15,11 +15,11 @@ Note that this page is automatically generated from [this template](${template})
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -27,17 +27,16 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
+```bash
+wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil-noexp.tar -P collections/
+tar xvf collections/msmarco-passage-unicoil-noexp.tar -C collections/
 ```
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil.tar -P collections/
 
-tar xvf collections/msmarco-passage-unicoil.tar -C collections/
-```
-
-To confirm, `msmarco-passage-unicoil.tar` is 3.3 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
+To confirm, `msmarco-passage-unicoil-noexp.tar` is 2.7 GB and has MD5 checksum `f17ddd8c7c00ff121c3c3b147d2e17d8`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
   --corpus-path collections/${corpus}
 ```
@@ -48,7 +47,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 ${index_cmds}
 ```
 
@@ -66,13 +65,13 @@ The regression experiments here evaluate on the 6980 dev set questions; see [thi
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 ${ranking_cmds}
 ```
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 ${eval_cmds}
 ```
 

--- a/src/main/resources/docgen/templates/msmarco-passage-unicoil-noexp.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-unicoil-noexp.template
@@ -81,30 +81,6 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-The above runs are in TREC output format and evaluated with `trec_eval`.
-In order to reproduce results reported in the paper, we need to convert to MS MARCO output format and then evaluate:
-
-```bash
-python tools/scripts/msmarco/convert_trec_to_msmarco_run.py \
-   --input runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.txt \
-   --output runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.tsv --quiet
-
-python tools/scripts/msmarco/msmarco_passage_eval.py \
-   tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt \
-   runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.tsv
-```
-
-The results should be as follows:
-
-```
-#####################
-MRR @10: 0.35155222404147896
-QueriesRanked: 6980
-#####################
-```
-
-This corresponds to the effectiveness reported in the paper and also the run named "uniCOIL-d2q" on the official MS MARCO Passage Ranking Leaderboard, submitted 2021/09/22.
-
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.

--- a/src/main/resources/docgen/templates/msmarco-passage-unicoil.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-unicoil.template
@@ -12,11 +12,11 @@ Note that this page is automatically generated from [this template](${template})
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-## Corpus
+## Corpus Download
 
 We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., gone through document expansion and term reweighting.
 Thus, no neural inference is involved.
@@ -24,17 +24,16 @@ For details on how to train uniCOIL and perform inference, please see [this guid
 
 Download the corpus and unpack into `collections/`:
 
-```
+```bash
 wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil.tar -P collections/
-
 tar xvf collections/msmarco-passage-unicoil.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-unicoil.tar` is 3.3 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
+To confirm, `msmarco-passage-unicoil.tar` is 3.4 GB and has MD5 checksum `78eef752c78c8691f7d61600ceed306f`.
 
 With the corpus downloaded, the following command will perform the complete regression, end to end, on any machine:
 
-```
+```bash
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
   --corpus-path collections/${corpus}
 ```
@@ -45,7 +44,7 @@ Alternatively, you can simply copy/paste from the commands below and obtain the 
 
 Sample indexing command:
 
-```
+```bash
 ${index_cmds}
 ```
 
@@ -63,13 +62,13 @@ The regression experiments here evaluate on the 6980 dev set questions; see [thi
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
-```
+```bash
 ${ranking_cmds}
 ```
 
 Evaluation can be performed using `trec_eval`:
 
-```
+```bash
 ${eval_cmds}
 ```
 


### PR DESCRIPTION
Minor fixes: broken links, clarified parameter options, etc.