### PR TITLE
Add initial ONNX regressions

### DIFF
--- a/src/main/resources/regression/dl19-passage-splade-pp-ed-onnx.yaml
+++ b/src/main/resources/regression/dl19-passage-splade-pp-ed-onnx.yaml
@@ -1,0 +1,93 @@
+---
+corpus: msmarco-passage-splade-pp-ed
+corpus_path: collections/msmarco/msmarco-passage-splade-pp-ed
+
+download_url: https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-ed.tar
+download_checksum: e489133bdc54ee1e7c62a32aa582bc77
+
+index_path: indexes/lucene-index.msmarco-passage-splade-pp-ed/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 16
+index_options: -impact -pretokenized -storeDocvectors
+index_stats:
+  documents: 8841823
+  documents (non-empty): 8841823
+  total terms: 52376261130
+
+metrics:
+  - metric: AP@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m map -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@10
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m ndcg_cut.10 -c
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m recall.100 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m recall.1000 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topic_root: src/main/resources/topics-and-qrels/
+qrels_root: src/main/resources/topics-and-qrels/
+topics:
+  - name: "[DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)"
+    id: dl19
+    path: topics.dl19-passage.txt
+    qrel: qrels.dl19-passage.txt
+
+models:
+  - name: splade-pp-ed
+    display: SPLADE++ CoCondenser-EnsembleDistil
+    params: -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil
+    results:
+      AP@1000:
+        - 0.5050
+      nDCG@10:
+        - 0.7308
+      R@100:
+        - 0.6390
+      R@1000:
+        - 0.8728
+  - name: rm3
+    display: +RM3
+    params: -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil -rm3
+    results:
+      AP@1000:
+        - 0.4995
+      nDCG@10:
+        - 0.6849
+      R@100:
+        - 0.6427
+      R@1000:
+        - 0.8684
+  - name: rocchio
+    display: +Rocchio
+    params: -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil -rocchio
+    results:
+      AP@1000:
+        - 0.5140
+      nDCG@10:
+        - 0.7119
+      R@100:
+        - 0.6394
+      R@1000:
+        - 0.8799

--- a/src/main/resources/regression/dl19-passage-splade-pp-sd-onnx.yaml
+++ b/src/main/resources/regression/dl19-passage-splade-pp-sd-onnx.yaml
@@ -1,0 +1,93 @@
+---
+corpus: msmarco-passage-splade-pp-sd
+corpus_path: collections/msmarco/msmarco-passage-splade-pp-sd
+
+download_url: https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-sd.tar
+download_checksum: cb7e264222f2bf2221dd2c9d28190be1
+
+index_path: indexes/lucene-index.msmarco-passage-splade-pp-sd/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 16
+index_options: -impact -pretokenized -storeDocvectors
+index_stats:
+  documents: 8841823
+  documents (non-empty): 8841823
+  total terms: 55456660129
+
+metrics:
+  - metric: AP@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m map -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@10
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m ndcg_cut.10 -c
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m recall.100 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m recall.1000 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topic_root: src/main/resources/topics-and-qrels/
+qrels_root: src/main/resources/topics-and-qrels/
+topics:
+  - name: "[DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)"
+    id: dl19
+    path: topics.dl19-passage.txt
+    qrel: qrels.dl19-passage.txt
+
+models:
+  - name: splade-pp-sd
+    display: SPLADE++ CoCondenser-SelfDistil
+    params: -impact -pretokenized -encoder SpladePlusPlusSelfDistil
+    results:
+      AP@1000:
+        - 0.4998
+      nDCG@10:
+        - 0.7358
+      R@100:
+        - 0.6370
+      R@1000:
+        - 0.8761
+  - name: rm3
+    display: +RM3
+    params: -impact -pretokenized -rm3 -encoder SpladePlusPlusSelfDistil
+    results:
+      AP@1000:
+        - 0.4914
+      nDCG@10:
+        - 0.6989
+      R@100:
+        - 0.6456
+      R@1000:
+        - 0.8793
+  - name: rocchio
+    display: +Rocchio
+    params: -impact -pretokenized -rocchio -encoder SpladePlusPlusSelfDistil
+    results:
+      AP@1000:
+        - 0.5072
+      nDCG@10:
+        - 0.7156
+      R@100:
+        - 0.6570
+      R@1000:
+        - 0.8918

--- a/src/main/resources/regression/dl20-passage-splade-pp-ed-onnx.yaml
+++ b/src/main/resources/regression/dl20-passage-splade-pp-ed-onnx.yaml
@@ -1,0 +1,93 @@
+---
+corpus: msmarco-passage-splade-pp-ed
+corpus_path: collections/msmarco/msmarco-passage-splade-pp-ed
+
+download_url: https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-ed.tar
+download_checksum: e489133bdc54ee1e7c62a32aa582bc77
+
+index_path: indexes/lucene-index.msmarco-passage-splade-pp-ed/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 16
+index_options: -impact -pretokenized -storeDocvectors
+index_stats:
+  documents: 8841823
+  documents (non-empty): 8841823
+  total terms: 52376261130
+
+metrics:
+  - metric: AP@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m map -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@10
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m ndcg_cut.10 -c
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m recall.100 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m recall.1000 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topic_root: src/main/resources/topics-and-qrels/
+qrels_root: src/main/resources/topics-and-qrels/
+topics:
+  - name: "[DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)"
+    id: dl20
+    path: topics.dl20.txt
+    qrel: qrels.dl20-passage.txt
+
+models:
+  - name: splade-pp-ed
+    display: SPLADE++ CoCondenser-EnsembleDistil
+    params: -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil
+    results:
+      AP@1000:
+        - 0.4999
+      nDCG@10:
+        - 0.7197
+      R@100:
+        - 0.7653
+      R@1000:
+        - 0.8998
+  - name: rm3
+    display: +RM3
+    params: -impact -pretokenized -rm3 -encoder SpladePlusPlusEnsembleDistil
+    results:
+      AP@1000:
+        - 0.5098
+      nDCG@10:
+        - 0.7145
+      R@100:
+        - 0.7555
+      R@1000:
+        - 0.9046
+  - name: rocchio
+    display: +Rocchio
+    params: -impact -pretokenized -rocchio -encoder SpladePlusPlusEnsembleDistil
+    results:
+      AP@1000:
+        - 0.5084
+      nDCG@10:
+        - 0.7280
+      R@100:
+        - 0.7704
+      R@1000:
+        - 0.9069

--- a/src/main/resources/regression/dl20-passage-splade-pp-sd-onnx.yaml
+++ b/src/main/resources/regression/dl20-passage-splade-pp-sd-onnx.yaml
@@ -1,0 +1,93 @@
+---
+corpus: msmarco-passage-splade-pp-sd
+corpus_path: collections/msmarco/msmarco-passage-splade-pp-sd
+
+download_url: https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-sd.tar
+download_checksum: cb7e264222f2bf2221dd2c9d28190be1
+
+index_path: indexes/lucene-index.msmarco-passage-splade-pp-sd/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 16
+index_options: -impact -pretokenized -storeDocvectors
+index_stats:
+  documents: 8841823
+  documents (non-empty): 8841823
+  total terms: 55456660129
+
+metrics:
+  - metric: AP@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m map -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@10
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m ndcg_cut.10 -c
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m recall.100 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m recall.1000 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topic_root: src/main/resources/topics-and-qrels/
+qrels_root: src/main/resources/topics-and-qrels/
+topics:
+  - name: "[DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)"
+    id: dl20
+    path: topics.dl20.txt
+    qrel: qrels.dl20-passage.txt
+
+models:
+  - name: splade-pp-sd
+    display: SPLADE++ CoCondenser-SelfDistil
+    params: -impact -pretokenized -encoder SpladePlusPlusSelfDistil
+    results:
+      AP@1000:
+        - 0.5139
+      nDCG@10:
+        - 0.7282
+      R@100:
+        - 0.7512
+      R@1000:
+        - 0.9024
+  - name: rm3
+    display: +RM3
+    params: -impact -pretokenized -rm3 -encoder SpladePlusPlusSelfDistil
+    results:
+      AP@1000:
+        - 0.5266
+      nDCG@10:
+        - 0.7227
+      R@100:
+        - 0.7648
+      R@1000:
+        - 0.9174
+  - name: rocchio
+    display: +Rocchio
+    params: -impact -pretokenized -rocchio -encoder SpladePlusPlusSelfDistil
+    results:
+      AP@1000:
+        - 0.5335
+      nDCG@10:
+        - 0.7388
+      R@100:
+        - 0.7656
+      R@1000:
+        - 0.9120

--- a/src/main/resources/regression/msmarco-passage-splade-pp-ed-onnx.yaml
+++ b/src/main/resources/regression/msmarco-passage-splade-pp-ed-onnx.yaml
@@ -1,0 +1,69 @@
+---
+corpus: msmarco-passage-splade-pp-ed
+corpus_path: collections/msmarco/msmarco-passage-splade-pp-ed
+
+download_url: https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-ed.tar
+download_checksum: e489133bdc54ee1e7c62a32aa582bc77
+
+index_path: indexes/lucene-index.msmarco-passage-splade-pp-ed/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 16
+index_options: -impact -pretokenized -storeDocvectors
+index_stats:
+  documents: 8841823
+  documents (non-empty): 8841823
+  total terms: 52376261130
+
+metrics:
+  - metric: AP@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -c -m map
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: RR@10
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -c -M 10 -m recip_rank
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topic_root: src/main/resources/topics-and-qrels/
+qrels_root: src/main/resources/topics-and-qrels/
+topics:
+  - name: "[MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)"
+    id: dev
+    path: topics.msmarco-passage.dev-subset.txt
+    qrel: qrels.msmarco-passage.dev-subset.txt
+
+models:
+  - name: splade-pp-ed
+    display: SPLADE++ CoCondenser-EnsembleDistil
+    params: -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil
+    results:
+      AP@1000:
+        - 0.3883
+      RR@10:
+        - 0.3828
+      R@100:
+        - 0.9092
+      R@1000:
+        - 0.9831

--- a/src/main/resources/regression/msmarco-passage-splade-pp-sd-onnx.yaml
+++ b/src/main/resources/regression/msmarco-passage-splade-pp-sd-onnx.yaml
@@ -1,0 +1,69 @@
+---
+corpus: msmarco-passage-splade-pp-sd
+corpus_path: collections/msmarco/msmarco-passage-splade-pp-sd
+
+download_url: https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-sd.tar
+download_checksum: cb7e264222f2bf2221dd2c9d28190be1
+
+index_path: indexes/lucene-index.msmarco-passage-splade-pp-sd/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 16
+index_options: -impact -pretokenized -storeDocvectors
+index_stats:
+  documents: 8841823
+  documents (non-empty): 8841823
+  total terms: 55456660129
+
+metrics:
+  - metric: AP@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -c -m map
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: RR@10
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -c -M 10 -m recip_rank
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topic_root: src/main/resources/topics-and-qrels/
+qrels_root: src/main/resources/topics-and-qrels/
+topics:
+  - name: "[MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)"
+    id: dev
+    path: topics.msmarco-passage.dev-subset.splade-pp-sd.tsv.gz
+    qrel: qrels.msmarco-passage.dev-subset.txt
+
+models:
+  - name: splade-pp-sd
+    display: SPLADE++ CoCondenser-SelfDistil
+    params: -impact -pretokenized
+    results:
+      AP@1000:
+        - 0.3837
+      RR@10:
+        - 0.3778
+      R@100:
+        - 0.9118
+      R@1000:
+        - 0.9846


### PR DESCRIPTION
Building on @ArthurChen189 's recent PR.

Some initial ONNX regressions so we can start playing around with it...

These work:

```bash
nohup python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-pp-ed-onnx >& logs/log.msmarco-passage-splade-pp-ed-onnx &
nohup python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-pp-sd-onnx >& logs/log.msmarco-passage-splade-pp-sd-onnx &
```

As well as:

```bash
nohup python src/main/python/run_regression.py --search-pool 1 --verify --search --regression dl19-passage-splade-pp-ed-onnx >& logs/log.dl19-passage-splade-pp-ed-onnx &
nohup python src/main/python/run_regression.py --search-pool 1 --verify --search --regression dl20-passage-splade-pp-ed-onnx >& logs/log.dl20-passage-splade-pp-ed-onnx &

nohup python src/main/python/run_regression.py --search-pool 1 --verify --search --regression dl19-passage-splade-pp-sd-onnx >& logs/log.dl19-passage-splade-pp-sd-onnx &
nohup python src/main/python/run_regression.py --search-pool 1 --verify --search --regression dl20-passage-splade-pp-sd-onnx >& logs/log.dl20-passage-splade-pp-sd-onnx &
```

I'm encountering some concurrency issues, so without `--search-pool 1`, the regressions fail. Will need to debug more.

cc @cadurosar