### PR TITLE
Fix path for topicreader

### DIFF
--- a/src/main/java/io/anserini/search/topicreader/TopicReader.java
+++ b/src/main/java/io/anserini/search/topicreader/TopicReader.java
@@ -254,14 +254,18 @@ public abstract class TopicReader<K> {
    * @throws IOException
    */
   public static Path getTopicPath(Path topicPath) throws IOException{
-    if (!TOPIC_FILE_TO_TYPE.containsKey(topicPath.getFileName().toString())) {
-      // If the topic file is not in the list of known topics, we assume it is a local file.
-      Path tempPath = Paths.get(getCacheDir(), topicPath.getFileName().toString());
-      if (Files.exists(tempPath)) {
-        // if it is an unregistred topic, but it is in the cache, we use it
-        return tempPath;
-      }
+    if (Files.exists(topicPath)) {
       return topicPath;
+    } else {
+      if (!TOPIC_FILE_TO_TYPE.containsKey(topicPath.getFileName().toString())) {
+        // If the topic file is not in the list of known topics, we assume it is a local file.
+        Path tempPath = Paths.get(getCacheDir(), topicPath.getFileName().toString());
+        if (Files.exists(tempPath)) {
+          // if it is an unregistred topic, but it is in the cache, we use it
+          return tempPath;
+        }
+        return topicPath;
+      }
     }
     
     Path resultPath = getNewTopicsAbsPath(topicPath);


### PR DESCRIPTION
**Issue:**
Topicreader will download all topics-and-qrels from the cloud to the local cache without looking at the local path first

**Fix:**
Topicreader will now prioritize on the local path, then search for cache or download from the cloud
