### PR TITLE
Reproduce Passage MS MARCO Passage and Document Ranking

### DIFF
--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -286,3 +286,4 @@ That's it!
 + Results reproduced by [@Cath](https://github.com/Cathrineee) on 2023-01-14 (commit [`732cba4`](https://github.com/castorini/anserini/commit/732cba4775312f606888778d1e705e1ccea926df))
 + Results reproduced by [@dlrudwo1269](https://github.com/dlrudwo1269) on 2023-03-07 (commit [`4b7662c7`](https://github.com/castorini/anserini/commit/4b7662c7f154b9fbfe68aec9c371d8204d9ed31e))
 + Results reproduced by [@aryamancodes](https://github.com/aryamancodes) on 2023-04-11 (commit [`ed89401`](https://github.com/castorini/anserini/commit/ed894015977347e6e04363dea67d19e5474848ee))
++ Results reproduced by [@Jocn2020](https://github.com/Jocn2020) on 2023-04-30 (commit [`30269d6`](https://github.com/castorini/anserini/commit/30269d636a556174e3756fe59accab6c22a7c732))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -395,3 +395,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@dlrudwo1269](https://github.com/dlrudwo1269) on 2023-03-06 (commit [`4b7662c7`](https://github.com/castorini/anserini/commit/4b7662c7f154b9fbfe68aec9c371d8204d9ed31e))
 + Results reproduced by [@aryamancodes](https://github.com/aryamancodes) on 2023-04-11 (commit [`ed89401`](https://github.com/castorini/anserini/commit/ed894015977347e6e04363dea67d19e5474848ee))
 + Results reproduced by [@tailaiwang](https://github.com/tailaiwang) on 2023-04-29 (commit [`44dc9db`](https://github.com/castorini/anserini/commit/44dc9db16266107e28d70c4a14e3ba50191c81a0))
++ Results reproduced by [@Jocn2020](https://github.com/Jocn2020) on 2023-04-30 (commit [`30269d6`](https://github.com/castorini/anserini/commit/30269d636a556174e3756fe59accab6c22a7c732))


### PR DESCRIPTION
**Environment**
Java: 20
Maven: 3.9.1
OS name: macOS Monterey ver. 12.6.3, 16GB RAM, processor: 2,6 GHz 6-Core Intel Core i7

**Result**
Both ran with the same output as the instruction, here are MPR outputs of certain config:
<img width="697" alt="jonathan-msmacro-passage-result" src="https://user-images.githubusercontent.com/63906312/235415450-486301db-588d-4445-8003-dd656e4d6a7c.png">
For `k1: 0.82` and `b: 0.68` (Optimized for recall@100)

<img width="652" alt="jonathan-ms-macro-result" src="https://user-images.githubusercontent.com/63906312/235415438-75d14547-bcef-4352-9bf9-bbef990a3107.png">
For `k1: 3.8` and `b: 0.87` (Optimized for MRR@100/MAP)
