### PR TITLE
Add ability to extract feedback terms

### DIFF
--- a/src/main/java/io/anserini/rerank/RerankerContext.java
+++ b/src/main/java/io/anserini/rerank/RerankerContext.java
@@ -22,6 +22,7 @@ import org.apache.lucene.search.Query;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 public class RerankerContext<K> {
   private final IndexSearcher searcher;
@@ -32,6 +33,8 @@ public class RerankerContext<K> {
   private final List<String> queryTokens;
   private final Query filter;
   private final SearchArgs searchArgs;
+
+  public Map<String, Float> feedbackTerms;
 
   public RerankerContext(IndexSearcher searcher, K queryId, Query query, String queryDocId, String queryText,
       List<String> queryTokens, Query filter, SearchArgs searchArgs) throws IOException {

--- a/src/main/java/io/anserini/rerank/lib/Rm3Reranker.java
+++ b/src/main/java/io/anserini/rerank/lib/Rm3Reranker.java
@@ -103,7 +103,7 @@ public class Rm3Reranker implements Reranker {
     if (this.outputQuery) {
       LOG.info("QID: " + context.getQueryId());
       LOG.info("Original Query: " + context.getQuery().toString(this.field));
-      LOG.info("Running new query: " + feedbackQuery.toString(this.field));
+      LOG.info("Feedback Query: " + feedbackQuery.toString(this.field));
       feedbackTerms.forEach((k, v) -> LOG.info("Feedback term: " + k + " -> " + v));
     }
 

--- a/src/main/java/io/anserini/rerank/lib/RocchioReranker.java
+++ b/src/main/java/io/anserini/rerank/lib/RocchioReranker.java
@@ -136,7 +136,7 @@ public class RocchioReranker implements Reranker {
     if (this.outputQuery) {
       LOG.info("QID: " + context.getQueryId());
       LOG.info("Original Query: " + context.getQuery().toString(this.field));
-      LOG.info("Running new query: " + feedbackQuery.toString(this.field));
+      LOG.info("Feedback Query: " + feedbackQuery.toString(this.field));
       feedbackTerms.forEach((k, v) -> LOG.info("Feedback term: " + k + " -> " + v));
     }
 

--- a/src/test/java/io/anserini/search/SimpleSearcherTest.java
+++ b/src/test/java/io/anserini/search/SimpleSearcherTest.java
@@ -266,6 +266,10 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(0, results[0].lucene_docid);
     assertEquals(0.14417f, results[0].score, 10e-5);
 
+    Map<String, Float> feedbackTerms = searcher.get_feedback_terms("text");
+    assertEquals(1, feedbackTerms.size());
+    assertEquals(0.5f, feedbackTerms.get("text"), 10e-5);
+
     searcher.unset_rm3();
     assertFalse(searcher.use_rm3());
 
@@ -274,6 +278,9 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals("doc1", results[0].docid);
     assertEquals(0, results[0].lucene_docid);
     assertEquals(0.28830f, results[0].score, 10e-5);
+
+    feedbackTerms = searcher.get_feedback_terms("text");
+    assertNull(feedbackTerms);
 
     searcher.close();
   }

--- a/src/test/java/io/anserini/search/SimpleSearcherTest.java
+++ b/src/test/java/io/anserini/search/SimpleSearcherTest.java
@@ -299,6 +299,10 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(0, results[0].lucene_docid);
     assertEquals(0.28830f, results[0].score, 10e-5);
 
+    Map<String, Float> feedbackTerms = searcher.get_feedback_terms("text");
+    assertEquals(1, feedbackTerms.size());
+    assertEquals(1.0f, feedbackTerms.get("text"), 10e-5);
+
     searcher.unset_rocchio();
     assertFalse(searcher.use_rocchio());
 
@@ -307,6 +311,9 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals("doc1", results[0].docid);
     assertEquals(0, results[0].lucene_docid);
     assertEquals(0.28830f, results[0].score, 10e-5);
+
+    feedbackTerms = searcher.get_feedback_terms("text");
+    assertNull(feedbackTerms);
 
     searcher.close();
   }


### PR DESCRIPTION
Right now, it's a pretty stupid implementation: uses the reranker context to store the feedback terms.
To get the feedback terms, we actually need to run the query - bindings in `SimpleSearcher`.
