### PR TITLE
Bump Onnx to v1.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -469,7 +469,7 @@
     <dependency>
       <groupId>com.microsoft.onnxruntime</groupId>
       <artifactId>onnxruntime</artifactId>
-      <version>1.11.0</version>
+      <version>1.12.1</version>
     </dependency>
     <dependency>
       <groupId>ai.djl</groupId>


### PR DESCRIPTION
Bumping to version 1.12.1 since 1.11.0 is not compatible with M1 Macs, [as described here](https://github.com/microsoft/onnxruntime/issues/11054)