### PR TITLE
Fix batch_search for RM3, made BM25prf thread-safe

### DIFF
--- a/docs/regressions-backgroundlinking18.md
+++ b/docs/regressions-backgroundlinking18.md
@@ -79,7 +79,7 @@ With the above commands, you should be able to reproduce the following results:
 
 | **MAP**                                                                                                      | **BM25**  | **+RM3**  | **+RM3+DF**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [TREC 2018 Topics](../src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt)                    | 0.2490    | 0.2661    | 0.2685    |
+| [TREC 2018 Topics](../src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt)                    | 0.2490    | 0.2661    | 0.2679    |
 | **nDCG@5**                                                                                                   | **BM25**  | **+RM3**  | **+RM3+DF**|
-| [TREC 2018 Topics](../src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt)                    | 0.3293    | 0.3447    | 0.4060    |
+| [TREC 2018 Topics](../src/main/resources/topics-and-qrels/topics.backgroundlinking18.txt)                    | 0.3293    | 0.3436    | 0.4027    |
 

--- a/docs/regressions-backgroundlinking19.md
+++ b/docs/regressions-backgroundlinking19.md
@@ -79,7 +79,7 @@ With the above commands, you should be able to reproduce the following results:
 
 | **MAP**                                                                                                      | **BM25**  | **+RM3**  | **+RM3+DF**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [TREC 2019 Topics](../src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt)                    | 0.3029    | 0.3756    | 0.3133    |
+| [TREC 2019 Topics](../src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt)                    | 0.3029    | 0.3787    | 0.3160    |
 | **nDCG@5**                                                                                                   | **BM25**  | **+RM3**  | **+RM3+DF**|
-| [TREC 2019 Topics](../src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt)                    | 0.4785    | 0.5124    | 0.4967    |
+| [TREC 2019 Topics](../src/main/resources/topics-and-qrels/topics.backgroundlinking19.txt)                    | 0.4785    | 0.5200    | 0.5018    |
 

--- a/docs/regressions-backgroundlinking20.md
+++ b/docs/regressions-backgroundlinking20.md
@@ -79,7 +79,7 @@ With the above commands, you should be able to reproduce the following results:
 
 | **MAP**                                                                                                      | **BM25**  | **+RM3**  | **+RM3+DF**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [TREC 2020 Topics](../src/main/resources/topics-and-qrels/topics.backgroundlinking20.txt)                    | 0.3286    | 0.4529    | 0.3443    |
+| [TREC 2020 Topics](../src/main/resources/topics-and-qrels/topics.backgroundlinking20.txt)                    | 0.3286    | 0.4528    | 0.3438    |
 | **nDCG@5**                                                                                                   | **BM25**  | **+RM3**  | **+RM3+DF**|
-| [TREC 2020 Topics](../src/main/resources/topics-and-qrels/topics.backgroundlinking20.txt)                    | 0.5231    | 0.5684    | 0.5316    |
+| [TREC 2020 Topics](../src/main/resources/topics-and-qrels/topics.backgroundlinking20.txt)                    | 0.5231    | 0.5696    | 0.5304    |
 

--- a/src/main/java/io/anserini/rerank/lib/Rm3Reranker.java
+++ b/src/main/java/io/anserini/rerank/lib/Rm3Reranker.java
@@ -79,7 +79,7 @@ public class Rm3Reranker implements Reranker {
     IndexSearcher searcher = context.getIndexSearcher();
     IndexReader reader = searcher.getIndexReader();
 
-    FeatureVector qfv = FeatureVector.fromTerms(AnalyzerUtils.analyze(analyzer, context.getQueryText())).scaleToUnitL1Norm();
+    FeatureVector qfv = FeatureVector.fromTerms(context.getQueryTokens()).scaleToUnitL1Norm();
 
     boolean useRf = (context.getSearchArgs().rf_qrels != null);
     FeatureVector rm = estimateRelevanceModel(docs, reader, context.getSearchArgs().searchtweets, useRf);

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -191,10 +191,6 @@ public final class SearchCollection implements Closeable {
 
         // This is the number of threads that we're going to devote to running the queries in parallel.
         int parallelism = args.parallelism;
-        // BM25 PRF is not thread safe, so we can't run in parallel.
-        if (args.bm25prf) {
-          parallelism = 1;
-        }
 
         // ThreadPool for parallelizing the execution of individual queries:
         ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(parallelism);

--- a/src/main/java/io/anserini/search/SimpleSearcher.java
+++ b/src/main/java/io/anserini/search/SimpleSearcher.java
@@ -582,8 +582,9 @@ public class SimpleSearcher implements Closeable {
    */
   public Result[] search(QueryGenerator generator, String q, int k) throws IOException {
     Query query = generator.buildQuery(IndexArgs.CONTENTS, analyzer, q);
+    List<String> queryTokens = AnalyzerUtils.analyze(analyzer, q);
 
-    return _search(query, null, null, k);
+    return _search(query, queryTokens, q, k);
   }
 
   // internal implementation

--- a/src/main/resources/regression/backgroundlinking18.yaml
+++ b/src/main/resources/regression/backgroundlinking18.yaml
@@ -53,12 +53,12 @@ models:
       MAP:
         - 0.2661
       nDCG@5:
-        - 0.3447
+        - 0.3436
   - name: bm25+rm3+df
     display: +RM3+DF
     params: -backgroundlinking -backgroundlinking.datefilter -backgroundlinking.k 100 -bm25 -rm3 -hits 100
     results:
       MAP:
-        - 0.2685
+        - 0.2679
       nDCG@5:
-        - 0.4060
+        - 0.4027

--- a/src/main/resources/regression/backgroundlinking19.yaml
+++ b/src/main/resources/regression/backgroundlinking19.yaml
@@ -51,14 +51,14 @@ models:
     params: -backgroundlinking -backgroundlinking.k 100 -bm25 -rm3 -hits 100
     results:
       MAP:
-        - 0.3756
+        - 0.3787
       nDCG@5:
-        - 0.5124
+        - 0.5200
   - name: bm25+rm3+df
     display: +RM3+DF
     params: -backgroundlinking -backgroundlinking.datefilter -backgroundlinking.k 100 -bm25 -rm3 -hits 100
     results:
       MAP:
-        - 0.3133
+        - 0.3160
       nDCG@5:
-        - 0.4967
+        - 0.5018

--- a/src/main/resources/regression/backgroundlinking20.yaml
+++ b/src/main/resources/regression/backgroundlinking20.yaml
@@ -51,14 +51,14 @@ models:
     params: -backgroundlinking -backgroundlinking.k 100 -bm25 -rm3 -hits 100
     results:
       MAP:
-        - 0.4529
+        - 0.4528
       nDCG@5:
-        - 0.5684
+        - 0.5696
   - name: bm25+rm3+df
     display: +RM3+DF
     params: -backgroundlinking -backgroundlinking.datefilter -backgroundlinking.k 100 -bm25 -rm3 -hits 100
     results:
       MAP:
-        - 0.3443
+        - 0.3438
       nDCG@5:
-        - 0.5316
+        - 0.5304

--- a/src/test/java/io/anserini/search/SimpleSearcherTest.java
+++ b/src/test/java/io/anserini/search/SimpleSearcherTest.java
@@ -334,9 +334,35 @@ public class SimpleSearcherTest extends IndexerTestBase {
   }
 
   @Test
-  public void testBatchSearch() throws Exception {
+  public void testBatchSearch1() throws Exception {
     SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
       
+    List<String> queries = new ArrayList<>();
+    queries.add("test");
+    queries.add("more");
+
+    List<String> qids = new ArrayList<>();
+    qids.add("query_test");
+    qids.add("query_more");
+
+    Map<String, SimpleSearcher.Result[]> hits = searcher.batch_search(queries, qids, 10, 2);
+    assertEquals(2, hits.size());
+
+    assertEquals(1, hits.get("query_test").length);
+    assertEquals("doc3", hits.get("query_test")[0].docid);
+
+    assertEquals(2, hits.get("query_more").length);
+    assertEquals("doc2", hits.get("query_more")[0].docid);
+    assertEquals("doc1", hits.get("query_more")[1].docid);
+
+    searcher.close();
+  }
+
+  @Test
+  public void testBatchSearch2() throws Exception {
+    SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
+    searcher.set_rm3();
+
     List<String> queries = new ArrayList<>();
     queries.add("test");
     queries.add("more");


### PR DESCRIPTION
batch_search for RM3 doesn't appear to work, as reported in https://github.com/castorini/pyserini/issues/831

I tracked down the issue to the fact that analyzers have state, and so concurrent calls to analyze the query causes issues.
Solution is to analyze the query just once.

I also fixed the thread safety issue with BM25prf. The issue is that we swap in a different similarity in the searcher,
so interleaved execution confuses the reranker wrt what similarity we're actually using.
