### PR TITLE
minor fixup

### DIFF
--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -907,9 +907,9 @@ public final class SearchCollection implements Closeable {
           try {
             InputStream inputStream = null;
             if (isMSMARCOv1_passage) {
-              inputStream = TopicReader.class.getClassLoader().getResourceAsStream(Topics.MSMARCO_PASSAGE_DEV_SUBSET.path);
+              inputStream = Files.newInputStream(TopicReader.getTopicPath(Path.of(Topics.MSMARCO_PASSAGE_DEV_SUBSET.path)), StandardOpenOption.READ);
             } else {
-              inputStream = TopicReader.class.getClassLoader().getResourceAsStream(Topics.MSMARCO_DOC_DEV.path);
+              inputStream = Files.newInputStream(TopicReader.getTopicPath(Path.of(Topics.MSMARCO_DOC_DEV.path)), StandardOpenOption.READ);
             }
 
             BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));

--- a/src/main/java/io/anserini/search/topicreader/TopicReader.java
+++ b/src/main/java/io/anserini/search/topicreader/TopicReader.java
@@ -253,7 +253,7 @@ public abstract class TopicReader<K> {
    * @return
    * @throws IOException
    */
-  private static Path getTopicPath(Path topicPath) throws IOException{
+  public static Path getTopicPath(Path topicPath) throws IOException{
     if (!TOPIC_FILE_TO_TYPE.containsKey(topicPath.getFileName().toString())) {
       // If the topic file is not in the list of known topics, we assume it is a local file.
       Path tempPath = Paths.get(getCacheDir(), topicPath.getFileName().toString());


### PR DESCRIPTION


Command: `python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc`

Error:
```
2023-04-10 20:08:13,771 ERROR [pool-2-thread-1] search.SearchCollection$SearcherThread (SearchCollection.java:937) - pool-2-thread-1: Unexpected Exception: 
java.lang.NullPointerException: null
	at java.io.Reader.<init>(Reader.java:167) ~[?:?]
	at java.io.InputStreamReader.<init>(InputStreamReader.java:72) ~[?:?]
	at io.anserini.search.SearchCollection$SearcherThread.run(SearchCollection.java:915) [anserini-0.21.1-SNAPSHOT.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
2023-04-10 20:08:14,743 INFO  [main] search.SearchCollection (SearchCollection.java:1439) - Total run time: 00:04:14
2023-04-10 20:08:15,364 INFO  [pool-3-thread-5] search.SearchCollection$SearcherThread (SearchCollection.java:865) - ranker: bm25(k1=4.46,b=0.82), reranker: default: 5100 queries processed
2023-04-10 20:08:16,660 INFO  [pool-3-thread-5] search.SearchCollection$SearcherThread (SearchCollection.java:865) - ranker: bm25(k1=0.9,b=0.4), reranker: default: 4100 queries processed
2023-04-10 20:08:19,300 INFO  [pool-2-thread-1] search.SearchCollection$SearcherThread (SearchCollection.java:883) - ranker: bm25(k1=4.46,b=0.82), reranker: default: 5193 queries processed in 00:04:18 = ~20.06 q/s
2023-04-10 20:08:19,305 ERROR [pool-2-thread-1] search.SearchCollection$SearcherThread (SearchCollection.java:937) - pool-2-thread-1: Unexpected Exception: 
java.lang.NullPointerException: null
	at java.io.Reader.<init>(Reader.java:167) ~[?:?]
	at java.io.InputStreamReader.<init>(InputStreamReader.java:72) ~[?:?]
	at io.anserini.search.SearchCollection$SearcherThread.run(SearchCollection.java:915) [anserini-0.21.1-SNAPSHOT.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
2023-04-10 20:08:20,842 INFO  [main] search.SearchCollection (SearchCollection.java:1439) - Total run time: 00:04:20
2023-04-10 20:08:21,987 INFO  [pool-3-thread-4] search.SearchCollection$SearcherThread (SearchCollection.java:865) - ranker: bm25(k1=0.9,b=0.4), reranker: default: 4200 queries processed
2023-04-10 20:08:27,159 INFO  [pool-3-thread-8] search.SearchCollection$SearcherThread (SearchCollection.java:865) - ranker: bm25(k1=0.9,b=0.4), reranker: default: 4300 queries processed
2023-04-10 20:08:32,258 INFO  [pool-3-thread-3] search.SearchCollection$SearcherThread (SearchCollection.java:865) - ranker: bm25(k1=0.9,b=0.4), reranker: default: 4400 queries processed
2023-04-10 20:08:36,298 INFO  [pool-3-thread-1] search.SearchCollection$SearcherThread (SearchCollection.java:865) - ranker: bm25(k1=0.9,b=0.4), reranker: default: 4500 queries processed
2023-04-10 20:08:40,804 INFO  [pool-3-thread-1] search.SearchCollection$SearcherThread (SearchCollection.java:865) - ranker: bm25(k1=0.9,b=0.4), reranker: default: 4600 queries processed
2023-04-10 20:08:45,186 INFO  [pool-3-thread-3] search.SearchCollection$SearcherThread (SearchCollection.java:865) - ranker: bm25(k1=0.9,b=0.4), reranker: default: 4700 queries processed
2023-04-10 20:08:49,437 INFO  [pool-3-thread-6] search.SearchCollection$SearcherThread (SearchCollection.java:865) - ranker: bm25(k1=0.9,b=0.4), reranker: default: 4800 queries processed
2023-04-10 20:08:55,103 INFO  [pool-3-thread-3] search.SearchCollection$SearcherThread (SearchCollection.java:865) - ranker: bm25(k1=0.9,b=0.4), reranker: default: 4900 queries processed
2023-04-10 20:09:00,681 INFO  [pool-3-thread-5] search.SearchCollection$SearcherThread (SearchCollection.java:865) - ranker: bm25(k1=0.9,b=0.4), reranker: default: 5000 queries processed
2023-04-10 20:09:05,164 INFO  [pool-3-thread-7] search.SearchCollection$SearcherThread (SearchCollection.java:865) - ranker: bm25(k1=0.9,b=0.4), reranker: default: 5100 queries processed
2023-04-10 20:09:09,641 INFO  [pool-2-thread-1] search.SearchCollection$SearcherThread (SearchCollection.java:883) - ranker: bm25(k1=0.9,b=0.4), reranker: default: 5193 queries processed in 00:05:09 = ~16.80 q/s
2023-04-10 20:09:09,646 ERROR [pool-2-thread-1] search.SearchCollection$SearcherThread (SearchCollection.java:937) - pool-2-thread-1: Unexpected Exception: 
java.lang.NullPointerException: null
	at java.io.Reader.<init>(Reader.java:167) ~[?:?]
	at java.io.InputStreamReader.<init>(InputStreamReader.java:72) ~[?:?]
	at io.anserini.search.SearchCollection$SearcherThread.run(SearchCollection.java:915) [anserini-0.21.1-SNAPSHOT.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
2023-04-10 20:09:10,608 INFO  [main] search.SearchCollection (SearchCollection.java:1439) - Total run time: 00:05:10
```