### PR TITLE
Reproduction of onnx results

### DIFF
--- a/docs/regressions-msmarco-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions-msmarco-passage-splade-pp-ed-onnx.md
@@ -108,4 +108,4 @@ With the above commands, you should be able to reproduce the following results:
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template) and run `bin/build.sh` to rebuild the documentation.
 
-+ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2a44af9322c7a2dbdb5240180a62398ab06`](https://github.com/castorini/anserini/commit/a403a2a44af9322c7a2dbdb5240180a62398ab06))
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2`](https://github.com/castorini/anserini/commit/https://github.com/castorini/anserini/commit/a403a2))

--- a/docs/regressions-msmarco-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions-msmarco-passage-splade-pp-ed-onnx.md
@@ -108,4 +108,4 @@ With the above commands, you should be able to reproduce the following results:
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template) and run `bin/build.sh` to rebuild the documentation.
 
-+ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2`](https://github.com/castorini/anserini/commit/https://github.com/castorini/anserini/commit/a403a2))
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2`](https://github.com/castorini/anserini/commit/a403a2a44af9322c7a2dbdb5240180a62398ab06))

--- a/docs/regressions-msmarco-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions-msmarco-passage-splade-pp-ed-onnx.md
@@ -107,3 +107,5 @@ With the above commands, you should be able to reproduce the following results:
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template) and run `bin/build.sh` to rebuild the documentation.
+
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2a44af9322c7a2dbdb5240180a62398ab06`](https://github.com/castorini/anserini/commit/a403a2a44af9322c7a2dbdb5240180a62398ab06))

--- a/docs/regressions-msmarco-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions-msmarco-passage-splade-pp-sd-onnx.md
@@ -108,4 +108,4 @@ With the above commands, you should be able to reproduce the following results:
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template) and run `bin/build.sh` to rebuild the documentation.
 
-+ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2a44af9322c7a2dbdb5240180a62398ab06`](https://github.com/castorini/anserini/commit/a403a2a44af9322c7a2dbdb5240180a62398ab06))
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2`](https://github.com/castorini/anserini/commit/https://github.com/castorini/anserini/commit/a403a2))

--- a/docs/regressions-msmarco-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions-msmarco-passage-splade-pp-sd-onnx.md
@@ -107,3 +107,5 @@ With the above commands, you should be able to reproduce the following results:
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template) and run `bin/build.sh` to rebuild the documentation.
+
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2a44af9322c7a2dbdb5240180a62398ab06`](https://github.com/castorini/anserini/commit/a403a2a44af9322c7a2dbdb5240180a62398ab06))

--- a/docs/regressions-msmarco-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions-msmarco-passage-splade-pp-sd-onnx.md
@@ -108,4 +108,4 @@ With the above commands, you should be able to reproduce the following results:
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template) and run `bin/build.sh` to rebuild the documentation.
 
-+ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2`](https://github.com/castorini/anserini/commit/https://github.com/castorini/anserini/commit/a403a2))
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2`](https://github.com/castorini/anserini/commit/a403a2a44af9322c7a2dbdb5240180a62398ab06))

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template
@@ -85,3 +85,5 @@ ${effectiveness}
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
+
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2a44af9322c7a2dbdb5240180a62398ab06`](https://github.com/castorini/anserini/commit/a403a2a44af9322c7a2dbdb5240180a62398ab06))

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template
@@ -86,4 +86,4 @@ ${effectiveness}
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
 
-+ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2a44af9322c7a2dbdb5240180a62398ab06`](https://github.com/castorini/anserini/commit/a403a2a44af9322c7a2dbdb5240180a62398ab06))
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2`](https://github.com/castorini/anserini/commit/a403a2))

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-ed-onnx.template
@@ -86,4 +86,4 @@ ${effectiveness}
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
 
-+ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2`](https://github.com/castorini/anserini/commit/a403a2))
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2`](https://github.com/castorini/anserini/commit/a403a2a44af9322c7a2dbdb5240180a62398ab06))

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template
@@ -86,4 +86,4 @@ ${effectiveness}
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
 
-+ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2`](https://github.com/castorini/anserini/commit/https://github.com/castorini/anserini/commit/a403a2))
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2`](https://github.com/castorini/anserini/commit/a403a2a44af9322c7a2dbdb5240180a62398ab06))

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template
@@ -85,3 +85,5 @@ ${effectiveness}
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
+
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2a44af9322c7a2dbdb5240180a62398ab06`](https://github.com/castorini/anserini/commit/a403a2a44af9322c7a2dbdb5240180a62398ab06))

--- a/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-splade-pp-sd-onnx.template
@@ -86,4 +86,4 @@ ${effectiveness}
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
 
-+ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2a44af9322c7a2dbdb5240180a62398ab06`](https://github.com/castorini/anserini/commit/a403a2a44af9322c7a2dbdb5240180a62398ab06))
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-05-31 (commit [`a403a2`](https://github.com/castorini/anserini/commit/https://github.com/castorini/anserini/commit/a403a2))


### PR DESCRIPTION
Correctly reproduced the results using onnx.

Environment
openjdk 11.0.13 2021-10-19
OpenJDK Runtime Environment JBR-11.0.13.7-1751.21-jcef (build 11.0.13+7-b1751.21)
OpenJDK 64-Bit Server VM JBR-11.0.13.7-1751.21-jcef (build 11.0.13+7-b1751.21, mixed mode)
Python 3.8.13

