### PR TITLE
Reproduce splade-pp-onnx with TREC DL 2019 and 2020

### DIFF
--- a/docs/regressions-dl19-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions-dl19-passage-splade-pp-ed-onnx.md
@@ -139,3 +139,5 @@ The experimental results reported here are directly comparable to the results re
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl19-passage-splade-pp-ed-onnx.template) and run `bin/build.sh` to rebuild the documentation.
+
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-06-01 (commit [`70ea75`](https://github.com/castorini/anserini/commit/70ea75314ba570001eb68134f2185b55f6c66044))

--- a/docs/regressions-dl19-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions-dl19-passage-splade-pp-sd-onnx.md
@@ -139,3 +139,5 @@ The experimental results reported here are directly comparable to the results re
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl19-passage-splade-pp-sd-onnx.template) and run `bin/build.sh` to rebuild the documentation.
+
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-06-01 (commit [`70ea75`](https://github.com/castorini/anserini/commit/70ea75314ba570001eb68134f2185b55f6c66044))

--- a/docs/regressions-dl20-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions-dl20-passage-splade-pp-ed-onnx.md
@@ -139,3 +139,5 @@ The experimental results reported here are directly comparable to the results re
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl20-passage-splade-pp-ed-onnx.template) and run `bin/build.sh` to rebuild the documentation.
+
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-06-01 (commit [`70ea75`](https://github.com/castorini/anserini/commit/70ea75314ba570001eb68134f2185b55f6c66044))

--- a/docs/regressions-dl20-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions-dl20-passage-splade-pp-sd-onnx.md
@@ -139,3 +139,5 @@ The experimental results reported here are directly comparable to the results re
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](../src/main/resources/docgen/templates/dl20-passage-splade-pp-sd-onnx.template) and run `bin/build.sh` to rebuild the documentation.
+
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-06-01 (commit [`70ea75`](https://github.com/castorini/anserini/commit/70ea75314ba570001eb68134f2185b55f6c66044))

--- a/src/main/resources/docgen/templates/dl19-passage-splade-pp-ed-onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage-splade-pp-ed-onnx.template
@@ -93,3 +93,5 @@ The experimental results reported here are directly comparable to the results re
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
+
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-06-01 (commit [`70ea75`](https://github.com/castorini/anserini/commit/70ea75314ba570001eb68134f2185b55f6c66044))

--- a/src/main/resources/docgen/templates/dl19-passage-splade-pp-sd-onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage-splade-pp-sd-onnx.template
@@ -93,3 +93,5 @@ The experimental results reported here are directly comparable to the results re
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
+
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-06-01 (commit [`70ea75`](https://github.com/castorini/anserini/commit/70ea75314ba570001eb68134f2185b55f6c66044))

--- a/src/main/resources/docgen/templates/dl20-passage-splade-pp-ed-onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage-splade-pp-ed-onnx.template
@@ -93,3 +93,5 @@ The experimental results reported here are directly comparable to the results re
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
+
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-06-01 (commit [`70ea75`](https://github.com/castorini/anserini/commit/70ea75314ba570001eb68134f2185b55f6c66044))

--- a/src/main/resources/docgen/templates/dl20-passage-splade-pp-sd-onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage-splade-pp-sd-onnx.template
@@ -93,3 +93,5 @@ The experimental results reported here are directly comparable to the results re
 ## Reproduction Log[*](reproducibility.md)
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
+
++ Results reproduced by [@cadurosar](https://github.com/cadurosar) on 2023-06-01 (commit [`70ea75`](https://github.com/castorini/anserini/commit/70ea75314ba570001eb68134f2185b55f6c66044))


### PR DESCRIPTION
Correctly reproduced the results using onnx.

Environment
openjdk 11.0.13 2021-10-19
OpenJDK Runtime Environment JBR-11.0.13.7-1751.21-jcef (build 11.0.13+7-b1751.21)
OpenJDK 64-Bit Server VM JBR-11.0.13.7-1751.21-jcef (build 11.0.13+7-b1751.21, mixed mode)
Python 3.8.13

Example:

2023-06-01 12:37:50,482 INFO  [python] ========== Verifying Results: msmarco-passage-splade-pp-sd ==========
2023-06-01 12:37:50,757 INFO  [python]    [OK] expected: 0.5139 actual: 0.5139 - metric: AP@1000  model: splade-pp-sd topics: dl20
2023-06-01 12:37:50,946 INFO  [python]    [OK] expected: 0.7282 actual: 0.7282 - metric: nDCG@10  model: splade-pp-sd topics: dl20
2023-06-01 12:37:51,154 INFO  [python]    [OK] expected: 0.7512 actual: 0.7512 - metric: R@100    model: splade-pp-sd topics: dl20
2023-06-01 12:37:51,358 INFO  [python]    [OK] expected: 0.9024 actual: 0.9024 - metric: R@1000   model: splade-pp-sd topics: dl20
2023-06-01 12:37:51,592 INFO  [python]    [OK] expected: 0.5266 actual: 0.5266 - metric: AP@1000  model: rm3 topics: dl20
2023-06-01 12:37:51,802 INFO  [python]    [OK] expected: 0.7227 actual: 0.7227 - metric: nDCG@10  model: rm3 topics: dl20
2023-06-01 12:37:52,017 INFO  [python]    [OK] expected: 0.7648 actual: 0.7648 - metric: R@100    model: rm3 topics: dl20
2023-06-01 12:37:52,217 INFO  [python]    [OK] expected: 0.9174 actual: 0.9174 - metric: R@1000   model: rm3 topics: dl20
2023-06-01 12:37:52,500 INFO  [python]    [OK] expected: 0.5335 actual: 0.5335 - metric: AP@1000  model: rocchio topics: dl20
2023-06-01 12:37:52,716 INFO  [python]    [OK] expected: 0.7388 actual: 0.7388 - metric: nDCG@10  model: rocchio topics: dl20
2023-06-01 12:37:52,916 INFO  [python]    [OK] expected: 0.7656 actual: 0.7656 - metric: R@100    model: rocchio topics: dl20
2023-06-01 12:37:53,116 INFO  [python]    [OK] expected: 0.9120 actual: 0.9120 - metric: R@1000   model: rocchio topics: dl20
2023-06-01 12:37:53,116 INFO  [python] All Tests Passed! Total elapsed time: 667s