### PR TITLE
Culling PRF regressions with MS MARCO sparse judgments

### DIFF
--- a/docs/regressions-msmarco-doc-docTTTTTquery.md
+++ b/docs/regressions-msmarco-doc-docTTTTTquery.md
@@ -61,36 +61,8 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-docTTTTTquery/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-doc-docTTTTTquery.bm25-default+rm3.topics.msmarco-doc.dev.txt \
-  -bm25 -rm3 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-docTTTTTquery.bm25-default+rocchio.topics.msmarco-doc.dev.txt \
-  -bm25 -rocchio &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
   -output runs/run.msmarco-doc-docTTTTTquery.bm25-tuned.topics.msmarco-doc.dev.txt \
   -bm25 -bm25.k1 4.68 -bm25.b 0.87 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-docTTTTTquery.bm25-tuned+rm3.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 4.68 -bm25.b 0.87 -rm3 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-docTTTTTquery.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 4.68 -bm25.b 0.87 -rocchio &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -101,45 +73,25 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-default.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-default.topics.msmarco-doc.dev.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-default+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-default+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-default+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-default+rm3.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-default+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-default+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-default+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-default+rocchio.topics.msmarco-doc.dev.txt
-
 tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-tuned.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-tuned.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-tuned.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-tuned.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-docTTTTTquery.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **AP@1000**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**| **BM25 (tuned)**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|-----------|-----------|-----------|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2886    | 0.1841    | 0.1841    | 0.3273    | 0.2628    | 0.2648    |
-| **RR@100**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**| **BM25 (tuned)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2880    | 0.1834    | 0.1833    | 0.3269    | 0.2623    | 0.2643    |
-| **R@100**                                                                                                    | **BM25 (default)**| **+RM3**  | **+Rocchio**| **BM25 (tuned)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.7993    | 0.7422    | 0.7441    | 0.8612    | 0.8390    | 0.8448    |
-| **R@1000**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**| **BM25 (tuned)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9259    | 0.9126    | 0.9128    | 0.9553    | 0.9522    | 0.9534    |
+| **AP@1000**                                                                                                  | **BM25 (default)**| **BM25 (tuned)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2886    | 0.3273    |
+| **RR@100**                                                                                                   | **BM25 (default)**| **BM25 (tuned)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2880    | 0.3269    |
+| **R@100**                                                                                                    | **BM25 (default)**| **BM25 (tuned)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.7993    | 0.8612    |
+| **R@1000**                                                                                                   | **BM25 (default)**| **BM25 (tuned)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9259    | 0.9553    |
 
 Explanation of settings:
 

--- a/docs/regressions-msmarco-doc-segmented-docTTTTTquery.md
+++ b/docs/regressions-msmarco-doc-segmented-docTTTTTquery.md
@@ -62,36 +62,8 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-docTTTTTquery/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default+rm3.topics.msmarco-doc.dev.txt \
-  -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default+rocchio.topics.msmarco-doc.dev.txt \
-  -bm25 -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned.topics.msmarco-doc.dev.txt \
   -bm25 -bm25.k1 2.56 -bm25.b 0.59 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned+rm3.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 2.56 -bm25.b 0.59 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 2.56 -bm25.b 0.59 -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -102,45 +74,25 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default.topics.msmarco-doc.dev.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default+rm3.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-default+rocchio.topics.msmarco-doc.dev.txt
-
 tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-docTTTTTquery.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **AP@1000**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**| **BM25 (tuned)**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|-----------|-----------|-----------|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.3184    | 0.2808    | 0.2846    | 0.3213    | 0.2978    | 0.2998    |
-| **RR@100**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**| **BM25 (tuned)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.3179    | 0.2803    | 0.2841    | 0.3209    | 0.2973    | 0.2994    |
-| **R@100**                                                                                                    | **BM25 (default)**| **+RM3**  | **+Rocchio**| **BM25 (tuned)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.8479    | 0.8477    | 0.8479    | 0.8627    | 0.8573    | 0.8600    |
-| **R@1000**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**| **BM25 (tuned)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9490    | 0.9551    | 0.9551    | 0.9530    | 0.9563    | 0.9571    |
+| **AP@1000**                                                                                                  | **BM25 (default)**| **BM25 (tuned)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.3184    | 0.3213    |
+| **RR@100**                                                                                                   | **BM25 (default)**| **BM25 (tuned)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.3179    | 0.3209    |
+| **R@100**                                                                                                    | **BM25 (default)**| **BM25 (tuned)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.8479    | 0.8627    |
+| **R@1000**                                                                                                   | **BM25 (default)**| **BM25 (tuned)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9490    | 0.9530    |
 
 Explanation of settings:
 

--- a/docs/regressions-msmarco-doc-segmented-unicoil-noexp.md
+++ b/docs/regressions-msmarco-doc-segmented-unicoil-noexp.md
@@ -83,20 +83,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.msmarco-doc.dev.unicoil-noexp.txt \
   -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented-unicoil-noexp/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.unicoil-noexp.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil-noexp.rm3.topics.msmarco-doc.dev.unicoil-noexp.txt \
-  -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented-unicoil-noexp/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.unicoil-noexp.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil-noexp.rocchio.topics.msmarco-doc.dev.unicoil-noexp.txt \
-  -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -106,31 +92,21 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qre
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.msmarco-doc.dev.unicoil-noexp.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.msmarco-doc.dev.unicoil-noexp.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.msmarco-doc.dev.unicoil-noexp.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rm3.topics.msmarco-doc.dev.unicoil-noexp.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rm3.topics.msmarco-doc.dev.unicoil-noexp.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rm3.topics.msmarco-doc.dev.unicoil-noexp.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rm3.topics.msmarco-doc.dev.unicoil-noexp.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rocchio.topics.msmarco-doc.dev.unicoil-noexp.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rocchio.topics.msmarco-doc.dev.unicoil-noexp.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rocchio.topics.msmarco-doc.dev.unicoil-noexp.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rocchio.topics.msmarco-doc.dev.unicoil-noexp.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **AP@1000**                                                                                                  | **uniCOIL (no expansions)**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.3413    | 0.3052    | 0.3092    |
-| **RR@100**                                                                                                   | **uniCOIL (no expansions)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.3409    | 0.3048    | 0.3088    |
-| **R@100**                                                                                                    | **uniCOIL (no expansions)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.8639    | 0.8600    | 0.8667    |
-| **R@1000**                                                                                                   | **uniCOIL (no expansions)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9420    | 0.9495    | 0.9521    |
+| **AP@1000**                                                                                                  | **uniCOIL (no expansions)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.3413    |
+| **RR@100**                                                                                                   | **uniCOIL (no expansions)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.3409    |
+| **R@100**                                                                                                    | **uniCOIL (no expansions)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.8639    |
+| **R@1000**                                                                                                   | **uniCOIL (no expansions)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9420    |
 
 ## Additional Notes
 

--- a/docs/regressions-msmarco-doc-segmented-unicoil.md
+++ b/docs/regressions-msmarco-doc-segmented-unicoil.md
@@ -83,20 +83,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.msmarco-doc.dev.unicoil.txt \
   -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.unicoil.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil.rm3.topics.msmarco-doc.dev.unicoil.txt \
-  -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.unicoil.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil.rocchio.topics.msmarco-doc.dev.unicoil.txt \
-  -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -106,31 +92,21 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qre
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.msmarco-doc.dev.unicoil.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.msmarco-doc.dev.unicoil.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.msmarco-doc.dev.unicoil.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.rm3.topics.msmarco-doc.dev.unicoil.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.rm3.topics.msmarco-doc.dev.unicoil.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.rm3.topics.msmarco-doc.dev.unicoil.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.rm3.topics.msmarco-doc.dev.unicoil.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.rocchio.topics.msmarco-doc.dev.unicoil.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.rocchio.topics.msmarco-doc.dev.unicoil.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.rocchio.topics.msmarco-doc.dev.unicoil.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.rocchio.topics.msmarco-doc.dev.unicoil.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **AP@1000**                                                                                                  | **uniCOIL (with doc2query-T5 expansions)**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.3535    | 0.3186    | 0.3256    |
-| **RR@100**                                                                                                   | **uniCOIL (with doc2query-T5 expansions)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.3531    | 0.3182    | 0.3252    |
-| **R@100**                                                                                                    | **uniCOIL (with doc2query-T5 expansions)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.8858    | 0.8800    | 0.8848    |
-| **R@1000**                                                                                                   | **uniCOIL (with doc2query-T5 expansions)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9546    | 0.9615    | 0.9619    |
+| **AP@1000**                                                                                                  | **uniCOIL (with doc2query-T5 expansions)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.3535    |
+| **RR@100**                                                                                                   | **uniCOIL (with doc2query-T5 expansions)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.3531    |
+| **R@100**                                                                                                    | **uniCOIL (with doc2query-T5 expansions)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.8858    |
+| **R@1000**                                                                                                   | **uniCOIL (with doc2query-T5 expansions)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9546    |
 
 ## Additional Notes
 

--- a/docs/regressions-msmarco-doc-segmented.md
+++ b/docs/regressions-msmarco-doc-segmented.md
@@ -62,78 +62,8 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented.bm25-default+rm3.topics.msmarco-doc.dev.txt \
-  -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented.bm25-default+rocchio.topics.msmarco-doc.dev.txt \
-  -bm25 -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented.bm25-default+rocchio-neg.topics.msmarco-doc.dev.txt \
-  -bm25 -rocchio -rocchio.useNegative -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented.bm25-default+ax.topics.msmarco-doc.dev.txt \
-  -bm25 -axiom -axiom.deterministic -rerankCutoff 20 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented.bm25-default+prf.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25prf -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
   -output runs/run.msmarco-doc-segmented.bm25-tuned.topics.msmarco-doc.dev.txt \
   -bm25 -bm25.k1 2.16 -bm25.b 0.61 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented.bm25-tuned+rm3.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 2.16 -bm25.b 0.61 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 2.16 -bm25.b 0.61 -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented.bm25-tuned+rocchio-neg.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 2.16 -bm25.b 0.61 -rocchio -rocchio.useNegative -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented.bm25-tuned+ax.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 2.16 -bm25.b 0.61 -axiom -axiom.deterministic -rerankCutoff 20 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc-segmented.bm25-tuned+prf.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 2.16 -bm25.b 0.61 -bm25prf -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -144,75 +74,25 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default.topics.msmarco-doc.dev.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+rm3.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+rocchio.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+rocchio-neg.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+rocchio-neg.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+rocchio-neg.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+rocchio-neg.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+ax.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+ax.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+ax.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+ax.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+prf.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+prf.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+prf.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-default+prf.topics.msmarco-doc.dev.txt
-
 tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+rocchio-neg.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+rocchio-neg.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+rocchio-neg.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+rocchio-neg.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+ax.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+ax.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+ax.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+ax.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+prf.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+prf.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+prf.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented.bm25-tuned+prf.topics.msmarco-doc.dev.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **AP@1000**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  | **BM25 (tuned)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  |
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2690    | 0.2420    | 0.2453    | 0.2464    | 0.2208    | 0.2325    | 0.2762    | 0.2455    | 0.2482    | 0.2497    | 0.2330    | 0.2276    |
-| **RR@100**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  | **BM25 (tuned)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  |
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2684    | 0.2413    | 0.2447    | 0.2458    | 0.2201    | 0.2318    | 0.2756    | 0.2448    | 0.2475    | 0.2491    | 0.2324    | 0.2269    |
-| **R@100**                                                                                                    | **BM25 (default)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  | **BM25 (tuned)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  |
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.7847    | 0.7891    | 0.7915    | 0.7888    | 0.7710    | 0.7722    | 0.8013    | 0.7978    | 0.8013    | 0.8042    | 0.7888    | 0.7687    |
-| **R@1000**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  | **BM25 (tuned)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  |
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9178    | 0.9351    | 0.9351    | 0.9339    | 0.9264    | 0.9185    | 0.9311    | 0.9359    | 0.9395    | 0.9395    | 0.9353    | 0.9157    |
+| **AP@1000**                                                                                                  | **BM25 (default)**| **BM25 (tuned)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2690    | 0.2762    |
+| **RR@100**                                                                                                   | **BM25 (default)**| **BM25 (tuned)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2684    | 0.2756    |
+| **R@100**                                                                                                    | **BM25 (default)**| **BM25 (tuned)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.7847    | 0.8013    |
+| **R@1000**                                                                                                   | **BM25 (default)**| **BM25 (tuned)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9178    | 0.9311    |
 
 Explanation of settings:
 

--- a/docs/regressions-msmarco-doc.md
+++ b/docs/regressions-msmarco-doc.md
@@ -61,41 +61,6 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-doc.bm25-default+rm3.topics.msmarco-doc.dev.txt \
-  -bm25 -rm3 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc.bm25-default+rocchio.topics.msmarco-doc.dev.txt \
-  -bm25 -rocchio &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc.bm25-default+rocchio-neg.topics.msmarco-doc.dev.txt \
-  -bm25 -rocchio -rocchio.useNegative -rerankCutoff 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc.bm25-default+ax.topics.msmarco-doc.dev.txt \
-  -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc.bm25-default+prf.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25prf &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
   -output runs/run.msmarco-doc.bm25-tuned.topics.msmarco-doc.dev.txt \
   -bm25 -bm25.k1 3.44 -bm25.b 0.87 &
 
@@ -103,78 +68,8 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-doc.bm25-tuned+rm3.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 3.44 -bm25.b 0.87 -rm3 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 3.44 -bm25.b 0.87 -rocchio &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc.bm25-tuned+rocchio-neg.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 3.44 -bm25.b 0.87 -rocchio -rocchio.useNegative -rerankCutoff 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc.bm25-tuned+ax.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 3.44 -bm25.b 0.87 -axiom -axiom.deterministic -rerankCutoff 20 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc.bm25-tuned+prf.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 3.44 -bm25.b 0.87 -bm25prf &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
   -output runs/run.msmarco-doc.bm25-tuned2.topics.msmarco-doc.dev.txt \
   -bm25 -bm25.k1 4.46 -bm25.b 0.82 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc.bm25-tuned2+rm3.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 4.46 -bm25.b 0.82 -rm3 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc.bm25-tuned2+rocchio.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 4.46 -bm25.b 0.82 -rocchio &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc.bm25-tuned2+rocchio-neg.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 4.46 -bm25.b 0.82 -rocchio -rocchio.useNegative -rerankCutoff 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc.bm25-tuned2+ax.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 4.46 -bm25.b 0.82 -axiom -axiom.deterministic -rerankCutoff 20 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-doc.bm25-tuned2+prf.topics.msmarco-doc.dev.txt \
-  -bm25 -bm25.k1 4.46 -bm25.b 0.82 -bm25prf &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -185,105 +80,30 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default.topics.msmarco-doc.dev.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+rm3.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+rocchio.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+rocchio-neg.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+rocchio-neg.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+rocchio-neg.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+rocchio-neg.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+ax.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+ax.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+ax.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+ax.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+prf.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+prf.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+prf.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-default+prf.topics.msmarco-doc.dev.txt
-
 tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned.topics.msmarco-doc.dev.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+rm3.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+rocchio.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+rocchio-neg.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+rocchio-neg.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+rocchio-neg.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+rocchio-neg.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+ax.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+ax.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+ax.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+ax.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+prf.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+prf.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+prf.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned+prf.topics.msmarco-doc.dev.txt
-
 tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2.topics.msmarco-doc.dev.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+rm3.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+rm3.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+rocchio.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+rocchio.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+rocchio-neg.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+rocchio-neg.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+rocchio-neg.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+rocchio-neg.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+ax.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+ax.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+ax.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+ax.topics.msmarco-doc.dev.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+prf.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+prf.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+prf.topics.msmarco-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc.bm25-tuned2+prf.topics.msmarco-doc.dev.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **AP@1000**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  | **BM25 (tuned)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  | **BM25 (tuned2)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  |
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2305    | 0.1627    | 0.1632    | 0.1630    | 0.1146    | 0.1357    | 0.2784    | 0.2271    | 0.2280    | 0.2271    | 0.1888    | 0.1559    | 0.2773    | 0.2234    | 0.2248    | 0.2231    | 0.1886    | 0.1530    |
-| **RR@100**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  | **BM25 (tuned)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  | **BM25 (tuned2)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  |
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2299    | 0.1618    | 0.1624    | 0.1622    | 0.1135    | 0.1347    | 0.2778    | 0.2264    | 0.2274    | 0.2265    | 0.1880    | 0.1550    | 0.2767    | 0.2227    | 0.2242    | 0.2224    | 0.1877    | 0.1521    |
-| **R@100**                                                                                                    | **BM25 (default)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  | **BM25 (tuned)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  | **BM25 (tuned2)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  |
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.7281    | 0.6771    | 0.6765    | 0.6794    | 0.5754    | 0.6374    | 0.8069    | 0.7870    | 0.7901    | 0.7924    | 0.7560    | 0.6852    | 0.8070    | 0.7785    | 0.7878    | 0.7863    | 0.7526    | 0.6825    |
-| **R@1000**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  | **BM25 (tuned)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  | **BM25 (tuned2)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  |
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.8856    | 0.8783    | 0.8789    | 0.8808    | 0.8373    | 0.8471    | 0.9324    | 0.9322    | 0.9334    | 0.9324    | 0.9268    | 0.8760    | 0.9357    | 0.9303    | 0.9314    | 0.9316    | 0.9249    | 0.8766    |
+| **AP@1000**                                                                                                  | **BM25 (default)**| **BM25 (tuned)**| **BM25 (tuned2)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2305    | 0.2784    | 0.2773    |
+| **RR@100**                                                                                                   | **BM25 (default)**| **BM25 (tuned)**| **BM25 (tuned2)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2299    | 0.2778    | 0.2767    |
+| **R@100**                                                                                                    | **BM25 (default)**| **BM25 (tuned)**| **BM25 (tuned2)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.7281    | 0.8069    | 0.8070    |
+| **R@1000**                                                                                                   | **BM25 (default)**| **BM25 (tuned)**| **BM25 (tuned2)**|
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.8856    | 0.9324    | 0.9357    |
 
 Explanation of settings:
 

--- a/docs/regressions-msmarco-passage-doc2query.md
+++ b/docs/regressions-msmarco-passage-doc2query.md
@@ -56,22 +56,8 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-doc2query/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage-doc2query.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -rm3 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-doc2query/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
   -output runs/run.msmarco-passage-doc2query.bm25-tuned.topics.msmarco-passage.dev-subset.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-doc2query/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-doc2query.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rm3 &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -82,35 +68,25 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/t
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-doc2query.bm25-default.topics.msmarco-passage.dev-subset.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-doc2query.bm25-default.topics.msmarco-passage.dev-subset.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-doc2query.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-doc2query.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-doc2query.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-doc2query.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt
-
 tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-doc2query.bm25-tuned.topics.msmarco-passage.dev-subset.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-doc2query.bm25-tuned.topics.msmarco-passage.dev-subset.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-doc2query.bm25-tuned.topics.msmarco-passage.dev-subset.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-doc2query.bm25-tuned.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-doc2query.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-doc2query.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-doc2query.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-doc2query.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **AP@1000**                                                                                                  | **BM25 (default)**| **+RM3**  | **BM25 (tuned)**| **+RM3**  |
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.2270    | 0.2030    | 0.2293    | 0.2081    |
-| **RR@10**                                                                                                    | **BM25 (default)**| **+RM3**  | **BM25 (tuned)**| **+RM3**  |
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.2189    | 0.1941    | 0.2213    | 0.1992    |
-| **R@100**                                                                                                    | **BM25 (default)**| **+RM3**  | **BM25 (tuned)**| **+RM3**  |
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.7133    | 0.7003    | 0.7171    | 0.7051    |
-| **R@1000**                                                                                                   | **BM25 (default)**| **+RM3**  | **BM25 (tuned)**| **+RM3**  |
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.8900    | 0.8909    | 0.8911    | 0.8946    |
+| **AP@1000**                                                                                                  | **BM25 (default)**| **BM25 (tuned)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.2270    | 0.2293    |
+| **RR@10**                                                                                                    | **BM25 (default)**| **BM25 (tuned)**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.2189    | 0.2213    |
+| **R@100**                                                                                                    | **BM25 (default)**| **BM25 (tuned)**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.7133    | 0.7171    |
+| **R@1000**                                                                                                   | **BM25 (default)**| **BM25 (tuned)**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.8900    | 0.8911    |
 
 Explanation of settings:
 

--- a/docs/regressions-msmarco-passage-docTTTTTquery.md
+++ b/docs/regressions-msmarco-passage-docTTTTTquery.md
@@ -55,27 +55,6 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage-docTTTTTquery.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -rm3 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-docTTTTTquery.bm25-default+rocchio.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -rocchio &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-docTTTTTquery.bm25-default+rocchio-neg.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -rocchio -rocchio.useNegative -rerankCutoff 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned.topics.msmarco-passage.dev-subset.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 &
 
@@ -83,50 +62,8 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rm3 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rocchio.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rocchio &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rocchio-neg.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rocchio -rocchio.useNegative -rerankCutoff 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
   -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2.topics.msmarco-passage.dev-subset.txt \
   -bm25 -bm25.k1 2.18 -bm25.b 0.86 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rm3.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -bm25.k1 2.18 -bm25.b 0.86 -rm3 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rocchio.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -bm25.k1 2.18 -bm25.b 0.86 -rocchio &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-docTTTTTquery/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rocchio-neg.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -bm25.k1 2.18 -bm25.b 0.86 -rocchio -rocchio.useNegative -rerankCutoff 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -137,75 +74,30 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/t
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-default.topics.msmarco-passage.dev-subset.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-default.topics.msmarco-passage.dev-subset.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-default+rocchio.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-default+rocchio.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-default+rocchio.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-default+rocchio.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-default+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-default+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-default+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-default+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-
 tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned.topics.msmarco-passage.dev-subset.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned.topics.msmarco-passage.dev-subset.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned.topics.msmarco-passage.dev-subset.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned.topics.msmarco-passage.dev-subset.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rocchio.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rocchio.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rocchio.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rocchio.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-
 tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2.topics.msmarco-passage.dev-subset.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2.topics.msmarco-passage.dev-subset.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2.topics.msmarco-passage.dev-subset.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rm3.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rocchio.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rocchio.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rocchio.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rocchio.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-docTTTTTquery.bm25-tuned2+rocchio-neg.topics.msmarco-passage.dev-subset.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **AP@1000**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **BM25 (tuned)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **BM25 (tuned2)**| **+RM3**  | **+Rocchio**| **+Rocchio***|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.2805    | 0.2241    | 0.2260    | 0.2234    | 0.2850    | 0.2260    | 0.2277    | 0.2276    | 0.2893    | 0.2472    | 0.2488    | 0.2467    |
-| **RR@10**                                                                                                    | **BM25 (default)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **BM25 (tuned)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **BM25 (tuned2)**| **+RM3**  | **+Rocchio**| **+Rocchio***|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.2723    | 0.2139    | 0.2158    | 0.2129    | 0.2768    | 0.2154    | 0.2174    | 0.2173    | 0.2816    | 0.2382    | 0.2395    | 0.2372    |
-| **R@100**                                                                                                    | **BM25 (default)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **BM25 (tuned)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **BM25 (tuned2)**| **+RM3**  | **+Rocchio**| **+Rocchio***|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.8192    | 0.8000    | 0.8019    | 0.8025    | 0.8190    | 0.8030    | 0.8052    | 0.8072    | 0.8277    | 0.8226    | 0.8238    | 0.8227    |
-| **R@1000**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **BM25 (tuned)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **BM25 (tuned2)**| **+RM3**  | **+Rocchio**| **+Rocchio***|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9470    | 0.9460    | 0.9467    | 0.9475    | 0.9471    | 0.9479    | 0.9496    | 0.9493    | 0.9506    | 0.9528    | 0.9535    | 0.9539    |
+| **AP@1000**                                                                                                  | **BM25 (default)**| **BM25 (tuned)**| **BM25 (tuned2)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.2805    | 0.2850    | 0.2893    |
+| **RR@10**                                                                                                    | **BM25 (default)**| **BM25 (tuned)**| **BM25 (tuned2)**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.2723    | 0.2768    | 0.2816    |
+| **R@100**                                                                                                    | **BM25 (default)**| **BM25 (tuned)**| **BM25 (tuned2)**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.8192    | 0.8190    | 0.8277    |
+| **R@1000**                                                                                                   | **BM25 (default)**| **BM25 (tuned)**| **BM25 (tuned2)**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9470    | 0.9471    | 0.9506    |
 
 Explanation of settings:
 

--- a/docs/regressions-msmarco-passage-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-msmarco-passage-splade-distil-cocodenser-medium.md
@@ -77,20 +77,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-passage-splade_distil_cocodenser_medium.splade_distil_cocodenser_medium.topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.txt \
   -impact -pretokenized &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-splade_distil_cocodenser_medium/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade_distil_cocodenser_medium.rm3.topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.txt \
-  -impact -pretokenized -rm3 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-splade_distil_cocodenser_medium/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade_distil_cocodenser_medium.rocchio.topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.txt \
-  -impact -pretokenized -rocchio &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -100,31 +86,21 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qre
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade_distil_cocodenser_medium.splade_distil_cocodenser_medium.topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade_distil_cocodenser_medium.splade_distil_cocodenser_medium.topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade_distil_cocodenser_medium.splade_distil_cocodenser_medium.topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade_distil_cocodenser_medium.rm3.topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade_distil_cocodenser_medium.rm3.topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade_distil_cocodenser_medium.rm3.topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade_distil_cocodenser_medium.rm3.topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade_distil_cocodenser_medium.rocchio.topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade_distil_cocodenser_medium.rocchio.topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade_distil_cocodenser_medium.rocchio.topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade_distil_cocodenser_medium.rocchio.topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **AP@1000**                                                                                                  | **SPLADE-distill CoCodenser Medium**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3943    | 0.3020    | 0.3345    |
-| **RR@10**                                                                                                    | **SPLADE-distill CoCodenser Medium**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3892    | 0.2936    | 0.3279    |
-| **R@100**                                                                                                    | **SPLADE-distill CoCodenser Medium**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9111    | 0.8750    | 0.8911    |
-| **R@1000**                                                                                                   | **SPLADE-distill CoCodenser Medium**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9817    | 0.9750    | 0.9804    |
+| **AP@1000**                                                                                                  | **SPLADE-distill CoCodenser Medium**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3943    |
+| **RR@10**                                                                                                    | **SPLADE-distill CoCodenser Medium**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3892    |
+| **R@100**                                                                                                    | **SPLADE-distill CoCodenser Medium**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9111    |
+| **R@1000**                                                                                                   | **SPLADE-distill CoCodenser Medium**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9817    |
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-msmarco-passage-splade-pp-ed.md
+++ b/docs/regressions-msmarco-passage-splade-pp-ed.md
@@ -77,20 +77,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.splade-pp-ed.txt \
   -impact -pretokenized &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.splade-pp-ed.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.rm3.topics.msmarco-passage.dev-subset.splade-pp-ed.txt \
-  -impact -pretokenized -rm3 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.splade-pp-ed.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.msmarco-passage.dev-subset.splade-pp-ed.txt \
-  -impact -pretokenized -rocchio &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -100,31 +86,21 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qre
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **AP@1000**                                                                                                  | **SPLADE++ CoCondenser-EnsembleDistil**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3884    | 0.2967    | 0.3365    |
-| **RR@10**                                                                                                    | **SPLADE++ CoCondenser-EnsembleDistil**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3830    | 0.2882    | 0.3293    |
-| **R@100**                                                                                                    | **SPLADE++ CoCondenser-EnsembleDistil**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9095    | 0.8728    | 0.8967    |
-| **R@1000**                                                                                                   | **SPLADE++ CoCondenser-EnsembleDistil**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9831    | 0.9744    | 0.9811    |
+| **AP@1000**                                                                                                  | **SPLADE++ CoCondenser-EnsembleDistil**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3884    |
+| **RR@10**                                                                                                    | **SPLADE++ CoCondenser-EnsembleDistil**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3830    |
+| **R@100**                                                                                                    | **SPLADE++ CoCondenser-EnsembleDistil**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9095    |
+| **R@1000**                                                                                                   | **SPLADE++ CoCondenser-EnsembleDistil**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9831    |
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-msmarco-passage-splade-pp-sd.md
+++ b/docs/regressions-msmarco-passage-splade-pp-sd.md
@@ -77,20 +77,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.msmarco-passage.dev-subset.splade-pp-sd.txt \
   -impact -pretokenized &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.splade-pp-sd.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.rm3.topics.msmarco-passage.dev-subset.splade-pp-sd.txt \
-  -impact -pretokenized -rm3 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.splade-pp-sd.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.msmarco-passage.dev-subset.splade-pp-sd.txt \
-  -impact -pretokenized -rocchio &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -100,31 +86,21 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qre
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **AP@1000**                                                                                                  | **SPLADE++ CoCondenser-SelfDistil**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3837    | 0.2879    | 0.3350    |
-| **RR@10**                                                                                                    | **SPLADE++ CoCondenser-SelfDistil**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3778    | 0.2790    | 0.3279    |
-| **R@100**                                                                                                    | **SPLADE++ CoCondenser-SelfDistil**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9118    | 0.8681    | 0.8943    |
-| **R@1000**                                                                                                   | **SPLADE++ CoCondenser-SelfDistil**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9846    | 0.9739    | 0.9826    |
+| **AP@1000**                                                                                                  | **SPLADE++ CoCondenser-SelfDistil**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3837    |
+| **RR@10**                                                                                                    | **SPLADE++ CoCondenser-SelfDistil**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3778    |
+| **R@100**                                                                                                    | **SPLADE++ CoCondenser-SelfDistil**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9118    |
+| **R@1000**                                                                                                   | **SPLADE++ CoCondenser-SelfDistil**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9846    |
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-msmarco-passage-unicoil-noexp.md
+++ b/docs/regressions-msmarco-passage-unicoil-noexp.md
@@ -82,20 +82,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp.topics.msmarco-passage.dev-subset.unicoil-noexp.txt \
   -impact -pretokenized &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-unicoil-noexp/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.unicoil-noexp.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-unicoil-noexp.rm3.topics.msmarco-passage.dev-subset.unicoil-noexp.txt \
-  -impact -pretokenized -rm3 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-unicoil-noexp/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.unicoil-noexp.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-unicoil-noexp.rocchio.topics.msmarco-passage.dev-subset.unicoil-noexp.txt \
-  -impact -pretokenized -rocchio &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -105,31 +91,21 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qre
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.rm3.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.rm3.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.rm3.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.rm3.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.rocchio.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.rocchio.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.rocchio.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.rocchio.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **AP@1000**                                                                                                  | **uniCOIL (no expansions)**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3215    | 0.2621    | 0.2643    |
-| **RR@10**                                                                                                    | **uniCOIL (no expansions)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3153    | 0.2537    | 0.2565    |
-| **R@100**                                                                                                    | **uniCOIL (no expansions)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.8070    | 0.7953    | 0.7971    |
-| **R@1000**                                                                                                   | **uniCOIL (no expansions)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9239    | 0.9296    | 0.9326    |
+| **AP@1000**                                                                                                  | **uniCOIL (no expansions)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3215    |
+| **RR@10**                                                                                                    | **uniCOIL (no expansions)**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3153    |
+| **R@100**                                                                                                    | **uniCOIL (no expansions)**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.8070    |
+| **R@1000**                                                                                                   | **uniCOIL (no expansions)**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9239    |
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-msmarco-passage-unicoil.md
+++ b/docs/regressions-msmarco-passage-unicoil.md
@@ -79,20 +79,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.txt \
   -impact -pretokenized &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-unicoil/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.unicoil.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-unicoil.rm3.topics.msmarco-passage.dev-subset.unicoil.txt \
-  -impact -pretokenized -rm3 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage-unicoil/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.unicoil.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage-unicoil.rocchio.topics.msmarco-passage.dev-subset.unicoil.txt \
-  -impact -pretokenized -rocchio &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -102,31 +88,21 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qre
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.rm3.topics.msmarco-passage.dev-subset.unicoil.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.rm3.topics.msmarco-passage.dev-subset.unicoil.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.rm3.topics.msmarco-passage.dev-subset.unicoil.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.rm3.topics.msmarco-passage.dev-subset.unicoil.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.rocchio.topics.msmarco-passage.dev-subset.unicoil.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.rocchio.topics.msmarco-passage.dev-subset.unicoil.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.rocchio.topics.msmarco-passage.dev-subset.unicoil.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.rocchio.topics.msmarco-passage.dev-subset.unicoil.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **AP@1000**                                                                                                  | **uniCOIL (with doc2query-T5 expansions)**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3574    | 0.2918    | 0.2950    |
-| **RR@10**                                                                                                    | **uniCOIL (with doc2query-T5 expansions)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3516    | 0.2836    | 0.2869    |
-| **R@100**                                                                                                    | **uniCOIL (with doc2query-T5 expansions)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.8609    | 0.8425    | 0.8525    |
-| **R@1000**                                                                                                   | **uniCOIL (with doc2query-T5 expansions)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9582    | 0.9603    | 0.9630    |
+| **AP@1000**                                                                                                  | **uniCOIL (with doc2query-T5 expansions)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3574    |
+| **RR@10**                                                                                                    | **uniCOIL (with doc2query-T5 expansions)**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3516    |
+| **R@100**                                                                                                    | **uniCOIL (with doc2query-T5 expansions)**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.8609    |
+| **R@1000**                                                                                                   | **uniCOIL (with doc2query-T5 expansions)**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9582    |
 
 The above runs are in TREC output format and evaluated with `trec_eval`.
 In order to reproduce results reported in the paper, we need to convert to MS MARCO output format and then evaluate:

--- a/docs/regressions-msmarco-passage.md
+++ b/docs/regressions-msmarco-passage.md
@@ -52,78 +52,8 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage/ \
   -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -rm3 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage.bm25-default+rocchio.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -rocchio &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage.bm25-default+rocchio-neg.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -rocchio -rocchio.useNegative -rerankCutoff 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage.bm25-default+ax.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -axiom -axiom.deterministic -rerankCutoff 20 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage.bm25-default+prf.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -bm25prf &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
   -output runs/run.msmarco-passage.bm25-tuned.topics.msmarco-passage.dev-subset.txt \
   -bm25 -bm25.k1 0.82 -bm25.b 0.68 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rm3 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage.bm25-tuned+rocchio.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rocchio &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage.bm25-tuned+rocchio-neg.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rocchio -rocchio.useNegative -rerankCutoff 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage.bm25-tuned+ax.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -bm25.k1 0.82 -bm25.b 0.68 -axiom -axiom.deterministic -rerankCutoff 20 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-passage.bm25-tuned+prf.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -bm25.k1 0.82 -bm25.b 0.68 -bm25prf &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -134,75 +64,25 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/t
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default.topics.msmarco-passage.dev-subset.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default.topics.msmarco-passage.dev-subset.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+rm3.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+rocchio.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+rocchio.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+rocchio.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+rocchio.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+ax.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+ax.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+ax.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+ax.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+prf.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+prf.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+prf.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-default+prf.topics.msmarco-passage.dev-subset.txt
-
 tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned.topics.msmarco-passage.dev-subset.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned.topics.msmarco-passage.dev-subset.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned.topics.msmarco-passage.dev-subset.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+rm3.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+rocchio.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+rocchio.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+rocchio.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+rocchio.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+rocchio-neg.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+ax.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+ax.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+ax.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+ax.topics.msmarco-passage.dev-subset.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+prf.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+prf.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+prf.topics.msmarco-passage.dev-subset.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage.bm25-tuned+prf.topics.msmarco-passage.dev-subset.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **AP@1000**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  | **BM25 (tuned)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  |
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.1926    | 0.1663    | 0.1690    | 0.1676    | 0.1625    | 0.1520    | 0.1958    | 0.1741    | 0.1777    | 0.1762    | 0.1699    | 0.1582    |
-| **RR@10**                                                                                                    | **BM25 (default)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  | **BM25 (tuned)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  |
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.1840    | 0.1566    | 0.1595    | 0.1576    | 0.1517    | 0.1421    | 0.1875    | 0.1646    | 0.1684    | 0.1669    | 0.1594    | 0.1484    |
-| **R@100**                                                                                                    | **BM25 (default)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  | **BM25 (tuned)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  |
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.6578    | 0.6538    | 0.6553    | 0.6559    | 0.6556    | 0.6535    | 0.6701    | 0.6674    | 0.6706    | 0.6748    | 0.6721    | 0.6589    |
-| **R@1000**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  | **BM25 (tuned)**| **+RM3**  | **+Rocchio**| **+Rocchio***| **+Ax**   | **+PRF**  |
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.8526    | 0.8606    | 0.8620    | 0.8652    | 0.8747    | 0.8537    | 0.8573    | 0.8704    | 0.8726    | 0.8757    | 0.8809    | 0.8561    |
+| **AP@1000**                                                                                                  | **BM25 (default)**| **BM25 (tuned)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.1926    | 0.1958    |
+| **RR@10**                                                                                                    | **BM25 (default)**| **BM25 (tuned)**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.1840    | 0.1875    |
+| **R@100**                                                                                                    | **BM25 (default)**| **BM25 (tuned)**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.6578    | 0.6701    |
+| **R@1000**                                                                                                   | **BM25 (default)**| **BM25 (tuned)**|
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.8526    | 0.8573    |
 
 Explanation of settings:
 

--- a/docs/regressions-msmarco-v2-doc-d2q-t5.md
+++ b/docs/regressions-msmarco-v2-doc-d2q-t5.md
@@ -53,32 +53,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-d2q-t5.bm25-default.topics.msmarco-v2-doc.dev2.txt \
   -bm25 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt \
-  -bm25 -rm3 -collection MsMarcoV2DocCollection &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt \
-  -bm25 -rm3 -collection MsMarcoV2DocCollection &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt \
-  -bm25 -rocchio -collection MsMarcoV2DocCollection &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt \
-  -bm25 -rocchio -collection MsMarcoV2DocCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -90,36 +64,22 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank sr
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-d2q-t5.bm25-default.topics.msmarco-v2-doc.dev2.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-d2q-t5.bm25-default.topics.msmarco-v2-doc.dev2.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-d2q-t5.bm25-default.topics.msmarco-v2-doc.dev2.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **MAP@100**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.1988    | 0.1126    | 0.1152    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.1986    | 0.1151    | 0.1170    |
-| **MRR@100**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.2011    | 0.1141    | 0.1168    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.2012    | 0.1170    | 0.1187    |
-| **R@100**                                                                                                    | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.6786    | 0.5924    | 0.5961    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.6821    | 0.5922    | 0.5963    |
-| **R@1000**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.8614    | 0.8191    | 0.8199    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.8568    | 0.8247    | 0.8288    |
+| **MAP@100**                                                                                                  | **BM25 (default)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.1988    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.1986    |
+| **MRR@100**                                                                                                  | **BM25 (default)**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.2011    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.2012    |
+| **R@100**                                                                                                    | **BM25 (default)**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.6786    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.6821    |
+| **R@1000**                                                                                                   | **BM25 (default)**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.8614    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.8568    |

--- a/docs/regressions-msmarco-v2-doc-segmented-d2q-t5.md
+++ b/docs/regressions-msmarco-v2-doc-segmented-d2q-t5.md
@@ -53,32 +53,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default.topics.msmarco-v2-doc.dev2.txt \
   -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt \
-  -bm25 -rm3 -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt \
-  -bm25 -rm3 -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt \
-  -bm25 -rocchio -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-segmented-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt \
-  -bm25 -rocchio -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -90,36 +64,22 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank sr
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default.topics.msmarco-v2-doc.dev2.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default.topics.msmarco-v2-doc.dev2.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default.topics.msmarco-v2-doc.dev2.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **MAP@100**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.2203    | 0.1956    | 0.1959    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.2205    | 0.1949    | 0.1938    |
-| **MRR@100**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.2226    | 0.1975    | 0.1980    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.2234    | 0.1978    | 0.1965    |
-| **R@100**                                                                                                    | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.7297    | 0.7131    | 0.7135    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.7316    | 0.7160    | 0.7197    |
-| **R@1000**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.8982    | 0.9002    | 0.9028    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.8952    | 0.8972    | 0.8976    |
+| **MAP@100**                                                                                                  | **BM25 (default)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.2203    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.2205    |
+| **MRR@100**                                                                                                  | **BM25 (default)**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.2226    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.2234    |
+| **R@100**                                                                                                    | **BM25 (default)**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.7297    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.7316    |
+| **R@1000**                                                                                                   | **BM25 (default)**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.8982    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.8952    |

--- a/docs/regressions-msmarco-v2-doc-segmented-unicoil-0shot-v2.md
+++ b/docs/regressions-msmarco-v2-doc-segmented-unicoil-0shot-v2.md
@@ -99,32 +99,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot.topics.msmarco-v2-doc.dev2.unicoil.0shot.txt \
   -parallelism 16 -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot-v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.unicoil.0shot.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rm3.topics.msmarco-v2-doc.dev.unicoil.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot-v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.unicoil.0shot.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rm3.topics.msmarco-v2-doc.dev2.unicoil.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot-v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.unicoil.0shot.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rocchio.topics.msmarco-v2-doc.dev.unicoil.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-0shot-v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.unicoil.0shot.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rocchio.topics.msmarco-v2-doc.dev2.unicoil.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -136,39 +110,25 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank sr
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot.topics.msmarco-v2-doc.dev2.unicoil.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot.topics.msmarco-v2-doc.dev2.unicoil.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot.topics.msmarco-v2-doc.dev2.unicoil.0shot.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rm3.topics.msmarco-v2-doc.dev.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rm3.topics.msmarco-v2-doc.dev.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rm3.topics.msmarco-v2-doc.dev.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rm3.topics.msmarco-v2-doc.dev2.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rm3.topics.msmarco-v2-doc.dev2.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rm3.topics.msmarco-v2-doc.dev2.unicoil.0shot.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rocchio.topics.msmarco-v2-doc.dev.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rocchio.topics.msmarco-v2-doc.dev.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rocchio.topics.msmarco-v2-doc.dev.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rocchio.topics.msmarco-v2-doc.dev2.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rocchio.topics.msmarco-v2-doc.dev2.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-0shot-v2.unicoil-0shot+rocchio.topics.msmarco-v2-doc.dev2.unicoil.0shot.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **MAP@100**                                                                                                  | **uniCOIL (with doc2query-T5) zero-shot**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.2388    | 0.2174    | 0.2229    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.2422    | 0.2198    | 0.2200    |
-| **MRR@100**                                                                                                  | **uniCOIL (with doc2query-T5) zero-shot**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.2419    | 0.2197    | 0.2252    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.2445    | 0.2225    | 0.2225    |
-| **R@100**                                                                                                    | **uniCOIL (with doc2query-T5) zero-shot**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.7791    | 0.7684    | 0.7775    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.7759    | 0.7640    | 0.7747    |
-| **R@1000**                                                                                                   | **uniCOIL (with doc2query-T5) zero-shot**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.9122    | 0.9175    | 0.9232    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.9172    | 0.9220    | 0.9253    |
+| **MAP@100**                                                                                                  | **uniCOIL (with doc2query-T5) zero-shot**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.2388    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.2422    |
+| **MRR@100**                                                                                                  | **uniCOIL (with doc2query-T5) zero-shot**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.2419    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.2445    |
+| **R@100**                                                                                                    | **uniCOIL (with doc2query-T5) zero-shot**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.7791    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.7759    |
+| **R@1000**                                                                                                   | **uniCOIL (with doc2query-T5) zero-shot**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.9122    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.9172    |
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.md
+++ b/docs/regressions-msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.md
@@ -99,32 +99,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot.topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.txt \
   -parallelism 16 -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rm3.topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rm3.topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -136,39 +110,25 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank sr
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot.topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot.topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot.topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rm3.topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rm3.topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rm3.topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rm3.topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rm3.topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rm3.topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **MAP@100**                                                                                                  | **uniCOIL (noexp) zero-shot**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.2205    | 0.1967    | 0.2011    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.2291    | 0.2066    | 0.2090    |
-| **MRR@100**                                                                                                  | **uniCOIL (noexp) zero-shot**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.2231    | 0.1986    | 0.2034    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.2314    | 0.2091    | 0.2112    |
-| **R@100**                                                                                                    | **uniCOIL (noexp) zero-shot**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.7460    | 0.7447    | 0.7520    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.7498    | 0.7468    | 0.7540    |
-| **R@1000**                                                                                                   | **uniCOIL (noexp) zero-shot**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.8987    | 0.9030    | 0.9084    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.8995    | 0.9082    | 0.9136    |
+| **MAP@100**                                                                                                  | **uniCOIL (noexp) zero-shot**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.2205    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.2291    |
+| **MRR@100**                                                                                                  | **uniCOIL (noexp) zero-shot**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.2231    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.2314    |
+| **R@100**                                                                                                    | **uniCOIL (noexp) zero-shot**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.7460    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.7498    |
+| **R@1000**                                                                                                   | **uniCOIL (noexp) zero-shot**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.8987    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.8995    |
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-msmarco-v2-doc-segmented.md
+++ b/docs/regressions-msmarco-v2-doc-segmented.md
@@ -54,32 +54,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc-segmented.bm25-default.topics.msmarco-v2-doc.dev2.txt \
   -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt \
-  -bm25 -rm3 -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt \
-  -bm25 -rm3 -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt \
-  -bm25 -rocchio -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc-segmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc-segmented.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt \
-  -bm25 -rocchio -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -91,36 +65,22 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank sr
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented.bm25-default.topics.msmarco-v2-doc.dev2.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented.bm25-default.topics.msmarco-v2-doc.dev2.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented.bm25-default.topics.msmarco-v2-doc.dev2.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc-segmented.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc-segmented.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **MAP@100**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.1875    | 0.1644    | 0.1663    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.1903    | 0.1681    | 0.1690    |
-| **MRR@100**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.1896    | 0.1660    | 0.1681    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.1930    | 0.1702    | 0.1710    |
-| **R@100**                                                                                                    | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.6555    | 0.6556    | 0.6535    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.6629    | 0.6566    | 0.6618    |
-| **R@1000**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.8542    | 0.8608    | 0.8657    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.8549    | 0.8639    | 0.8642    |
+| **MAP@100**                                                                                                  | **BM25 (default)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.1875    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.1903    |
+| **MRR@100**                                                                                                  | **BM25 (default)**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.1896    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.1930    |
+| **R@100**                                                                                                    | **BM25 (default)**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.6555    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.6629    |
+| **R@1000**                                                                                                   | **BM25 (default)**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.8542    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.8549    |

--- a/docs/regressions-msmarco-v2-doc.md
+++ b/docs/regressions-msmarco-v2-doc.md
@@ -54,32 +54,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-doc.bm25-default.topics.msmarco-v2-doc.dev2.txt \
   -bm25 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt \
-  -bm25 -rm3 -collection MsMarcoV2DocCollection &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt \
-  -bm25 -rm3 -collection MsMarcoV2DocCollection &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt \
-  -bm25 -rocchio -collection MsMarcoV2DocCollection &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-doc/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-doc.dev2.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-doc.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt \
-  -bm25 -rocchio -collection MsMarcoV2DocCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -91,36 +65,22 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank sr
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc.bm25-default.topics.msmarco-v2-doc.dev2.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc.bm25-default.topics.msmarco-v2-doc.dev2.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc.bm25-default.topics.msmarco-v2-doc.dev2.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc.bm25-default+rm3.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc.bm25-default+rm3.topics.msmarco-v2-doc.dev2.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev.txt runs/run.msmarco-v2-doc.bm25-default+rocchio.topics.msmarco-v2-doc.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-doc.dev2.txt runs/run.msmarco-v2-doc.bm25-default+rocchio.topics.msmarco-v2-doc.dev2.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **MAP@100**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.1552    | 0.0965    | 0.0965    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.1639    | 0.1016    | 0.1037    |
-| **MRR@100**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.1572    | 0.0974    | 0.0974    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.1659    | 0.1033    | 0.1052    |
-| **R@100**                                                                                                    | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.5956    | 0.5108    | 0.5135    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.5970    | 0.5253    | 0.5261    |
-| **R@1000**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.8054    | 0.7699    | 0.7697    |
-| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.8029    | 0.7736    | 0.7762    |
+| **MAP@100**                                                                                                  | **BM25 (default)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.1552    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.1639    |
+| **MRR@100**                                                                                                  | **BM25 (default)**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.1572    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.1659    |
+| **R@100**                                                                                                    | **BM25 (default)**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.5956    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.5970    |
+| **R@1000**                                                                                                   | **BM25 (default)**|
+| [MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                          | 0.8054    |
+| [MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                         | 0.8029    |

--- a/docs/regressions-msmarco-v2-passage-augmented-d2q-t5.md
+++ b/docs/regressions-msmarco-v2-passage-augmented-d2q-t5.md
@@ -52,32 +52,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default.topics.msmarco-v2-passage.dev2.txt \
   -bm25 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt \
-  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt \
-  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt \
-  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-augmented-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt \
-  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -89,36 +63,22 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank sr
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default.topics.msmarco-v2-passage.dev2.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default.topics.msmarco-v2-passage.dev2.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default.topics.msmarco-v2-passage.dev2.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **MAP@100**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.1160    | 0.0873    | 0.0882    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.1158    | 0.0896    | 0.0900    |
-| **MRR@100**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.1172    | 0.0883    | 0.0893    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.1170    | 0.0904    | 0.0908    |
-| **R@100**                                                                                                    | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.5039    | 0.4774    | 0.4756    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.5158    | 0.4905    | 0.4880    |
-| **R@1000**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.7647    | 0.7607    | 0.7648    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.7659    | 0.7649    | 0.7666    |
+| **MAP@100**                                                                                                  | **BM25 (default)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.1160    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.1158    |
+| **MRR@100**                                                                                                  | **BM25 (default)**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.1172    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.1170    |
+| **R@100**                                                                                                    | **BM25 (default)**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.5039    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.5158    |
+| **R@1000**                                                                                                   | **BM25 (default)**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.7647    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.7659    |

--- a/docs/regressions-msmarco-v2-passage-augmented.md
+++ b/docs/regressions-msmarco-v2-passage-augmented.md
@@ -54,32 +54,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-augmented.bm25-default.topics.msmarco-v2-passage.dev2.txt \
   -bm25 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-augmented.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt \
-  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-augmented.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt \
-  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-augmented.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt \
-  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-augmented/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-augmented.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt \
-  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -91,36 +65,22 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank sr
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented.bm25-default.topics.msmarco-v2-passage.dev2.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented.bm25-default.topics.msmarco-v2-passage.dev2.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented.bm25-default.topics.msmarco-v2-passage.dev2.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-augmented.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-augmented.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-augmented.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-augmented.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-augmented.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-augmented.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-augmented.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **MAP@100**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.0863    | 0.0662    | 0.0665    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.0904    | 0.0692    | 0.0676    |
-| **MRR@100**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.0872    | 0.0667    | 0.0671    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.0917    | 0.0700    | 0.0684    |
-| **R@100**                                                                                                    | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.4030    | 0.3735    | 0.3752    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.4159    | 0.3831    | 0.3876    |
-| **R@1000**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.6925    | 0.6857    | 0.6912    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.6933    | 0.6826    | 0.6867    |
+| **MAP@100**                                                                                                  | **BM25 (default)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.0863    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.0904    |
+| **MRR@100**                                                                                                  | **BM25 (default)**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.0872    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.0917    |
+| **R@100**                                                                                                    | **BM25 (default)**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.4030    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.4159    |
+| **R@1000**                                                                                                   | **BM25 (default)**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.6925    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.6933    |

--- a/docs/regressions-msmarco-v2-passage-d2q-t5.md
+++ b/docs/regressions-msmarco-v2-passage-d2q-t5.md
@@ -52,32 +52,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default.topics.msmarco-v2-passage.dev2.txt \
   -bm25 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt \
-  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt \
-  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt \
-  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-d2q-t5/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt \
-  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -89,36 +63,22 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank sr
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-d2q-t5.bm25-default.topics.msmarco-v2-passage.dev2.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-d2q-t5.bm25-default.topics.msmarco-v2-passage.dev2.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-d2q-t5.bm25-default.topics.msmarco-v2-passage.dev2.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-d2q-t5.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **MAP@100**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.1057    | 0.0938    | 0.0943    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.1112    | 0.0976    | 0.0990    |
-| **MRR@100**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.1072    | 0.0947    | 0.0952    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.1123    | 0.0984    | 0.0997    |
-| **R@100**                                                                                                    | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.4670    | 0.4713    | 0.4723    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.4803    | 0.4803    | 0.4815    |
-| **R@1000**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.7083    | 0.7181    | 0.7211    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.7151    | 0.7222    | 0.7274    |
+| **MAP@100**                                                                                                  | **BM25 (default)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.1057    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.1112    |
+| **MRR@100**                                                                                                  | **BM25 (default)**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.1072    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.1123    |
+| **R@100**                                                                                                    | **BM25 (default)**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.4670    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.4803    |
+| **R@1000**                                                                                                   | **BM25 (default)**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.7083    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.7151    |

--- a/docs/regressions-msmarco-v2-passage-unicoil-0shot.md
+++ b/docs/regressions-msmarco-v2-passage-unicoil-0shot.md
@@ -93,32 +93,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot.topics.msmarco-v2-passage.dev2.unicoil.0shot.txt \
   -parallelism 16 -impact -pretokenized &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.unicoil.0shot.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rm3.topics.msmarco-v2-passage.dev.unicoil.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.unicoil.0shot.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rm3.topics.msmarco-v2-passage.dev2.unicoil.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.unicoil.0shot.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rocchio.topics.msmarco-v2-passage.dev.unicoil.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-unicoil-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.unicoil.0shot.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rocchio.topics.msmarco-v2-passage.dev2.unicoil.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -130,39 +104,25 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank sr
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot.topics.msmarco-v2-passage.dev2.unicoil.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot.topics.msmarco-v2-passage.dev2.unicoil.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot.topics.msmarco-v2-passage.dev2.unicoil.0shot.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rm3.topics.msmarco-v2-passage.dev.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rm3.topics.msmarco-v2-passage.dev.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rm3.topics.msmarco-v2-passage.dev.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rm3.topics.msmarco-v2-passage.dev2.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rm3.topics.msmarco-v2-passage.dev2.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rm3.topics.msmarco-v2-passage.dev2.unicoil.0shot.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rocchio.topics.msmarco-v2-passage.dev.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rocchio.topics.msmarco-v2-passage.dev.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rocchio.topics.msmarco-v2-passage.dev.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rocchio.topics.msmarco-v2-passage.dev2.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rocchio.topics.msmarco-v2-passage.dev2.unicoil.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-0shot.unicoil-0shot+rocchio.topics.msmarco-v2-passage.dev2.unicoil.0shot.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **MAP@100**                                                                                                  | **uniCOIL (with doc2query-T5) zero-shot**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.1485    | 0.1319    | 0.1319    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.1561    | 0.1343    | 0.1371    |
-| **MRR@100**                                                                                                  | **uniCOIL (with doc2query-T5) zero-shot**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.1499    | 0.1330    | 0.1334    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.1577    | 0.1352    | 0.1380    |
-| **R@100**                                                                                                    | **uniCOIL (with doc2query-T5) zero-shot**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.5518    | 0.5521    | 0.5557    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.5661    | 0.5552    | 0.5696    |
-| **R@1000**                                                                                                   | **uniCOIL (with doc2query-T5) zero-shot**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.7616    | 0.7736    | 0.7800    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.7671    | 0.7700    | 0.7849    |
+| **MAP@100**                                                                                                  | **uniCOIL (with doc2query-T5) zero-shot**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.1485    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.1561    |
+| **MRR@100**                                                                                                  | **uniCOIL (with doc2query-T5) zero-shot**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.1499    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.1577    |
+| **R@100**                                                                                                    | **uniCOIL (with doc2query-T5) zero-shot**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.5518    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.5661    |
+| **R@1000**                                                                                                   | **uniCOIL (with doc2query-T5) zero-shot**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.7616    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.7671    |
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-msmarco-v2-passage-unicoil-noexp-0shot.md
+++ b/docs/regressions-msmarco-v2-passage-unicoil-noexp-0shot.md
@@ -93,32 +93,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot.topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.txt \
   -parallelism 16 -impact -pretokenized &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rm3.topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rm3.topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage-unicoil-noexp-0shot/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.tsv.gz \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.txt \
-  -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -130,39 +104,25 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank sr
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot.topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot.topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot.topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rm3.topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rm3.topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rm3.topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rm3.topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rm3.topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rm3.topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage-unicoil-noexp-0shot.unicoil-noexp-0shot+rocchio.topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **MAP@100**                                                                                                  | **uniCOIL (noexp) zero-shot**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.1333    | 0.1115    | 0.1163    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.1374    | 0.1190    | 0.1179    |
-| **MRR@100**                                                                                                  | **uniCOIL (noexp) zero-shot**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.1342    | 0.1124    | 0.1172    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.1385    | 0.1197    | 0.1186    |
-| **R@100**                                                                                                    | **uniCOIL (noexp) zero-shot**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.4976    | 0.5006    | 0.5082    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.5217    | 0.5129    | 0.5218    |
-| **R@1000**                                                                                                   | **uniCOIL (noexp) zero-shot**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.7010    | 0.7258    | 0.7299    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.7114    | 0.7346    | 0.7387    |
+| **MAP@100**                                                                                                  | **uniCOIL (noexp) zero-shot**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.1333    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.1374    |
+| **MRR@100**                                                                                                  | **uniCOIL (noexp) zero-shot**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.1342    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.1385    |
+| **R@100**                                                                                                    | **uniCOIL (noexp) zero-shot**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.4976    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.5217    |
+| **R@1000**                                                                                                   | **uniCOIL (noexp) zero-shot**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.7010    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.7114    |
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/docs/regressions-msmarco-v2-passage.md
+++ b/docs/regressions-msmarco-v2-passage.md
@@ -54,32 +54,6 @@ target/appassembler/bin/SearchCollection \
   -topicreader TsvInt \
   -output runs/run.msmarco-v2-passage.bm25-default.topics.msmarco-v2-passage.dev2.txt \
   -bm25 &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt \
-  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt \
-  -bm25 -rm3 -collection MsMarcoV2PassageCollection &
-
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt \
-  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
-target/appassembler/bin/SearchCollection \
-  -index indexes/lucene-index.msmarco-v2-passage/ \
-  -topics src/main/resources/topics-and-qrels/topics.msmarco-v2-passage.dev2.txt \
-  -topicreader TsvInt \
-  -output runs/run.msmarco-v2-passage.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt \
-  -bm25 -rocchio -collection MsMarcoV2PassageCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:
@@ -91,36 +65,22 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank sr
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage.bm25-default.topics.msmarco-v2-passage.dev2.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage.bm25-default.topics.msmarco-v2-passage.dev2.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage.bm25-default.topics.msmarco-v2-passage.dev2.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage.bm25-default+rm3.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage.bm25-default+rm3.topics.msmarco-v2-passage.dev2.txt
-
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev.txt runs/run.msmarco-v2-passage.bm25-default+rocchio.topics.msmarco-v2-passage.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 100 -m map -c -M 100 -m recip_rank src/main/resources/topics-and-qrels/qrels.msmarco-v2-passage.dev2.txt runs/run.msmarco-v2-passage.bm25-default+rocchio.topics.msmarco-v2-passage.dev2.txt
 ```
 
 ## Effectiveness
 
 With the above commands, you should be able to reproduce the following results:
 
-| **MAP@100**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-|:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.0709    | 0.0621    | 0.0622    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.0794    | 0.0651    | 0.0663    |
-| **MRR@100**                                                                                                  | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.0719    | 0.0630    | 0.0631    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.0802    | 0.0659    | 0.0671    |
-| **R@100**                                                                                                    | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.3397    | 0.3370    | 0.3413    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.3459    | 0.3435    | 0.3516    |
-| **R@1000**                                                                                                   | **BM25 (default)**| **+RM3**  | **+Rocchio**|
-| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.5733    | 0.5947    | 0.5968    |
-| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.5839    | 0.6062    | 0.6104    |
+| **MAP@100**                                                                                                  | **BM25 (default)**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.0709    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.0794    |
+| **MRR@100**                                                                                                  | **BM25 (default)**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.0719    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.0802    |
+| **R@100**                                                                                                    | **BM25 (default)**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.3397    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.3459    |
+| **R@1000**                                                                                                   | **BM25 (default)**|
+| [MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                      | 0.5733    |
+| [MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)                     | 0.5839    |

--- a/src/main/resources/regression/msmarco-doc-docTTTTTquery.yaml
+++ b/src/main/resources/regression/msmarco-doc-docTTTTTquery.yaml
@@ -64,30 +64,33 @@ models:
         - 0.7993
       R@1000:
         - 0.9259
-  - name: bm25-default+rm3
-    display: +RM3
-    params: -bm25 -rm3
-    results:
-      AP@1000:
-        - 0.1841
-      RR@100:
-        - 0.1834
-      R@100:
-        - 0.7422
-      R@1000:
-        - 0.9126
-  - name: bm25-default+rocchio
-    display: +Rocchio
-    params: -bm25 -rocchio
-    results:
-      AP@1000:
-        - 0.1841
-      RR@100:
-        - 0.1833
-      R@100:
-        - 0.7441
-      R@1000:
-        - 0.9128
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-default+rm3
+#    display: +RM3
+#    params: -bm25 -rm3
+#    results:
+#      AP@1000:
+#        - 0.1841
+#      RR@100:
+#        - 0.1834
+#      R@100:
+#        - 0.7422
+#      R@1000:
+#        - 0.9126
+#  - name: bm25-default+rocchio
+#    display: +Rocchio
+#    params: -bm25 -rocchio
+#    results:
+#      AP@1000:
+#        - 0.1841
+#      RR@100:
+#        - 0.1833
+#      R@100:
+#        - 0.7441
+#      R@1000:
+#        - 0.9128
   - name: bm25-tuned
     display: BM25 (tuned)
     params: -bm25 -bm25.k1 4.68 -bm25.b 0.87
@@ -100,27 +103,30 @@ models:
         - 0.8612
       R@1000:
         - 0.9553
-  - name: bm25-tuned+rm3
-    display: +RM3
-    params: -bm25 -bm25.k1 4.68 -bm25.b 0.87 -rm3
-    results:
-      AP@1000:
-        - 0.2628
-      RR@100:
-        - 0.2623
-      R@100:
-        - 0.8390
-      R@1000:
-        - 0.9522
-  - name: bm25-tuned+rocchio
-    display: +Rocchio
-    params: -bm25 -bm25.k1 4.68 -bm25.b 0.87 -rocchio
-    results:
-      AP@1000:
-        - 0.2648
-      RR@100:
-        - 0.2643
-      R@100:
-        - 0.8448
-      R@1000:
-        - 0.9534
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-tuned+rm3
+#    display: +RM3
+#    params: -bm25 -bm25.k1 4.68 -bm25.b 0.87 -rm3
+#    results:
+#      AP@1000:
+#        - 0.2628
+#      RR@100:
+#        - 0.2623
+#      R@100:
+#        - 0.8390
+#      R@1000:
+#        - 0.9522
+#  - name: bm25-tuned+rocchio
+#    display: +Rocchio
+#    params: -bm25 -bm25.k1 4.68 -bm25.b 0.87 -rocchio
+#    results:
+#      AP@1000:
+#        - 0.2648
+#      RR@100:
+#        - 0.2643
+#      R@100:
+#        - 0.8448
+#      R@1000:
+#        - 0.9534

--- a/src/main/resources/regression/msmarco-doc-segmented-docTTTTTquery.yaml
+++ b/src/main/resources/regression/msmarco-doc-segmented-docTTTTTquery.yaml
@@ -64,30 +64,33 @@ models:
         - 0.8479
       R@1000:
         - 0.9490
-  - name: bm25-default+rm3
-    display: +RM3
-    params: -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.2808
-      RR@100:
-        - 0.2803
-      R@100:
-        - 0.8477
-      R@1000:
-        - 0.9551
-  - name: bm25-default+rocchio
-    display: +Rocchio
-    params: -bm25 -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.2846
-      RR@100:
-        - 0.2841
-      R@100:
-        - 0.8479
-      R@1000:
-        - 0.9551
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-default+rm3
+#    display: +RM3
+#    params: -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.2808
+#      RR@100:
+#        - 0.2803
+#      R@100:
+#        - 0.8477
+#      R@1000:
+#        - 0.9551
+#  - name: bm25-default+rocchio
+#    display: +Rocchio
+#    params: -bm25 -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.2846
+#      RR@100:
+#        - 0.2841
+#      R@100:
+#        - 0.8479
+#      R@1000:
+#        - 0.9551
   - name: bm25-tuned
     display: BM25 (tuned)
     params: -bm25 -bm25.k1 2.56 -bm25.b 0.59 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
@@ -100,27 +103,30 @@ models:
         - 0.8627
       R@1000:
         - 0.9530
-  - name: bm25-tuned+rm3
-    display: +RM3
-    params: -bm25 -bm25.k1 2.56 -bm25.b 0.59 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.2978
-      RR@100:
-        - 0.2973
-      R@100:
-        - 0.8573
-      R@1000:
-        - 0.9563
-  - name: bm25-tuned+rocchio
-    display: +Rocchio
-    params: -bm25 -bm25.k1 2.56 -bm25.b 0.59 -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.2998
-      RR@100:
-        - 0.2994
-      R@100:
-        - 0.8600
-      R@1000:
-        - 0.9571
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-tuned+rm3
+#    display: +RM3
+#    params: -bm25 -bm25.k1 2.56 -bm25.b 0.59 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.2978
+#      RR@100:
+#        - 0.2973
+#      R@100:
+#        - 0.8573
+#      R@1000:
+#        - 0.9563
+#  - name: bm25-tuned+rocchio
+#    display: +Rocchio
+#    params: -bm25 -bm25.k1 2.56 -bm25.b 0.59 -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.2998
+#      RR@100:
+#        - 0.2994
+#      R@100:
+#        - 0.8600
+#      R@1000:
+#        - 0.9571

--- a/src/main/resources/regression/msmarco-doc-segmented-unicoil-noexp.yaml
+++ b/src/main/resources/regression/msmarco-doc-segmented-unicoil-noexp.yaml
@@ -67,27 +67,30 @@ models:
         - 0.8639
       R@1000:
         - 0.9420
-  - name: rm3
-    display: +RM3
-    params: -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.3052
-      RR@100:
-        - 0.3048
-      R@100:
-        - 0.8600
-      R@1000:
-        - 0.9495
-  - name: rocchio
-    display: +Rocchio
-    params: -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.3092
-      RR@100:
-        - 0.3088
-      R@100:
-        - 0.8667
-      R@1000:
-        - 0.9521
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: rm3
+#    display: +RM3
+#    params: -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.3052
+#      RR@100:
+#        - 0.3048
+#      R@100:
+#        - 0.8600
+#      R@1000:
+#        - 0.9495
+#  - name: rocchio
+#    display: +Rocchio
+#    params: -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.3092
+#      RR@100:
+#        - 0.3088
+#      R@100:
+#        - 0.8667
+#      R@1000:
+#        - 0.9521

--- a/src/main/resources/regression/msmarco-doc-segmented-unicoil.yaml
+++ b/src/main/resources/regression/msmarco-doc-segmented-unicoil.yaml
@@ -67,27 +67,30 @@ models:
         - 0.8858
       R@1000:
         - 0.9546
-  - name: rm3
-    display: +RM3
-    params: -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.3186
-      RR@100:
-        - 0.3182
-      R@100:
-        - 0.8800
-      R@1000:
-        - 0.9615
-  - name: rocchio
-    display: +Rocchio
-    params: -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.3256
-      RR@100:
-        - 0.3252
-      R@100:
-        - 0.8848
-      R@1000:
-        - 0.9619
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: rm3
+#    display: +RM3
+#    params: -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.3186
+#      RR@100:
+#        - 0.3182
+#      R@100:
+#        - 0.8800
+#      R@1000:
+#        - 0.9615
+#  - name: rocchio
+#    display: +Rocchio
+#    params: -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.3256
+#      RR@100:
+#        - 0.3252
+#      R@100:
+#        - 0.8848
+#      R@1000:
+#        - 0.9619

--- a/src/main/resources/regression/msmarco-doc-segmented.yaml
+++ b/src/main/resources/regression/msmarco-doc-segmented.yaml
@@ -64,66 +64,69 @@ models:
         - 0.7847
       R@1000:
         - 0.9178
-  - name: bm25-default+rm3
-    display: +RM3
-    params: -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.2420
-      RR@100:
-        - 0.2413
-      R@100:
-        - 0.7891
-      R@1000:
-        - 0.9351
-  - name: bm25-default+rocchio
-    display: +Rocchio
-    params: -bm25 -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.2453
-      RR@100:
-        - 0.2447
-      R@100:
-        - 0.7915
-      R@1000:
-        - 0.9351
-  - name: bm25-default+rocchio-neg
-    display: +Rocchio*
-    params: -bm25 -rocchio -rocchio.useNegative -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.2464
-      RR@100:
-        - 0.2458
-      R@100:
-        - 0.7888
-      R@1000:
-        - 0.9339
-  - name: bm25-default+ax
-    display: +Ax
-    params: -bm25 -axiom -axiom.deterministic -rerankCutoff 20 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.2208
-      RR@100:
-        - 0.2201
-      R@100:
-        - 0.7710
-      R@1000:
-        - 0.9264
-  - name: bm25-default+prf
-    display: +PRF
-    params: -bm25 -bm25prf -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.2325
-      RR@100:
-        - 0.2318
-      R@100:
-        - 0.7722
-      R@1000:
-        - 0.9185
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-default+rm3
+#    display: +RM3
+#    params: -bm25 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.2420
+#      RR@100:
+#        - 0.2413
+#      R@100:
+#        - 0.7891
+#      R@1000:
+#        - 0.9351
+#  - name: bm25-default+rocchio
+#    display: +Rocchio
+#    params: -bm25 -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.2453
+#      RR@100:
+#        - 0.2447
+#      R@100:
+#        - 0.7915
+#      R@1000:
+#        - 0.9351
+#  - name: bm25-default+rocchio-neg
+#    display: +Rocchio*
+#    params: -bm25 -rocchio -rocchio.useNegative -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.2464
+#      RR@100:
+#        - 0.2458
+#      R@100:
+#        - 0.7888
+#      R@1000:
+#        - 0.9339
+#  - name: bm25-default+ax
+#    display: +Ax
+#    params: -bm25 -axiom -axiom.deterministic -rerankCutoff 20 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.2208
+#      RR@100:
+#        - 0.2201
+#      R@100:
+#        - 0.7710
+#      R@1000:
+#        - 0.9264
+#  - name: bm25-default+prf
+#    display: +PRF
+#    params: -bm25 -bm25prf -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.2325
+#      RR@100:
+#        - 0.2318
+#      R@100:
+#        - 0.7722
+#      R@1000:
+#        - 0.9185
   - name: bm25-tuned
     display: BM25 (tuned)
     params: -bm25 -bm25.k1 2.16 -bm25.b 0.61 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
@@ -136,63 +139,66 @@ models:
         - 0.8013
       R@1000:
         - 0.9311
-  - name: bm25-tuned+rm3
-    display: +RM3
-    params: -bm25 -bm25.k1 2.16 -bm25.b 0.61 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.2455
-      RR@100:
-        - 0.2448
-      R@100:
-        - 0.7978
-      R@1000:
-        - 0.9359
-  - name: bm25-tuned+rocchio
-    display: +Rocchio
-    params: -bm25 -bm25.k1 2.16 -bm25.b 0.61 -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.2482
-      RR@100:
-        - 0.2475
-      R@100:
-        - 0.8013
-      R@1000:
-        - 0.9395
-  - name: bm25-tuned+rocchio-neg
-    display: +Rocchio*
-    params: -bm25 -bm25.k1 2.16 -bm25.b 0.61 -rocchio -rocchio.useNegative -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.2497
-      RR@100:
-        - 0.2491
-      R@100:
-        - 0.8042
-      R@1000:
-        - 0.9395
-  - name: bm25-tuned+ax
-    display: +Ax
-    params: -bm25 -bm25.k1 2.16 -bm25.b 0.61 -axiom -axiom.deterministic -rerankCutoff 20 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.2330
-      RR@100:
-        - 0.2324
-      R@100:
-        - 0.7888
-      R@1000:
-        - 0.9353
-  - name: bm25-tuned+prf
-    display: +PRF
-    params: -bm25 -bm25.k1 2.16 -bm25.b 0.61 -bm25prf -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      AP@1000:
-        - 0.2276
-      RR@100:
-        - 0.2269
-      R@100:
-        - 0.7687
-      R@1000:
-        - 0.9157
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-tuned+rm3
+#    display: +RM3
+#    params: -bm25 -bm25.k1 2.16 -bm25.b 0.61 -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.2455
+#      RR@100:
+#        - 0.2448
+#      R@100:
+#        - 0.7978
+#      R@1000:
+#        - 0.9359
+#  - name: bm25-tuned+rocchio
+#    display: +Rocchio
+#    params: -bm25 -bm25.k1 2.16 -bm25.b 0.61 -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.2482
+#      RR@100:
+#        - 0.2475
+#      R@100:
+#        - 0.8013
+#      R@1000:
+#        - 0.9395
+#  - name: bm25-tuned+rocchio-neg
+#    display: +Rocchio*
+#    params: -bm25 -bm25.k1 2.16 -bm25.b 0.61 -rocchio -rocchio.useNegative -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.2497
+#      RR@100:
+#        - 0.2491
+#      R@100:
+#        - 0.8042
+#      R@1000:
+#        - 0.9395
+#  - name: bm25-tuned+ax
+#    display: +Ax
+#    params: -bm25 -bm25.k1 2.16 -bm25.b 0.61 -axiom -axiom.deterministic -rerankCutoff 20 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.2330
+#      RR@100:
+#        - 0.2324
+#      R@100:
+#        - 0.7888
+#      R@1000:
+#        - 0.9353
+#  - name: bm25-tuned+prf
+#    display: +PRF
+#    params: -bm25 -bm25.k1 2.16 -bm25.b 0.61 -bm25prf -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      AP@1000:
+#        - 0.2276
+#      RR@100:
+#        - 0.2269
+#      R@100:
+#        - 0.7687
+#      R@1000:
+#        - 0.9157

--- a/src/main/resources/regression/msmarco-doc.yaml
+++ b/src/main/resources/regression/msmarco-doc.yaml
@@ -64,66 +64,69 @@ models:
         - 0.7281
       R@1000:
         - 0.8856
-  - name: bm25-default+rm3
-    display: +RM3
-    params: -bm25 -rm3
-    results:
-      AP@1000:
-        - 0.1627
-      RR@100:
-        - 0.1618
-      R@100:
-        - 0.6771
-      R@1000:
-        - 0.8783
-  - name: bm25-default+rocchio
-    display: +Rocchio
-    params: -bm25 -rocchio
-    results:
-      AP@1000:
-        - 0.1632
-      RR@100:
-        - 0.1624
-      R@100:
-        - 0.6765
-      R@1000:
-        - 0.8789
-  - name: bm25-default+rocchio-neg
-    display: +Rocchio*
-    params: -bm25 -rocchio -rocchio.useNegative -rerankCutoff 1000
-    results:
-      AP@1000:
-        - 0.1630
-      RR@100:
-        - 0.1622
-      R@100:
-        - 0.6794
-      R@1000:
-        - 0.8808
-  - name: bm25-default+ax
-    display: +Ax
-    params: -bm25 -axiom -axiom.deterministic -rerankCutoff 20
-    results:
-      AP@1000:
-        - 0.1146
-      RR@100:
-        - 0.1135
-      R@100:
-        - 0.5754
-      R@1000:
-        - 0.8373
-  - name: bm25-default+prf
-    display: +PRF
-    params: -bm25 -bm25prf
-    results:
-      AP@1000:
-        - 0.1357
-      RR@100:
-        - 0.1347
-      R@100:
-        - 0.6374
-      R@1000:
-        - 0.8471
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-default+rm3
+#    display: +RM3
+#    params: -bm25 -rm3
+#    results:
+#      AP@1000:
+#        - 0.1627
+#      RR@100:
+#        - 0.1618
+#      R@100:
+#        - 0.6771
+#      R@1000:
+#        - 0.8783
+#  - name: bm25-default+rocchio
+#    display: +Rocchio
+#    params: -bm25 -rocchio
+#    results:
+#      AP@1000:
+#        - 0.1632
+#      RR@100:
+#        - 0.1624
+#      R@100:
+#        - 0.6765
+#      R@1000:
+#        - 0.8789
+#  - name: bm25-default+rocchio-neg
+#    display: +Rocchio*
+#    params: -bm25 -rocchio -rocchio.useNegative -rerankCutoff 1000
+#    results:
+#      AP@1000:
+#        - 0.1630
+#      RR@100:
+#        - 0.1622
+#      R@100:
+#        - 0.6794
+#      R@1000:
+#        - 0.8808
+#  - name: bm25-default+ax
+#    display: +Ax
+#    params: -bm25 -axiom -axiom.deterministic -rerankCutoff 20
+#    results:
+#      AP@1000:
+#        - 0.1146
+#      RR@100:
+#        - 0.1135
+#      R@100:
+#        - 0.5754
+#      R@1000:
+#        - 0.8373
+#  - name: bm25-default+prf
+#    display: +PRF
+#    params: -bm25 -bm25prf
+#    results:
+#      AP@1000:
+#        - 0.1357
+#      RR@100:
+#        - 0.1347
+#      R@100:
+#        - 0.6374
+#      R@1000:
+#        - 0.8471
   - name: bm25-tuned
     display: BM25 (tuned)
     params: -bm25 -bm25.k1 3.44 -bm25.b 0.87
@@ -136,66 +139,69 @@ models:
         - 0.8069
       R@1000:
         - 0.9324
-  - name: bm25-tuned+rm3
-    display: +RM3
-    params: -bm25 -bm25.k1 3.44 -bm25.b 0.87 -rm3
-    results:
-      AP@1000:
-        - 0.2271
-      RR@100:
-        - 0.2264
-      R@100:
-        - 0.7870
-      R@1000:
-        - 0.9322
-  - name: bm25-tuned+rocchio
-    display: +Rocchio
-    params: -bm25 -bm25.k1 3.44 -bm25.b 0.87 -rocchio
-    results:
-      AP@1000:
-        - 0.2280
-      RR@100:
-        - 0.2274
-      R@100:
-        - 0.7901
-      R@1000:
-        - 0.9334
-  - name: bm25-tuned+rocchio-neg
-    display: +Rocchio*
-    params: -bm25 -bm25.k1 3.44 -bm25.b 0.87 -rocchio -rocchio.useNegative -rerankCutoff 1000
-    results:
-      AP@1000:
-        - 0.2271
-      RR@100:
-        - 0.2265
-      R@100:
-        - 0.7924
-      R@1000:
-        - 0.9324
-  - name: bm25-tuned+ax
-    display: +Ax
-    params: -bm25 -bm25.k1 3.44 -bm25.b 0.87 -axiom -axiom.deterministic -rerankCutoff 20
-    results:
-      AP@1000:
-        - 0.1888
-      RR@100:
-        - 0.1880
-      R@100:
-        - 0.7560
-      R@1000:
-        - 0.9268
-  - name: bm25-tuned+prf
-    display: +PRF
-    params: -bm25 -bm25.k1 3.44 -bm25.b 0.87 -bm25prf
-    results:
-      AP@1000:
-        - 0.1559
-      RR@100:
-        - 0.1550
-      R@100:
-        - 0.6852
-      R@1000:
-        - 0.8760
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-tuned+rm3
+#    display: +RM3
+#    params: -bm25 -bm25.k1 3.44 -bm25.b 0.87 -rm3
+#    results:
+#      AP@1000:
+#        - 0.2271
+#      RR@100:
+#        - 0.2264
+#      R@100:
+#        - 0.7870
+#      R@1000:
+#        - 0.9322
+#  - name: bm25-tuned+rocchio
+#    display: +Rocchio
+#    params: -bm25 -bm25.k1 3.44 -bm25.b 0.87 -rocchio
+#    results:
+#      AP@1000:
+#        - 0.2280
+#      RR@100:
+#        - 0.2274
+#      R@100:
+#        - 0.7901
+#      R@1000:
+#        - 0.9334
+#  - name: bm25-tuned+rocchio-neg
+#    display: +Rocchio*
+#    params: -bm25 -bm25.k1 3.44 -bm25.b 0.87 -rocchio -rocchio.useNegative -rerankCutoff 1000
+#    results:
+#      AP@1000:
+#        - 0.2271
+#      RR@100:
+#        - 0.2265
+#      R@100:
+#        - 0.7924
+#      R@1000:
+#        - 0.9324
+#  - name: bm25-tuned+ax
+#    display: +Ax
+#    params: -bm25 -bm25.k1 3.44 -bm25.b 0.87 -axiom -axiom.deterministic -rerankCutoff 20
+#    results:
+#      AP@1000:
+#        - 0.1888
+#      RR@100:
+#        - 0.1880
+#      R@100:
+#        - 0.7560
+#      R@1000:
+#        - 0.9268
+#  - name: bm25-tuned+prf
+#    display: +PRF
+#    params: -bm25 -bm25.k1 3.44 -bm25.b 0.87 -bm25prf
+#    results:
+#      AP@1000:
+#        - 0.1559
+#      RR@100:
+#        - 0.1550
+#      R@100:
+#        - 0.6852
+#      R@1000:
+#        - 0.8760
   - name: bm25-tuned2
     display: BM25 (tuned2)
     params: -bm25 -bm25.k1 4.46 -bm25.b 0.82
@@ -208,63 +214,66 @@ models:
         - 0.8070
       R@1000:
         - 0.9357
-  - name: bm25-tuned2+rm3
-    display: +RM3
-    params: -bm25 -bm25.k1 4.46 -bm25.b 0.82 -rm3
-    results:
-      AP@1000:
-        - 0.2234
-      RR@100:
-        - 0.2227
-      R@100:
-        - 0.7785
-      R@1000:
-        - 0.9303
-  - name: bm25-tuned2+rocchio
-    display: +Rocchio
-    params: -bm25 -bm25.k1 4.46 -bm25.b 0.82 -rocchio
-    results:
-      AP@1000:
-        - 0.2248
-      RR@100:
-        - 0.2242
-      R@100:
-        - 0.7878
-      R@1000:
-        - 0.9314
-  - name: bm25-tuned2+rocchio-neg
-    display: +Rocchio*
-    params: -bm25 -bm25.k1 4.46 -bm25.b 0.82 -rocchio -rocchio.useNegative -rerankCutoff 1000
-    results:
-      AP@1000:
-        - 0.2231
-      RR@100:
-        - 0.2224
-      R@100:
-        - 0.7863
-      R@1000:
-        - 0.9316
-  - name: bm25-tuned2+ax
-    display: +Ax
-    params: -bm25 -bm25.k1 4.46 -bm25.b 0.82 -axiom -axiom.deterministic -rerankCutoff 20
-    results:
-      AP@1000:
-        - 0.1886
-      RR@100:
-        - 0.1877
-      R@100:
-        - 0.7526
-      R@1000:
-        - 0.9249
-  - name: bm25-tuned2+prf
-    display: +PRF
-    params: -bm25 -bm25.k1 4.46 -bm25.b 0.82 -bm25prf
-    results:
-      AP@1000:
-        - 0.1530
-      RR@100:
-        - 0.1521
-      R@100:
-        - 0.6825
-      R@1000:
-        - 0.8766
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-tuned2+rm3
+#    display: +RM3
+#    params: -bm25 -bm25.k1 4.46 -bm25.b 0.82 -rm3
+#    results:
+#      AP@1000:
+#        - 0.2234
+#      RR@100:
+#        - 0.2227
+#      R@100:
+#        - 0.7785
+#      R@1000:
+#        - 0.9303
+#  - name: bm25-tuned2+rocchio
+#    display: +Rocchio
+#    params: -bm25 -bm25.k1 4.46 -bm25.b 0.82 -rocchio
+#    results:
+#      AP@1000:
+#        - 0.2248
+#      RR@100:
+#        - 0.2242
+#      R@100:
+#        - 0.7878
+#      R@1000:
+#        - 0.9314
+#  - name: bm25-tuned2+rocchio-neg
+#    display: +Rocchio*
+#    params: -bm25 -bm25.k1 4.46 -bm25.b 0.82 -rocchio -rocchio.useNegative -rerankCutoff 1000
+#    results:
+#      AP@1000:
+#        - 0.2231
+#      RR@100:
+#        - 0.2224
+#      R@100:
+#        - 0.7863
+#      R@1000:
+#        - 0.9316
+#  - name: bm25-tuned2+ax
+#    display: +Ax
+#    params: -bm25 -bm25.k1 4.46 -bm25.b 0.82 -axiom -axiom.deterministic -rerankCutoff 20
+#    results:
+#      AP@1000:
+#        - 0.1886
+#      RR@100:
+#        - 0.1877
+#      R@100:
+#        - 0.7526
+#      R@1000:
+#        - 0.9249
+#  - name: bm25-tuned2+prf
+#    display: +PRF
+#    params: -bm25 -bm25.k1 4.46 -bm25.b 0.82 -bm25prf
+#    results:
+#      AP@1000:
+#        - 0.1530
+#      RR@100:
+#        - 0.1521
+#      R@100:
+#        - 0.6825
+#      R@1000:
+#        - 0.8766

--- a/src/main/resources/regression/msmarco-passage-doc2query.yaml
+++ b/src/main/resources/regression/msmarco-passage-doc2query.yaml
@@ -64,18 +64,21 @@ models:
         - 0.7133
       R@1000:
         - 0.8900
-  - name: bm25-default+rm3
-    display: +RM3
-    params: -bm25 -rm3
-    results:
-      AP@1000:
-        - 0.2030
-      RR@10:
-        - 0.1941
-      R@100:
-        - 0.7003
-      R@1000:
-        - 0.8909
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-default+rm3
+#    display: +RM3
+#    params: -bm25 -rm3
+#    results:
+#      AP@1000:
+#        - 0.2030
+#      RR@10:
+#        - 0.1941
+#      R@100:
+#        - 0.7003
+#      R@1000:
+#        - 0.8909
   - name: bm25-tuned
     display: BM25 (tuned)
     params: -bm25 -bm25.k1 0.82 -bm25.b 0.68
@@ -88,15 +91,18 @@ models:
         - 0.7171
       R@1000:
         - 0.8911
-  - name: bm25-tuned+rm3
-    display: +RM3
-    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rm3
-    results:
-      AP@1000:
-        - 0.2081
-      RR@10:
-        - 0.1992
-      R@100:
-        - 0.7051
-      R@1000:
-        - 0.8946
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-tuned+rm3
+#    display: +RM3
+#    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rm3
+#    results:
+#      AP@1000:
+#        - 0.2081
+#      RR@10:
+#        - 0.1992
+#      R@100:
+#        - 0.7051
+#      R@1000:
+#        - 0.8946

--- a/src/main/resources/regression/msmarco-passage-docTTTTTquery.yaml
+++ b/src/main/resources/regression/msmarco-passage-docTTTTTquery.yaml
@@ -64,42 +64,45 @@ models:
         - 0.8192
       R@1000:
         - 0.9470
-  - name: bm25-default+rm3
-    display: +RM3
-    params: -bm25 -rm3
-    results:
-      AP@1000:
-        - 0.2241
-      RR@10:
-        - 0.2139
-      R@100:
-        - 0.8000
-      R@1000:
-        - 0.9460
-  - name: bm25-default+rocchio
-    display: +Rocchio
-    params: -bm25 -rocchio
-    results:
-      AP@1000:
-        - 0.2260
-      RR@10:
-        - 0.2158
-      R@100:
-        - 0.8019
-      R@1000:
-        - 0.9467
-  - name: bm25-default+rocchio-neg
-    display: +Rocchio*
-    params: -bm25 -rocchio -rocchio.useNegative -rerankCutoff 1000
-    results:
-      AP@1000:
-        - 0.2234
-      RR@10:
-        - 0.2129
-      R@100:
-        - 0.8025
-      R@1000:
-        - 0.9475
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-default+rm3
+#    display: +RM3
+#    params: -bm25 -rm3
+#    results:
+#      AP@1000:
+#        - 0.2241
+#      RR@10:
+#        - 0.2139
+#      R@100:
+#        - 0.8000
+#      R@1000:
+#        - 0.9460
+#  - name: bm25-default+rocchio
+#    display: +Rocchio
+#    params: -bm25 -rocchio
+#    results:
+#      AP@1000:
+#        - 0.2260
+#      RR@10:
+#        - 0.2158
+#      R@100:
+#        - 0.8019
+#      R@1000:
+#        - 0.9467
+#  - name: bm25-default+rocchio-neg
+#    display: +Rocchio*
+#    params: -bm25 -rocchio -rocchio.useNegative -rerankCutoff 1000
+#    results:
+#      AP@1000:
+#        - 0.2234
+#      RR@10:
+#        - 0.2129
+#      R@100:
+#        - 0.8025
+#      R@1000:
+#        - 0.9475
   - name: bm25-tuned
     display: BM25 (tuned)
     params: -bm25 -bm25.k1 0.82 -bm25.b 0.68
@@ -112,42 +115,45 @@ models:
         - 0.8190
       R@1000:
         - 0.9471
-  - name: bm25-tuned+rm3
-    display: +RM3
-    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rm3
-    results:
-      AP@1000:
-        - 0.2260
-      RR@10:
-        - 0.2154
-      R@100:
-        - 0.8030
-      R@1000:
-        - 0.9479
-  - name: bm25-tuned+rocchio
-    display: +Rocchio
-    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rocchio
-    results:
-      AP@1000:
-        - 0.2277
-      RR@10:
-        - 0.2174
-      R@100:
-        - 0.8052
-      R@1000:
-        - 0.9496
-  - name: bm25-tuned+rocchio-neg
-    display: +Rocchio*
-    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rocchio -rocchio.useNegative -rerankCutoff 1000
-    results:
-      AP@1000:
-        - 0.2276
-      RR@10:
-        - 0.2173
-      R@100:
-        - 0.8072
-      R@1000:
-        - 0.9493
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-tuned+rm3
+#    display: +RM3
+#    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rm3
+#    results:
+#      AP@1000:
+#        - 0.2260
+#      RR@10:
+#        - 0.2154
+#      R@100:
+#        - 0.8030
+#      R@1000:
+#        - 0.9479
+#  - name: bm25-tuned+rocchio
+#    display: +Rocchio
+#    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rocchio
+#    results:
+#      AP@1000:
+#        - 0.2277
+#      RR@10:
+#        - 0.2174
+#      R@100:
+#        - 0.8052
+#      R@1000:
+#        - 0.9496
+#  - name: bm25-tuned+rocchio-neg
+#    display: +Rocchio*
+#    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rocchio -rocchio.useNegative -rerankCutoff 1000
+#    results:
+#      AP@1000:
+#        - 0.2276
+#      RR@10:
+#        - 0.2173
+#      R@100:
+#        - 0.8072
+#      R@1000:
+#        - 0.9493
   - name: bm25-tuned2
     display: BM25 (tuned2)
     params: -bm25 -bm25.k1 2.18 -bm25.b 0.86
@@ -160,39 +166,42 @@ models:
         - 0.8277
       R@1000:
         - 0.9506
-  - name: bm25-tuned2+rm3
-    display: +RM3
-    params: -bm25 -bm25.k1 2.18 -bm25.b 0.86 -rm3
-    results:
-      AP@1000:
-        - 0.2472
-      RR@10:
-        - 0.2382
-      R@100:
-        - 0.8226
-      R@1000:
-        - 0.9528
-  - name: bm25-tuned2+rocchio
-    display: +Rocchio
-    params: -bm25 -bm25.k1 2.18 -bm25.b 0.86 -rocchio
-    results:
-      AP@1000:
-        - 0.2488
-      RR@10:
-        - 0.2395
-      R@100:
-        - 0.8238
-      R@1000:
-        - 0.9535
-  - name: bm25-tuned2+rocchio-neg
-    display: +Rocchio*
-    params: -bm25 -bm25.k1 2.18 -bm25.b 0.86 -rocchio -rocchio.useNegative -rerankCutoff 1000
-    results:
-      AP@1000:
-        - 0.2467
-      RR@10:
-        - 0.2372
-      R@100:
-        - 0.8227
-      R@1000:
-        - 0.9539
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-tuned2+rm3
+#    display: +RM3
+#    params: -bm25 -bm25.k1 2.18 -bm25.b 0.86 -rm3
+#    results:
+#      AP@1000:
+#        - 0.2472
+#      RR@10:
+#        - 0.2382
+#      R@100:
+#        - 0.8226
+#      R@1000:
+#        - 0.9528
+#  - name: bm25-tuned2+rocchio
+#    display: +Rocchio
+#    params: -bm25 -bm25.k1 2.18 -bm25.b 0.86 -rocchio
+#    results:
+#      AP@1000:
+#        - 0.2488
+#      RR@10:
+#        - 0.2395
+#      R@100:
+#        - 0.8238
+#      R@1000:
+#        - 0.9535
+#  - name: bm25-tuned2+rocchio-neg
+#    display: +Rocchio*
+#    params: -bm25 -bm25.k1 2.18 -bm25.b 0.86 -rocchio -rocchio.useNegative -rerankCutoff 1000
+#    results:
+#      AP@1000:
+#        - 0.2467
+#      RR@10:
+#        - 0.2372
+#      R@100:
+#        - 0.8227
+#      R@1000:
+#        - 0.9539

--- a/src/main/resources/regression/msmarco-passage-splade-distil-cocodenser-medium.yaml
+++ b/src/main/resources/regression/msmarco-passage-splade-distil-cocodenser-medium.yaml
@@ -67,27 +67,30 @@ models:
         - 0.9111
       R@1000:
         - 0.9817
-  - name: rm3
-    display: +RM3
-    params: -impact -pretokenized -rm3
-    results:
-      AP@1000:
-        - 0.3020
-      RR@10:
-        - 0.2936
-      R@100:
-        - 0.8750
-      R@1000:
-        - 0.9750
-  - name: rocchio
-    display: +Rocchio
-    params: -impact -pretokenized -rocchio
-    results:
-      AP@1000:
-        - 0.3345
-      RR@10:
-        - 0.3279
-      R@100:
-        - 0.8911
-      R@1000:
-        - 0.9804
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: rm3
+#    display: +RM3
+#    params: -impact -pretokenized -rm3
+#    results:
+#      AP@1000:
+#        - 0.3020
+#      RR@10:
+#        - 0.2936
+#      R@100:
+#        - 0.8750
+#      R@1000:
+#        - 0.9750
+#  - name: rocchio
+#    display: +Rocchio
+#    params: -impact -pretokenized -rocchio
+#    results:
+#      AP@1000:
+#        - 0.3345
+#      RR@10:
+#        - 0.3279
+#      R@100:
+#        - 0.8911
+#      R@1000:
+#        - 0.9804

--- a/src/main/resources/regression/msmarco-passage-splade-pp-ed.yaml
+++ b/src/main/resources/regression/msmarco-passage-splade-pp-ed.yaml
@@ -67,27 +67,30 @@ models:
         - 0.9095
       R@1000:
         - 0.9831
-  - name: rm3
-    display: +RM3
-    params: -impact -pretokenized -rm3
-    results:
-      AP@1000:
-        - 0.2967
-      RR@10:
-        - 0.2882
-      R@100:
-        - 0.8728
-      R@1000:
-        - 0.9744
-  - name: rocchio
-    display: +Rocchio
-    params: -impact -pretokenized -rocchio
-    results:
-      AP@1000:
-        - 0.3365
-      RR@10:
-        - 0.3293
-      R@100:
-        - 0.8967
-      R@1000:
-        - 0.9811
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: rm3
+#    display: +RM3
+#    params: -impact -pretokenized -rm3
+#    results:
+#      AP@1000:
+#        - 0.2967
+#      RR@10:
+#        - 0.2882
+#      R@100:
+#        - 0.8728
+#      R@1000:
+#        - 0.9744
+#  - name: rocchio
+#    display: +Rocchio
+#    params: -impact -pretokenized -rocchio
+#    results:
+#      AP@1000:
+#        - 0.3365
+#      RR@10:
+#        - 0.3293
+#      R@100:
+#        - 0.8967
+#      R@1000:
+#        - 0.9811

--- a/src/main/resources/regression/msmarco-passage-splade-pp-sd.yaml
+++ b/src/main/resources/regression/msmarco-passage-splade-pp-sd.yaml
@@ -67,27 +67,30 @@ models:
         - 0.9118
       R@1000:
         - 0.9846
-  - name: rm3
-    display: +RM3
-    params: -impact -pretokenized -rm3
-    results:
-      AP@1000:
-        - 0.2879
-      RR@10:
-        - 0.2790
-      R@100:
-        - 0.8681
-      R@1000:
-        - 0.9739
-  - name: rocchio
-    display: +Rocchio
-    params: -impact -pretokenized -rocchio
-    results:
-      AP@1000:
-        - 0.3350
-      RR@10:
-        - 0.3279
-      R@100:
-        - 0.8943
-      R@1000:
-        - 0.9826
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: rm3
+#    display: +RM3
+#    params: -impact -pretokenized -rm3
+#    results:
+#      AP@1000:
+#        - 0.2879
+#      RR@10:
+#        - 0.2790
+#      R@100:
+#        - 0.8681
+#      R@1000:
+#        - 0.9739
+#  - name: rocchio
+#    display: +Rocchio
+#    params: -impact -pretokenized -rocchio
+#    results:
+#      AP@1000:
+#        - 0.3350
+#      RR@10:
+#        - 0.3279
+#      R@100:
+#        - 0.8943
+#      R@1000:
+#        - 0.9826

--- a/src/main/resources/regression/msmarco-passage-unicoil-noexp.yaml
+++ b/src/main/resources/regression/msmarco-passage-unicoil-noexp.yaml
@@ -67,27 +67,30 @@ models:
         - 0.8070
       R@1000:
         - 0.9239
-  - name: rm3
-    display: +RM3
-    params: -impact -pretokenized -rm3
-    results:
-      AP@1000:
-        - 0.2621
-      RR@10:
-        - 0.2537
-      R@100:
-        - 0.7953
-      R@1000:
-        - 0.9296
-  - name: rocchio
-    display: +Rocchio
-    params: -impact -pretokenized -rocchio
-    results:
-      AP@1000:
-        - 0.2643
-      RR@10:
-        - 0.2565
-      R@100:
-        - 0.7971
-      R@1000:
-        - 0.9326
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: rm3
+#    display: +RM3
+#    params: -impact -pretokenized -rm3
+#    results:
+#      AP@1000:
+#        - 0.2621
+#      RR@10:
+#        - 0.2537
+#      R@100:
+#        - 0.7953
+#      R@1000:
+#        - 0.9296
+#  - name: rocchio
+#    display: +Rocchio
+#    params: -impact -pretokenized -rocchio
+#    results:
+#      AP@1000:
+#        - 0.2643
+#      RR@10:
+#        - 0.2565
+#      R@100:
+#        - 0.7971
+#      R@1000:
+#        - 0.9326

--- a/src/main/resources/regression/msmarco-passage-unicoil.yaml
+++ b/src/main/resources/regression/msmarco-passage-unicoil.yaml
@@ -67,27 +67,30 @@ models:
         - 0.8609
       R@1000:
         - 0.9582
-  - name: rm3
-    display: +RM3
-    params: -impact -pretokenized -rm3
-    results:
-      AP@1000:
-        - 0.2918
-      RR@10:
-        - 0.2836
-      R@100:
-        - 0.8425
-      R@1000:
-        - 0.9603
-  - name: rocchio
-    display: +Rocchio
-    params: -impact -pretokenized -rocchio
-    results:
-      AP@1000:
-        - 0.2950
-      RR@10:
-        - 0.2869
-      R@100:
-        - 0.8525
-      R@1000:
-        - 0.9630
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: rm3
+#    display: +RM3
+#    params: -impact -pretokenized -rm3
+#    results:
+#      AP@1000:
+#        - 0.2918
+#      RR@10:
+#        - 0.2836
+#      R@100:
+#        - 0.8425
+#      R@1000:
+#        - 0.9603
+#  - name: rocchio
+#    display: +Rocchio
+#    params: -impact -pretokenized -rocchio
+#    results:
+#      AP@1000:
+#        - 0.2950
+#      RR@10:
+#        - 0.2869
+#      R@100:
+#        - 0.8525
+#      R@1000:
+#        - 0.9630

--- a/src/main/resources/regression/msmarco-passage.yaml
+++ b/src/main/resources/regression/msmarco-passage.yaml
@@ -64,66 +64,69 @@ models:
         - 0.6578
       R@1000:
         - 0.8526
-  - name: bm25-default+rm3
-    display: +RM3
-    params: -bm25 -rm3
-    results:
-      AP@1000:
-        - 0.1663
-      RR@10:
-        - 0.1566
-      R@100:
-        - 0.6538
-      R@1000:
-        - 0.8606
-  - name: bm25-default+rocchio
-    display: +Rocchio
-    params: -bm25 -rocchio
-    results:
-      AP@1000:
-        - 0.1690
-      RR@10:
-        - 0.1595
-      R@100:
-        - 0.6553
-      R@1000:
-        - 0.8620
-  - name: bm25-default+rocchio-neg
-    display: +Rocchio*
-    params: -bm25 -rocchio -rocchio.useNegative -rerankCutoff 1000
-    results:
-      AP@1000:
-        - 0.1676
-      RR@10:
-        - 0.1576
-      R@100:
-        - 0.6559
-      R@1000:
-        - 0.8652
-  - name: bm25-default+ax
-    display: +Ax
-    params: -bm25 -axiom -axiom.deterministic -rerankCutoff 20
-    results:
-      AP@1000:
-        - 0.1625
-      RR@10:
-        - 0.1517
-      R@100:
-        - 0.6556
-      R@1000:
-        - 0.8747
-  - name: bm25-default+prf
-    display: +PRF
-    params: -bm25 -bm25prf
-    results:
-      AP@1000:
-        - 0.1520
-      RR@10:
-        - 0.1421
-      R@100:
-        - 0.6535
-      R@1000:
-        - 0.8537
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-default+rm3
+#    display: +RM3
+#    params: -bm25 -rm3
+#    results:
+#      AP@1000:
+#        - 0.1663
+#      RR@10:
+#        - 0.1566
+#      R@100:
+#        - 0.6538
+#      R@1000:
+#        - 0.8606
+#  - name: bm25-default+rocchio
+#    display: +Rocchio
+#    params: -bm25 -rocchio
+#    results:
+#      AP@1000:
+#        - 0.1690
+#      RR@10:
+#        - 0.1595
+#      R@100:
+#        - 0.6553
+#      R@1000:
+#        - 0.8620
+#  - name: bm25-default+rocchio-neg
+#    display: +Rocchio*
+#    params: -bm25 -rocchio -rocchio.useNegative -rerankCutoff 1000
+#    results:
+#      AP@1000:
+#        - 0.1676
+#      RR@10:
+#        - 0.1576
+#      R@100:
+#        - 0.6559
+#      R@1000:
+#        - 0.8652
+#  - name: bm25-default+ax
+#    display: +Ax
+#    params: -bm25 -axiom -axiom.deterministic -rerankCutoff 20
+#    results:
+#      AP@1000:
+#        - 0.1625
+#      RR@10:
+#        - 0.1517
+#      R@100:
+#        - 0.6556
+#      R@1000:
+#        - 0.8747
+#  - name: bm25-default+prf
+#    display: +PRF
+#    params: -bm25 -bm25prf
+#    results:
+#      AP@1000:
+#        - 0.1520
+#      RR@10:
+#        - 0.1421
+#      R@100:
+#        - 0.6535
+#      R@1000:
+#        - 0.8537
   - name: bm25-tuned
     display: BM25 (tuned)
     params: -bm25 -bm25.k1 0.82 -bm25.b 0.68
@@ -136,63 +139,66 @@ models:
         - 0.6701
       R@1000:
         - 0.8573
-  - name: bm25-tuned+rm3
-    display: +RM3
-    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rm3
-    results:
-      AP@1000:
-        - 0.1741
-      RR@10:
-        - 0.1646
-      R@100:
-        - 0.6674
-      R@1000:
-        - 0.8704
-  - name: bm25-tuned+rocchio
-    display: +Rocchio
-    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rocchio
-    results:
-      AP@1000:
-        - 0.1777
-      RR@10:
-        - 0.1684
-      R@100:
-        - 0.6706
-      R@1000:
-        - 0.8726
-  - name: bm25-tuned+rocchio-neg 
-    display: +Rocchio*
-    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rocchio -rocchio.useNegative -rerankCutoff 1000
-    results:
-      AP@1000:
-        - 0.1762
-      RR@10:
-        - 0.1669
-      R@100:
-        - 0.6748
-      R@1000:
-        - 0.8757
-  - name: bm25-tuned+ax
-    display: +Ax
-    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -axiom -axiom.deterministic -rerankCutoff 20
-    results:
-      AP@1000:
-        - 0.1699
-      RR@10:
-        - 0.1594
-      R@100:
-        - 0.6721
-      R@1000:
-        - 0.8809
-  - name: bm25-tuned+prf
-    display: +PRF
-    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -bm25prf
-    results:
-      AP@1000:
-        - 0.1582
-      RR@10:
-        - 0.1484
-      R@100:
-        - 0.6589
-      R@1000:
-        - 0.8561
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-tuned+rm3
+#    display: +RM3
+#    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rm3
+#    results:
+#      AP@1000:
+#        - 0.1741
+#      RR@10:
+#        - 0.1646
+#      R@100:
+#        - 0.6674
+#      R@1000:
+#        - 0.8704
+#  - name: bm25-tuned+rocchio
+#    display: +Rocchio
+#    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rocchio
+#    results:
+#      AP@1000:
+#        - 0.1777
+#      RR@10:
+#        - 0.1684
+#      R@100:
+#        - 0.6706
+#      R@1000:
+#        - 0.8726
+#  - name: bm25-tuned+rocchio-neg
+#    display: +Rocchio*
+#    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -rocchio -rocchio.useNegative -rerankCutoff 1000
+#    results:
+#      AP@1000:
+#        - 0.1762
+#      RR@10:
+#        - 0.1669
+#      R@100:
+#        - 0.6748
+#      R@1000:
+#        - 0.8757
+#  - name: bm25-tuned+ax
+#    display: +Ax
+#    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -axiom -axiom.deterministic -rerankCutoff 20
+#    results:
+#      AP@1000:
+#        - 0.1699
+#      RR@10:
+#        - 0.1594
+#      R@100:
+#        - 0.6721
+#      R@1000:
+#        - 0.8809
+#  - name: bm25-tuned+prf
+#    display: +PRF
+#    params: -bm25 -bm25.k1 0.82 -bm25.b 0.68 -bm25prf
+#    results:
+#      AP@1000:
+#        - 0.1582
+#      RR@10:
+#        - 0.1484
+#      R@100:
+#        - 0.6589
+#      R@1000:
+#        - 0.8561

--- a/src/main/resources/regression/msmarco-v2-doc-d2q-t5.yaml
+++ b/src/main/resources/regression/msmarco-v2-doc-d2q-t5.yaml
@@ -72,35 +72,38 @@ models:
       R@1000:
         - 0.8614
         - 0.8568
-  - name: bm25-default+rm3
-    display: +RM3
-    params: -bm25 -rm3 -collection MsMarcoV2DocCollection
-    results:
-      MAP@100:
-        - 0.1126
-        - 0.1151
-      MRR@100:
-        - 0.1141
-        - 0.1170
-      R@100:
-        - 0.5924
-        - 0.5922
-      R@1000:
-        - 0.8191
-        - 0.8247
-  - name: bm25-default+rocchio
-    display: +Rocchio
-    params: -bm25 -rocchio -collection MsMarcoV2DocCollection
-    results:
-      MAP@100:
-        - 0.1152
-        - 0.1170
-      MRR@100:
-        - 0.1168
-        - 0.1187
-      R@100:
-        - 0.5961
-        - 0.5963
-      R@1000:
-        - 0.8199
-        - 0.8288
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-default+rm3
+#    display: +RM3
+#    params: -bm25 -rm3 -collection MsMarcoV2DocCollection
+#    results:
+#      MAP@100:
+#        - 0.1126
+#        - 0.1151
+#      MRR@100:
+#        - 0.1141
+#        - 0.1170
+#      R@100:
+#        - 0.5924
+#        - 0.5922
+#      R@1000:
+#        - 0.8191
+#        - 0.8247
+#  - name: bm25-default+rocchio
+#    display: +Rocchio
+#    params: -bm25 -rocchio -collection MsMarcoV2DocCollection
+#    results:
+#      MAP@100:
+#        - 0.1152
+#        - 0.1170
+#      MRR@100:
+#        - 0.1168
+#        - 0.1187
+#      R@100:
+#        - 0.5961
+#        - 0.5963
+#      R@1000:
+#        - 0.8199
+#        - 0.8288

--- a/src/main/resources/regression/msmarco-v2-doc-segmented-d2q-t5.yaml
+++ b/src/main/resources/regression/msmarco-v2-doc-segmented-d2q-t5.yaml
@@ -72,35 +72,38 @@ models:
       R@1000:
         - 0.8982
         - 0.8952
-  - name: bm25-default+rm3
-    display: +RM3
-    params: -bm25 -rm3 -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      MAP@100:
-        - 0.1956
-        - 0.1949
-      MRR@100:
-        - 0.1975
-        - 0.1978
-      R@100:
-        - 0.7131
-        - 0.7160
-      R@1000:
-        - 0.9002
-        - 0.8972
-  - name: bm25-default+rocchio
-    display: +Rocchio
-    params: -bm25 -rocchio -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      MAP@100:
-        - 0.1959
-        - 0.1938
-      MRR@100:
-        - 0.1980
-        - 0.1965
-      R@100:
-        - 0.7135
-        - 0.7197
-      R@1000:
-        - 0.9028
-        - 0.8976
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-default+rm3
+#    display: +RM3
+#    params: -bm25 -rm3 -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      MAP@100:
+#        - 0.1956
+#        - 0.1949
+#      MRR@100:
+#        - 0.1975
+#        - 0.1978
+#      R@100:
+#        - 0.7131
+#        - 0.7160
+#      R@1000:
+#        - 0.9002
+#        - 0.8972
+#  - name: bm25-default+rocchio
+#    display: +Rocchio
+#    params: -bm25 -rocchio -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      MAP@100:
+#        - 0.1959
+#        - 0.1938
+#      MRR@100:
+#        - 0.1980
+#        - 0.1965
+#      R@100:
+#        - 0.7135
+#        - 0.7197
+#      R@1000:
+#        - 0.9028
+#        - 0.8976

--- a/src/main/resources/regression/msmarco-v2-doc-segmented-unicoil-0shot-v2.yaml
+++ b/src/main/resources/regression/msmarco-v2-doc-segmented-unicoil-0shot-v2.yaml
@@ -76,35 +76,38 @@ models:
       R@1000:
         - 0.9122
         - 0.9172
-  - name: unicoil-0shot+rm3
-    display: +RM3
-    params: -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      MAP@100:
-        - 0.2174
-        - 0.2198
-      MRR@100:
-        - 0.2197
-        - 0.2225
-      R@100:
-        - 0.7684
-        - 0.7640
-      R@1000:
-        - 0.9175
-        - 0.9220
-  - name: unicoil-0shot+rocchio
-    display: +Rocchio
-    params: -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      MAP@100:
-        - 0.2229
-        - 0.2200
-      MRR@100:
-        - 0.2252
-        - 0.2225
-      R@100:
-        - 0.7775
-        - 0.7747
-      R@1000:
-        - 0.9232
-        - 0.9253
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: unicoil-0shot+rm3
+#    display: +RM3
+#    params: -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      MAP@100:
+#        - 0.2174
+#        - 0.2198
+#      MRR@100:
+#        - 0.2197
+#        - 0.2225
+#      R@100:
+#        - 0.7684
+#        - 0.7640
+#      R@1000:
+#        - 0.9175
+#        - 0.9220
+#  - name: unicoil-0shot+rocchio
+#    display: +Rocchio
+#    params: -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      MAP@100:
+#        - 0.2229
+#        - 0.2200
+#      MRR@100:
+#        - 0.2252
+#        - 0.2225
+#      R@100:
+#        - 0.7775
+#        - 0.7747
+#      R@1000:
+#        - 0.9232
+#        - 0.9253

--- a/src/main/resources/regression/msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.yaml
+++ b/src/main/resources/regression/msmarco-v2-doc-segmented-unicoil-noexp-0shot-v2.yaml
@@ -76,35 +76,38 @@ models:
       R@1000:
         - 0.8987
         - 0.8995
-  - name: unicoil-noexp-0shot+rm3
-    display: +RM3
-    params: -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      MAP@100:
-        - 0.1967
-        - 0.2066
-      MRR@100:
-        - 0.1986
-        - 0.2091
-      R@100:
-        - 0.7447
-        - 0.7468
-      R@1000:
-        - 0.9030
-        - 0.9082
-  - name: unicoil-noexp-0shot+rocchio
-    display: +Rocchio
-    params: -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      MAP@100:
-        - 0.2011
-        - 0.2090
-      MRR@100:
-        - 0.2034
-        - 0.2112
-      R@100:
-        - 0.7520
-        - 0.7540
-      R@1000:
-        - 0.9084
-        - 0.9136
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: unicoil-noexp-0shot+rm3
+#    display: +RM3
+#    params: -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      MAP@100:
+#        - 0.1967
+#        - 0.2066
+#      MRR@100:
+#        - 0.1986
+#        - 0.2091
+#      R@100:
+#        - 0.7447
+#        - 0.7468
+#      R@1000:
+#        - 0.9030
+#        - 0.9082
+#  - name: unicoil-noexp-0shot+rocchio
+#    display: +Rocchio
+#    params: -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      MAP@100:
+#        - 0.2011
+#        - 0.2090
+#      MRR@100:
+#        - 0.2034
+#        - 0.2112
+#      R@100:
+#        - 0.7520
+#        - 0.7540
+#      R@1000:
+#        - 0.9084
+#        - 0.9136

--- a/src/main/resources/regression/msmarco-v2-doc-segmented.yaml
+++ b/src/main/resources/regression/msmarco-v2-doc-segmented.yaml
@@ -72,35 +72,38 @@ models:
       R@1000:
         - 0.8542
         - 0.8549
-  - name: bm25-default+rm3
-    display: +RM3
-    params: -bm25 -rm3 -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      MAP@100:
-        - 0.1644
-        - 0.1681
-      MRR@100:
-        - 0.1660
-        - 0.1702
-      R@100:
-        - 0.6556
-        - 0.6566
-      R@1000:
-        - 0.8608
-        - 0.8639
-  - name: bm25-default+rocchio
-    display: +Rocchio
-    params: -bm25 -rocchio -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
-    results:
-      MAP@100:
-        - 0.1663
-        - 0.1690
-      MRR@100:
-        - 0.1681
-        - 0.1710
-      R@100:
-        - 0.6535
-        - 0.6618
-      R@1000:
-        - 0.8657
-        - 0.8642
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-default+rm3
+#    display: +RM3
+#    params: -bm25 -rm3 -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      MAP@100:
+#        - 0.1644
+#        - 0.1681
+#      MRR@100:
+#        - 0.1660
+#        - 0.1702
+#      R@100:
+#        - 0.6556
+#        - 0.6566
+#      R@1000:
+#        - 0.8608
+#        - 0.8639
+#  - name: bm25-default+rocchio
+#    display: +Rocchio
+#    params: -bm25 -rocchio -collection MsMarcoV2DocCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+#    results:
+#      MAP@100:
+#        - 0.1663
+#        - 0.1690
+#      MRR@100:
+#        - 0.1681
+#        - 0.1710
+#      R@100:
+#        - 0.6535
+#        - 0.6618
+#      R@1000:
+#        - 0.8657
+#        - 0.8642

--- a/src/main/resources/regression/msmarco-v2-doc.yaml
+++ b/src/main/resources/regression/msmarco-v2-doc.yaml
@@ -72,35 +72,38 @@ models:
       R@1000:
         - 0.8054
         - 0.8029
-  - name: bm25-default+rm3
-    display: +RM3
-    params: -bm25 -rm3 -collection MsMarcoV2DocCollection
-    results:
-      MAP@100:
-        - 0.0965
-        - 0.1016
-      MRR@100:
-        - 0.0974
-        - 0.1033
-      R@100:
-        - 0.5108
-        - 0.5253
-      R@1000:
-        - 0.7699
-        - 0.7736
-  - name: bm25-default+rocchio
-    display: +Rocchio
-    params: -bm25 -rocchio -collection MsMarcoV2DocCollection
-    results:
-      MAP@100:
-        - 0.0965
-        - 0.1037
-      MRR@100:
-        - 0.0974
-        - 0.1052
-      R@100:
-        - 0.5135
-        - 0.5261
-      R@1000:
-        - 0.7697
-        - 0.7762
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-default+rm3
+#    display: +RM3
+#    params: -bm25 -rm3 -collection MsMarcoV2DocCollection
+#    results:
+#      MAP@100:
+#        - 0.0965
+#        - 0.1016
+#      MRR@100:
+#        - 0.0974
+#        - 0.1033
+#      R@100:
+#        - 0.5108
+#        - 0.5253
+#      R@1000:
+#        - 0.7699
+#        - 0.7736
+#  - name: bm25-default+rocchio
+#    display: +Rocchio
+#    params: -bm25 -rocchio -collection MsMarcoV2DocCollection
+#    results:
+#      MAP@100:
+#        - 0.0965
+#        - 0.1037
+#      MRR@100:
+#        - 0.0974
+#        - 0.1052
+#      R@100:
+#        - 0.5135
+#        - 0.5261
+#      R@1000:
+#        - 0.7697
+#        - 0.7762

--- a/src/main/resources/regression/msmarco-v2-passage-augmented-d2q-t5.yaml
+++ b/src/main/resources/regression/msmarco-v2-passage-augmented-d2q-t5.yaml
@@ -72,35 +72,38 @@ models:
       R@1000:
         - 0.7647
         - 0.7659
-  - name: bm25-default+rm3
-    display: +RM3
-    params: -bm25 -rm3 -collection MsMarcoV2PassageCollection
-    results:
-      MAP@100:
-        - 0.0873
-        - 0.0896
-      MRR@100:
-        - 0.0883
-        - 0.0904
-      R@100:
-        - 0.4774
-        - 0.4905
-      R@1000:
-        - 0.7607
-        - 0.7649
-  - name: bm25-default+rocchio
-    display: +Rocchio
-    params: -bm25 -rocchio -collection MsMarcoV2PassageCollection
-    results:
-      MAP@100:
-        - 0.0882
-        - 0.0900
-      MRR@100:
-        - 0.0893
-        - 0.0908
-      R@100:
-        - 0.4756
-        - 0.4880
-      R@1000:
-        - 0.7648
-        - 0.7666
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-default+rm3
+#    display: +RM3
+#    params: -bm25 -rm3 -collection MsMarcoV2PassageCollection
+#    results:
+#      MAP@100:
+#        - 0.0873
+#        - 0.0896
+#      MRR@100:
+#        - 0.0883
+#        - 0.0904
+#      R@100:
+#        - 0.4774
+#        - 0.4905
+#      R@1000:
+#        - 0.7607
+#        - 0.7649
+#  - name: bm25-default+rocchio
+#    display: +Rocchio
+#    params: -bm25 -rocchio -collection MsMarcoV2PassageCollection
+#    results:
+#      MAP@100:
+#        - 0.0882
+#        - 0.0900
+#      MRR@100:
+#        - 0.0893
+#        - 0.0908
+#      R@100:
+#        - 0.4756
+#        - 0.4880
+#      R@1000:
+#        - 0.7648
+#        - 0.7666

--- a/src/main/resources/regression/msmarco-v2-passage-augmented.yaml
+++ b/src/main/resources/regression/msmarco-v2-passage-augmented.yaml
@@ -72,35 +72,38 @@ models:
       R@1000:
         - 0.6925
         - 0.6933
-  - name: bm25-default+rm3
-    display: +RM3
-    params: -bm25 -rm3 -collection MsMarcoV2PassageCollection
-    results:
-      MAP@100:
-        - 0.0662
-        - 0.0692
-      MRR@100:
-        - 0.0667
-        - 0.0700
-      R@100:
-        - 0.3735
-        - 0.3831
-      R@1000:
-        - 0.6857
-        - 0.6826
-  - name: bm25-default+rocchio
-    display: +Rocchio
-    params: -bm25 -rocchio -collection MsMarcoV2PassageCollection
-    results:
-      MAP@100:
-        - 0.0665
-        - 0.0676
-      MRR@100:
-        - 0.0671
-        - 0.0684
-      R@100:
-        - 0.3752
-        - 0.3876
-      R@1000:
-        - 0.6912
-        - 0.6867
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-default+rm3
+#    display: +RM3
+#    params: -bm25 -rm3 -collection MsMarcoV2PassageCollection
+#    results:
+#      MAP@100:
+#        - 0.0662
+#        - 0.0692
+#      MRR@100:
+#        - 0.0667
+#        - 0.0700
+#      R@100:
+#        - 0.3735
+#        - 0.3831
+#      R@1000:
+#        - 0.6857
+#        - 0.6826
+#  - name: bm25-default+rocchio
+#    display: +Rocchio
+#    params: -bm25 -rocchio -collection MsMarcoV2PassageCollection
+#    results:
+#      MAP@100:
+#        - 0.0665
+#        - 0.0676
+#      MRR@100:
+#        - 0.0671
+#        - 0.0684
+#      R@100:
+#        - 0.3752
+#        - 0.3876
+#      R@1000:
+#        - 0.6912
+#        - 0.6867

--- a/src/main/resources/regression/msmarco-v2-passage-d2q-t5.yaml
+++ b/src/main/resources/regression/msmarco-v2-passage-d2q-t5.yaml
@@ -72,35 +72,38 @@ models:
       R@1000:
         - 0.7083
         - 0.7151
-  - name: bm25-default+rm3
-    display: +RM3
-    params: -bm25 -rm3 -collection MsMarcoV2PassageCollection
-    results:
-      MAP@100:
-        - 0.0938
-        - 0.0976
-      MRR@100:
-        - 0.0947
-        - 0.0984
-      R@100:
-        - 0.4713
-        - 0.4803
-      R@1000:
-        - 0.7181
-        - 0.7222
-  - name: bm25-default+rocchio
-    display: +Rocchio
-    params: -bm25 -rocchio -collection MsMarcoV2PassageCollection
-    results:
-      MAP@100:
-        - 0.0943
-        - 0.0990
-      MRR@100:
-        - 0.0952
-        - 0.0997
-      R@100:
-        - 0.4723
-        - 0.4815
-      R@1000:
-        - 0.7211
-        - 0.7274
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-default+rm3
+#    display: +RM3
+#    params: -bm25 -rm3 -collection MsMarcoV2PassageCollection
+#    results:
+#      MAP@100:
+#        - 0.0938
+#        - 0.0976
+#      MRR@100:
+#        - 0.0947
+#        - 0.0984
+#      R@100:
+#        - 0.4713
+#        - 0.4803
+#      R@1000:
+#        - 0.7181
+#        - 0.7222
+#  - name: bm25-default+rocchio
+#    display: +Rocchio
+#    params: -bm25 -rocchio -collection MsMarcoV2PassageCollection
+#    results:
+#      MAP@100:
+#        - 0.0943
+#        - 0.0990
+#      MRR@100:
+#        - 0.0952
+#        - 0.0997
+#      R@100:
+#        - 0.4723
+#        - 0.4815
+#      R@1000:
+#        - 0.7211
+#        - 0.7274

--- a/src/main/resources/regression/msmarco-v2-passage-unicoil-0shot.yaml
+++ b/src/main/resources/regression/msmarco-v2-passage-unicoil-0shot.yaml
@@ -76,35 +76,38 @@ models:
       R@1000:
         - 0.7616
         - 0.7671
-  - name: unicoil-0shot+rm3
-    display: +RM3
-    params: -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection
-    results:
-      MAP@100:
-        - 0.1319
-        - 0.1343
-      MRR@100:
-        - 0.1330
-        - 0.1352
-      R@100:
-        - 0.5521
-        - 0.5552
-      R@1000:
-        - 0.7736
-        - 0.7700
-  - name: unicoil-0shot+rocchio
-    display: +Rocchio
-    params: -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection
-    results:
-      MAP@100:
-        - 0.1319
-        - 0.1371
-      MRR@100:
-        - 0.1334
-        - 0.1380
-      R@100:
-        - 0.5557
-        - 0.5696
-      R@1000:
-        - 0.7800
-        - 0.7849
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: unicoil-0shot+rm3
+#    display: +RM3
+#    params: -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection
+#    results:
+#      MAP@100:
+#        - 0.1319
+#        - 0.1343
+#      MRR@100:
+#        - 0.1330
+#        - 0.1352
+#      R@100:
+#        - 0.5521
+#        - 0.5552
+#      R@1000:
+#        - 0.7736
+#        - 0.7700
+#  - name: unicoil-0shot+rocchio
+#    display: +Rocchio
+#    params: -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection
+#    results:
+#      MAP@100:
+#        - 0.1319
+#        - 0.1371
+#      MRR@100:
+#        - 0.1334
+#        - 0.1380
+#      R@100:
+#        - 0.5557
+#        - 0.5696
+#      R@1000:
+#        - 0.7800
+#        - 0.7849

--- a/src/main/resources/regression/msmarco-v2-passage-unicoil-noexp-0shot.yaml
+++ b/src/main/resources/regression/msmarco-v2-passage-unicoil-noexp-0shot.yaml
@@ -76,35 +76,38 @@ models:
       R@1000:
         - 0.7010
         - 0.7114
-  - name: unicoil-noexp-0shot+rm3
-    display: +RM3
-    params: -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection
-    results:
-      MAP@100:
-        - 0.1115
-        - 0.1190
-      MRR@100:
-        - 0.1124
-        - 0.1197
-      R@100:
-        - 0.5006
-        - 0.5129
-      R@1000:
-        - 0.7258
-        - 0.7346
-  - name: unicoil-noexp-0shot+rocchio
-    display: +Rocchio
-    params: -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection
-    results:
-      MAP@100:
-        - 0.1163
-        - 0.1179
-      MRR@100:
-        - 0.1172
-        - 0.1186
-      R@100:
-        - 0.5082
-        - 0.5218
-      R@1000:
-        - 0.7299
-        - 0.7387
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: unicoil-noexp-0shot+rm3
+#    display: +RM3
+#    params: -parallelism 16 -impact -pretokenized -rm3 -collection JsonVectorCollection
+#    results:
+#      MAP@100:
+#        - 0.1115
+#        - 0.1190
+#      MRR@100:
+#        - 0.1124
+#        - 0.1197
+#      R@100:
+#        - 0.5006
+#        - 0.5129
+#      R@1000:
+#        - 0.7258
+#        - 0.7346
+#  - name: unicoil-noexp-0shot+rocchio
+#    display: +Rocchio
+#    params: -parallelism 16 -impact -pretokenized -rocchio -collection JsonVectorCollection
+#    results:
+#      MAP@100:
+#        - 0.1163
+#        - 0.1179
+#      MRR@100:
+#        - 0.1172
+#        - 0.1186
+#      R@100:
+#        - 0.5082
+#        - 0.5218
+#      R@1000:
+#        - 0.7299
+#        - 0.7387

--- a/src/main/resources/regression/msmarco-v2-passage.yaml
+++ b/src/main/resources/regression/msmarco-v2-passage.yaml
@@ -72,35 +72,38 @@ models:
       R@1000:
         - 0.5733
         - 0.5839
-  - name: bm25-default+rm3
-    display: +RM3
-    params: -bm25 -rm3 -collection MsMarcoV2PassageCollection
-    results:
-      MAP@100:
-        - 0.0621
-        - 0.0651
-      MRR@100:
-        - 0.0630
-        - 0.0659
-      R@100:
-        - 0.3370
-        - 0.3435
-      R@1000:
-        - 0.5947
-        - 0.6062
-  - name: bm25-default+rocchio
-    display: +Rocchio
-    params: -bm25 -rocchio -collection MsMarcoV2PassageCollection
-    results:
-      MAP@100:
-        - 0.0622
-        - 0.0663
-      MRR@100:
-        - 0.0631
-        - 0.0671
-      R@100:
-        - 0.3413
-        - 0.3516
-      R@1000:
-        - 0.5968
-        - 0.6104
+# PRF regressions are no longer maintained for sparse judgments to reduce running times.
+# (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
+#
+#  - name: bm25-default+rm3
+#    display: +RM3
+#    params: -bm25 -rm3 -collection MsMarcoV2PassageCollection
+#    results:
+#      MAP@100:
+#        - 0.0621
+#        - 0.0651
+#      MRR@100:
+#        - 0.0630
+#        - 0.0659
+#      R@100:
+#        - 0.3370
+#        - 0.3435
+#      R@1000:
+#        - 0.5947
+#        - 0.6062
+#  - name: bm25-default+rocchio
+#    display: +Rocchio
+#    params: -bm25 -rocchio -collection MsMarcoV2PassageCollection
+#    results:
+#      MAP@100:
+#        - 0.0622
+#        - 0.0663
+#      MRR@100:
+#        - 0.0631
+#        - 0.0671
+#      R@100:
+#        - 0.3413
+#        - 0.3516
+#      R@1000:
+#        - 0.5968
+#        - 0.6104


### PR DESCRIPTION
This is an effort to reduce the running times of our regressions.
Commenting out instead of removing so that we can re-create if needed for experiments.