### PR TITLE
Expose in SimpleSearcher ability to parse docs on-the-fly

### DIFF
--- a/src/test/java/io/anserini/IndexerWithoutDocvectorsTestBase.java
+++ b/src/test/java/io/anserini/IndexerWithoutDocvectorsTestBase.java
@@ -1,0 +1,114 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini;
+
+import io.anserini.index.Constants;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.en.EnglishAnalyzer;
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.lucene.util.BytesRef;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Locale;
+
+public class IndexerWithoutDocvectorsTestBase extends LuceneTestCase {
+  protected Path tempDir1;
+
+  // A very simple example of how to build an index.
+  private void buildTestIndex() throws IOException {
+    Directory dir = FSDirectory.open(tempDir1);
+
+    Analyzer analyzer = new EnglishAnalyzer();
+    IndexWriterConfig config = new IndexWriterConfig(analyzer);
+    config.setOpenMode(IndexWriterConfig.OpenMode.CREATE);
+
+    IndexWriter writer = new IndexWriter(dir, config);
+
+    FieldType textOptions = new FieldType();
+    textOptions.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
+    textOptions.setStored(true);
+    textOptions.setTokenized(true);
+    //textOptions.setStoreTermVectors(true);
+    //textOptions.setStoreTermVectorPositions(true);
+
+    Document doc1 = new Document();
+    String doc1Text = "here is some text here is some more text. city.";
+    doc1.add(new StringField(Constants.ID, "doc1", Field.Store.YES));
+    doc1.add(new BinaryDocValuesField(Constants.ID, new BytesRef("doc1".getBytes())));
+    doc1.add(new Field(Constants.CONTENTS, doc1Text , textOptions));
+    // specifically demonstrate how "contents" and "raw" might diverge:
+    doc1.add(new StoredField(Constants.RAW, String.format("{\"contents\": \"%s\"}", doc1Text)));
+    writer.addDocument(doc1);
+
+    Document doc2 = new Document();
+    String doc2Text = "more texts";
+    doc2.add(new StringField(Constants.ID, "doc2", Field.Store.YES));
+    doc2.add(new BinaryDocValuesField(Constants.ID, new BytesRef("doc2".getBytes())));
+    doc2.add(new Field(Constants.CONTENTS, doc2Text, textOptions));  // Note plural, to test stemming
+    // specifically demonstrate how "contents" and "raw" might diverge:
+    doc2.add(new StoredField(Constants.RAW, String.format("{\"contents\": \"%s\"}", doc2Text)));
+    writer.addDocument(doc2);
+
+    Document doc3 = new Document();
+    String doc3Text = "here is a test";
+    doc3.add(new StringField(Constants.ID, "doc3", Field.Store.YES));
+    doc3.add(new BinaryDocValuesField(Constants.ID, new BytesRef("doc3".getBytes())));
+    doc3.add(new Field(Constants.CONTENTS, doc3Text, textOptions));
+    // specifically demonstrate how "contents" and "raw" might diverge:
+    doc3.add(new StoredField(Constants.RAW, String.format("{\"contents\": \"%s\"}", doc3Text)));
+    writer.addDocument(doc3);
+
+    writer.commit();
+    writer.forceMerge(1);
+    writer.close();
+
+    dir.close();
+  }
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    Locale.setDefault(Locale.US);
+
+    tempDir1 = createTempDir();
+    buildTestIndex();
+  }
+
+  @After
+  @Override
+  public void tearDown() throws Exception {
+    // Call garbage collector for Windows compatibility
+    System.gc();
+    super.tearDown();
+  }
+}

--- a/src/test/java/io/anserini/search/SimpleSearcherTest.java
+++ b/src/test/java/io/anserini/search/SimpleSearcherTest.java
@@ -142,13 +142,15 @@ public class SimpleSearcherTest extends IndexerTestBase {
 
   @Test
   public void testSearch1() throws Exception {
+    // This is the non-batch version of test case "testBatchSearch1"; results should be the same.
     SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
 
+    // Q1: "test"
     SimpleSearcher.Result[] hits = searcher.search("test", 10);
     assertEquals(1, hits.length);
     assertEquals("doc3", hits[0].docid);
     assertEquals(2, hits[0].lucene_docid);
-    assertEquals(0.5702000f, hits[0].score, 10e-6);
+    assertEquals(0.57020f, hits[0].score, 10e-6);
     assertEquals("here is a test", hits[0].contents);
     assertEquals("{\"contents\": \"here is a test\"}", hits[0].raw);
 
@@ -157,6 +159,34 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals("here is a test", hits[0].lucene_document.getField(Constants.CONTENTS).stringValue());
     assertEquals("{\"contents\": \"here is a test\"}",
         hits[0].lucene_document.getField(Constants.RAW).stringValue());
+
+    // Q2: "more"
+    hits = searcher.search("more", 10);
+    assertEquals(2, hits.length);
+
+    assertEquals("doc2", hits[0].docid);
+    assertEquals(1, hits[0].lucene_docid);
+    assertEquals(0.27330f, hits[0].score, 10e-6);
+    assertEquals("more texts", hits[0].contents);
+    assertEquals("{\"contents\": \"more texts\"}", hits[0].raw);
+
+    // We can fetch the exact same information from the raw Lucene document also.
+    assertEquals("doc2", hits[0].lucene_document.getField(Constants.ID).stringValue());
+    assertEquals("more texts", hits[0].lucene_document.getField(Constants.CONTENTS).stringValue());
+    assertEquals("{\"contents\": \"more texts\"}",
+        hits[0].lucene_document.getField(Constants.RAW).stringValue());
+
+    assertEquals("doc1", hits[1].docid);
+    assertEquals(0, hits[1].lucene_docid);
+    assertEquals(0.20800f, hits[1].score, 10e-6);
+    assertEquals("here is some text here is some more text. city.", hits[1].contents);
+    assertEquals("{\"contents\": \"here is some text here is some more text. city.\"}", hits[1].raw);
+
+    // We can fetch the exact same information from the raw Lucene document also.
+    assertEquals("doc1", hits[1].lucene_document.getField(Constants.ID).stringValue());
+    assertEquals("here is some text here is some more text. city.", hits[1].lucene_document.getField(Constants.CONTENTS).stringValue());
+    assertEquals("{\"contents\": \"here is some text here is some more text. city.\"}",
+        hits[1].lucene_document.getField(Constants.RAW).stringValue());
 
     searcher.close();
   }
@@ -170,7 +200,7 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(1, results.length);
     assertEquals("doc1", results[0].docid);
     assertEquals(0, results[0].lucene_docid);
-    assertEquals(0.28830000f, results[0].score, 10e-6);
+    assertEquals(0.28830f, results[0].score, 10e-6);
     assertEquals("here is some text here is some more text. city.", results[0].contents);
     assertEquals("{\"contents\": \"here is some text here is some more text. city.\"}", results[0].raw);
 
@@ -178,16 +208,25 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(2, results.length);
     assertEquals("doc1", results[0].docid);
     assertEquals(0, results[0].lucene_docid);
-    assertEquals(0.28830000f, results[0].score, 10e-6);
+    assertEquals(0.28830f, results[0].score, 10e-6);
     assertEquals("doc2", results[1].docid);
     assertEquals(1, results[1].lucene_docid);
-    assertEquals(0.27329999f, results[1].score, 10e-6);
+    assertEquals(0.27330f, results[1].score, 10e-6);
 
     results = searcher.search("test");
     assertEquals(1, results.length);
     assertEquals("doc3", results[0].docid);
     assertEquals(2, results[0].lucene_docid);
-    assertEquals(0.5702000f, results[0].score, 10e-6);
+    assertEquals(0.57020f, results[0].score, 10e-6);
+
+    results = searcher.search("more");
+    assertEquals(2, results.length);
+    assertEquals("doc2", results[0].docid);
+    assertEquals(1, results[0].lucene_docid);
+    assertEquals(0.27330f, results[0].score, 10e-6);
+    assertEquals("doc1", results[1].docid);
+    assertEquals(0, results[1].lucene_docid);
+    assertEquals(0.20800f, results[1].score, 10e-6);
 
     searcher.close();
   }
@@ -202,22 +241,31 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(1, results.length);
     assertEquals("doc2", results[0].docid);
     assertEquals(1, results[0].lucene_docid);
-    assertEquals(0.16070f, results[0].score, 10e-5);
+    assertEquals(0.16070f, results[0].score, 10e-6);
 
     results = searcher.search("text");
     assertEquals(2, results.length);
     assertEquals("doc2", results[0].docid);
     assertEquals(1, results[0].lucene_docid);
-    assertEquals(0.16070f, results[0].score, 10e-5);
+    assertEquals(0.16070f, results[0].score, 10e-6);
     assertEquals("doc1", results[1].docid);
     assertEquals(0, results[1].lucene_docid);
-    assertEquals(0.10870f, results[1].score, 10e-5);
+    assertEquals(0.10870f, results[1].score, 10e-6);
 
     results = searcher.search("test");
     assertEquals(1, results.length);
     assertEquals("doc3", results[0].docid);
     assertEquals(2, results[0].lucene_docid);
-    assertEquals(0.33530f, results[0].score, 10e-5);
+    assertEquals(0.33530f, results[0].score, 10e-6);
+
+    results = searcher.search("more");
+    assertEquals(2, results.length);
+    assertEquals("doc2", results[0].docid);
+    assertEquals(1, results[0].lucene_docid);
+    assertEquals(0.16070f, results[0].score, 10e-6);
+    assertEquals("doc1", results[1].docid);
+    assertEquals(0, results[1].lucene_docid);
+    assertEquals(0.06140f, results[1].score, 10e-6);
 
     searcher.close();
   }
@@ -249,6 +297,15 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(2, results[0].lucene_docid);
     assertEquals(0.31850f, results[0].score, 10e-5);
 
+    results = searcher.search("more");
+    assertEquals(2, results.length);
+    assertEquals("doc2", results[0].docid);
+    assertEquals(1, results[0].lucene_docid);
+    assertEquals(0.17770f, results[0].score, 10e-6);
+    assertEquals("doc1", results[1].docid);
+    assertEquals(0, results[1].lucene_docid);
+    assertEquals(0.0f, results[1].score, 10e-6);
+
     searcher.close();
   }
 
@@ -264,11 +321,26 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(1, results.length);
     assertEquals("doc1", results[0].docid);
     assertEquals(0, results[0].lucene_docid);
-    assertEquals(0.14417f, results[0].score, 10e-5);
+    assertEquals(0.14420f, results[0].score, 10e-6);
 
     Map<String, Float> feedbackTerms = searcher.get_feedback_terms("text");
     assertEquals(1, feedbackTerms.size());
-    assertEquals(0.5f, feedbackTerms.get("text"), 10e-5);
+    assertEquals(0.5f, feedbackTerms.get("text"), 10e-6);
+
+    results = searcher.search("test");
+    assertEquals(1, results.length);
+    assertEquals("doc3", results[0].docid);
+    assertEquals(2, results[0].lucene_docid);
+    assertEquals(0.28510f, results[0].score, 10e-6);
+
+    results = searcher.search("more");
+    assertEquals(2, results.length);
+    assertEquals("doc2", results[0].docid);
+    assertEquals(1, results[0].lucene_docid);
+    assertEquals(0.13660f, results[0].score, 10e-6);
+    assertEquals("doc1", results[1].docid);
+    assertEquals(0, results[1].lucene_docid);
+    assertEquals(0.10400f, results[1].score, 10e-6);
 
     searcher.unset_rm3();
     assertFalse(searcher.use_rm3());
@@ -287,21 +359,49 @@ public class SimpleSearcherTest extends IndexerTestBase {
 
   @Test
   public void testSearch6() throws Exception {
+    // This adds Rocchio on top of "testSearch1"
     SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
     searcher.set_rocchio();
     assertTrue(searcher.use_rocchio());
 
     Result[] results;
+    Map<String, Float> feedbackTerms;
 
     results = searcher.search("text", 1);
     assertEquals(1, results.length);
     assertEquals("doc1", results[0].docid);
     assertEquals(0, results[0].lucene_docid);
-    assertEquals(0.28830f, results[0].score, 10e-5);
+    assertEquals(0.28830f, results[0].score, 10e-6);
 
-    Map<String, Float> feedbackTerms = searcher.get_feedback_terms("text");
+    // Note that the feedback term is just the query, the scores are the same.
+    feedbackTerms = searcher.get_feedback_terms("text");
     assertEquals(1, feedbackTerms.size());
-    assertEquals(1.0f, feedbackTerms.get("text"), 10e-5);
+    assertEquals(1.0f, feedbackTerms.get("text"), 10e-6);
+
+    results = searcher.search("test");
+    assertEquals(1, results.length);
+    assertEquals("doc3", results[0].docid);
+    assertEquals(2, results[0].lucene_docid);
+    assertEquals(0.57020f, results[0].score, 10e-6);
+
+    // Note that the feedback term is just the query, the scores are the same.
+    feedbackTerms = searcher.get_feedback_terms("test");
+    assertEquals(1, feedbackTerms.size());
+    assertEquals(1.0f, feedbackTerms.get("test"), 10e-6);
+
+    results = searcher.search("more");
+    assertEquals(2, results.length);
+    assertEquals("doc2", results[0].docid);
+    assertEquals(1, results[0].lucene_docid);
+    assertEquals(0.27330f, results[0].score, 10e-6);
+    assertEquals("doc1", results[1].docid);
+    assertEquals(0, results[1].lucene_docid);
+    assertEquals(0.20800f, results[1].score, 10e-6);
+
+    // Note that the feedback term is just the query, the scores are the same.
+    feedbackTerms = searcher.get_feedback_terms("more");
+    assertEquals(1, feedbackTerms.size());
+    assertEquals(1.0f, feedbackTerms.get("more"), 10e-6);
 
     searcher.unset_rocchio();
     assertFalse(searcher.use_rocchio());
@@ -335,6 +435,7 @@ public class SimpleSearcherTest extends IndexerTestBase {
 
   @Test
   public void testBatchSearch1() throws Exception {
+    // This is the batch version of test case "testSearch1"; results should be the same.
     SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
       
     List<String> queries = new ArrayList<>();
@@ -350,36 +451,237 @@ public class SimpleSearcherTest extends IndexerTestBase {
 
     assertEquals(1, hits.get("query_test").length);
     assertEquals("doc3", hits.get("query_test")[0].docid);
+    assertEquals(2, hits.get("query_test")[0].lucene_docid);
+    assertEquals(0.57020f, hits.get("query_test")[0].score, 10e-6);
+    assertEquals("here is a test", hits.get("query_test")[0].contents);
+    assertEquals("{\"contents\": \"here is a test\"}", hits.get("query_test")[0].raw);
 
     assertEquals(2, hits.get("query_more").length);
     assertEquals("doc2", hits.get("query_more")[0].docid);
+    assertEquals(1, hits.get("query_more")[0].lucene_docid);
+    assertEquals(0.27330f, hits.get("query_more")[0].score, 10e-6);
+    assertEquals("more texts", hits.get("query_more")[0].contents);
+    assertEquals("{\"contents\": \"more texts\"}", hits.get("query_more")[0].raw);
+
     assertEquals("doc1", hits.get("query_more")[1].docid);
+    assertEquals(0, hits.get("query_more")[1].lucene_docid);
+    assertEquals(0.20800f, hits.get("query_more")[1].score, 10e-6);
+    assertEquals("here is some text here is some more text. city.", hits.get("query_more")[1].contents);
+    assertEquals("{\"contents\": \"here is some text here is some more text. city.\"}", hits.get("query_more")[1].raw);
 
     searcher.close();
   }
 
   @Test
   public void testBatchSearch2() throws Exception {
+    // This is the batch version of test case "testSearch2"; results should be the same.
     SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
-    searcher.set_rm3();
 
     List<String> queries = new ArrayList<>();
+    queries.add("text");
     queries.add("test");
     queries.add("more");
 
     List<String> qids = new ArrayList<>();
+    qids.add("query_text");
     qids.add("query_test");
     qids.add("query_more");
 
     Map<String, SimpleSearcher.Result[]> hits = searcher.batch_search(queries, qids, 10, 2);
-    assertEquals(2, hits.size());
+    assertEquals(3, hits.size());
+
+    assertEquals(2, hits.get("query_text").length);
+    assertEquals("doc1", hits.get("query_text")[0].docid);
+    assertEquals(0, hits.get("query_text")[0].lucene_docid);
+    assertEquals(0.28830f, hits.get("query_text")[0].score, 10e-6);
+    assertEquals("doc2", hits.get("query_text")[1].docid);
+    assertEquals(1, hits.get("query_text")[1].lucene_docid);
+    assertEquals(0.27330f, hits.get("query_text")[1].score, 10e-6);
 
     assertEquals(1, hits.get("query_test").length);
     assertEquals("doc3", hits.get("query_test")[0].docid);
+    assertEquals(2, hits.get("query_test")[0].lucene_docid);
+    assertEquals(0.57020f, hits.get("query_test")[0].score, 10e-6);
 
     assertEquals(2, hits.get("query_more").length);
     assertEquals("doc2", hits.get("query_more")[0].docid);
+    assertEquals(1, hits.get("query_more")[0].lucene_docid);
+    assertEquals(0.27330f, hits.get("query_more")[0].score, 10e-6);
     assertEquals("doc1", hits.get("query_more")[1].docid);
+    assertEquals(0, hits.get("query_more")[1].lucene_docid);
+    assertEquals(0.20800f, hits.get("query_more")[1].score, 10e-6);
+
+    searcher.close();
+  }
+
+  @Test
+  public void testBatchSearch3() throws Exception {
+    // This is the batch version of test case "testSearch3"; results should be the same.
+    SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
+    searcher.set_bm25(3.5f, 0.9f);
+
+    List<String> queries = new ArrayList<>();
+    queries.add("text");
+    queries.add("test");
+    queries.add("more");
+
+    List<String> qids = new ArrayList<>();
+    qids.add("query_text");
+    qids.add("query_test");
+    qids.add("query_more");
+
+    Map<String, SimpleSearcher.Result[]> hits = searcher.batch_search(queries, qids, 10, 2);
+    assertEquals(3, hits.size());
+
+    assertEquals(2, hits.get("query_text").length);
+    assertEquals("doc2", hits.get("query_text")[0].docid);
+    assertEquals(1, hits.get("query_text")[0].lucene_docid);
+    assertEquals(0.16070f, hits.get("query_text")[0].score, 10e-6);
+    assertEquals("doc1", hits.get("query_text")[1].docid);
+    assertEquals(0, hits.get("query_text")[1].lucene_docid);
+    assertEquals(0.10870f, hits.get("query_text")[1].score, 10e-6);
+
+    assertEquals(1, hits.get("query_test").length);
+    assertEquals("doc3", hits.get("query_test")[0].docid);
+    assertEquals(2, hits.get("query_test")[0].lucene_docid);
+    assertEquals(0.33530f, hits.get("query_test")[0].score, 10e-6);
+
+    assertEquals(2, hits.get("query_more").length);
+    assertEquals("doc2", hits.get("query_more")[0].docid);
+    assertEquals(1, hits.get("query_more")[0].lucene_docid);
+    assertEquals(0.16070f, hits.get("query_more")[0].score, 10e-6);
+    assertEquals("doc1", hits.get("query_more")[1].docid);
+    assertEquals(0, hits.get("query_more")[1].lucene_docid);
+    assertEquals(0.06140f, hits.get("query_more")[1].score, 10e-6);
+
+    searcher.close();
+  }
+
+  @Test
+  public void testBatchSearch4() throws Exception {
+    // This is the batch version of test case "testSearch4"; results should be the same.
+    SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
+    searcher.set_qld(10);
+
+    List<String> queries = new ArrayList<>();
+    queries.add("text");
+    queries.add("test");
+    queries.add("more");
+
+    List<String> qids = new ArrayList<>();
+    qids.add("query_text");
+    qids.add("query_test");
+    qids.add("query_more");
+
+    Map<String, SimpleSearcher.Result[]> hits = searcher.batch_search(queries, qids, 10, 2);
+    assertEquals(3, hits.size());
+
+    assertEquals(2, hits.get("query_text").length);
+    assertEquals("doc2", hits.get("query_text")[0].docid);
+    assertEquals(1, hits.get("query_text")[0].lucene_docid);
+    assertEquals(0.09910f, hits.get("query_text")[0].score, 10e-6);
+    assertEquals("doc1", hits.get("query_text")[1].docid);
+    assertEquals(0, hits.get("query_text")[1].lucene_docid);
+    assertEquals(0.0f, hits.get("query_text")[1].score, 10e-6);
+
+    assertEquals(1, hits.get("query_test").length);
+    assertEquals("doc3", hits.get("query_test")[0].docid);
+    assertEquals(2, hits.get("query_test")[0].lucene_docid);
+    assertEquals(0.31850f, hits.get("query_test")[0].score, 10e-6);
+
+    assertEquals(2, hits.get("query_more").length);
+    assertEquals("doc2", hits.get("query_more")[0].docid);
+    assertEquals(1, hits.get("query_more")[0].lucene_docid);
+    assertEquals(0.17770f, hits.get("query_more")[0].score, 10e-6);
+    assertEquals("doc1", hits.get("query_more")[1].docid);
+    assertEquals(0, hits.get("query_more")[1].lucene_docid);
+    assertEquals(0.0f, hits.get("query_more")[1].score, 10e-6);
+
+    searcher.close();
+  }
+
+  @Test
+  public void testBatchSearch5() throws Exception {
+    // This is the batch version of test case "testSearch5"; results should be the same.
+    SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
+    searcher.set_rm3();
+
+    List<String> queries = new ArrayList<>();
+    queries.add("text");
+    queries.add("test");
+    queries.add("more");
+
+    List<String> qids = new ArrayList<>();
+    qids.add("query_text");
+    qids.add("query_test");
+    qids.add("query_more");
+
+    Map<String, SimpleSearcher.Result[]> hits = searcher.batch_search(queries, qids, 10, 2);
+    assertEquals(3, hits.size());
+
+    assertEquals(2, hits.get("query_text").length);
+    assertEquals("doc1", hits.get("query_text")[0].docid);
+    assertEquals(0, hits.get("query_text")[0].lucene_docid);
+    assertEquals(0.14420f, hits.get("query_text")[0].score, 10e-6);
+    assertEquals("doc2", hits.get("query_text")[1].docid);
+    assertEquals(1, hits.get("query_text")[1].lucene_docid);
+    assertEquals(0.13660f, hits.get("query_text")[1].score, 10e-6);
+
+    assertEquals(1, hits.get("query_test").length);
+    assertEquals("doc3", hits.get("query_test")[0].docid);
+    assertEquals(2, hits.get("query_test")[0].lucene_docid);
+    assertEquals(0.28510f, hits.get("query_test")[0].score, 10e-5);
+
+    assertEquals(2, hits.get("query_more").length);
+    assertEquals("doc2", hits.get("query_more")[0].docid);
+    assertEquals(1, hits.get("query_more")[0].lucene_docid);
+    assertEquals(0.13660f, hits.get("query_more")[0].score, 10e-5);
+    assertEquals("doc1", hits.get("query_more")[1].docid);
+    assertEquals(0, hits.get("query_more")[1].lucene_docid);
+    assertEquals(0.10400f, hits.get("query_more")[1].score, 10e-5);
+
+    searcher.close();
+  }
+
+  @Test
+  public void testBatchSearch6() throws Exception {
+    // This is the batch version of test case "testSearch6"; results should be the same.
+    SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
+    searcher.set_rocchio();
+
+    List<String> queries = new ArrayList<>();
+    queries.add("text");
+    queries.add("test");
+    queries.add("more");
+
+    List<String> qids = new ArrayList<>();
+    qids.add("query_text");
+    qids.add("query_test");
+    qids.add("query_more");
+
+    Map<String, SimpleSearcher.Result[]> hits = searcher.batch_search(queries, qids, 10, 2);
+    assertEquals(3, hits.size());
+
+    assertEquals(2, hits.get("query_text").length);
+    assertEquals("doc1", hits.get("query_text")[0].docid);
+    assertEquals(0, hits.get("query_text")[0].lucene_docid);
+    assertEquals(0.28830f, hits.get("query_text")[0].score, 10e-6);
+    assertEquals("doc2", hits.get("query_text")[1].docid);
+    assertEquals(1, hits.get("query_text")[1].lucene_docid);
+    assertEquals(0.27330f, hits.get("query_text")[1].score, 10e-6);
+
+    assertEquals(1, hits.get("query_test").length);
+    assertEquals("doc3", hits.get("query_test")[0].docid);
+    assertEquals(2, hits.get("query_test")[0].lucene_docid);
+    assertEquals(0.57020f, hits.get("query_test")[0].score, 10e-6);
+
+    assertEquals(2, hits.get("query_more").length);
+    assertEquals("doc2", hits.get("query_more")[0].docid);
+    assertEquals(1, hits.get("query_more")[0].lucene_docid);
+    assertEquals(0.27330f, hits.get("query_more")[0].score, 10e-6);
+    assertEquals("doc1", hits.get("query_more")[1].docid);
+    assertEquals(0, hits.get("query_more")[1].lucene_docid);
+    assertEquals(0.20800f, hits.get("query_more")[1].score, 10e-6);
 
     searcher.close();
   }

--- a/src/test/java/io/anserini/search/SimpleSearcherTest.java
+++ b/src/test/java/io/anserini/search/SimpleSearcherTest.java
@@ -150,7 +150,7 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(1, hits.length);
     assertEquals("doc3", hits[0].docid);
     assertEquals(2, hits[0].lucene_docid);
-    assertEquals(0.57020f, hits[0].score, 10e-6);
+    assertEquals(0.57020f, hits[0].score, 10e-5);
     assertEquals("here is a test", hits[0].contents);
     assertEquals("{\"contents\": \"here is a test\"}", hits[0].raw);
 
@@ -166,7 +166,7 @@ public class SimpleSearcherTest extends IndexerTestBase {
 
     assertEquals("doc2", hits[0].docid);
     assertEquals(1, hits[0].lucene_docid);
-    assertEquals(0.27330f, hits[0].score, 10e-6);
+    assertEquals(0.27330f, hits[0].score, 10e-5);
     assertEquals("more texts", hits[0].contents);
     assertEquals("{\"contents\": \"more texts\"}", hits[0].raw);
 
@@ -178,7 +178,7 @@ public class SimpleSearcherTest extends IndexerTestBase {
 
     assertEquals("doc1", hits[1].docid);
     assertEquals(0, hits[1].lucene_docid);
-    assertEquals(0.20800f, hits[1].score, 10e-6);
+    assertEquals(0.20800f, hits[1].score, 10e-5);
     assertEquals("here is some text here is some more text. city.", hits[1].contents);
     assertEquals("{\"contents\": \"here is some text here is some more text. city.\"}", hits[1].raw);
 
@@ -200,7 +200,7 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(1, results.length);
     assertEquals("doc1", results[0].docid);
     assertEquals(0, results[0].lucene_docid);
-    assertEquals(0.28830f, results[0].score, 10e-6);
+    assertEquals(0.28830f, results[0].score, 10e-5);
     assertEquals("here is some text here is some more text. city.", results[0].contents);
     assertEquals("{\"contents\": \"here is some text here is some more text. city.\"}", results[0].raw);
 
@@ -208,25 +208,25 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(2, results.length);
     assertEquals("doc1", results[0].docid);
     assertEquals(0, results[0].lucene_docid);
-    assertEquals(0.28830f, results[0].score, 10e-6);
+    assertEquals(0.28830f, results[0].score, 10e-5);
     assertEquals("doc2", results[1].docid);
     assertEquals(1, results[1].lucene_docid);
-    assertEquals(0.27330f, results[1].score, 10e-6);
+    assertEquals(0.27330f, results[1].score, 10e-5);
 
     results = searcher.search("test");
     assertEquals(1, results.length);
     assertEquals("doc3", results[0].docid);
     assertEquals(2, results[0].lucene_docid);
-    assertEquals(0.57020f, results[0].score, 10e-6);
+    assertEquals(0.57020f, results[0].score, 10e-5);
 
     results = searcher.search("more");
     assertEquals(2, results.length);
     assertEquals("doc2", results[0].docid);
     assertEquals(1, results[0].lucene_docid);
-    assertEquals(0.27330f, results[0].score, 10e-6);
+    assertEquals(0.27330f, results[0].score, 10e-5);
     assertEquals("doc1", results[1].docid);
     assertEquals(0, results[1].lucene_docid);
-    assertEquals(0.20800f, results[1].score, 10e-6);
+    assertEquals(0.20800f, results[1].score, 10e-5);
 
     searcher.close();
   }
@@ -241,31 +241,31 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(1, results.length);
     assertEquals("doc2", results[0].docid);
     assertEquals(1, results[0].lucene_docid);
-    assertEquals(0.16070f, results[0].score, 10e-6);
+    assertEquals(0.16070f, results[0].score, 10e-5);
 
     results = searcher.search("text");
     assertEquals(2, results.length);
     assertEquals("doc2", results[0].docid);
     assertEquals(1, results[0].lucene_docid);
-    assertEquals(0.16070f, results[0].score, 10e-6);
+    assertEquals(0.16070f, results[0].score, 10e-5);
     assertEquals("doc1", results[1].docid);
     assertEquals(0, results[1].lucene_docid);
-    assertEquals(0.10870f, results[1].score, 10e-6);
+    assertEquals(0.10870f, results[1].score, 10e-5);
 
     results = searcher.search("test");
     assertEquals(1, results.length);
     assertEquals("doc3", results[0].docid);
     assertEquals(2, results[0].lucene_docid);
-    assertEquals(0.33530f, results[0].score, 10e-6);
+    assertEquals(0.33530f, results[0].score, 10e-5);
 
     results = searcher.search("more");
     assertEquals(2, results.length);
     assertEquals("doc2", results[0].docid);
     assertEquals(1, results[0].lucene_docid);
-    assertEquals(0.16070f, results[0].score, 10e-6);
+    assertEquals(0.16070f, results[0].score, 10e-5);
     assertEquals("doc1", results[1].docid);
     assertEquals(0, results[1].lucene_docid);
-    assertEquals(0.06140f, results[1].score, 10e-6);
+    assertEquals(0.06140f, results[1].score, 10e-5);
 
     searcher.close();
   }
@@ -301,10 +301,10 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(2, results.length);
     assertEquals("doc2", results[0].docid);
     assertEquals(1, results[0].lucene_docid);
-    assertEquals(0.17770f, results[0].score, 10e-6);
+    assertEquals(0.17770f, results[0].score, 10e-5);
     assertEquals("doc1", results[1].docid);
     assertEquals(0, results[1].lucene_docid);
-    assertEquals(0.0f, results[1].score, 10e-6);
+    assertEquals(0.0f, results[1].score, 10e-5);
 
     searcher.close();
   }
@@ -321,26 +321,26 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(1, results.length);
     assertEquals("doc1", results[0].docid);
     assertEquals(0, results[0].lucene_docid);
-    assertEquals(0.14420f, results[0].score, 10e-6);
+    assertEquals(0.14420f, results[0].score, 10e-5);
 
     Map<String, Float> feedbackTerms = searcher.get_feedback_terms("text");
     assertEquals(1, feedbackTerms.size());
-    assertEquals(0.5f, feedbackTerms.get("text"), 10e-6);
+    assertEquals(0.5f, feedbackTerms.get("text"), 10e-5);
 
     results = searcher.search("test");
     assertEquals(1, results.length);
     assertEquals("doc3", results[0].docid);
     assertEquals(2, results[0].lucene_docid);
-    assertEquals(0.28510f, results[0].score, 10e-6);
+    assertEquals(0.28510f, results[0].score, 10e-5);
 
     results = searcher.search("more");
     assertEquals(2, results.length);
     assertEquals("doc2", results[0].docid);
     assertEquals(1, results[0].lucene_docid);
-    assertEquals(0.13660f, results[0].score, 10e-6);
+    assertEquals(0.13660f, results[0].score, 10e-5);
     assertEquals("doc1", results[1].docid);
     assertEquals(0, results[1].lucene_docid);
-    assertEquals(0.10400f, results[1].score, 10e-6);
+    assertEquals(0.10400f, results[1].score, 10e-5);
 
     searcher.unset_rm3();
     assertFalse(searcher.use_rm3());
@@ -371,37 +371,37 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(1, results.length);
     assertEquals("doc1", results[0].docid);
     assertEquals(0, results[0].lucene_docid);
-    assertEquals(0.28830f, results[0].score, 10e-6);
+    assertEquals(0.28830f, results[0].score, 10e-5);
 
     // Note that the feedback term is just the query, the scores are the same.
     feedbackTerms = searcher.get_feedback_terms("text");
     assertEquals(1, feedbackTerms.size());
-    assertEquals(1.0f, feedbackTerms.get("text"), 10e-6);
+    assertEquals(1.0f, feedbackTerms.get("text"), 10e-5);
 
     results = searcher.search("test");
     assertEquals(1, results.length);
     assertEquals("doc3", results[0].docid);
     assertEquals(2, results[0].lucene_docid);
-    assertEquals(0.57020f, results[0].score, 10e-6);
+    assertEquals(0.57020f, results[0].score, 10e-5);
 
     // Note that the feedback term is just the query, the scores are the same.
     feedbackTerms = searcher.get_feedback_terms("test");
     assertEquals(1, feedbackTerms.size());
-    assertEquals(1.0f, feedbackTerms.get("test"), 10e-6);
+    assertEquals(1.0f, feedbackTerms.get("test"), 10e-5);
 
     results = searcher.search("more");
     assertEquals(2, results.length);
     assertEquals("doc2", results[0].docid);
     assertEquals(1, results[0].lucene_docid);
-    assertEquals(0.27330f, results[0].score, 10e-6);
+    assertEquals(0.27330f, results[0].score, 10e-5);
     assertEquals("doc1", results[1].docid);
     assertEquals(0, results[1].lucene_docid);
-    assertEquals(0.20800f, results[1].score, 10e-6);
+    assertEquals(0.20800f, results[1].score, 10e-5);
 
     // Note that the feedback term is just the query, the scores are the same.
     feedbackTerms = searcher.get_feedback_terms("more");
     assertEquals(1, feedbackTerms.size());
-    assertEquals(1.0f, feedbackTerms.get("more"), 10e-6);
+    assertEquals(1.0f, feedbackTerms.get("more"), 10e-5);
 
     searcher.unset_rocchio();
     assertFalse(searcher.use_rocchio());
@@ -452,20 +452,20 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(1, hits.get("query_test").length);
     assertEquals("doc3", hits.get("query_test")[0].docid);
     assertEquals(2, hits.get("query_test")[0].lucene_docid);
-    assertEquals(0.57020f, hits.get("query_test")[0].score, 10e-6);
+    assertEquals(0.57020f, hits.get("query_test")[0].score, 10e-5);
     assertEquals("here is a test", hits.get("query_test")[0].contents);
     assertEquals("{\"contents\": \"here is a test\"}", hits.get("query_test")[0].raw);
 
     assertEquals(2, hits.get("query_more").length);
     assertEquals("doc2", hits.get("query_more")[0].docid);
     assertEquals(1, hits.get("query_more")[0].lucene_docid);
-    assertEquals(0.27330f, hits.get("query_more")[0].score, 10e-6);
+    assertEquals(0.27330f, hits.get("query_more")[0].score, 10e-5);
     assertEquals("more texts", hits.get("query_more")[0].contents);
     assertEquals("{\"contents\": \"more texts\"}", hits.get("query_more")[0].raw);
 
     assertEquals("doc1", hits.get("query_more")[1].docid);
     assertEquals(0, hits.get("query_more")[1].lucene_docid);
-    assertEquals(0.20800f, hits.get("query_more")[1].score, 10e-6);
+    assertEquals(0.20800f, hits.get("query_more")[1].score, 10e-5);
     assertEquals("here is some text here is some more text. city.", hits.get("query_more")[1].contents);
     assertEquals("{\"contents\": \"here is some text here is some more text. city.\"}", hits.get("query_more")[1].raw);
 
@@ -493,23 +493,23 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(2, hits.get("query_text").length);
     assertEquals("doc1", hits.get("query_text")[0].docid);
     assertEquals(0, hits.get("query_text")[0].lucene_docid);
-    assertEquals(0.28830f, hits.get("query_text")[0].score, 10e-6);
+    assertEquals(0.28830f, hits.get("query_text")[0].score, 10e-5);
     assertEquals("doc2", hits.get("query_text")[1].docid);
     assertEquals(1, hits.get("query_text")[1].lucene_docid);
-    assertEquals(0.27330f, hits.get("query_text")[1].score, 10e-6);
+    assertEquals(0.27330f, hits.get("query_text")[1].score, 10e-5);
 
     assertEquals(1, hits.get("query_test").length);
     assertEquals("doc3", hits.get("query_test")[0].docid);
     assertEquals(2, hits.get("query_test")[0].lucene_docid);
-    assertEquals(0.57020f, hits.get("query_test")[0].score, 10e-6);
+    assertEquals(0.57020f, hits.get("query_test")[0].score, 10e-5);
 
     assertEquals(2, hits.get("query_more").length);
     assertEquals("doc2", hits.get("query_more")[0].docid);
     assertEquals(1, hits.get("query_more")[0].lucene_docid);
-    assertEquals(0.27330f, hits.get("query_more")[0].score, 10e-6);
+    assertEquals(0.27330f, hits.get("query_more")[0].score, 10e-5);
     assertEquals("doc1", hits.get("query_more")[1].docid);
     assertEquals(0, hits.get("query_more")[1].lucene_docid);
-    assertEquals(0.20800f, hits.get("query_more")[1].score, 10e-6);
+    assertEquals(0.20800f, hits.get("query_more")[1].score, 10e-5);
 
     searcher.close();
   }
@@ -536,23 +536,23 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(2, hits.get("query_text").length);
     assertEquals("doc2", hits.get("query_text")[0].docid);
     assertEquals(1, hits.get("query_text")[0].lucene_docid);
-    assertEquals(0.16070f, hits.get("query_text")[0].score, 10e-6);
+    assertEquals(0.16070f, hits.get("query_text")[0].score, 10e-5);
     assertEquals("doc1", hits.get("query_text")[1].docid);
     assertEquals(0, hits.get("query_text")[1].lucene_docid);
-    assertEquals(0.10870f, hits.get("query_text")[1].score, 10e-6);
+    assertEquals(0.10870f, hits.get("query_text")[1].score, 10e-5);
 
     assertEquals(1, hits.get("query_test").length);
     assertEquals("doc3", hits.get("query_test")[0].docid);
     assertEquals(2, hits.get("query_test")[0].lucene_docid);
-    assertEquals(0.33530f, hits.get("query_test")[0].score, 10e-6);
+    assertEquals(0.33530f, hits.get("query_test")[0].score, 10e-5);
 
     assertEquals(2, hits.get("query_more").length);
     assertEquals("doc2", hits.get("query_more")[0].docid);
     assertEquals(1, hits.get("query_more")[0].lucene_docid);
-    assertEquals(0.16070f, hits.get("query_more")[0].score, 10e-6);
+    assertEquals(0.16070f, hits.get("query_more")[0].score, 10e-5);
     assertEquals("doc1", hits.get("query_more")[1].docid);
     assertEquals(0, hits.get("query_more")[1].lucene_docid);
-    assertEquals(0.06140f, hits.get("query_more")[1].score, 10e-6);
+    assertEquals(0.06140f, hits.get("query_more")[1].score, 10e-5);
 
     searcher.close();
   }
@@ -579,23 +579,23 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(2, hits.get("query_text").length);
     assertEquals("doc2", hits.get("query_text")[0].docid);
     assertEquals(1, hits.get("query_text")[0].lucene_docid);
-    assertEquals(0.09910f, hits.get("query_text")[0].score, 10e-6);
+    assertEquals(0.09910f, hits.get("query_text")[0].score, 10e-5);
     assertEquals("doc1", hits.get("query_text")[1].docid);
     assertEquals(0, hits.get("query_text")[1].lucene_docid);
-    assertEquals(0.0f, hits.get("query_text")[1].score, 10e-6);
+    assertEquals(0.0f, hits.get("query_text")[1].score, 10e-5);
 
     assertEquals(1, hits.get("query_test").length);
     assertEquals("doc3", hits.get("query_test")[0].docid);
     assertEquals(2, hits.get("query_test")[0].lucene_docid);
-    assertEquals(0.31850f, hits.get("query_test")[0].score, 10e-6);
+    assertEquals(0.31850f, hits.get("query_test")[0].score, 10e-5);
 
     assertEquals(2, hits.get("query_more").length);
     assertEquals("doc2", hits.get("query_more")[0].docid);
     assertEquals(1, hits.get("query_more")[0].lucene_docid);
-    assertEquals(0.17770f, hits.get("query_more")[0].score, 10e-6);
+    assertEquals(0.17770f, hits.get("query_more")[0].score, 10e-5);
     assertEquals("doc1", hits.get("query_more")[1].docid);
     assertEquals(0, hits.get("query_more")[1].lucene_docid);
-    assertEquals(0.0f, hits.get("query_more")[1].score, 10e-6);
+    assertEquals(0.0f, hits.get("query_more")[1].score, 10e-5);
 
     searcher.close();
   }
@@ -622,10 +622,10 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(2, hits.get("query_text").length);
     assertEquals("doc1", hits.get("query_text")[0].docid);
     assertEquals(0, hits.get("query_text")[0].lucene_docid);
-    assertEquals(0.14420f, hits.get("query_text")[0].score, 10e-6);
+    assertEquals(0.14420f, hits.get("query_text")[0].score, 10e-5);
     assertEquals("doc2", hits.get("query_text")[1].docid);
     assertEquals(1, hits.get("query_text")[1].lucene_docid);
-    assertEquals(0.13660f, hits.get("query_text")[1].score, 10e-6);
+    assertEquals(0.13660f, hits.get("query_text")[1].score, 10e-5);
 
     assertEquals(1, hits.get("query_test").length);
     assertEquals("doc3", hits.get("query_test")[0].docid);
@@ -665,23 +665,23 @@ public class SimpleSearcherTest extends IndexerTestBase {
     assertEquals(2, hits.get("query_text").length);
     assertEquals("doc1", hits.get("query_text")[0].docid);
     assertEquals(0, hits.get("query_text")[0].lucene_docid);
-    assertEquals(0.28830f, hits.get("query_text")[0].score, 10e-6);
+    assertEquals(0.28830f, hits.get("query_text")[0].score, 10e-5);
     assertEquals("doc2", hits.get("query_text")[1].docid);
     assertEquals(1, hits.get("query_text")[1].lucene_docid);
-    assertEquals(0.27330f, hits.get("query_text")[1].score, 10e-6);
+    assertEquals(0.27330f, hits.get("query_text")[1].score, 10e-5);
 
     assertEquals(1, hits.get("query_test").length);
     assertEquals("doc3", hits.get("query_test")[0].docid);
     assertEquals(2, hits.get("query_test")[0].lucene_docid);
-    assertEquals(0.57020f, hits.get("query_test")[0].score, 10e-6);
+    assertEquals(0.57020f, hits.get("query_test")[0].score, 10e-5);
 
     assertEquals(2, hits.get("query_more").length);
     assertEquals("doc2", hits.get("query_more")[0].docid);
     assertEquals(1, hits.get("query_more")[0].lucene_docid);
-    assertEquals(0.27330f, hits.get("query_more")[0].score, 10e-6);
+    assertEquals(0.27330f, hits.get("query_more")[0].score, 10e-5);
     assertEquals("doc1", hits.get("query_more")[1].docid);
     assertEquals(0, hits.get("query_more")[1].lucene_docid);
-    assertEquals(0.20800f, hits.get("query_more")[1].score, 10e-6);
+    assertEquals(0.20800f, hits.get("query_more")[1].score, 10e-5);
 
     searcher.close();
   }

--- a/src/test/java/io/anserini/search/SimpleSearcherWithoutDocvectorsTest.java
+++ b/src/test/java/io/anserini/search/SimpleSearcherWithoutDocvectorsTest.java
@@ -1,0 +1,234 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.search;
+
+import io.anserini.IndexerTestBase;
+import io.anserini.IndexerWithoutDocvectorsTestBase;
+import io.anserini.analysis.DefaultEnglishAnalyzer;
+import io.anserini.index.Constants;
+import io.anserini.search.SimpleSearcher.Result;
+import org.apache.lucene.analysis.ar.ArabicAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.similarities.BM25Similarity;
+import org.apache.lucene.search.similarities.LMDirichletSimilarity;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+// This is a variant of SimpleSearcherTest where we use an index that does not store docvectors.
+// Here, we test that relevance feedback still works using on-the-fly document parsing.
+public class SimpleSearcherWithoutDocvectorsTest extends IndexerWithoutDocvectorsTestBase {
+  @Test
+  public void testSearch6() throws Exception {
+    // This adds Rocchio on top of "testSearch1"
+    SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
+    searcher.set_rocchio("JsonCollection");
+    assertTrue(searcher.use_rocchio());
+
+    Result[] results;
+    Map<String, Float> feedbackTerms;
+
+    results = searcher.search("text", 1);
+    assertEquals(1, results.length);
+    assertEquals("doc1", results[0].docid);
+    assertEquals(0, results[0].lucene_docid);
+    assertEquals(0.28830f, results[0].score, 10e-6);
+
+    // Note that the feedback term is just the query, the scores are the same.
+    feedbackTerms = searcher.get_feedback_terms("text");
+    assertEquals(1, feedbackTerms.size());
+    assertEquals(1.0f, feedbackTerms.get("text"), 10e-6);
+
+    results = searcher.search("test");
+    assertEquals(1, results.length);
+    assertEquals("doc3", results[0].docid);
+    assertEquals(2, results[0].lucene_docid);
+    assertEquals(0.57020f, results[0].score, 10e-6);
+
+    // Note that the feedback term is just the query, the scores are the same.
+    feedbackTerms = searcher.get_feedback_terms("test");
+    assertEquals(1, feedbackTerms.size());
+    assertEquals(1.0f, feedbackTerms.get("test"), 10e-6);
+
+    results = searcher.search("more");
+    assertEquals(2, results.length);
+    assertEquals("doc2", results[0].docid);
+    assertEquals(1, results[0].lucene_docid);
+    assertEquals(0.27330f, results[0].score, 10e-6);
+    assertEquals("doc1", results[1].docid);
+    assertEquals(0, results[1].lucene_docid);
+    assertEquals(0.20800f, results[1].score, 10e-6);
+
+    // Note that the feedback term is just the query, the scores are the same.
+    feedbackTerms = searcher.get_feedback_terms("more");
+    assertEquals(1, feedbackTerms.size());
+    assertEquals(1.0f, feedbackTerms.get("more"), 10e-6);
+
+    searcher.unset_rocchio();
+    assertFalse(searcher.use_rocchio());
+
+    results = searcher.search("text", 1);
+    assertEquals(1, results.length);
+    assertEquals("doc1", results[0].docid);
+    assertEquals(0, results[0].lucene_docid);
+    assertEquals(0.28830f, results[0].score, 10e-5);
+
+    feedbackTerms = searcher.get_feedback_terms("text");
+    assertNull(feedbackTerms);
+
+    searcher.close();
+  }
+
+  @Test
+  public void testSearch5() throws Exception {
+    SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
+    searcher.set_rm3("JsonCollection");
+    assertTrue(searcher.use_rm3());
+
+    Result[] results;
+
+    results = searcher.search("text", 1);
+    assertEquals(1, results.length);
+    assertEquals("doc1", results[0].docid);
+    assertEquals(0, results[0].lucene_docid);
+    assertEquals(0.14420f, results[0].score, 10e-6);
+
+    Map<String, Float> feedbackTerms = searcher.get_feedback_terms("text");
+    assertEquals(1, feedbackTerms.size());
+    assertEquals(0.5f, feedbackTerms.get("text"), 10e-6);
+
+    results = searcher.search("test");
+    assertEquals(1, results.length);
+    assertEquals("doc3", results[0].docid);
+    assertEquals(2, results[0].lucene_docid);
+    assertEquals(0.28510f, results[0].score, 10e-6);
+
+    results = searcher.search("more");
+    assertEquals(2, results.length);
+    assertEquals("doc2", results[0].docid);
+    assertEquals(1, results[0].lucene_docid);
+    assertEquals(0.13660f, results[0].score, 10e-6);
+    assertEquals("doc1", results[1].docid);
+    assertEquals(0, results[1].lucene_docid);
+    assertEquals(0.10400f, results[1].score, 10e-6);
+
+    searcher.unset_rm3();
+    assertFalse(searcher.use_rm3());
+
+    results = searcher.search("text", 1);
+    assertEquals(1, results.length);
+    assertEquals("doc1", results[0].docid);
+    assertEquals(0, results[0].lucene_docid);
+    assertEquals(0.28830f, results[0].score, 10e-5);
+
+    feedbackTerms = searcher.get_feedback_terms("text");
+    assertNull(feedbackTerms);
+
+    searcher.close();
+  }
+
+  @Test
+  public void testBatchSearch5() throws Exception {
+    // This is the batch version of test case "testSearch5"; results should be the same.
+    SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
+    searcher.set_rm3("JsonCollection");
+
+    List<String> queries = new ArrayList<>();
+    queries.add("text");
+    queries.add("test");
+    queries.add("more");
+
+    List<String> qids = new ArrayList<>();
+    qids.add("query_text");
+    qids.add("query_test");
+    qids.add("query_more");
+
+    Map<String, SimpleSearcher.Result[]> hits = searcher.batch_search(queries, qids, 10, 2);
+    assertEquals(3, hits.size());
+
+    assertEquals(2, hits.get("query_text").length);
+    assertEquals("doc1", hits.get("query_text")[0].docid);
+    assertEquals(0, hits.get("query_text")[0].lucene_docid);
+    assertEquals(0.14420f, hits.get("query_text")[0].score, 10e-6);
+    assertEquals("doc2", hits.get("query_text")[1].docid);
+    assertEquals(1, hits.get("query_text")[1].lucene_docid);
+    assertEquals(0.13660f, hits.get("query_text")[1].score, 10e-6);
+
+    assertEquals(1, hits.get("query_test").length);
+    assertEquals("doc3", hits.get("query_test")[0].docid);
+    assertEquals(2, hits.get("query_test")[0].lucene_docid);
+    assertEquals(0.28510f, hits.get("query_test")[0].score, 10e-5);
+
+    assertEquals(2, hits.get("query_more").length);
+    assertEquals("doc2", hits.get("query_more")[0].docid);
+    assertEquals(1, hits.get("query_more")[0].lucene_docid);
+    assertEquals(0.13660f, hits.get("query_more")[0].score, 10e-5);
+    assertEquals("doc1", hits.get("query_more")[1].docid);
+    assertEquals(0, hits.get("query_more")[1].lucene_docid);
+    assertEquals(0.10400f, hits.get("query_more")[1].score, 10e-5);
+
+    searcher.close();
+  }
+
+  @Test
+  public void testBatchSearch6() throws Exception {
+    // This is the batch version of test case "testSearch6"; results should be the same.
+    SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
+    searcher.set_rocchio("JsonCollection");
+
+    List<String> queries = new ArrayList<>();
+    queries.add("text");
+    queries.add("test");
+    queries.add("more");
+
+    List<String> qids = new ArrayList<>();
+    qids.add("query_text");
+    qids.add("query_test");
+    qids.add("query_more");
+
+    Map<String, SimpleSearcher.Result[]> hits = searcher.batch_search(queries, qids, 10, 2);
+    assertEquals(3, hits.size());
+
+    assertEquals(2, hits.get("query_text").length);
+    assertEquals("doc1", hits.get("query_text")[0].docid);
+    assertEquals(0, hits.get("query_text")[0].lucene_docid);
+    assertEquals(0.28830f, hits.get("query_text")[0].score, 10e-6);
+    assertEquals("doc2", hits.get("query_text")[1].docid);
+    assertEquals(1, hits.get("query_text")[1].lucene_docid);
+    assertEquals(0.27330f, hits.get("query_text")[1].score, 10e-6);
+
+    assertEquals(1, hits.get("query_test").length);
+    assertEquals("doc3", hits.get("query_test")[0].docid);
+    assertEquals(2, hits.get("query_test")[0].lucene_docid);
+    assertEquals(0.57020f, hits.get("query_test")[0].score, 10e-6);
+
+    assertEquals(2, hits.get("query_more").length);
+    assertEquals("doc2", hits.get("query_more")[0].docid);
+    assertEquals(1, hits.get("query_more")[0].lucene_docid);
+    assertEquals(0.27330f, hits.get("query_more")[0].score, 10e-6);
+    assertEquals("doc1", hits.get("query_more")[1].docid);
+    assertEquals(0, hits.get("query_more")[1].lucene_docid);
+    assertEquals(0.20800f, hits.get("query_more")[1].score, 10e-6);
+
+    searcher.close();
+  }
+}

--- a/src/test/java/io/anserini/search/SimpleSearcherWithoutDocvectorsTest.java
+++ b/src/test/java/io/anserini/search/SimpleSearcherWithoutDocvectorsTest.java
@@ -38,68 +38,8 @@ import java.util.Map;
 // Here, we test that relevance feedback still works using on-the-fly document parsing.
 public class SimpleSearcherWithoutDocvectorsTest extends IndexerWithoutDocvectorsTestBase {
   @Test
-  public void testSearch6() throws Exception {
-    // This adds Rocchio on top of "testSearch1"
-    SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
-    searcher.set_rocchio("JsonCollection");
-    assertTrue(searcher.use_rocchio());
-
-    Result[] results;
-    Map<String, Float> feedbackTerms;
-
-    results = searcher.search("text", 1);
-    assertEquals(1, results.length);
-    assertEquals("doc1", results[0].docid);
-    assertEquals(0, results[0].lucene_docid);
-    assertEquals(0.28830f, results[0].score, 10e-6);
-
-    // Note that the feedback term is just the query, the scores are the same.
-    feedbackTerms = searcher.get_feedback_terms("text");
-    assertEquals(1, feedbackTerms.size());
-    assertEquals(1.0f, feedbackTerms.get("text"), 10e-6);
-
-    results = searcher.search("test");
-    assertEquals(1, results.length);
-    assertEquals("doc3", results[0].docid);
-    assertEquals(2, results[0].lucene_docid);
-    assertEquals(0.57020f, results[0].score, 10e-6);
-
-    // Note that the feedback term is just the query, the scores are the same.
-    feedbackTerms = searcher.get_feedback_terms("test");
-    assertEquals(1, feedbackTerms.size());
-    assertEquals(1.0f, feedbackTerms.get("test"), 10e-6);
-
-    results = searcher.search("more");
-    assertEquals(2, results.length);
-    assertEquals("doc2", results[0].docid);
-    assertEquals(1, results[0].lucene_docid);
-    assertEquals(0.27330f, results[0].score, 10e-6);
-    assertEquals("doc1", results[1].docid);
-    assertEquals(0, results[1].lucene_docid);
-    assertEquals(0.20800f, results[1].score, 10e-6);
-
-    // Note that the feedback term is just the query, the scores are the same.
-    feedbackTerms = searcher.get_feedback_terms("more");
-    assertEquals(1, feedbackTerms.size());
-    assertEquals(1.0f, feedbackTerms.get("more"), 10e-6);
-
-    searcher.unset_rocchio();
-    assertFalse(searcher.use_rocchio());
-
-    results = searcher.search("text", 1);
-    assertEquals(1, results.length);
-    assertEquals("doc1", results[0].docid);
-    assertEquals(0, results[0].lucene_docid);
-    assertEquals(0.28830f, results[0].score, 10e-5);
-
-    feedbackTerms = searcher.get_feedback_terms("text");
-    assertNull(feedbackTerms);
-
-    searcher.close();
-  }
-
-  @Test
   public void testSearch5() throws Exception {
+    // Counterpart of testSearch5 in SimpleSearcherTest
     SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
     searcher.set_rm3("JsonCollection");
     assertTrue(searcher.use_rm3());
@@ -110,26 +50,26 @@ public class SimpleSearcherWithoutDocvectorsTest extends IndexerWithoutDocvector
     assertEquals(1, results.length);
     assertEquals("doc1", results[0].docid);
     assertEquals(0, results[0].lucene_docid);
-    assertEquals(0.14420f, results[0].score, 10e-6);
+    assertEquals(0.14420f, results[0].score, 10e-5);
 
     Map<String, Float> feedbackTerms = searcher.get_feedback_terms("text");
     assertEquals(1, feedbackTerms.size());
-    assertEquals(0.5f, feedbackTerms.get("text"), 10e-6);
+    assertEquals(0.5f, feedbackTerms.get("text"), 10e-5);
 
     results = searcher.search("test");
     assertEquals(1, results.length);
     assertEquals("doc3", results[0].docid);
     assertEquals(2, results[0].lucene_docid);
-    assertEquals(0.28510f, results[0].score, 10e-6);
+    assertEquals(0.28510f, results[0].score, 10e-5);
 
     results = searcher.search("more");
     assertEquals(2, results.length);
     assertEquals("doc2", results[0].docid);
     assertEquals(1, results[0].lucene_docid);
-    assertEquals(0.13660f, results[0].score, 10e-6);
+    assertEquals(0.13660f, results[0].score, 10e-5);
     assertEquals("doc1", results[1].docid);
     assertEquals(0, results[1].lucene_docid);
-    assertEquals(0.10400f, results[1].score, 10e-6);
+    assertEquals(0.10400f, results[1].score, 10e-5);
 
     searcher.unset_rm3();
     assertFalse(searcher.use_rm3());
@@ -147,8 +87,69 @@ public class SimpleSearcherWithoutDocvectorsTest extends IndexerWithoutDocvector
   }
 
   @Test
+  public void testSearch6() throws Exception {
+    // Counterpart of testSearch6 in SimpleSearcherTest
+    SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
+    searcher.set_rocchio("JsonCollection");
+    assertTrue(searcher.use_rocchio());
+
+    Result[] results;
+    Map<String, Float> feedbackTerms;
+
+    results = searcher.search("text", 1);
+    assertEquals(1, results.length);
+    assertEquals("doc1", results[0].docid);
+    assertEquals(0, results[0].lucene_docid);
+    assertEquals(0.28830f, results[0].score, 10e-5);
+
+    // Note that the feedback term is just the query, the scores are the same.
+    feedbackTerms = searcher.get_feedback_terms("text");
+    assertEquals(1, feedbackTerms.size());
+    assertEquals(1.0f, feedbackTerms.get("text"), 10e-5);
+
+    results = searcher.search("test");
+    assertEquals(1, results.length);
+    assertEquals("doc3", results[0].docid);
+    assertEquals(2, results[0].lucene_docid);
+    assertEquals(0.57020f, results[0].score, 10e-5);
+
+    // Note that the feedback term is just the query, the scores are the same.
+    feedbackTerms = searcher.get_feedback_terms("test");
+    assertEquals(1, feedbackTerms.size());
+    assertEquals(1.0f, feedbackTerms.get("test"), 10e-5);
+
+    results = searcher.search("more");
+    assertEquals(2, results.length);
+    assertEquals("doc2", results[0].docid);
+    assertEquals(1, results[0].lucene_docid);
+    assertEquals(0.27330f, results[0].score, 10e-5);
+    assertEquals("doc1", results[1].docid);
+    assertEquals(0, results[1].lucene_docid);
+    assertEquals(0.20800f, results[1].score, 10e-5);
+
+    // Note that the feedback term is just the query, the scores are the same.
+    feedbackTerms = searcher.get_feedback_terms("more");
+    assertEquals(1, feedbackTerms.size());
+    assertEquals(1.0f, feedbackTerms.get("more"), 10e-5);
+
+    searcher.unset_rocchio();
+    assertFalse(searcher.use_rocchio());
+
+    results = searcher.search("text", 1);
+    assertEquals(1, results.length);
+    assertEquals("doc1", results[0].docid);
+    assertEquals(0, results[0].lucene_docid);
+    assertEquals(0.28830f, results[0].score, 10e-5);
+
+    feedbackTerms = searcher.get_feedback_terms("text");
+    assertNull(feedbackTerms);
+
+    searcher.close();
+  }
+
+  @Test
   public void testBatchSearch5() throws Exception {
-    // This is the batch version of test case "testSearch5"; results should be the same.
+    // Counterpart of testBatchSearch5 in SimpleSearcherTest
     SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
     searcher.set_rm3("JsonCollection");
 
@@ -168,10 +169,10 @@ public class SimpleSearcherWithoutDocvectorsTest extends IndexerWithoutDocvector
     assertEquals(2, hits.get("query_text").length);
     assertEquals("doc1", hits.get("query_text")[0].docid);
     assertEquals(0, hits.get("query_text")[0].lucene_docid);
-    assertEquals(0.14420f, hits.get("query_text")[0].score, 10e-6);
+    assertEquals(0.14420f, hits.get("query_text")[0].score, 10e-5);
     assertEquals("doc2", hits.get("query_text")[1].docid);
     assertEquals(1, hits.get("query_text")[1].lucene_docid);
-    assertEquals(0.13660f, hits.get("query_text")[1].score, 10e-6);
+    assertEquals(0.13660f, hits.get("query_text")[1].score, 10e-5);
 
     assertEquals(1, hits.get("query_test").length);
     assertEquals("doc3", hits.get("query_test")[0].docid);
@@ -191,7 +192,7 @@ public class SimpleSearcherWithoutDocvectorsTest extends IndexerWithoutDocvector
 
   @Test
   public void testBatchSearch6() throws Exception {
-    // This is the batch version of test case "testSearch6"; results should be the same.
+    // Counterpart of testBatchSearch6 in SimpleSearcherTest
     SimpleSearcher searcher = new SimpleSearcher(super.tempDir1.toString());
     searcher.set_rocchio("JsonCollection");
 
@@ -211,23 +212,23 @@ public class SimpleSearcherWithoutDocvectorsTest extends IndexerWithoutDocvector
     assertEquals(2, hits.get("query_text").length);
     assertEquals("doc1", hits.get("query_text")[0].docid);
     assertEquals(0, hits.get("query_text")[0].lucene_docid);
-    assertEquals(0.28830f, hits.get("query_text")[0].score, 10e-6);
+    assertEquals(0.28830f, hits.get("query_text")[0].score, 10e-5);
     assertEquals("doc2", hits.get("query_text")[1].docid);
     assertEquals(1, hits.get("query_text")[1].lucene_docid);
-    assertEquals(0.27330f, hits.get("query_text")[1].score, 10e-6);
+    assertEquals(0.27330f, hits.get("query_text")[1].score, 10e-5);
 
     assertEquals(1, hits.get("query_test").length);
     assertEquals("doc3", hits.get("query_test")[0].docid);
     assertEquals(2, hits.get("query_test")[0].lucene_docid);
-    assertEquals(0.57020f, hits.get("query_test")[0].score, 10e-6);
+    assertEquals(0.57020f, hits.get("query_test")[0].score, 10e-5);
 
     assertEquals(2, hits.get("query_more").length);
     assertEquals("doc2", hits.get("query_more")[0].docid);
     assertEquals(1, hits.get("query_more")[0].lucene_docid);
-    assertEquals(0.27330f, hits.get("query_more")[0].score, 10e-6);
+    assertEquals(0.27330f, hits.get("query_more")[0].score, 10e-5);
     assertEquals("doc1", hits.get("query_more")[1].docid);
     assertEquals(0, hits.get("query_more")[1].lucene_docid);
-    assertEquals(0.20800f, hits.get("query_more")[1].score, 10e-6);
+    assertEquals(0.20800f, hits.get("query_more")[1].score, 10e-5);
 
     searcher.close();
   }


### PR DESCRIPTION
This allows us to perform relevance feedback without storing docvectors.