### PR TITLE
Tweak all MS MARCO V2 regressions to use 24 indexing threads

### DIFF
--- a/docs/regressions-cw09b.md
+++ b/docs/regressions-cw09b.md
@@ -22,7 +22,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/cw09b \
   -index indexes/lucene-index.cw09b/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 44 -storePositions -storeDocvectors -storeRaw \
+  -threads 44 -storeRaw \
   >& logs/log.cw09b &
 ```
 
@@ -51,114 +51,114 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.bm25.topics.web.51-100.txt \
-  -bm25 &
+  -parallelism 16 -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.bm25.topics.web.101-150.txt \
-  -bm25 &
+  -parallelism 16 -bm25 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.bm25.topics.web.151-200.txt \
-  -bm25 &
+  -parallelism 16 -bm25 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.bm25+rm3.topics.web.51-100.txt \
-  -bm25 -rm3 &
+  -parallelism 16 -bm25 -rm3 -collection ClueWeb09Collection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.bm25+rm3.topics.web.101-150.txt \
-  -bm25 -rm3 &
+  -parallelism 16 -bm25 -rm3 -collection ClueWeb09Collection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.bm25+rm3.topics.web.151-200.txt \
-  -bm25 -rm3 &
+  -parallelism 16 -bm25 -rm3 -collection ClueWeb09Collection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.bm25+ax.topics.web.51-100.txt \
-  -bm25 -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
+  -parallelism 16 -bm25 -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 -collection ClueWeb09Collection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.bm25+ax.topics.web.101-150.txt \
-  -bm25 -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
+  -parallelism 16 -bm25 -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 -collection ClueWeb09Collection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.bm25+ax.topics.web.151-200.txt \
-  -bm25 -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
+  -parallelism 16 -bm25 -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 -collection ClueWeb09Collection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.ql.topics.web.51-100.txt \
-  -qld &
+  -parallelism 16 -qld &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.ql.topics.web.101-150.txt \
-  -qld &
+  -parallelism 16 -qld &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.ql.topics.web.151-200.txt \
-  -qld &
+  -parallelism 16 -qld &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.ql+rm3.topics.web.51-100.txt \
-  -qld -rm3 &
+  -parallelism 16 -qld -rm3 -collection ClueWeb09Collection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.ql+rm3.topics.web.101-150.txt \
-  -qld -rm3 &
+  -parallelism 16 -qld -rm3 -collection ClueWeb09Collection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.ql+rm3.topics.web.151-200.txt \
-  -qld -rm3 &
+  -parallelism 16 -qld -rm3 -collection ClueWeb09Collection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.51-100.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.ql+ax.topics.web.51-100.txt \
-  -qld -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
+  -parallelism 16 -qld -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 -collection ClueWeb09Collection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.101-150.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.ql+ax.topics.web.101-150.txt \
-  -qld -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
+  -parallelism 16 -qld -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 -collection ClueWeb09Collection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw09b/ \
   -topics src/main/resources/topics-and-qrels/topics.web.151-200.txt \
   -topicreader Webxml \
   -output runs/run.cw09b.ql+ax.topics.web.151-200.txt \
-  -qld -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
+  -parallelism 16 -qld -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 -collection ClueWeb09Collection &
 ```
 
 Evaluation can be performed using `trec_eval` and `gdeval.pl`:

--- a/docs/regressions-cw12.md
+++ b/docs/regressions-cw12.md
@@ -22,7 +22,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/cw12 \
   -index indexes/lucene-index.cw12/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 44 -storePositions -storeDocvectors -storeRaw \
+  -threads 44 -storeRaw \
   >& logs/log.cw12 &
 ```
 
@@ -60,13 +60,13 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt \
   -topicreader Webxml \
   -output runs/run.cw12.bm25+rm3.topics.web.201-250.txt \
-  -bm25 -rm3 &
+  -parallelism 16 -bm25 -rm3 -collection ClueWeb09Collection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12/ \
   -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt \
   -topicreader Webxml \
   -output runs/run.cw12.bm25+rm3.topics.web.251-300.txt \
-  -bm25 -rm3 &
+  -parallelism 16 -bm25 -rm3 -collection ClueWeb09Collection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12/ \
@@ -86,13 +86,13 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt \
   -topicreader Webxml \
   -output runs/run.cw12.ql+rm3.topics.web.201-250.txt \
-  -qld -rm3 &
+  -parallelism 16 -qld -rm3 -collection ClueWeb09Collection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12/ \
   -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt \
   -topicreader Webxml \
   -output runs/run.cw12.ql+rm3.topics.web.251-300.txt \
-  -qld -rm3 &
+  -parallelism 16 -qld -rm3 -collection ClueWeb09Collection &
 ```
 
 Evaluation can be performed using `trec_eval` and `gdeval.pl`:

--- a/docs/regressions-cw12b13.md
+++ b/docs/regressions-cw12b13.md
@@ -22,7 +22,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/cw12b13 \
   -index indexes/lucene-index.cw12b13/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 44 -storePositions -storeDocvectors -storeRaw \
+  -threads 44 -storeRaw \
   >& logs/log.cw12b13 &
 ```
 
@@ -60,26 +60,26 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt \
   -topicreader Webxml \
   -output runs/run.cw12b13.bm25+rm3.topics.web.201-250.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection ClueWeb09Collection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
   -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt \
   -topicreader Webxml \
   -output runs/run.cw12b13.bm25+rm3.topics.web.251-300.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection ClueWeb09Collection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
   -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt \
   -topicreader Webxml \
   -output runs/run.cw12b13.bm25+ax.topics.web.201-250.txt \
-  -bm25 -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
+  -bm25 -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 -collection ClueWeb09Collection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
   -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt \
   -topicreader Webxml \
   -output runs/run.cw12b13.bm25+ax.topics.web.251-300.txt \
-  -bm25 -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
+  -bm25 -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 -collection ClueWeb09Collection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
@@ -99,26 +99,26 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt \
   -topicreader Webxml \
   -output runs/run.cw12b13.ql+rm3.topics.web.201-250.txt \
-  -qld -rm3 &
+  -qld -rm3 -collection ClueWeb09Collection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
   -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt \
   -topicreader Webxml \
   -output runs/run.cw12b13.ql+rm3.topics.web.251-300.txt \
-  -qld -rm3 &
+  -qld -rm3 -collection ClueWeb09Collection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
   -topics src/main/resources/topics-and-qrels/topics.web.201-250.txt \
   -topicreader Webxml \
   -output runs/run.cw12b13.ql+ax.topics.web.201-250.txt \
-  -qld -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
+  -qld -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 -collection ClueWeb09Collection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.cw12b13/ \
   -topics src/main/resources/topics-and-qrels/topics.web.251-300.txt \
   -topicreader Webxml \
   -output runs/run.cw12b13.ql+ax.topics.web.251-300.txt \
-  -qld -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 &
+  -qld -axiom -axiom.deterministic -axiom.beta 0.1 -rerankCutoff 20 -collection ClueWeb09Collection &
 ```
 
 Evaluation can be performed using `trec_eval` and `gdeval.pl`:

--- a/docs/regressions-dl21-doc-d2q-t5.md
+++ b/docs/regressions-dl21-doc-d2q-t5.md
@@ -31,7 +31,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-doc-d2q-t5 \
   -index indexes/lucene-index.msmarco-v2-doc-d2q-t5/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 24 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-doc-d2q-t5 &
 ```
 
@@ -61,14 +61,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rm3.topics.dl21.txt \
-  -hits 1000 -bm25 -rm3 &
+  -hits 1000 -bm25 -rm3 -collection MsMarcoV2DocCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rocchio.topics.dl21.txt \
-  -hits 1000 -bm25 -rocchio &
+  -hits 1000 -bm25 -rocchio -collection MsMarcoV2DocCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl21-doc-segmented-d2q-t5.md
+++ b/docs/regressions-dl21-doc-segmented-d2q-t5.md
@@ -31,7 +31,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-doc-segmented-d2q-t5 \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 24 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-doc-segmented-d2q-t5 &
 ```
 
@@ -61,14 +61,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rm3.topics.dl21.txt \
-  -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rocchio.topics.dl21.txt \
-  -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl21-doc-segmented-unicoil-0shot-v2.md
+++ b/docs/regressions-dl21-doc-segmented-unicoil-0shot-v2.md
@@ -71,7 +71,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-doc-segmented-unicoil-0shot-v2 \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot-v2/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -impact -pretokenized -storeDocvectors \
+  -threads 24 -impact -pretokenized -storeRaw \
   >& logs/log.msmarco-v2-doc-segmented-unicoil-0shot-v2 &
 ```
 
@@ -103,14 +103,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl21.unicoil.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rm3.topics.dl21.unicoil.0shot.txt \
-  -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -rm3 &
+  -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -rm3 -collection JsonVectorCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot-v2/ \
   -topics src/main/resources/topics-and-qrels/topics.dl21.unicoil.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rocchio.topics.dl21.unicoil.0shot.txt \
-  -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -rocchio &
+  -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -rocchio -collection JsonVectorCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl21-doc-segmented-unicoil-0shot.md
+++ b/docs/regressions-dl21-doc-segmented-unicoil-0shot.md
@@ -70,7 +70,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-doc-segmented-unicoil-0shot \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -impact -pretokenized \
+  -threads 24 -impact -pretokenized \
   >& logs/log.msmarco-v2-doc-segmented-unicoil-0shot &
 ```
 

--- a/docs/regressions-dl21-doc-segmented-unicoil-noexp-0shot-v2.md
+++ b/docs/regressions-dl21-doc-segmented-unicoil-noexp-0shot-v2.md
@@ -71,7 +71,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2 \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -impact -pretokenized -storeDocvectors \
+  -threads 24 -impact -pretokenized -storeRaw \
   >& logs/log.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2 &
 ```
 
@@ -103,14 +103,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl21.unicoil-noexp.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rm3.topics.dl21.unicoil-noexp.0shot.txt \
-  -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -rm3 &
+  -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -rm3 -collection JsonVectorCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2/ \
   -topics src/main/resources/topics-and-qrels/topics.dl21.unicoil-noexp.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rocchio.topics.dl21.unicoil-noexp.0shot.txt \
-  -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -rocchio &
+  -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -rocchio -collection JsonVectorCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl21-doc-segmented-unicoil-noexp-0shot.md
+++ b/docs/regressions-dl21-doc-segmented-unicoil-noexp-0shot.md
@@ -70,7 +70,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-doc-segmented-unicoil-noexp-0shot \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -impact -pretokenized \
+  -threads 24 -impact -pretokenized \
   >& logs/log.msmarco-v2-doc-segmented-unicoil-noexp-0shot &
 ```
 

--- a/docs/regressions-dl21-doc-segmented.md
+++ b/docs/regressions-dl21-doc-segmented.md
@@ -31,7 +31,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-doc-segmented \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-doc-segmented &
 ```
 
@@ -54,21 +54,21 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default.topics.dl21.txt \
-  -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -bm25 &
+  -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default+rm3.topics.dl21.txt \
-  -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default+rocchio.topics.dl21.txt \
-  -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl21-doc.md
+++ b/docs/regressions-dl21-doc.md
@@ -31,7 +31,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-doc \
   -index indexes/lucene-index.msmarco-v2-doc/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-doc &
 ```
 
@@ -61,14 +61,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default+rm3.topics.dl21.txt \
-  -hits 1000 -bm25 -rm3 &
+  -hits 1000 -bm25 -rm3 -collection MsMarcoV2DocCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc/ \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default+rocchio.topics.dl21.txt \
-  -hits 1000 -bm25 -rocchio &
+  -hits 1000 -bm25 -rocchio -collection MsMarcoV2DocCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl21-passage-augmented-d2q-t5.md
+++ b/docs/regressions-dl21-passage-augmented-d2q-t5.md
@@ -26,7 +26,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage-augmented-d2q-t5 \
   -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-passage-augmented-d2q-t5 &
 ```
 
@@ -56,14 +56,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rm3.topics.dl21.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rocchio.topics.dl21.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl21-passage-augmented.md
+++ b/docs/regressions-dl21-passage-augmented.md
@@ -26,7 +26,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage-augmented \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-passage-augmented &
 ```
 
@@ -56,14 +56,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+rm3.topics.dl21.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+rocchio.topics.dl21.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl21-passage-d2q-t5.md
+++ b/docs/regressions-dl21-passage-d2q-t5.md
@@ -26,7 +26,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage-d2q-t5 \
   -index indexes/lucene-index.msmarco-v2-passage-d2q-t5/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-passage-d2q-t5 &
 ```
 
@@ -56,14 +56,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rm3.topics.dl21.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rocchio.topics.dl21.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl21-passage-unicoil-0shot.md
+++ b/docs/regressions-dl21-passage-unicoil-0shot.md
@@ -65,7 +65,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage-unicoil-0shot \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -impact -pretokenized -storeDocvectors \
+  -threads 24 -impact -pretokenized -storeRaw \
   >& logs/log.msmarco-v2-passage-unicoil-0shot &
 ```
 
@@ -97,14 +97,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl21.unicoil.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rm3.topics.dl21.unicoil.0shot.txt \
-  -impact -pretokenized -rm3 &
+  -impact -pretokenized -rm3 -collection JsonVectorCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
   -topics src/main/resources/topics-and-qrels/topics.dl21.unicoil.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rocchio.topics.dl21.unicoil.0shot.txt \
-  -impact -pretokenized -rocchio &
+  -impact -pretokenized -rocchio -collection JsonVectorCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl21-passage-unicoil-noexp-0shot.md
+++ b/docs/regressions-dl21-passage-unicoil-noexp-0shot.md
@@ -65,7 +65,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage-unicoil-noexp-0shot \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -impact -pretokenized -storeDocvectors \
+  -threads 24 -impact -pretokenized -storeRaw \
   >& logs/log.msmarco-v2-passage-unicoil-noexp-0shot &
 ```
 
@@ -97,14 +97,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl21.unicoil-noexp.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rm3.topics.dl21.unicoil-noexp.0shot.txt \
-  -impact -pretokenized -rm3 &
+  -impact -pretokenized -rm3 -collection JsonVectorCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
   -topics src/main/resources/topics-and-qrels/topics.dl21.unicoil-noexp.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rocchio.topics.dl21.unicoil-noexp.0shot.txt \
-  -impact -pretokenized -rocchio &
+  -impact -pretokenized -rocchio -collection JsonVectorCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl21-passage.md
+++ b/docs/regressions-dl21-passage.md
@@ -26,7 +26,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage \
   -index indexes/lucene-index.msmarco-v2-passage/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-passage &
 ```
 
@@ -56,14 +56,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+rm3.topics.dl21.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
   -topics src/main/resources/topics-and-qrels/topics.dl21.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+rocchio.topics.dl21.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl22-passage-augmented-d2q-t5.md
+++ b/docs/regressions-dl22-passage-augmented-d2q-t5.md
@@ -26,7 +26,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage-augmented-d2q-t5 \
   -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-passage-augmented-d2q-t5 &
 ```
 
@@ -59,14 +59,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl22.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rm3.topics.dl22.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.dl22.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rocchio.topics.dl22.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl22-passage-augmented.md
+++ b/docs/regressions-dl22-passage-augmented.md
@@ -26,7 +26,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage-augmented \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-passage-augmented &
 ```
 
@@ -59,14 +59,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl22.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+rm3.topics.dl22.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
   -topics src/main/resources/topics-and-qrels/topics.dl22.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+rocchio.topics.dl22.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl22-passage-d2q-t5.md
+++ b/docs/regressions-dl22-passage-d2q-t5.md
@@ -26,7 +26,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage-d2q-t5 \
   -index indexes/lucene-index.msmarco-v2-passage-d2q-t5/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-passage-d2q-t5 &
 ```
 
@@ -59,14 +59,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl22.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rm3.topics.dl22.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.dl22.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rocchio.topics.dl22.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl22-passage-unicoil-0shot.md
+++ b/docs/regressions-dl22-passage-unicoil-0shot.md
@@ -65,7 +65,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage-unicoil-0shot \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -impact -pretokenized -storeDocvectors \
+  -threads 24 -impact -pretokenized -storeRaw \
   >& logs/log.msmarco-v2-passage-unicoil-0shot &
 ```
 
@@ -100,14 +100,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl22.unicoil.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rm3.topics.dl22.unicoil.0shot.txt \
-  -impact -pretokenized -rm3 &
+  -impact -pretokenized -rm3 -collection JsonVectorCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
   -topics src/main/resources/topics-and-qrels/topics.dl22.unicoil.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rocchio.topics.dl22.unicoil.0shot.txt \
-  -impact -pretokenized -rocchio &
+  -impact -pretokenized -rocchio -collection JsonVectorCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl22-passage-unicoil-noexp-0shot.md
+++ b/docs/regressions-dl22-passage-unicoil-noexp-0shot.md
@@ -65,7 +65,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage-unicoil-noexp-0shot \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -impact -pretokenized -storeDocvectors \
+  -threads 24 -impact -pretokenized -storeRaw \
   >& logs/log.msmarco-v2-passage-unicoil-noexp-0shot &
 ```
 
@@ -100,14 +100,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl22.unicoil-noexp.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rm3.topics.dl22.unicoil-noexp.0shot.txt \
-  -impact -pretokenized -rm3 &
+  -impact -pretokenized -rm3 -collection JsonVectorCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
   -topics src/main/resources/topics-and-qrels/topics.dl22.unicoil-noexp.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rocchio.topics.dl22.unicoil-noexp.0shot.txt \
-  -impact -pretokenized -rocchio &
+  -impact -pretokenized -rocchio -collection JsonVectorCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-dl22-passage.md
+++ b/docs/regressions-dl22-passage.md
@@ -26,7 +26,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage \
   -index indexes/lucene-index.msmarco-v2-passage/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-passage &
 ```
 
@@ -59,14 +59,14 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.dl22.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+rm3.topics.dl22.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
   -topics src/main/resources/topics-and-qrels/topics.dl22.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+rocchio.topics.dl22.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-msmarco-v2-doc-d2q-t5.md
+++ b/docs/regressions-msmarco-v2-doc-d2q-t5.md
@@ -24,7 +24,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-doc-d2q-t5 \
   -index indexes/lucene-index.msmarco-v2-doc-d2q-t5/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 24 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-doc-d2q-t5 &
 ```
 
@@ -59,26 +59,26 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2DocCollection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2DocCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2DocCollection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2DocCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-msmarco-v2-doc-segmented-d2q-t5.md
+++ b/docs/regressions-msmarco-v2-doc-segmented-d2q-t5.md
@@ -24,7 +24,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-doc-segmented-d2q-t5 \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 24 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-doc-segmented-d2q-t5 &
 ```
 
@@ -59,26 +59,26 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt \
-  -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+  -bm25 -rm3 -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt \
-  -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+  -bm25 -rm3 -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt \
-  -bm25 -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+  -bm25 -rocchio -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt \
-  -bm25 -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+  -bm25 -rocchio -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-msmarco-v2-doc-segmented-unicoil-0shot-v2.md
+++ b/docs/regressions-msmarco-v2-doc-segmented-unicoil-0shot-v2.md
@@ -68,7 +68,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-doc-segmented-unicoil-0shot-v2 \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot-v2/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 32 -impact -pretokenized -storeDocvectors \
+  -threads 24 -impact -pretokenized -storeRaw \
   >& logs/log.msmarco-v2-doc-segmented-unicoil-0shot-v2 &
 ```
 
@@ -105,26 +105,26 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.unicoil.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rm3.topics.msmarco-v2-doc.dev.unicoil.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+  -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot-v2/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.unicoil.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rm3.topics.msmarco-v2-doc.dev2.unicoil.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+  -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot-v2/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.unicoil.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rocchio.topics.msmarco-v2-doc.dev.unicoil.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+  -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot-v2/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.unicoil.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rocchio.topics.msmarco-v2-doc.dev2.unicoil.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+  -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-msmarco-v2-doc-segmented-unicoil-0shot.md
+++ b/docs/regressions-msmarco-v2-doc-segmented-unicoil-0shot.md
@@ -67,7 +67,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-doc-segmented-unicoil-0shot \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 32 -impact -pretokenized \
+  -threads 24 -impact -pretokenized \
   >& logs/log.msmarco-v2-doc-segmented-unicoil-0shot &
 ```
 

--- a/docs/regressions-msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.md
+++ b/docs/regressions-msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.md
@@ -68,7 +68,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2 \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 32 -impact -pretokenized -storeDocvectors \
+  -threads 24 -impact -pretokenized -storeRaw \
   >& logs/log.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2 &
 ```
 
@@ -105,26 +105,26 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rm3.topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+  -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rm3.topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+  -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+  -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+  -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-msmarco-v2-doc-segmented-unicoil-noexp-0shot.md
+++ b/docs/regressions-msmarco-v2-doc-segmented-unicoil-noexp-0shot.md
@@ -67,7 +67,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-doc-segmented-unicoil-noexp-0shot \
   -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 32 -impact -pretokenized \
+  -threads 24 -impact -pretokenized \
   >& logs/log.msmarco-v2-doc-segmented-unicoil-noexp-0shot &
 ```
 

--- a/docs/regressions-msmarco-v2-doc-segmented.md
+++ b/docs/regressions-msmarco-v2-doc-segmented.md
@@ -25,7 +25,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-doc-segmented \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-doc-segmented &
 ```
 
@@ -60,26 +60,26 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt \
-  -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+  -bm25 -rm3 -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt \
-  -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+  -bm25 -rm3 -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt \
-  -bm25 -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+  -bm25 -rocchio -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt \
-  -bm25 -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
+  -bm25 -rocchio -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-msmarco-v2-doc.md
+++ b/docs/regressions-msmarco-v2-doc.md
@@ -25,7 +25,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-doc \
   -index indexes/lucene-index.msmarco-v2-doc/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-doc &
 ```
 
@@ -60,26 +60,26 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2DocCollection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2DocCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2DocCollection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-doc/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2DocCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-msmarco-v2-passage-augmented-d2q-t5.md
+++ b/docs/regressions-msmarco-v2-passage-augmented-d2q-t5.md
@@ -24,7 +24,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage-augmented-d2q-t5 \
   -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-passage-augmented-d2q-t5 &
 ```
 
@@ -58,26 +58,26 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-msmarco-v2-passage-augmented.md
+++ b/docs/regressions-msmarco-v2-passage-augmented.md
@@ -25,7 +25,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage-augmented \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-passage-augmented &
 ```
 
@@ -60,26 +60,26 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-msmarco-v2-passage-d2q-t5.md
+++ b/docs/regressions-msmarco-v2-passage-d2q-t5.md
@@ -24,7 +24,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage-d2q-t5 \
   -index indexes/lucene-index.msmarco-v2-passage-d2q-t5/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-passage-d2q-t5 &
 ```
 
@@ -58,26 +58,26 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-d2q-t5/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-msmarco-v2-passage-unicoil-0shot.md
+++ b/docs/regressions-msmarco-v2-passage-unicoil-0shot.md
@@ -62,7 +62,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage-unicoil-0shot \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 32 -impact -pretokenized -storeDocvectors \
+  -threads 24 -impact -pretokenized -storeRaw \
   >& logs/log.msmarco-v2-passage-unicoil-0shot &
 ```
 
@@ -99,26 +99,26 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.unicoil.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rm3.topics.msmarco-v2-passage.dev.unicoil.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rm3 &
+  -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.unicoil.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rm3.topics.msmarco-v2-passage.dev2.unicoil.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rm3 &
+  -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.unicoil.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rocchio.topics.msmarco-v2-passage.dev.unicoil.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rocchio &
+  -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.unicoil.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rocchio.topics.msmarco-v2-passage.dev2.unicoil.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rocchio &
+  -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-msmarco-v2-passage-unicoil-noexp-0shot.md
+++ b/docs/regressions-msmarco-v2-passage-unicoil-noexp-0shot.md
@@ -62,7 +62,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage-unicoil-noexp-0shot \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 32 -impact -pretokenized -storeDocvectors \
+  -threads 24 -impact -pretokenized -storeRaw \
   >& logs/log.msmarco-v2-passage-unicoil-noexp-0shot &
 ```
 
@@ -99,26 +99,26 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rm3.topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rm3 &
+  -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rm3.topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rm3 &
+  -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rocchio &
+  -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.tsv.gz \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rocchio &
+  -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions-msmarco-v2-passage.md
+++ b/docs/regressions-msmarco-v2-passage.md
@@ -25,7 +25,7 @@ target/appassembler/bin/IndexCollection \
   -input /path/to/msmarco-v2-passage \
   -index indexes/lucene-index.msmarco-v2-passage/ \
   -generator DefaultLuceneDocumentGenerator \
-  -threads 18 -storePositions -storeDocvectors -storeRaw \
+  -threads 24 -storeRaw \
   >& logs/log.msmarco-v2-passage &
 ```
 
@@ -60,26 +60,26 @@ target/appassembler/bin/SearchCollection \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt \
-  -bm25 -rm3 &
+  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-v2-passage/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt \
-  -bm25 -rocchio &
+  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/src/main/resources/regression/dl21-doc-segmented-unicoil-0shot-v2.yaml
+++ b/src/main/resources/regression/dl21-doc-segmented-unicoil-0shot-v2.yaml
@@ -9,7 +9,7 @@ download_corpus: msmarco_v2_doc_segmented_unicoil_0shot_v2
 index_path: indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot-v2/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -impact -pretokenized -storeRaw
 index_stats:
   documents: 124131414

--- a/src/main/resources/regression/dl21-doc-segmented-unicoil-0shot.yaml
+++ b/src/main/resources/regression/dl21-doc-segmented-unicoil-0shot.yaml
@@ -9,7 +9,7 @@ download_corpus: msmarco_v2_doc_segmented_unicoil_0shot
 index_path: indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -impact -pretokenized
 index_stats:
   documents: 124131414

--- a/src/main/resources/regression/dl21-doc-segmented-unicoil-noexp-0shot-v2.yaml
+++ b/src/main/resources/regression/dl21-doc-segmented-unicoil-noexp-0shot-v2.yaml
@@ -9,7 +9,7 @@ download_corpus: msmarco_v2_doc_segmented_unicoil_noexp_0shot_v2
 index_path: indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -impact -pretokenized -storeRaw
 index_stats:
   documents: 124131404

--- a/src/main/resources/regression/dl21-doc-segmented-unicoil-noexp-0shot.yaml
+++ b/src/main/resources/regression/dl21-doc-segmented-unicoil-noexp-0shot.yaml
@@ -9,7 +9,7 @@ download_corpus: msmarco_v2_doc_segmented_unicoil_noexp_0shot
 index_path: indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -impact -pretokenized
 index_stats:
   documents: 124131404

--- a/src/main/resources/regression/dl21-doc-segmented.yaml
+++ b/src/main/resources/regression/dl21-doc-segmented.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/msmarco/msmarco_v2_doc_segmented/
 index_path: indexes/lucene-index.msmarco-v2-doc-segmented/
 collection_class: MsMarcoV2DocCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -storeRaw
 index_stats:
   documents: 124131414

--- a/src/main/resources/regression/dl21-doc.yaml
+++ b/src/main/resources/regression/dl21-doc.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/msmarco/msmarco_v2_doc/
 index_path: indexes/lucene-index.msmarco-v2-doc/
 collection_class: MsMarcoV2DocCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -storeRaw
 index_stats:
   documents: 11959635

--- a/src/main/resources/regression/dl21-passage-augmented-d2q-t5.yaml
+++ b/src/main/resources/regression/dl21-passage-augmented-d2q-t5.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/msmarco/msmarco_v2_passage_augmented_d2q-t5/
 index_path: indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/
 collection_class: MsMarcoV2PassageCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/dl21-passage-augmented.yaml
+++ b/src/main/resources/regression/dl21-passage-augmented.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/msmarco/msmarco_v2_passage_augmented/
 index_path: indexes/lucene-index.msmarco-v2-passage-augmented/
 collection_class: MsMarcoV2PassageCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/dl21-passage-d2q-t5.yaml
+++ b/src/main/resources/regression/dl21-passage-d2q-t5.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/msmarco/msmarco_v2_passage_d2q-t5/
 index_path: indexes/lucene-index.msmarco-v2-passage-d2q-t5/
 collection_class: MsMarcoV2PassageCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/dl21-passage-unicoil-0shot.yaml
+++ b/src/main/resources/regression/dl21-passage-unicoil-0shot.yaml
@@ -9,7 +9,7 @@ download_corpus: msmarco_v2_passage_unicoil_0shot
 index_path: indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -impact -pretokenized -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/dl21-passage-unicoil-noexp-0shot.yaml
+++ b/src/main/resources/regression/dl21-passage-unicoil-noexp-0shot.yaml
@@ -9,7 +9,7 @@ download_corpus: msmarco_v2_passage_unicoil_noexp_0shot
 index_path: indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -impact -pretokenized -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/dl21-passage.yaml
+++ b/src/main/resources/regression/dl21-passage.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/msmarco/msmarco_v2_passage/
 index_path: indexes/lucene-index.msmarco-v2-passage/
 collection_class: MsMarcoV2PassageCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/dl22-passage-augmented-d2q-t5.yaml
+++ b/src/main/resources/regression/dl22-passage-augmented-d2q-t5.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/msmarco/msmarco_v2_passage_augmented_d2q-t5/
 index_path: indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/
 collection_class: MsMarcoV2PassageCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/dl22-passage-augmented.yaml
+++ b/src/main/resources/regression/dl22-passage-augmented.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/msmarco/msmarco_v2_passage_augmented/
 index_path: indexes/lucene-index.msmarco-v2-passage-augmented/
 collection_class: MsMarcoV2PassageCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/dl22-passage-d2q-t5.yaml
+++ b/src/main/resources/regression/dl22-passage-d2q-t5.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/msmarco/msmarco_v2_passage_d2q-t5/
 index_path: indexes/lucene-index.msmarco-v2-passage-d2q-t5/
 collection_class: MsMarcoV2PassageCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/dl22-passage-unicoil-0shot.yaml
+++ b/src/main/resources/regression/dl22-passage-unicoil-0shot.yaml
@@ -9,7 +9,7 @@ download_corpus: msmarco_v2_passage_unicoil_0shot
 index_path: indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -impact -pretokenized -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/dl22-passage-unicoil-noexp-0shot.yaml
+++ b/src/main/resources/regression/dl22-passage-unicoil-noexp-0shot.yaml
@@ -9,7 +9,7 @@ download_corpus: msmarco_v2_passage_unicoil_noexp_0shot
 index_path: indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -impact -pretokenized -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/dl22-passage.yaml
+++ b/src/main/resources/regression/dl22-passage.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/msmarco/msmarco_v2_passage/
 index_path: indexes/lucene-index.msmarco-v2-passage/
 collection_class: MsMarcoV2PassageCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/msmarco-v2-doc-segmented-unicoil-0shot-v2.yaml
+++ b/src/main/resources/regression/msmarco-v2-doc-segmented-unicoil-0shot-v2.yaml
@@ -9,7 +9,7 @@ download_corpus: msmarco_v2_doc_segmented_unicoil_0shot_v2
 index_path: indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot-v2/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 32
+index_threads: 24
 index_options: -impact -pretokenized -storeRaw
 index_stats:
   documents: 124131414

--- a/src/main/resources/regression/msmarco-v2-doc-segmented-unicoil-0shot.yaml
+++ b/src/main/resources/regression/msmarco-v2-doc-segmented-unicoil-0shot.yaml
@@ -9,7 +9,7 @@ download_corpus: msmarco_v2_doc_segmented_unicoil_0shot
 index_path: indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 32
+index_threads: 24
 index_options: -impact -pretokenized
 index_stats:
   documents: 124131414

--- a/src/main/resources/regression/msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.yaml
+++ b/src/main/resources/regression/msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.yaml
@@ -9,7 +9,7 @@ download_corpus: msmarco_v2_doc_segmented_unicoil_noexp_0shot_v2
 index_path: indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 32
+index_threads: 24
 index_options: -impact -pretokenized -storeRaw
 index_stats:
   documents: 124131404

--- a/src/main/resources/regression/msmarco-v2-doc-segmented-unicoil-noexp-0shot.yaml
+++ b/src/main/resources/regression/msmarco-v2-doc-segmented-unicoil-noexp-0shot.yaml
@@ -9,7 +9,7 @@ download_corpus: msmarco_v2_doc_segmented_unicoil_noexp_0shot
 index_path: indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 32
+index_threads: 24
 index_options: -impact -pretokenized
 index_stats:
   documents: 124131404

--- a/src/main/resources/regression/msmarco-v2-doc-segmented.yaml
+++ b/src/main/resources/regression/msmarco-v2-doc-segmented.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/msmarco/msmarco_v2_doc_segmented/
 index_path: indexes/lucene-index.msmarco-v2-doc-segmented/
 collection_class: MsMarcoV2DocCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -storeRaw
 index_stats:
   documents: 124131414

--- a/src/main/resources/regression/msmarco-v2-doc.yaml
+++ b/src/main/resources/regression/msmarco-v2-doc.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/msmarco/msmarco_v2_doc/
 index_path: indexes/lucene-index.msmarco-v2-doc/
 collection_class: MsMarcoV2DocCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -storeRaw
 index_stats:
   documents: 11959635

--- a/src/main/resources/regression/msmarco-v2-passage-augmented-d2q-t5.yaml
+++ b/src/main/resources/regression/msmarco-v2-passage-augmented-d2q-t5.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/msmarco/msmarco_v2_passage_augmented_d2q-t5/
 index_path: indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/
 collection_class: MsMarcoV2PassageCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/msmarco-v2-passage-augmented.yaml
+++ b/src/main/resources/regression/msmarco-v2-passage-augmented.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/msmarco/msmarco_v2_passage_augmented/
 index_path: indexes/lucene-index.msmarco-v2-passage-augmented/
 collection_class: MsMarcoV2PassageCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/msmarco-v2-passage-d2q-t5.yaml
+++ b/src/main/resources/regression/msmarco-v2-passage-d2q-t5.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/msmarco/msmarco_v2_passage_d2q-t5/
 index_path: indexes/lucene-index.msmarco-v2-passage-d2q-t5/
 collection_class: MsMarcoV2PassageCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/msmarco-v2-passage-unicoil-0shot.yaml
+++ b/src/main/resources/regression/msmarco-v2-passage-unicoil-0shot.yaml
@@ -9,7 +9,7 @@ download_corpus: msmarco_v2_passage_unicoil_0shot
 index_path: indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 32
+index_threads: 24
 index_options: -impact -pretokenized -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/msmarco-v2-passage-unicoil-noexp-0shot.yaml
+++ b/src/main/resources/regression/msmarco-v2-passage-unicoil-noexp-0shot.yaml
@@ -9,7 +9,7 @@ download_corpus: msmarco_v2_passage_unicoil_noexp_0shot
 index_path: indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/
 collection_class: JsonVectorCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 32
+index_threads: 24
 index_options: -impact -pretokenized -storeRaw
 index_stats:
   documents: 138364198

--- a/src/main/resources/regression/msmarco-v2-passage.yaml
+++ b/src/main/resources/regression/msmarco-v2-passage.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/msmarco/msmarco_v2_passage/
 index_path: indexes/lucene-index.msmarco-v2-passage/
 collection_class: MsMarcoV2PassageCollection
 generator_class: DefaultLuceneDocumentGenerator
-index_threads: 18
+index_threads: 24
 index_options: -storeRaw
 index_stats:
   documents: 138364198


### PR DESCRIPTION
Rebuild out-of-date documentation pages.