### PR TITLE
update SimpleIndexer to use IndexCollection.Args

### DIFF
--- a/src/main/java/io/anserini/analysis/AnalyzerMap.java
+++ b/src/main/java/io/anserini/analysis/AnalyzerMap.java
@@ -1,3 +1,19 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.anserini.analysis;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -5,38 +21,38 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class AnalyzerMap {
-    public static final Map<String, String> analyzerMap = new HashMap<String, String>() {
-      {
-        analyzerMap.put("ar", "org.apache.lucene.analysis.ar.ArabicAnalyzer");
-        analyzerMap.put("bn", "org.apache.lucene.analysis.bn.BengaliAnalyzer");
-        analyzerMap.put("da", "org.apache.lucene.analysis.da.DanishAnalyzer");
-        analyzerMap.put("es", "org.apache.lucene.analysis.es.SpanishAnalyzer");
-        analyzerMap.put("fa", "org.apache.lucene.analysis.fa.PersianAnalyzer");
-        analyzerMap.put("fi", "org.apache.lucene.analysis.fi.FinnishAnalyzer");
-        analyzerMap.put("fr", "org.apache.lucene.analysis.fr.FrenchAnalyzer");
-        analyzerMap.put("de", "org.apache.lucene.analysis.de.GermanAnalyzer");
-        analyzerMap.put("hi", "org.apache.lucene.analysis.hi.HindiAnalyzer");
-        analyzerMap.put("hu", "org.apache.lucene.analysis.hu.HungarianAnalyzer");
-        analyzerMap.put("id", "org.apache.lucene.analysis.id.IndonesianAnalyzer");
-        analyzerMap.put("it", "org.apache.lucene.analysis.it.ItalianAnalyzer");
-        analyzerMap.put("ja", "org.apache.lucene.analysis.ja.JapaneseAnalyzer");
-        analyzerMap.put("ko", "org.apache.lucene.analysis.cjk.CJKAnalyzer");
-        analyzerMap.put("nl", "org.apache.lucene.analysis.nl.DutchAnalyzer");
-        analyzerMap.put("no", "org.apache.lucene.analysis.no.NorwegianAnalyzer");
-        analyzerMap.put("pl", "org.apache.lucene.analysis.morfologik.MorfologikAnalyzer");
-        analyzerMap.put("pt", "org.apache.lucene.analysis.pt.PortugueseAnalyzer");
-        analyzerMap.put("ru", "org.apache.lucene.analysis.ru.RussianAnalyzer");
-        analyzerMap.put("sv", "org.apache.lucene.analysis.sv.SwedishAnalyzer");
-        analyzerMap.put("te", "org.apache.lucene.analysis.te.TeluguAnalyzer");
-        analyzerMap.put("th", "org.apache.lucene.analysis.th.ThaiAnalyzer");
-        analyzerMap.put("tr", "org.apache.lucene.analysis.tr.TurkishAnalyzer");
-        analyzerMap.put("uk", "org.apache.lucene.analysis.uk.UkrainianMorfologikAnalyzer");
-        analyzerMap.put("zh", "org.apache.lucene.analysis.cjk.CJKAnalyzer");
-      }
-    };
-
-    public static Analyzer getLangSpecificAnalyzer(String language) throws Exception {
-      String analyzerClazz = analyzerMap.get(language); 
-    return (Analyzer) Class.forName(analyzerClazz).getDeclaredConstructor().newInstance();
+  public static final Map<String, String> analyzerMap = new HashMap<String, String>() {
+    {
+      put("ar", "org.apache.lucene.analysis.ar.ArabicAnalyzer");
+      put("bn", "org.apache.lucene.analysis.bn.BengaliAnalyzer");
+      put("da", "org.apache.lucene.analysis.da.DanishAnalyzer");
+      put("es", "org.apache.lucene.analysis.es.SpanishAnalyzer");
+      put("fa", "org.apache.lucene.analysis.fa.PersianAnalyzer");
+      put("fi", "org.apache.lucene.analysis.fi.FinnishAnalyzer");
+      put("fr", "org.apache.lucene.analysis.fr.FrenchAnalyzer");
+      put("de", "org.apache.lucene.analysis.de.GermanAnalyzer");
+      put("hi", "org.apache.lucene.analysis.hi.HindiAnalyzer");
+      put("hu", "org.apache.lucene.analysis.hu.HungarianAnalyzer");
+      put("id", "org.apache.lucene.analysis.id.IndonesianAnalyzer");
+      put("it", "org.apache.lucene.analysis.it.ItalianAnalyzer");
+      put("ja", "org.apache.lucene.analysis.ja.JapaneseAnalyzer");
+      put("ko", "org.apache.lucene.analysis.cjk.CJKAnalyzer");
+      put("nl", "org.apache.lucene.analysis.nl.DutchAnalyzer");
+      put("no", "org.apache.lucene.analysis.no.NorwegianAnalyzer");
+      put("pl", "org.apache.lucene.analysis.morfologik.MorfologikAnalyzer");
+      put("pt", "org.apache.lucene.analysis.pt.PortugueseAnalyzer");
+      put("ru", "org.apache.lucene.analysis.ru.RussianAnalyzer");
+      put("sv", "org.apache.lucene.analysis.sv.SwedishAnalyzer");
+      put("te", "org.apache.lucene.analysis.te.TeluguAnalyzer");
+      put("th", "org.apache.lucene.analysis.th.ThaiAnalyzer");
+      put("tr", "org.apache.lucene.analysis.tr.TurkishAnalyzer");
+      put("uk", "org.apache.lucene.analysis.uk.UkrainianMorfologikAnalyzer");
+      put("zh", "org.apache.lucene.analysis.cjk.CJKAnalyzer");
     }
+  };
+
+  public static Analyzer getLangSpecificAnalyzer(String language) throws Exception {
+    String analyzerClazz = analyzerMap.get(language); 
+  return (Analyzer) Class.forName(analyzerClazz).getDeclaredConstructor().newInstance();
+  }
 }

--- a/src/main/java/io/anserini/analysis/AnalyzerMap.java
+++ b/src/main/java/io/anserini/analysis/AnalyzerMap.java
@@ -1,0 +1,42 @@
+package io.anserini.analysis;
+
+import org.apache.lucene.analysis.Analyzer;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AnalyzerMap {
+    public static final Map<String, String> analyzerMap = new HashMap<String, String>() {
+      {
+        analyzerMap.put("ar", "org.apache.lucene.analysis.ar.ArabicAnalyzer");
+        analyzerMap.put("bn", "org.apache.lucene.analysis.bn.BengaliAnalyzer");
+        analyzerMap.put("da", "org.apache.lucene.analysis.da.DanishAnalyzer");
+        analyzerMap.put("es", "org.apache.lucene.analysis.es.SpanishAnalyzer");
+        analyzerMap.put("fa", "org.apache.lucene.analysis.fa.PersianAnalyzer");
+        analyzerMap.put("fi", "org.apache.lucene.analysis.fi.FinnishAnalyzer");
+        analyzerMap.put("fr", "org.apache.lucene.analysis.fr.FrenchAnalyzer");
+        analyzerMap.put("de", "org.apache.lucene.analysis.de.GermanAnalyzer");
+        analyzerMap.put("hi", "org.apache.lucene.analysis.hi.HindiAnalyzer");
+        analyzerMap.put("hu", "org.apache.lucene.analysis.hu.HungarianAnalyzer");
+        analyzerMap.put("id", "org.apache.lucene.analysis.id.IndonesianAnalyzer");
+        analyzerMap.put("it", "org.apache.lucene.analysis.it.ItalianAnalyzer");
+        analyzerMap.put("ja", "org.apache.lucene.analysis.ja.JapaneseAnalyzer");
+        analyzerMap.put("ko", "org.apache.lucene.analysis.cjk.CJKAnalyzer");
+        analyzerMap.put("nl", "org.apache.lucene.analysis.nl.DutchAnalyzer");
+        analyzerMap.put("no", "org.apache.lucene.analysis.no.NorwegianAnalyzer");
+        analyzerMap.put("pl", "org.apache.lucene.analysis.morfologik.MorfologikAnalyzer");
+        analyzerMap.put("pt", "org.apache.lucene.analysis.pt.PortugueseAnalyzer");
+        analyzerMap.put("ru", "org.apache.lucene.analysis.ru.RussianAnalyzer");
+        analyzerMap.put("sv", "org.apache.lucene.analysis.sv.SwedishAnalyzer");
+        analyzerMap.put("te", "org.apache.lucene.analysis.te.TeluguAnalyzer");
+        analyzerMap.put("th", "org.apache.lucene.analysis.th.ThaiAnalyzer");
+        analyzerMap.put("tr", "org.apache.lucene.analysis.tr.TurkishAnalyzer");
+        analyzerMap.put("uk", "org.apache.lucene.analysis.uk.UkrainianMorfologikAnalyzer");
+        analyzerMap.put("zh", "org.apache.lucene.analysis.cjk.CJKAnalyzer");
+      }
+    };
+
+    public static Analyzer getLangSpecificAnalyzer(String language) throws Exception {
+      String analyzerClazz = analyzerMap.get(language); 
+    return (Analyzer) Class.forName(analyzerClazz).getDeclaredConstructor().newInstance();
+    }
+}

--- a/src/main/java/io/anserini/analysis/AnalyzerMap.java
+++ b/src/main/java/io/anserini/analysis/AnalyzerMap.java
@@ -51,7 +51,7 @@ public class AnalyzerMap {
     }
   };
 
-  public static Analyzer getLangSpecificAnalyzer(String language) throws Exception {
+  public static Analyzer getLanguageSpecificAnalyzer(String language) throws Exception {
     String analyzerClazz = analyzerMap.get(language); 
   return (Analyzer) Class.forName(analyzerClazz).getDeclaredConstructor().newInstance();
   }

--- a/src/main/java/io/anserini/index/SimpleIndexer.java
+++ b/src/main/java/io/anserini/index/SimpleIndexer.java
@@ -121,7 +121,7 @@ public class SimpleIndexer {
       return new HuggingFaceTokenizerAnalyzer(args.analyzeWithHuggingFaceTokenizer);
     } else if (AnalyzerMap.analyzerMap.containsKey(args.language)){
       LOG.info("Language: " + args.language);
-      return AnalyzerMap.getLangSpecificAnalyzer(args.language);
+      return AnalyzerMap.getLanguageSpecificAnalyzer(args.language);
     } else if (args.pretokenized || args.language.equals("sw")) {
       LOG.info("Pretokenized");
       return new WhitespaceAnalyzer();

--- a/src/test/java/io/anserini/index/SimpleIndexerTest.java
+++ b/src/test/java/io/anserini/index/SimpleIndexerTest.java
@@ -57,4 +57,35 @@ public class SimpleIndexerTest extends LuceneTestCase {
     searcher.close();
   }
 
+  @Test
+  public void testInitWithArgs() throws Exception {
+    Path tempDir = createTempDir();
+
+    SimpleIndexer.main(new String[] {
+      "-input",
+      "src/test/resources/sample_docs/json/collection3",
+      "-index",
+      tempDir.toString(),
+      "-collection",
+      "JsonCollection",
+      "-threads",
+      "1",
+      "-storePositions",
+      "-storeDocvectors",
+      "-storeRaw",
+      "-language",
+      "sw",
+    });
+
+    SimpleSearcher searcher = new SimpleSearcher(tempDir.toString());
+    // Set language to sw so that same Analyzer is used for indexing & searching
+    searcher.set_language("sw");
+    SimpleSearcher.Result[] hits = searcher.search("1.", 10);
+
+    assertEquals(1, hits.length);
+    assertEquals("doc1", hits[0].docid);
+    assertEquals(0.3648, hits[0].score, 1e-4);
+
+    searcher.close();
+  }
 }


### PR DESCRIPTION
A couple of notes:
- AnalyzerMap.java helps avoid a lengthy if/else in SimpleIndexer as we have currently in IndexCollection when selecting language-specific analyzers
- `storeDocvectors`, `storePositions` etc are usually passed through IndexCollection.Args to the generator. Rather than update all generators with new constructors able to use SimpleIndexer.Args to collect this argument, I currently allow SimpleIndexer to reuse `IndexCollection.Args`. 
- A downside of this decision is that when SimpleIndexer is initialized from Args, `-collection` and `-threads` must be passed (because they are marked as required in IndexCollection.Args). However, they are not used by Simplelndexer.


See #2060 