### PR TITLE
upgrade djl tokenizer to 0.21.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
     <dependency>
       <groupId>ai.djl.huggingface</groupId>
       <artifactId>tokenizers</artifactId>
-      <version>0.18.0</version>
+      <version>0.21.0</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Upgrade the tokenizer version to solve `HuggingFaceTokenizerEndToEndTest` fail
Tested env:
- Ubuntu GLIBC 2.27
- CentOS 7
- (M1) MacOS 12.6

Related issues:
https://github.com/castorini/anserini/pull/2072#issue-1613565914