### PR TITLE
fix(sec): upgrade org.apache.commons:commons-text to 1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -448,7 +448,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.9</version>
+      <version>1.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.commons:commons-text 1.9
- [CVE-2022-42889](https://www.oscs1024.com/hd/CVE-2022-42889)


### What did I do？
Upgrade org.apache.commons:commons-text from 1.9 to 1.10.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS