### PR TITLE
Add SimpleIndexer

### DIFF
--- a/src/main/java/io/anserini/collection/JsonCollection.java
+++ b/src/main/java/io/anserini/collection/JsonCollection.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -165,14 +166,19 @@ public class JsonCollection extends DocumentCollection<JsonCollection.Document> 
     private String raw;
     private Map<String, String> fields;
 
-    protected Document() {
-      // This is no-op constructor for sub-classes that want to do everything themselves.
+    public static Document fromString(String raw) throws IOException {
+      ObjectMapper mapper = new ObjectMapper();
+      MappingIterator<JsonNode> iterator =
+          mapper.readerFor(JsonNode.class).readValues(new ByteArrayInputStream(raw.getBytes()));
+      if (iterator.hasNext()) {
+        return new Document(iterator.next());
+      }
+
+      return null;
     }
 
-    public Document(String id, String contents) {
-      this.id = id;
-      this.contents = contents;
-      this.fields = new HashMap<>();
+    protected Document() {
+      // This is no-op constructor for sub-classes that want to do everything themselves.
     }
 
     public Document(JsonNode json) {

--- a/src/main/java/io/anserini/collection/JsonCollection.java
+++ b/src/main/java/io/anserini/collection/JsonCollection.java
@@ -149,6 +149,12 @@ public class JsonCollection extends DocumentCollection<JsonCollection.Document> 
       // This is no-op constructor for sub-classes that want to do everything themselves.
     }
 
+    public Document(String id, String contents) {
+      this.id = id;
+      this.contents = contents;
+      this.fields = new HashMap<>();
+    }
+
     public Document(JsonNode json) {
       this.raw = json.toPrettyString();
       this.fields = new HashMap<>();

--- a/src/main/java/io/anserini/index/SimpleIndexer.java
+++ b/src/main/java/io/anserini/index/SimpleIndexer.java
@@ -83,9 +83,11 @@ public class SimpleIndexer {
   }
 
   public void close() {
-    boolean optimize = false;
+    close(false);
+  }
 
-    // Do a final commit
+  public void close(boolean optimize) {
+    // Do a final commit.
     try {
       if (writer != null) {
         writer.commit();
@@ -96,6 +98,7 @@ public class SimpleIndexer {
     } catch (IOException e) {
       // It is possible that this happens... but nothing much we can do at this point,
       // so just log the error and move on.
+      LOG.error(e.getMessage());
     } finally {
       try {
         if (writer != null) {
@@ -104,6 +107,7 @@ public class SimpleIndexer {
       } catch (IOException e) {
         // It is possible that this happens... but nothing much we can do at this point,
         // so just log the error and move on.
+        LOG.error(e.getMessage());
       }
     }
   }

--- a/src/main/java/io/anserini/index/SimpleIndexer.java
+++ b/src/main/java/io/anserini/index/SimpleIndexer.java
@@ -1,0 +1,101 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.index;
+
+import io.anserini.analysis.DefaultEnglishAnalyzer;
+import io.anserini.collection.JsonCollection;
+import io.anserini.index.generator.DefaultLuceneDocumentGenerator;
+import io.anserini.index.generator.GeneratorException;
+import io.anserini.index.generator.LuceneDocumentGenerator;
+import org.apache.lucene.index.ConcurrentMergeScheduler;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class SimpleIndexer {
+  private final Path indexPath;
+  private final IndexWriter writer;
+  private final LuceneDocumentGenerator generator = new DefaultLuceneDocumentGenerator();
+
+  public SimpleIndexer(String indexPath) throws IOException {
+    this.indexPath = Paths.get(indexPath);
+    if (!Files.exists(this.indexPath)) {
+      Files.createDirectories(this.indexPath);
+    }
+
+    final Directory dir = FSDirectory.open(this.indexPath);
+    final DefaultEnglishAnalyzer analyzer = DefaultEnglishAnalyzer.newDefaultInstance();
+
+    final IndexWriterConfig config;
+    config = new IndexWriterConfig(analyzer);
+
+    config.setOpenMode(IndexWriterConfig.OpenMode.CREATE);
+    config.setRAMBufferSizeMB(2048);
+    config.setUseCompoundFile(false);
+    config.setMergeScheduler(new ConcurrentMergeScheduler());
+
+    writer = new IndexWriter(dir, config);
+
+  }
+
+  public boolean addDocument(String docid, String contents) {
+    JsonCollection.Document doc = new JsonCollection.Document(docid, contents);
+    try {
+      writer.addDocument(generator.createDocument(doc));
+    } catch (GeneratorException e) {
+      e.printStackTrace();
+      return false;
+    } catch (IOException e) {
+      e.printStackTrace();
+      return false;
+    }
+
+    return true;
+  }
+
+  public void close() {
+    boolean optimize = false;
+
+    // Do a final commit
+    try {
+      if (writer != null) {
+        writer.commit();
+        if (optimize) {
+          writer.forceMerge(1);
+        }
+      }
+    } catch (IOException e) {
+      // It is possible that this happens... but nothing much we can do at this point,
+      // so just log the error and move on.
+    } finally {
+      try {
+        if (writer != null) {
+          writer.close();
+        }
+      } catch (IOException e) {
+        // It is possible that this happens... but nothing much we can do at this point,
+        // so just log the error and move on.
+      }
+    }
+  }
+}

--- a/src/main/java/io/anserini/index/generator/DefaultLuceneDocumentGenerator.java
+++ b/src/main/java/io/anserini/index/generator/DefaultLuceneDocumentGenerator.java
@@ -40,7 +40,8 @@ import java.util.Arrays;
 public class DefaultLuceneDocumentGenerator<T extends SourceDocument> implements LuceneDocumentGenerator<T> {
   protected IndexArgs args;
 
-  protected DefaultLuceneDocumentGenerator() {
+  public DefaultLuceneDocumentGenerator() {
+    this(new IndexArgs());
   }
 
   /**

--- a/src/test/java/io/anserini/collection/JsonCollectionLineObjectTest.java
+++ b/src/test/java/io/anserini/collection/JsonCollectionLineObjectTest.java
@@ -17,7 +17,9 @@
 package io.anserini.collection;
 
 import org.junit.Before;
+import org.junit.Test;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -78,4 +80,23 @@ public class JsonCollectionLineObjectTest extends JsonCollectionTest {
     assertEquals(expected.get("field1"), ((JsonCollection.Document) doc).fields().get("field1"));
     assertEquals(expected.get("field2"), ((JsonCollection.Document) doc).fields().get("field2"));
   }
+
+
+  @Test
+  public void testFromString() throws IOException {
+    JsonCollection.Document doc1 = JsonCollection.Document.fromString(expected.get("doc1").get("raw"));
+    assertEquals("doc1", doc1.id());
+    assertEquals("this is the contents 1.", doc1.contents());
+    assertEquals("doc1 field1 content", doc1.fields().get("field1"));
+    assertEquals("doc1 field2 content", doc1.fields().get("field2"));
+    assertEquals(expected.get("doc1").get("raw"), doc1.raw());
+
+    JsonCollection.Document doc2 = JsonCollection.Document.fromString(expected.get("doc2").get("raw"));
+    assertEquals("doc2", doc2.id());
+    assertEquals("this is the contents 2.", doc2.contents());
+    assertEquals("doc2 field1 content", doc2.fields().get("field1"));
+    assertEquals("doc2 field2 content", doc2.fields().get("field2"));
+    assertEquals(expected.get("doc2").get("raw"), doc2.raw());
+  }
+
 }

--- a/src/test/java/io/anserini/index/SimpleIndexerTest.java
+++ b/src/test/java/io/anserini/index/SimpleIndexerTest.java
@@ -1,0 +1,45 @@
+package io.anserini.index;
+
+import io.anserini.collection.FileSegment;
+import io.anserini.collection.JsonCollection;
+import io.anserini.search.SearchCollection;
+import io.anserini.search.SimpleSearcher;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SimpleIndexerTest {
+
+  @Test
+  public void test1() throws IOException {
+    Path collectionPath = Paths.get("src/test/resources/sample_docs/json/collection3");
+    JsonCollection collection = new JsonCollection(collectionPath);
+
+    SimpleIndexer indexer = new SimpleIndexer("tmp/");
+    for (FileSegment<JsonCollection.Document> segment : collection ) {
+      for (JsonCollection.Document doc : segment) {
+        System.out.println(doc.id() + "\t" + doc.contents());
+        indexer.addDocument(doc.id(), doc.contents());
+      }
+      segment.close();
+    }
+
+    indexer.close();
+
+    SimpleSearcher searcher = new SimpleSearcher("tmp/");
+    SimpleSearcher.Result[] hits = searcher.search("1", 10);
+    System.out.println(hits[0].docid + " " + hits[0].score);
+    assertEquals(1, hits.length);
+
+    searcher.close();
+  }
+
+}

--- a/src/test/java/io/anserini/index/SimpleIndexerTest.java
+++ b/src/test/java/io/anserini/index/SimpleIndexerTest.java
@@ -1,43 +1,58 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.anserini.index;
 
 import io.anserini.collection.FileSegment;
 import io.anserini.collection.JsonCollection;
-import io.anserini.search.SearchCollection;
 import io.anserini.search.SimpleSearcher;
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collection;
-import java.util.Iterator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-public class SimpleIndexerTest {
+public class SimpleIndexerTest extends LuceneTestCase {
 
   @Test
-  public void test1() throws IOException {
+  public void testBasic() throws IOException {
+    Path tempDir = createTempDir();
+
     Path collectionPath = Paths.get("src/test/resources/sample_docs/json/collection3");
     JsonCollection collection = new JsonCollection(collectionPath);
 
-    SimpleIndexer indexer = new SimpleIndexer("tmp/");
+    int cnt = 0;
+    SimpleIndexer indexer = new SimpleIndexer(tempDir.toString());
     for (FileSegment<JsonCollection.Document> segment : collection ) {
       for (JsonCollection.Document doc : segment) {
-        System.out.println(doc.id() + "\t" + doc.contents());
-        indexer.addDocument(doc.id(), doc.contents());
+        indexer.addDocument(doc.raw());
+        cnt++;
       }
       segment.close();
     }
 
     indexer.close();
+    assertEquals(2, cnt);
 
-    SimpleSearcher searcher = new SimpleSearcher("tmp/");
+    SimpleSearcher searcher = new SimpleSearcher(tempDir.toString());
     SimpleSearcher.Result[] hits = searcher.search("1", 10);
-    System.out.println(hits[0].docid + " " + hits[0].score);
     assertEquals(1, hits.length);
+    assertEquals("doc1", hits[0].docid);
+    assertEquals(0.3648, hits[0].score, 1e-4);
 
     searcher.close();
   }


### PR DESCRIPTION
Goal is to enable indexing from the Python end without first having to write out a file.

Initial impl, which is quite simple, uses only a single thread. This will be too painful for indexing even moderate size collections.
