### PR TITLE
Add SPLADE++ ED/SD ONNX regression pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ See individual pages for details!
 | SPLADEv2                                    |       [✓](docs/regressions-msmarco-passage-distill-splade-max.md)        |                                                                       |                                                                       |
 | SPLADE-distill CoCodenser-medium            | [✓](docs/regressions-msmarco-passage-splade-distil-cocodenser-medium.md) | [✓](docs/regressions-dl19-passage-splade-distil-cocodenser-medium.md) | [✓](docs/regressions-dl20-passage-splade-distil-cocodenser-medium.md) |
 | SPLADE++ CoCondenser-EnsembleDistil         |          [✓](docs/regressions-msmarco-passage-splade-pp-ed.md)           |          [✓](docs/regressions-dl19-passage-splade-pp-ed.md)           |          [✓](docs/regressions-dl20-passage-splade-pp-ed.md)           |
+| SPLADE++ CoCondenser-EnsembleDistil (ONNX)  |        [✓](docs/regressions-msmarco-passage-splade-pp-ed-onnx.md)        |        [✓](docs/regressions-dl19-passage-splade-pp-ed-onnx.md)        |        [✓](docs/regressions-dl20-passage-splade-pp-ed-onnx.md)        |
 | SPLADE++ CoCondenser-SelfDistil             |          [✓](docs/regressions-msmarco-passage-splade-pp-sd.md)           |          [✓](docs/regressions-dl19-passage-splade-pp-sd.md)           |          [✓](docs/regressions-dl20-passage-splade-pp-sd.md)           |
+| SPLADE++ CoCondenser-SelfDistil (ONNX)      |        [✓](docs/regressions-msmarco-passage-splade-pp-sd-onnx.md)        |        [✓](docs/regressions-dl19-passage-splade-pp-sd-onnx.md)        |        [✓](docs/regressions-dl20-passage-splade-pp-sd-onnx.md)        |
 
 ### Available Corpora for Download
 

--- a/docs/regressions-dl19-passage-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-dl19-passage-splade-distil-cocodenser-medium.md
@@ -17,7 +17,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-distil-cocodenser-medium
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., performed model inference on every document and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., performed model inference on every document and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/docs/regressions-dl19-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions-dl19-passage-splade-pp-ed-onnx.md
@@ -139,5 +139,3 @@ The experimental results reported here are directly comparable to the results re
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl19-passage-splade-pp-ed-onnx.template) and run `bin/build.sh` to rebuild the documentation.
-
-+ Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/docs/regressions-dl19-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions-dl19-passage-splade-pp-ed-onnx.md
@@ -20,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-pp-ed-onnx
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/docs/regressions-dl19-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions-dl19-passage-splade-pp-ed-onnx.md
@@ -1,23 +1,23 @@
 # Anserini Regressions: TREC 2019 Deep Learning Track (Passage)
 
-**Model**: SPLADE++ CoCondenser-EnsembleDistil (using pre-encoded queries)
+**Model**: SPLADE++ CoCondenser-EnsembleDistil (using ONNX for on-the-fly query encoding)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-EnsembleDistil](https://huggingface.co/naver/splade-cocondenser-ensembledistil) model on the [TREC 2019 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
 
-In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
+In these experiments, we are using ONNX to perform query encoding on the fly.
 
 Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
 For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).
 
-The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/dl19-passage-splade-pp-ed.yaml).
-Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/dl19-passage-splade-pp-ed.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/dl19-passage-splade-pp-ed-onnx.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/dl19-passage-splade-pp-ed-onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-pp-ed
+python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-pp-ed-onnx
 ```
 
 We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
@@ -25,7 +25,7 @@ We make available a version of the MS MARCO passage corpus that has already been
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 
 ```bash
-python src/main/python/run_regression.py --download --index --verify --search --regression dl19-passage-splade-pp-ed
+python src/main/python/run_regression.py --download --index --verify --search --regression dl19-passage-splade-pp-ed-onnx
 ```
 
 The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
@@ -43,7 +43,7 @@ To confirm, `msmarco-passage-splade-pp-ed.tar` is 4.2 GB and has MD5 checksum `e
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-pp-ed \
+python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-pp-ed-onnx \
   --corpus-path collections/msmarco-passage-splade-pp-ed
 ```
 
@@ -79,43 +79,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
-  -topics tools/topics-and-qrels/topics.dl19-passage.splade-pp-ed.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl19-passage.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.splade-pp-ed.txt \
-  -impact -pretokenized &
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.txt \
+  -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
-  -topics tools/topics-and-qrels/topics.dl19-passage.splade-pp-ed.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl19-passage.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.splade-pp-ed.txt \
-  -impact -pretokenized -rm3 &
+  -output runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.txt \
+  -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
-  -topics tools/topics-and-qrels/topics.dl19-passage.splade-pp-ed.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl19-passage.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.splade-pp-ed.txt \
-  -impact -pretokenized -rocchio &
+  -output runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.txt \
+  -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil -rocchio &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.splade-pp-ed.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.splade-pp-ed.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.splade-pp-ed.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.txt
 ```
 
 ## Effectiveness
@@ -124,13 +124,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **SPLADE++ CoCondenser-EnsembleDistil**| **+RM3**  | **+Rocchio**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.5053    | 0.4998    | 0.5139    |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.5050    | 0.4995    | 0.5140    |
 | **nDCG@10**                                                                                                  | **SPLADE++ CoCondenser-EnsembleDistil**| **+RM3**  | **+Rocchio**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.7317    | 0.6857    | 0.7124    |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.7308    | 0.6849    | 0.7119    |
 | **R@100**                                                                                                    | **SPLADE++ CoCondenser-EnsembleDistil**| **+RM3**  | **+Rocchio**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.6390    | 0.6425    | 0.6390    |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.6390    | 0.6427    | 0.6394    |
 | **R@1000**                                                                                                   | **SPLADE++ CoCondenser-EnsembleDistil**| **+RM3**  | **+Rocchio**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.8726    | 0.8684    | 0.8799    |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.8728    | 0.8684    | 0.8799    |
 
 Note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).
@@ -138,6 +138,6 @@ The experimental results reported here are directly comparable to the results re
 
 ## Reproduction Log[*](reproducibility.md)
 
-To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl19-passage-splade-pp-ed.template) and run `bin/build.sh` to rebuild the documentation.
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl19-passage-splade-pp-ed-onnx.template) and run `bin/build.sh` to rebuild the documentation.
 
 + Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/docs/regressions-dl19-passage-splade-pp-ed.md
+++ b/docs/regressions-dl19-passage-splade-pp-ed.md
@@ -33,11 +33,11 @@ The `run_regression.py` script automates the following steps, but if you want to
 Download the corpus and unpack into `collections/`:
 
 ```bash
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-splade_distil_cocodenser_medium.tar -P collections/
-tar xvf collections/msmarco-passage-splade_distil_cocodenser_medium.tar -C collections/
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-ed.tar -P collections/
+tar xvf collections/msmarco-passage-splade-pp-ed.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-splade_distil_cocodenser_medium.tar` is 4.9 GB and has MD5 checksum `f77239a26d08856e6491a34062893b0c`.
+To confirm, `msmarco-passage-splade-pp-ed.tar` is 4.2 GB and has MD5 checksum `e489133bdc54ee1e7c62a32aa582bc77`.
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash

--- a/docs/regressions-dl19-passage-splade-pp-ed.md
+++ b/docs/regressions-dl19-passage-splade-pp-ed.md
@@ -20,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-pp-ed
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/docs/regressions-dl19-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions-dl19-passage-splade-pp-sd-onnx.md
@@ -139,5 +139,3 @@ The experimental results reported here are directly comparable to the results re
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl19-passage-splade-pp-sd-onnx.template) and run `bin/build.sh` to rebuild the documentation.
-
-+ Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/docs/regressions-dl19-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions-dl19-passage-splade-pp-sd-onnx.md
@@ -1,23 +1,23 @@
 # Anserini Regressions: TREC 2019 Deep Learning Track (Passage)
 
-**Model**: SPLADE++ CoCondenser-SelfDistil (using pre-encoded queries)
+**Model**: SPLADE++ CoCondenser-SelfDistil (using ONNX for on-the-fly query encoding)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-SelfDistil](https://huggingface.co/naver/splade-cocondenser-selfdistil) model on the [TREC 2019 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
 
-In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
+In these experiments, we are using ONNX to perform query encoding on the fly.
 
 Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
 For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).
 
-The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/dl19-passage-splade-pp-sd.yaml).
-Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/dl19-passage-splade-pp-sd.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/dl19-passage-splade-pp-sd-onnx.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/dl19-passage-splade-pp-sd-onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-pp-sd
+python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-pp-sd-onnx
 ```
 
 We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
@@ -25,7 +25,7 @@ We make available a version of the MS MARCO passage corpus that has already been
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 
 ```bash
-python src/main/python/run_regression.py --download --index --verify --search --regression dl19-passage-splade-pp-sd
+python src/main/python/run_regression.py --download --index --verify --search --regression dl19-passage-splade-pp-sd-onnx
 ```
 
 The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
@@ -43,7 +43,7 @@ To confirm, `msmarco-passage-splade-pp-sd.tar` is 4.8 GB and has MD5 checksum `c
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-pp-sd \
+python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-pp-sd-onnx \
   --corpus-path collections/msmarco-passage-splade-pp-sd
 ```
 
@@ -79,43 +79,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
-  -topics tools/topics-and-qrels/topics.dl19-passage.splade-pp-sd.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl19-passage.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.splade-pp-sd.txt \
-  -impact -pretokenized &
+  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.txt \
+  -impact -pretokenized -encoder SpladePlusPlusSelfDistil &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
-  -topics tools/topics-and-qrels/topics.dl19-passage.splade-pp-sd.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl19-passage.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.splade-pp-sd.txt \
-  -impact -pretokenized -rm3 &
+  -output runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.txt \
+  -impact -pretokenized -rm3 -encoder SpladePlusPlusSelfDistil &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
-  -topics tools/topics-and-qrels/topics.dl19-passage.splade-pp-sd.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl19-passage.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.splade-pp-sd.txt \
-  -impact -pretokenized -rocchio &
+  -output runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.txt \
+  -impact -pretokenized -rocchio -encoder SpladePlusPlusSelfDistil &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.splade-pp-sd.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.splade-pp-sd.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.splade-pp-sd.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.txt
 ```
 
 ## Effectiveness
@@ -124,13 +124,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **SPLADE++ CoCondenser-SelfDistil**| **+RM3**  | **+Rocchio**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.4998    | 0.4915    | 0.5068    |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.4998    | 0.4914    | 0.5072    |
 | **nDCG@10**                                                                                                  | **SPLADE++ CoCondenser-SelfDistil**| **+RM3**  | **+Rocchio**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.7357    | 0.6986    | 0.7155    |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.7358    | 0.6989    | 0.7156    |
 | **R@100**                                                                                                    | **SPLADE++ CoCondenser-SelfDistil**| **+RM3**  | **+Rocchio**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.6353    | 0.6456    | 0.6540    |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.6370    | 0.6456    | 0.6570    |
 | **R@1000**                                                                                                   | **SPLADE++ CoCondenser-SelfDistil**| **+RM3**  | **+Rocchio**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.8758    | 0.8793    | 0.8916    |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.8761    | 0.8793    | 0.8918    |
 
 Note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).
@@ -138,6 +138,6 @@ The experimental results reported here are directly comparable to the results re
 
 ## Reproduction Log[*](reproducibility.md)
 
-To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl19-passage-splade-pp-sd.template) and run `bin/build.sh` to rebuild the documentation.
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl19-passage-splade-pp-sd-onnx.template) and run `bin/build.sh` to rebuild the documentation.
 
 + Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/docs/regressions-dl19-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions-dl19-passage-splade-pp-sd-onnx.md
@@ -20,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-pp-sd-onnx
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/docs/regressions-dl19-passage-splade-pp-sd.md
+++ b/docs/regressions-dl19-passage-splade-pp-sd.md
@@ -33,11 +33,11 @@ The `run_regression.py` script automates the following steps, but if you want to
 Download the corpus and unpack into `collections/`:
 
 ```bash
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-splade_distil_cocodenser_medium.tar -P collections/
-tar xvf collections/msmarco-passage-splade_distil_cocodenser_medium.tar -C collections/
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-sd.tar -P collections/
+tar xvf collections/msmarco-passage-splade-pp-sd.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-splade_distil_cocodenser_medium.tar` is 4.9 GB and has MD5 checksum `f77239a26d08856e6491a34062893b0c`.
+To confirm, `msmarco-passage-splade-pp-sd.tar` is 4.8 GB and has MD5 checksum `cb7e264222f2bf2221dd2c9d28190be1`.
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash

--- a/docs/regressions-dl19-passage-splade-pp-sd.md
+++ b/docs/regressions-dl19-passage-splade-pp-sd.md
@@ -20,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-pp-sd
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/docs/regressions-dl19-passage-unicoil-noexp.md
+++ b/docs/regressions-dl19-passage-unicoil-noexp.md
@@ -22,7 +22,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-unicoil-noexp
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., we have performed model inference on every document and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with uniCOIL, i.e., we have performed model inference on every document and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/docs/regressions-dl19-passage-unicoil.md
+++ b/docs/regressions-dl19-passage-unicoil.md
@@ -22,7 +22,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-unicoil
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., we have applied doc2query-T5 expansions, performed model inference on every document, and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with uniCOIL, i.e., we have applied doc2query-T5 expansions, performed model inference on every document, and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/docs/regressions-dl20-passage-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-dl20-passage-splade-distil-cocodenser-medium.md
@@ -17,7 +17,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-distil-cocodenser-medium
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., performed model inference on every document and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., performed model inference on every document and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/docs/regressions-dl20-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions-dl20-passage-splade-pp-ed-onnx.md
@@ -1,23 +1,23 @@
 # Anserini Regressions: TREC 2020 Deep Learning Track (Passage)
 
-**Model**: SPLADE++ CoCondenser-EnsembleDistil (using pre-encoded queries)
+**Model**: SPLADE++ CoCondenser-EnsembleDistil (using ONNX for on-the-fly query encoding)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-EnsembleDistil](https://huggingface.co/naver/splade-cocondenser-ensembledistil) model on the [TREC 2020 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
 
-In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
+In these experiments, we are using ONNX to perform query encoding on the fly.
 
 Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
 For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).
 
-The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/dl20-passage-splade-pp-ed.yaml).
-Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/dl20-passage-splade-pp-ed.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/dl20-passage-splade-pp-ed-onnx.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/dl20-passage-splade-pp-ed-onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-pp-ed
+python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-pp-ed-onnx
 ```
 
 We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
@@ -25,7 +25,7 @@ We make available a version of the MS MARCO passage corpus that has already been
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 
 ```bash
-python src/main/python/run_regression.py --download --index --verify --search --regression dl20-passage-splade-pp-ed
+python src/main/python/run_regression.py --download --index --verify --search --regression dl20-passage-splade-pp-ed-onnx
 ```
 
 The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
@@ -43,7 +43,7 @@ To confirm, `msmarco-passage-splade-pp-ed.tar` is 4.2 GB and has MD5 checksum `e
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-pp-ed \
+python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-pp-ed-onnx \
   --corpus-path collections/msmarco-passage-splade-pp-ed
 ```
 
@@ -79,43 +79,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
-  -topics tools/topics-and-qrels/topics.dl20.splade-pp-ed.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.splade-pp-ed.txt \
-  -impact -pretokenized &
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.txt \
+  -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
-  -topics tools/topics-and-qrels/topics.dl20.splade-pp-ed.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.splade-pp-ed.txt \
-  -impact -pretokenized -rm3 &
+  -output runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.txt \
+  -impact -pretokenized -rm3 -encoder SpladePlusPlusEnsembleDistil &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
-  -topics tools/topics-and-qrels/topics.dl20.splade-pp-ed.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.splade-pp-ed.txt \
-  -impact -pretokenized -rocchio &
+  -output runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.txt \
+  -impact -pretokenized -rocchio -encoder SpladePlusPlusEnsembleDistil &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.splade-pp-ed.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.splade-pp-ed.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.splade-pp-ed.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.txt
 ```
 
 ## Effectiveness
@@ -124,13 +124,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **SPLADE++ CoCondenser-EnsembleDistil**| **+RM3**  | **+Rocchio**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.5001    | 0.5096    | 0.5084    |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.4999    | 0.5098    | 0.5084    |
 | **nDCG@10**                                                                                                  | **SPLADE++ CoCondenser-EnsembleDistil**| **+RM3**  | **+Rocchio**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.7198    | 0.7131    | 0.7280    |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.7197    | 0.7145    | 0.7280    |
 | **R@100**                                                                                                    | **SPLADE++ CoCondenser-EnsembleDistil**| **+RM3**  | **+Rocchio**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.7653    | 0.7553    | 0.7704    |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.7653    | 0.7555    | 0.7704    |
 | **R@1000**                                                                                                   | **SPLADE++ CoCondenser-EnsembleDistil**| **+RM3**  | **+Rocchio**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.8995    | 0.9046    | 0.9069    |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.8998    | 0.9046    | 0.9069    |
 
 Note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).
@@ -138,6 +138,6 @@ The experimental results reported here are directly comparable to the results re
 
 ## Reproduction Log[*](reproducibility.md)
 
-To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl20-passage-splade-pp-ed.template) and run `bin/build.sh` to rebuild the documentation.
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl20-passage-splade-pp-ed-onnx.template) and run `bin/build.sh` to rebuild the documentation.
 
 + Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/docs/regressions-dl20-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions-dl20-passage-splade-pp-ed-onnx.md
@@ -139,5 +139,3 @@ The experimental results reported here are directly comparable to the results re
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl20-passage-splade-pp-ed-onnx.template) and run `bin/build.sh` to rebuild the documentation.
-
-+ Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/docs/regressions-dl20-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions-dl20-passage-splade-pp-ed-onnx.md
@@ -20,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-pp-ed-onnx
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/docs/regressions-dl20-passage-splade-pp-ed.md
+++ b/docs/regressions-dl20-passage-splade-pp-ed.md
@@ -20,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-pp-ed
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/docs/regressions-dl20-passage-splade-pp-ed.md
+++ b/docs/regressions-dl20-passage-splade-pp-ed.md
@@ -33,11 +33,11 @@ The `run_regression.py` script automates the following steps, but if you want to
 Download the corpus and unpack into `collections/`:
 
 ```bash
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-splade_distil_cocodenser_medium.tar -P collections/
-tar xvf collections/msmarco-passage-splade_distil_cocodenser_medium.tar -C collections/
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-ed.tar -P collections/
+tar xvf collections/msmarco-passage-splade-pp-ed.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-splade_distil_cocodenser_medium.tar` is 4.9 GB and has MD5 checksum `f77239a26d08856e6491a34062893b0c`.
+To confirm, `msmarco-passage-splade-pp-ed.tar` is 4.2 GB and has MD5 checksum `e489133bdc54ee1e7c62a32aa582bc77`.
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash

--- a/docs/regressions-dl20-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions-dl20-passage-splade-pp-sd-onnx.md
@@ -1,23 +1,23 @@
 # Anserini Regressions: TREC 2020 Deep Learning Track (Passage)
 
-**Model**: SPLADE++ CoCondenser-SelfDistil (using pre-encoded queries)
+**Model**: SPLADE++ CoCondenser-SelfDistil (using ONNX for on-the-fly query encoding)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-SelfDistil](https://huggingface.co/naver/splade-cocondenser-selfdistil) model on the [TREC 2020 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
 
-In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
+In these experiments, we are using ONNX to perform query encoding on the fly.
 
 Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
 For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).
 
-The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/dl20-passage-splade-pp-sd.yaml).
-Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/dl20-passage-splade-pp-sd.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/dl20-passage-splade-pp-sd-onnx.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/dl20-passage-splade-pp-sd-onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-pp-sd
+python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-pp-sd-onnx
 ```
 
 We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
@@ -25,7 +25,7 @@ We make available a version of the MS MARCO passage corpus that has already been
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 
 ```bash
-python src/main/python/run_regression.py --download --index --verify --search --regression dl20-passage-splade-pp-sd
+python src/main/python/run_regression.py --download --index --verify --search --regression dl20-passage-splade-pp-sd-onnx
 ```
 
 The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
@@ -43,7 +43,7 @@ To confirm, `msmarco-passage-splade-pp-sd.tar` is 4.8 GB and has MD5 checksum `c
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-pp-sd \
+python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-pp-sd-onnx \
   --corpus-path collections/msmarco-passage-splade-pp-sd
 ```
 
@@ -79,43 +79,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
-  -topics tools/topics-and-qrels/topics.dl20.splade-pp-sd.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.splade-pp-sd.txt \
-  -impact -pretokenized &
+  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.txt \
+  -impact -pretokenized -encoder SpladePlusPlusSelfDistil &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
-  -topics tools/topics-and-qrels/topics.dl20.splade-pp-sd.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.splade-pp-sd.txt \
-  -impact -pretokenized -rm3 &
+  -output runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.txt \
+  -impact -pretokenized -rm3 -encoder SpladePlusPlusSelfDistil &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
-  -topics tools/topics-and-qrels/topics.dl20.splade-pp-sd.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.splade-pp-sd.txt \
-  -impact -pretokenized -rocchio &
+  -output runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.txt \
+  -impact -pretokenized -rocchio -encoder SpladePlusPlusSelfDistil &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.splade-pp-sd.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.splade-pp-sd.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.txt
 
-tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.splade-pp-sd.txt
-tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.splade-pp-sd.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.txt
 ```
 
 ## Effectiveness
@@ -124,13 +124,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **SPLADE++ CoCondenser-SelfDistil**| **+RM3**  | **+Rocchio**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|-----------|-----------|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.5140    | 0.5261    | 0.5296    |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.5139    | 0.5266    | 0.5335    |
 | **nDCG@10**                                                                                                  | **SPLADE++ CoCondenser-SelfDistil**| **+RM3**  | **+Rocchio**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.7285    | 0.7199    | 0.7364    |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.7282    | 0.7227    | 0.7388    |
 | **R@100**                                                                                                    | **SPLADE++ CoCondenser-SelfDistil**| **+RM3**  | **+Rocchio**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.7512    | 0.7631    | 0.7656    |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.7512    | 0.7648    | 0.7656    |
 | **R@1000**                                                                                                   | **SPLADE++ CoCondenser-SelfDistil**| **+RM3**  | **+Rocchio**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.9023    | 0.9174    | 0.9122    |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.9024    | 0.9174    | 0.9120    |
 
 Note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).
@@ -138,6 +138,6 @@ The experimental results reported here are directly comparable to the results re
 
 ## Reproduction Log[*](reproducibility.md)
 
-To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl20-passage-splade-pp-sd.template) and run `bin/build.sh` to rebuild the documentation.
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl20-passage-splade-pp-sd-onnx.template) and run `bin/build.sh` to rebuild the documentation.
 
 + Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/docs/regressions-dl20-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions-dl20-passage-splade-pp-sd-onnx.md
@@ -139,5 +139,3 @@ The experimental results reported here are directly comparable to the results re
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl20-passage-splade-pp-sd-onnx.template) and run `bin/build.sh` to rebuild the documentation.
-
-+ Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/docs/regressions-dl20-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions-dl20-passage-splade-pp-sd-onnx.md
@@ -20,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-pp-sd-onnx
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/docs/regressions-dl20-passage-splade-pp-sd.md
+++ b/docs/regressions-dl20-passage-splade-pp-sd.md
@@ -20,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-pp-sd
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/docs/regressions-dl20-passage-splade-pp-sd.md
+++ b/docs/regressions-dl20-passage-splade-pp-sd.md
@@ -33,11 +33,11 @@ The `run_regression.py` script automates the following steps, but if you want to
 Download the corpus and unpack into `collections/`:
 
 ```bash
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-splade_distil_cocodenser_medium.tar -P collections/
-tar xvf collections/msmarco-passage-splade_distil_cocodenser_medium.tar -C collections/
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-sd.tar -P collections/
+tar xvf collections/msmarco-passage-splade-pp-sd.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-splade_distil_cocodenser_medium.tar` is 4.9 GB and has MD5 checksum `f77239a26d08856e6491a34062893b0c`.
+To confirm, `msmarco-passage-splade-pp-sd.tar` is 4.8 GB and has MD5 checksum `cb7e264222f2bf2221dd2c9d28190be1`.
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash

--- a/docs/regressions-dl20-passage-unicoil-noexp.md
+++ b/docs/regressions-dl20-passage-unicoil-noexp.md
@@ -22,7 +22,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-unicoil-noexp
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., we have performed model inference on every document and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with uniCOIL, i.e., we have performed model inference on every document and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/docs/regressions-dl20-passage-unicoil.md
+++ b/docs/regressions-dl20-passage-unicoil.md
@@ -22,7 +22,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-unicoil
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., we have applied doc2query-T5 expansions, performed model inference on every document, and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with uniCOIL, i.e., we have applied doc2query-T5 expansions, performed model inference on every document, and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/docs/regressions-msmarco-passage-deepimpact.md
+++ b/docs/regressions-msmarco-passage-deepimpact.md
@@ -16,7 +16,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-deepimpact
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with DeepImpact, i.e., we have applied neural inference and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with DeepImpact, i.e., we have applied neural inference and stored the output sparse vectors.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/docs/regressions-msmarco-passage-distill-splade-max.md
+++ b/docs/regressions-msmarco-passage-distill-splade-max.md
@@ -16,7 +16,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-distill-splade-max
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with DistilSPLADE-max, i.e., performed model inference on every document and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with DistilSPLADE-max, i.e., performed model inference on every document and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/docs/regressions-msmarco-passage-splade-distil-cocodenser-medium.md
+++ b/docs/regressions-msmarco-passage-splade-distil-cocodenser-medium.md
@@ -14,7 +14,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-distil-cocodenser-medium
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., performed model inference on every document and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., performed model inference on every document and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/docs/regressions-msmarco-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions-msmarco-passage-splade-pp-ed-onnx.md
@@ -107,5 +107,3 @@ With the above commands, you should be able to reproduce the following results:
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template) and run `bin/build.sh` to rebuild the documentation.
-
-+ Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/docs/regressions-msmarco-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions-msmarco-passage-splade-pp-ed-onnx.md
@@ -17,7 +17,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-pp-ed-onnx
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/docs/regressions-msmarco-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions-msmarco-passage-splade-pp-ed-onnx.md
@@ -1,20 +1,20 @@
 # Anserini Regressions: MS MARCO Passage Ranking
 
-**Model**: SPLADE++ CoCondenser-EnsembleDistil (using pre-encoded queries)
+**Model**: SPLADE++ CoCondenser-EnsembleDistil (using ONNX for on-the-fly query encoding)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-EnsembleDistil](https://huggingface.co/naver/splade-cocondenser-ensembledistil) model on the [MS MARCO passage ranking task](https://github.com/microsoft/MSMARCO-Passage-Ranking), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
 
-In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
+In these experiments, we are using ONNX to perform query encoding on the fly.
 
-The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/msmarco-passage-splade-pp-ed.yaml).
-Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/msmarco-passage-splade-pp-ed-onnx.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-pp-ed
+python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-pp-ed-onnx
 ```
 
 We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
@@ -22,7 +22,7 @@ We make available a version of the MS MARCO passage corpus that has already been
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 
 ```bash
-python src/main/python/run_regression.py --download --index --verify --search --regression msmarco-passage-splade-pp-ed
+python src/main/python/run_regression.py --download --index --verify --search --regression msmarco-passage-splade-pp-ed-onnx
 ```
 
 The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
@@ -40,7 +40,7 @@ To confirm, `msmarco-passage-splade-pp-ed.tar` is 4.2 GB and has MD5 checksum `e
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-pp-ed \
+python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-pp-ed-onnx \
   --corpus-path collections/msmarco-passage-splade-pp-ed
 ```
 
@@ -75,19 +75,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
-  -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.splade-pp-ed.tsv.gz \
+  -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
   -topicreader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.splade-pp-ed.txt \
-  -impact -pretokenized &
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.txt \
+  -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-tools/eval/trec_eval.9.0.4/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.txt
 ```
 
 ## Effectiveness
@@ -96,16 +96,16 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **SPLADE++ CoCondenser-EnsembleDistil**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3884    |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3883    |
 | **RR@10**                                                                                                    | **SPLADE++ CoCondenser-EnsembleDistil**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3830    |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.3828    |
 | **R@100**                                                                                                    | **SPLADE++ CoCondenser-EnsembleDistil**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9095    |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9092    |
 | **R@1000**                                                                                                   | **SPLADE++ CoCondenser-EnsembleDistil**|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.9831    |
 
 ## Reproduction Log[*](reproducibility.md)
 
-To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed.template) and run `bin/build.sh` to rebuild the documentation.
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template) and run `bin/build.sh` to rebuild the documentation.
 
 + Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/docs/regressions-msmarco-passage-splade-pp-ed.md
+++ b/docs/regressions-msmarco-passage-splade-pp-ed.md
@@ -30,11 +30,11 @@ The `run_regression.py` script automates the following steps, but if you want to
 Download the corpus and unpack into `collections/`:
 
 ```bash
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-splade_distil_cocodenser_medium.tar -P collections/
-tar xvf collections/msmarco-passage-splade_distil_cocodenser_medium.tar -C collections/
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-ed.tar -P collections/
+tar xvf collections/msmarco-passage-splade-pp-ed.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-splade_distil_cocodenser_medium.tar` is 4.9 GB and has MD5 checksum `f77239a26d08856e6491a34062893b0c`.
+To confirm, `msmarco-passage-splade-pp-ed.tar` is 4.2 GB and has MD5 checksum `e489133bdc54ee1e7c62a32aa582bc77`.
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash

--- a/docs/regressions-msmarco-passage-splade-pp-ed.md
+++ b/docs/regressions-msmarco-passage-splade-pp-ed.md
@@ -17,7 +17,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-pp-ed
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/docs/regressions-msmarco-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions-msmarco-passage-splade-pp-sd-onnx.md
@@ -17,7 +17,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-pp-sd-onnx
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/docs/regressions-msmarco-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions-msmarco-passage-splade-pp-sd-onnx.md
@@ -107,5 +107,3 @@ With the above commands, you should be able to reproduce the following results:
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template) and run `bin/build.sh` to rebuild the documentation.
-
-+ Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/docs/regressions-msmarco-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions-msmarco-passage-splade-pp-sd-onnx.md
@@ -1,20 +1,20 @@
 # Anserini Regressions: MS MARCO Passage Ranking
 
-**Model**: SPLADE++ CoCondenser-SelfDistil (using pre-encoded queries)
+**Model**: SPLADE++ CoCondenser-SelfDistil (using ONNX for on-the-fly query encoding)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-SelfDistil](https://huggingface.co/naver/splade-cocondenser-selfdistil) model on the [MS MARCO passage ranking task](https://github.com/microsoft/MSMARCO-Passage-Ranking), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
 
-In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
+In these experiments, we are using ONNX to perform query encoding on the fly.
 
-The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/msmarco-passage-splade-pp-sd.yaml).
-Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+The exact configurations for these regressions are stored in [this YAML file](../src/main/resources/regression/msmarco-passage-splade-pp-sd-onnx.yaml).
+Note that this page is automatically generated from [this template](../src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
 
 From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-pp-sd
+python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-pp-sd-onnx
 ```
 
 We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
@@ -22,7 +22,7 @@ We make available a version of the MS MARCO passage corpus that has already been
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 
 ```bash
-python src/main/python/run_regression.py --download --index --verify --search --regression msmarco-passage-splade-pp-sd
+python src/main/python/run_regression.py --download --index --verify --search --regression msmarco-passage-splade-pp-sd-onnx
 ```
 
 The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
@@ -40,7 +40,7 @@ To confirm, `msmarco-passage-splade-pp-sd.tar` is 4.8 GB and has MD5 checksum `c
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-pp-sd \
+python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-pp-sd-onnx \
   --corpus-path collections/msmarco-passage-splade-pp-sd
 ```
 
@@ -106,6 +106,6 @@ With the above commands, you should be able to reproduce the following results:
 
 ## Reproduction Log[*](reproducibility.md)
 
-To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd.template) and run `bin/build.sh` to rebuild the documentation.
+To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template) and run `bin/build.sh` to rebuild the documentation.
 
 + Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/docs/regressions-msmarco-passage-splade-pp-sd.md
+++ b/docs/regressions-msmarco-passage-splade-pp-sd.md
@@ -17,7 +17,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-pp-sd
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/docs/regressions-msmarco-passage-splade-pp-sd.md
+++ b/docs/regressions-msmarco-passage-splade-pp-sd.md
@@ -30,11 +30,11 @@ The `run_regression.py` script automates the following steps, but if you want to
 Download the corpus and unpack into `collections/`:
 
 ```bash
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-splade_distil_cocodenser_medium.tar -P collections/
-tar xvf collections/msmarco-passage-splade_distil_cocodenser_medium.tar -C collections/
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-sd.tar -P collections/
+tar xvf collections/msmarco-passage-splade-pp-sd.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-splade_distil_cocodenser_medium.tar` is 4.9 GB and has MD5 checksum `f77239a26d08856e6491a34062893b0c`.
+To confirm, `msmarco-passage-splade-pp-sd.tar` is 4.8 GB and has MD5 checksum `cb7e264222f2bf2221dd2c9d28190be1`.
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash

--- a/docs/regressions-msmarco-passage-unicoil-noexp.md
+++ b/docs/regressions-msmarco-passage-unicoil-noexp.md
@@ -19,7 +19,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-unicoil-noexp
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., we have performed model inference on every document and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with uniCOIL, i.e., we have performed model inference on every document and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/docs/regressions-msmarco-passage-unicoil-tilde-expansion.md
+++ b/docs/regressions-msmarco-passage-unicoil-tilde-expansion.md
@@ -16,7 +16,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-unicoil-tilde-expansion
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL + TILDE expansions, i.e., performed model inference on every document and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with uniCOIL + TILDE expansions, i.e., performed model inference on every document and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/docs/regressions-msmarco-passage-unicoil.md
+++ b/docs/regressions-msmarco-passage-unicoil.md
@@ -16,7 +16,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-unicoil
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., we have applied doc2query-T5 expansions, performed model inference on every document, and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with uniCOIL, i.e., we have applied doc2query-T5 expansions, performed model inference on every document, and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/src/main/resources/docgen/templates/dl19-passage-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/dl19-passage-splade-distil-cocodenser-medium.template
@@ -17,7 +17,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., performed model inference on every document and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., performed model inference on every document and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/src/main/resources/docgen/templates/dl19-passage-splade-pp-ed-onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage-splade-pp-ed-onnx.template
@@ -20,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/src/main/resources/docgen/templates/dl19-passage-splade-pp-ed-onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage-splade-pp-ed-onnx.template
@@ -93,5 +93,3 @@ The experimental results reported here are directly comparable to the results re
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
-
-+ Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/src/main/resources/docgen/templates/dl19-passage-splade-pp-ed-onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage-splade-pp-ed-onnx.template
@@ -1,12 +1,15 @@
-# Anserini Regressions: MS MARCO Passage Ranking
+# Anserini Regressions: TREC 2019 Deep Learning Track (Passage)
 
-**Model**: SPLADE++ CoCondenser-EnsembleDistil (using pre-encoded queries)
+**Model**: SPLADE++ CoCondenser-EnsembleDistil (using ONNX for on-the-fly query encoding)
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-EnsembleDistil](https://huggingface.co/naver/splade-cocondenser-ensembledistil) model on the [MS MARCO passage ranking task](https://github.com/microsoft/MSMARCO-Passage-Ranking), as described in the following paper:
+This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-EnsembleDistil](https://huggingface.co/naver/splade-cocondenser-ensembledistil) model on the [TREC 2019 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
 
-In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
+For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
 Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
@@ -54,7 +57,7 @@ ${index_cmds}
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
-The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doc lengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the SPLADE-distil CoCodenser Medium tokens.
 Upon completion, we should have an index with 8,841,823 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
@@ -62,7 +65,8 @@ For additional details, see explanation of [common indexing options](common-inde
 ## Retrieval
 
 Topics and qrels are stored in [`tools/topics-and-qrels/`](../tools/topics-and-qrels/).
-The regression experiments here evaluate on the 6980 dev set questions; see [this page](experiments-msmarco-passage.md) for more details.
+The regression experiments here evaluate on the 43 topics for which NIST has provided judgments as part of the TREC 2019 Deep Learning Track.
+The original data can be found [here](https://trec.nist.gov/data/deep2019.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
@@ -81,6 +85,10 @@ ${eval_cmds}
 With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
+
+Note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
+Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).
+The experimental results reported here are directly comparable to the results reported in the [track overview paper](https://arxiv.org/abs/2003.07820).
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/src/main/resources/docgen/templates/dl19-passage-splade-pp-ed.template
+++ b/src/main/resources/docgen/templates/dl19-passage-splade-pp-ed.template
@@ -1,10 +1,12 @@
 # Anserini Regressions: TREC 2019 Deep Learning Track (Passage)
 
-**Model**: SPLADE++ CoCondenser-EnsembleDistil
+**Model**: SPLADE++ CoCondenser-EnsembleDistil (using pre-encoded queries)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-EnsembleDistil](https://huggingface.co/naver/splade-cocondenser-ensembledistil) model on the [TREC 2019 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
+
+In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
 Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
 For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).

--- a/src/main/resources/docgen/templates/dl19-passage-splade-pp-ed.template
+++ b/src/main/resources/docgen/templates/dl19-passage-splade-pp-ed.template
@@ -20,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/src/main/resources/docgen/templates/dl19-passage-splade-pp-ed.template
+++ b/src/main/resources/docgen/templates/dl19-passage-splade-pp-ed.template
@@ -33,11 +33,11 @@ The `run_regression.py` script automates the following steps, but if you want to
 Download the corpus and unpack into `collections/`:
 
 ```bash
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-splade_distil_cocodenser_medium.tar -P collections/
-tar xvf collections/msmarco-passage-splade_distil_cocodenser_medium.tar -C collections/
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-ed.tar -P collections/
+tar xvf collections/msmarco-passage-splade-pp-ed.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-splade_distil_cocodenser_medium.tar` is 4.9 GB and has MD5 checksum `f77239a26d08856e6491a34062893b0c`.
+To confirm, `msmarco-passage-splade-pp-ed.tar` is 4.2 GB and has MD5 checksum `e489133bdc54ee1e7c62a32aa582bc77`.
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash

--- a/src/main/resources/docgen/templates/dl19-passage-splade-pp-sd-onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage-splade-pp-sd-onnx.template
@@ -1,12 +1,15 @@
-# Anserini Regressions: MS MARCO Passage Ranking
+# Anserini Regressions: TREC 2019 Deep Learning Track (Passage)
 
-**Model**: SPLADE++ CoCondenser-EnsembleDistil (using pre-encoded queries)
+**Model**: SPLADE++ CoCondenser-SelfDistil (using ONNX for on-the-fly query encoding)
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-EnsembleDistil](https://huggingface.co/naver/splade-cocondenser-ensembledistil) model on the [MS MARCO passage ranking task](https://github.com/microsoft/MSMARCO-Passage-Ranking), as described in the following paper:
+This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-SelfDistil](https://huggingface.co/naver/splade-cocondenser-selfdistil) model on the [TREC 2019 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
 
-In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
+For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
 Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
@@ -17,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
+We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 
@@ -32,11 +35,11 @@ The `run_regression.py` script automates the following steps, but if you want to
 Download the corpus and unpack into `collections/`:
 
 ```bash
-wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-ed.tar -P collections/
-tar xvf collections/msmarco-passage-splade-pp-ed.tar -C collections/
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-sd.tar -P collections/
+tar xvf collections/msmarco-passage-splade-pp-sd.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-splade-pp-ed.tar` is 4.2 GB and has MD5 checksum `e489133bdc54ee1e7c62a32aa582bc77`.
+To confirm, `msmarco-passage-splade-pp-sd.tar` is 4.8 GB and has MD5 checksum `cb7e264222f2bf2221dd2c9d28190be1`.
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash
@@ -54,7 +57,7 @@ ${index_cmds}
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
-The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doc lengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the SPLADE-distil CoCodenser Medium tokens.
 Upon completion, we should have an index with 8,841,823 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
@@ -62,7 +65,8 @@ For additional details, see explanation of [common indexing options](common-inde
 ## Retrieval
 
 Topics and qrels are stored in [`tools/topics-and-qrels/`](../tools/topics-and-qrels/).
-The regression experiments here evaluate on the 6980 dev set questions; see [this page](experiments-msmarco-passage.md) for more details.
+The regression experiments here evaluate on the 43 topics for which NIST has provided judgments as part of the TREC 2019 Deep Learning Track.
+The original data can be found [here](https://trec.nist.gov/data/deep2019.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
@@ -81,6 +85,10 @@ ${eval_cmds}
 With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
+
+Note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
+Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).
+The experimental results reported here are directly comparable to the results reported in the [track overview paper](https://arxiv.org/abs/2003.07820).
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/src/main/resources/docgen/templates/dl19-passage-splade-pp-sd-onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage-splade-pp-sd-onnx.template
@@ -20,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/src/main/resources/docgen/templates/dl19-passage-splade-pp-sd-onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage-splade-pp-sd-onnx.template
@@ -93,5 +93,3 @@ The experimental results reported here are directly comparable to the results re
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
-
-+ Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/src/main/resources/docgen/templates/dl19-passage-splade-pp-sd.template
+++ b/src/main/resources/docgen/templates/dl19-passage-splade-pp-sd.template
@@ -1,10 +1,12 @@
 # Anserini Regressions: TREC 2019 Deep Learning Track (Passage)
 
-**Model**: SPLADE++ CoCondenser-SelfDistil
+**Model**: SPLADE++ CoCondenser-SelfDistil (using pre-encoded queries)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-SelfDistil](https://huggingface.co/naver/splade-cocondenser-selfdistil) model on the [TREC 2019 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
+
+In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
 Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
 For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).

--- a/src/main/resources/docgen/templates/dl19-passage-splade-pp-sd.template
+++ b/src/main/resources/docgen/templates/dl19-passage-splade-pp-sd.template
@@ -20,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/src/main/resources/docgen/templates/dl19-passage-splade-pp-sd.template
+++ b/src/main/resources/docgen/templates/dl19-passage-splade-pp-sd.template
@@ -33,11 +33,11 @@ The `run_regression.py` script automates the following steps, but if you want to
 Download the corpus and unpack into `collections/`:
 
 ```bash
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-splade_distil_cocodenser_medium.tar -P collections/
-tar xvf collections/msmarco-passage-splade_distil_cocodenser_medium.tar -C collections/
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-sd.tar -P collections/
+tar xvf collections/msmarco-passage-splade-pp-sd.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-splade_distil_cocodenser_medium.tar` is 4.9 GB and has MD5 checksum `f77239a26d08856e6491a34062893b0c`.
+To confirm, `msmarco-passage-splade-pp-sd.tar` is 4.8 GB and has MD5 checksum `cb7e264222f2bf2221dd2c9d28190be1`.
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash

--- a/src/main/resources/docgen/templates/dl19-passage-unicoil-noexp.template
+++ b/src/main/resources/docgen/templates/dl19-passage-unicoil-noexp.template
@@ -22,7 +22,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., we have performed model inference on every document and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with uniCOIL, i.e., we have performed model inference on every document and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/src/main/resources/docgen/templates/dl19-passage-unicoil.template
+++ b/src/main/resources/docgen/templates/dl19-passage-unicoil.template
@@ -22,7 +22,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., we have applied doc2query-T5 expansions, performed model inference on every document, and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with uniCOIL, i.e., we have applied doc2query-T5 expansions, performed model inference on every document, and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/src/main/resources/docgen/templates/dl20-passage-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/dl20-passage-splade-distil-cocodenser-medium.template
@@ -17,7 +17,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., performed model inference on every document and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., performed model inference on every document and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/src/main/resources/docgen/templates/dl20-passage-splade-pp-ed-onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage-splade-pp-ed-onnx.template
@@ -20,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/src/main/resources/docgen/templates/dl20-passage-splade-pp-ed-onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage-splade-pp-ed-onnx.template
@@ -93,5 +93,3 @@ The experimental results reported here are directly comparable to the results re
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
-
-+ Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/src/main/resources/docgen/templates/dl20-passage-splade-pp-ed-onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage-splade-pp-ed-onnx.template
@@ -1,12 +1,15 @@
-# Anserini Regressions: MS MARCO Passage Ranking
+# Anserini Regressions: TREC 2020 Deep Learning Track (Passage)
 
-**Model**: SPLADE++ CoCondenser-EnsembleDistil (using pre-encoded queries)
+**Model**: SPLADE++ CoCondenser-EnsembleDistil (using ONNX for on-the-fly query encoding)
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-EnsembleDistil](https://huggingface.co/naver/splade-cocondenser-ensembledistil) model on the [MS MARCO passage ranking task](https://github.com/microsoft/MSMARCO-Passage-Ranking), as described in the following paper:
+This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-EnsembleDistil](https://huggingface.co/naver/splade-cocondenser-ensembledistil) model on the [TREC 2020 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
 
-In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
+For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
 Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
@@ -54,7 +57,7 @@ ${index_cmds}
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
-The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doc lengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the SPLADE-distil CoCodenser Medium tokens.
 Upon completion, we should have an index with 8,841,823 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
@@ -62,7 +65,8 @@ For additional details, see explanation of [common indexing options](common-inde
 ## Retrieval
 
 Topics and qrels are stored in [`tools/topics-and-qrels/`](../tools/topics-and-qrels/).
-The regression experiments here evaluate on the 6980 dev set questions; see [this page](experiments-msmarco-passage.md) for more details.
+The regression experiments here evaluate on the 54 topics for which NIST has provided judgments as part of the TREC 2020 Deep Learning Track.
+The original data can be found [here](https://trec.nist.gov/data/deep2020.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
@@ -81,6 +85,10 @@ ${eval_cmds}
 With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
+
+Note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
+Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).
+The experimental results reported here are directly comparable to the results reported in the [track overview paper](https://arxiv.org/abs/2003.07820).
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/src/main/resources/docgen/templates/dl20-passage-splade-pp-ed.template
+++ b/src/main/resources/docgen/templates/dl20-passage-splade-pp-ed.template
@@ -20,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/src/main/resources/docgen/templates/dl20-passage-splade-pp-ed.template
+++ b/src/main/resources/docgen/templates/dl20-passage-splade-pp-ed.template
@@ -1,10 +1,12 @@
 # Anserini Regressions: TREC 2020 Deep Learning Track (Passage)
 
-**Model**: SPLADE++ CoCondenser-EnsembleDistil
+**Model**: SPLADE++ CoCondenser-EnsembleDistil (using pre-encoded queries)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-EnsembleDistil](https://huggingface.co/naver/splade-cocondenser-ensembledistil) model on the [TREC 2020 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
+
+In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
 Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
 For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).

--- a/src/main/resources/docgen/templates/dl20-passage-splade-pp-ed.template
+++ b/src/main/resources/docgen/templates/dl20-passage-splade-pp-ed.template
@@ -33,11 +33,11 @@ The `run_regression.py` script automates the following steps, but if you want to
 Download the corpus and unpack into `collections/`:
 
 ```bash
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-splade_distil_cocodenser_medium.tar -P collections/
-tar xvf collections/msmarco-passage-splade_distil_cocodenser_medium.tar -C collections/
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-ed.tar -P collections/
+tar xvf collections/msmarco-passage-splade-pp-ed.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-splade_distil_cocodenser_medium.tar` is 4.9 GB and has MD5 checksum `f77239a26d08856e6491a34062893b0c`.
+To confirm, `msmarco-passage-splade-pp-ed.tar` is 4.2 GB and has MD5 checksum `e489133bdc54ee1e7c62a32aa582bc77`.
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash

--- a/src/main/resources/docgen/templates/dl20-passage-splade-pp-sd-onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage-splade-pp-sd-onnx.template
@@ -20,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/src/main/resources/docgen/templates/dl20-passage-splade-pp-sd-onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage-splade-pp-sd-onnx.template
@@ -93,5 +93,3 @@ The experimental results reported here are directly comparable to the results re
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
-
-+ Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/src/main/resources/docgen/templates/dl20-passage-splade-pp-sd-onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage-splade-pp-sd-onnx.template
@@ -1,12 +1,15 @@
-# Anserini Regressions: MS MARCO Passage Ranking
+# Anserini Regressions: TREC 2020 Deep Learning Track (Passage)
 
-**Model**: SPLADE++ CoCondenser-EnsembleDistil (using pre-encoded queries)
+**Model**: SPLADE++ CoCondenser-SelfDistil (using ONNX for on-the-fly query encoding)
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-EnsembleDistil](https://huggingface.co/naver/splade-cocondenser-ensembledistil) model on the [MS MARCO passage ranking task](https://github.com/microsoft/MSMARCO-Passage-Ranking), as described in the following paper:
+This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-SelfDistil](https://huggingface.co/naver/splade-cocondenser-selfdistil) model on the [TREC 2020 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
 
-In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
+For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
 Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
@@ -17,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
+We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 
@@ -32,11 +35,11 @@ The `run_regression.py` script automates the following steps, but if you want to
 Download the corpus and unpack into `collections/`:
 
 ```bash
-wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-ed.tar -P collections/
-tar xvf collections/msmarco-passage-splade-pp-ed.tar -C collections/
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-sd.tar -P collections/
+tar xvf collections/msmarco-passage-splade-pp-sd.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-splade-pp-ed.tar` is 4.2 GB and has MD5 checksum `e489133bdc54ee1e7c62a32aa582bc77`.
+To confirm, `msmarco-passage-splade-pp-sd.tar` is 4.8 GB and has MD5 checksum `cb7e264222f2bf2221dd2c9d28190be1`.
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash
@@ -54,7 +57,7 @@ ${index_cmds}
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
-The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doc lengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the SPLADE-distil CoCodenser Medium tokens.
 Upon completion, we should have an index with 8,841,823 documents.
 
 For additional details, see explanation of [common indexing options](common-indexing-options.md).
@@ -62,7 +65,8 @@ For additional details, see explanation of [common indexing options](common-inde
 ## Retrieval
 
 Topics and qrels are stored in [`tools/topics-and-qrels/`](../tools/topics-and-qrels/).
-The regression experiments here evaluate on the 6980 dev set questions; see [this page](experiments-msmarco-passage.md) for more details.
+The regression experiments here evaluate on the 54 topics for which NIST has provided judgments as part of the TREC 2020 Deep Learning Track.
+The original data can be found [here](https://trec.nist.gov/data/deep2020.html).
 
 After indexing has completed, you should be able to perform retrieval as follows:
 
@@ -81,6 +85,10 @@ ${eval_cmds}
 With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
+
+Note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
+Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).
+The experimental results reported here are directly comparable to the results reported in the [track overview paper](https://arxiv.org/abs/2003.07820).
 
 ## Reproduction Log[*](reproducibility.md)
 

--- a/src/main/resources/docgen/templates/dl20-passage-splade-pp-sd.template
+++ b/src/main/resources/docgen/templates/dl20-passage-splade-pp-sd.template
@@ -20,7 +20,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/src/main/resources/docgen/templates/dl20-passage-splade-pp-sd.template
+++ b/src/main/resources/docgen/templates/dl20-passage-splade-pp-sd.template
@@ -33,11 +33,11 @@ The `run_regression.py` script automates the following steps, but if you want to
 Download the corpus and unpack into `collections/`:
 
 ```bash
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-splade_distil_cocodenser_medium.tar -P collections/
-tar xvf collections/msmarco-passage-splade_distil_cocodenser_medium.tar -C collections/
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-sd.tar -P collections/
+tar xvf collections/msmarco-passage-splade-pp-sd.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-splade_distil_cocodenser_medium.tar` is 4.9 GB and has MD5 checksum `f77239a26d08856e6491a34062893b0c`.
+To confirm, `msmarco-passage-splade-pp-sd.tar` is 4.8 GB and has MD5 checksum `cb7e264222f2bf2221dd2c9d28190be1`.
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash

--- a/src/main/resources/docgen/templates/dl20-passage-splade-pp-sd.template
+++ b/src/main/resources/docgen/templates/dl20-passage-splade-pp-sd.template
@@ -1,10 +1,12 @@
 # Anserini Regressions: TREC 2020 Deep Learning Track (Passage)
 
-**Model**: SPLADE++ CoCondenser-SelfDistil
+**Model**: SPLADE++ CoCondenser-SelfDistil (using pre-encoded queries)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-SelfDistil](https://huggingface.co/naver/splade-cocondenser-selfdistil) model on the [TREC 2020 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
+
+In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
 Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
 For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).

--- a/src/main/resources/docgen/templates/dl20-passage-unicoil-noexp.template
+++ b/src/main/resources/docgen/templates/dl20-passage-unicoil-noexp.template
@@ -22,7 +22,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., we have performed model inference on every document and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with uniCOIL, i.e., we have performed model inference on every document and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/src/main/resources/docgen/templates/dl20-passage-unicoil.template
+++ b/src/main/resources/docgen/templates/dl20-passage-unicoil.template
@@ -22,7 +22,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., we have applied doc2query-T5 expansions, performed model inference on every document, and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with uniCOIL, i.e., we have applied doc2query-T5 expansions, performed model inference on every document, and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/src/main/resources/docgen/templates/msmarco-passage-deepimpact.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-deepimpact.template
@@ -16,7 +16,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with DeepImpact, i.e., we have applied neural inference and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with DeepImpact, i.e., we have applied neural inference and stored the output sparse vectors.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/src/main/resources/docgen/templates/msmarco-passage-distill-splade-max.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-distill-splade-max.template
@@ -16,7 +16,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with DistilSPLADE-max, i.e., performed model inference on every document and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with DistilSPLADE-max, i.e., performed model inference on every document and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-distil-cocodenser-medium.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-distil-cocodenser-medium.template
@@ -14,7 +14,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., performed model inference on every document and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with SPLADE-distil CoCodenser Medium, i.e., performed model inference on every document and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template
@@ -85,5 +85,3 @@ ${effectiveness}
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
-
-+ Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template
@@ -1,12 +1,12 @@
 # Anserini Regressions: MS MARCO Passage Ranking
 
-**Model**: SPLADE++ CoCondenser-EnsembleDistil (using pre-encoded queries)
+**Model**: SPLADE++ CoCondenser-EnsembleDistil (using ONNX for on-the-fly query encoding)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-EnsembleDistil](https://huggingface.co/naver/splade-cocondenser-ensembledistil) model on the [MS MARCO passage ranking task](https://github.com/microsoft/MSMARCO-Passage-Ranking), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
 
-In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
+In these experiments, we are using ONNX to perform query encoding on the fly.
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
 Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template
@@ -17,7 +17,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed.template
@@ -30,11 +30,11 @@ The `run_regression.py` script automates the following steps, but if you want to
 Download the corpus and unpack into `collections/`:
 
 ```bash
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-splade_distil_cocodenser_medium.tar -P collections/
-tar xvf collections/msmarco-passage-splade_distil_cocodenser_medium.tar -C collections/
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-ed.tar -P collections/
+tar xvf collections/msmarco-passage-splade-pp-ed.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-splade_distil_cocodenser_medium.tar` is 4.9 GB and has MD5 checksum `f77239a26d08856e6491a34062893b0c`.
+To confirm, `msmarco-passage-splade-pp-ed.tar` is 4.2 GB and has MD5 checksum `e489133bdc54ee1e7c62a32aa582bc77`.
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed.template
@@ -17,7 +17,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template
@@ -85,5 +85,3 @@ ${effectiveness}
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
-
-+ Results reproduced by [@justram](https://github.com/justram) on 2023-03-08 (commit [`03f95a8`](https://github.com/castorini/anserini/commit/03f95a8e1ae09ab09efe046bfcbd3a4cdda691b4))

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template
@@ -1,12 +1,12 @@
 # Anserini Regressions: MS MARCO Passage Ranking
 
-**Model**: SPLADE++ CoCondenser-EnsembleDistil (using pre-encoded queries)
+**Model**: SPLADE++ CoCondenser-SelfDistil (using ONNX for on-the-fly query encoding)
 
-This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-EnsembleDistil](https://huggingface.co/naver/splade-cocondenser-ensembledistil) model on the [MS MARCO passage ranking task](https://github.com/microsoft/MSMARCO-Passage-Ranking), as described in the following paper:
+This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-SelfDistil](https://huggingface.co/naver/splade-cocondenser-selfdistil) model on the [MS MARCO passage ranking task](https://github.com/microsoft/MSMARCO-Passage-Ranking), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
 
-In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
+In these experiments, we are using ONNX to perform query encoding on the fly.
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
 Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
@@ -17,7 +17,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-EnsembleDistil.
+We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 
@@ -32,11 +32,11 @@ The `run_regression.py` script automates the following steps, but if you want to
 Download the corpus and unpack into `collections/`:
 
 ```bash
-wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-ed.tar -P collections/
-tar xvf collections/msmarco-passage-splade-pp-ed.tar -C collections/
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-sd.tar -P collections/
+tar xvf collections/msmarco-passage-splade-pp-sd.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-splade-pp-ed.tar` is 4.2 GB and has MD5 checksum `e489133bdc54ee1e7c62a32aa582bc77`.
+To confirm, `msmarco-passage-splade-pp-sd.tar` is 4.8 GB and has MD5 checksum `cb7e264222f2bf2221dd2c9d28190be1`.
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template
@@ -17,7 +17,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd.template
@@ -1,10 +1,12 @@
 # Anserini Regressions: MS MARCO Passage Ranking
 
-**Model**: SPLADE++ CoCondenser-SelfDistil
+**Model**: SPLADE++ CoCondenser-SelfDistil (using pre-encoded queries)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the [SPLADE++ CoCondenser-SelfDistil](https://huggingface.co/naver/splade-cocondenser-selfdistil) model on the [MS MARCO passage ranking task](https://github.com/microsoft/MSMARCO-Passage-Ranking), as described in the following paper:
 
 > Thibault Formal, Carlos Lassance, Benjamin Piwowarski, and Stéphane Clinchant. [From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://dl.acm.org/doi/10.1145/3477495.3531857) _Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval_, pages 2353–2359.
+
+In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
 Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd.template
@@ -30,11 +30,11 @@ The `run_regression.py` script automates the following steps, but if you want to
 Download the corpus and unpack into `collections/`:
 
 ```bash
-wget https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-splade_distil_cocodenser_medium.tar -P collections/
-tar xvf collections/msmarco-passage-splade_distil_cocodenser_medium.tar -C collections/
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-splade-pp-sd.tar -P collections/
+tar xvf collections/msmarco-passage-splade-pp-sd.tar -C collections/
 ```
 
-To confirm, `msmarco-passage-splade_distil_cocodenser_medium.tar` is 4.9 GB and has MD5 checksum `f77239a26d08856e6491a34062893b0c`.
+To confirm, `msmarco-passage-splade-pp-sd.tar` is 4.8 GB and has MD5 checksum `cb7e264222f2bf2221dd2c9d28190be1`.
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd.template
@@ -17,7 +17,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with SPLADE++ CoCondenser-SelfDistil.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:
 

--- a/src/main/resources/docgen/templates/msmarco-passage-unicoil-noexp.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-unicoil-noexp.template
@@ -19,7 +19,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., we have performed model inference on every document and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with uniCOIL, i.e., we have performed model inference on every document and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/src/main/resources/docgen/templates/msmarco-passage-unicoil-tilde-expansion.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-unicoil-tilde-expansion.template
@@ -16,7 +16,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL + TILDE expansions, i.e., performed model inference on every document and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with uniCOIL + TILDE expansions, i.e., performed model inference on every document and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:

--- a/src/main/resources/docgen/templates/msmarco-passage-unicoil.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-unicoil.template
@@ -16,7 +16,7 @@ From one of our Waterloo servers (e.g., `orca`), the following command will perf
 python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
 ```
 
-We make available a version of the MS MARCO passage corpus that has already been processed with uniCOIL, i.e., we have applied doc2query-T5 expansions, performed model inference on every document, and stored the output sparse vectors.
+We make available a version of the MS MARCO Passage Corpus that has already been processed with uniCOIL, i.e., we have applied doc2query-T5 expansions, performed model inference on every document, and stored the output sparse vectors.
 Thus, no neural inference is involved.
 
 From any machine, the following command will download the corpus and perform the complete regression, end to end:


### PR DESCRIPTION
+ Regressions themselves were added https://github.com/castorini/anserini/pull/2094 - this adds the documentation.
+ Fix download paths for SPLADE++ ED/SD corpora.
+ Minor tweaks for other docs