### PR TITLE
make it possible to index/search MSMarco with fw/lexlsh ann

### DIFF
--- a/docs/approximate-nearestneighbor.md
+++ b/docs/approximate-nearestneighbor.md
@@ -39,7 +39,7 @@ Also, check our [Colab demo](https://colab.research.google.com/drive/1PBrAlthWsl
 Index:
 
 ```bash
-$ target/appassembler/bin/IndexVectors -input glove.6B.300d.txt -path glove300-fw -encoding fw -fw.q 60
+$ target/appassembler/bin/IndexVectors -input glove.6B.300d.txt -index glove300-fw -encoding fw -fw.q 60
 Loading model glove.6B.300d.txt
 Creating index at glove300-fw...
 100000 words added
@@ -55,7 +55,7 @@ Search:
 
 ```bash
 $ target/appassembler/bin/ApproximateNearestNeighborSearch -input glove.6B.300d.txt \
-   -path glove300-fw -encoding fw -fw.q 60 -word italy
+   -index glove300-fw -encoding fw -fw.q 60 -word italy
 Loading model glove.6B.300d.txt
 Reading index at glove300-fw
 10 nearest neighbors of 'italy':
@@ -75,7 +75,7 @@ Search time: 417ms
 Evaluate recall at retrieval depth=100:
 
 ```bash
-$ target/appassembler/bin/ApproximateNearestNeighborEval -input glove.6B.300d.txt -path glove300-fw/ \
+$ target/appassembler/bin/ApproximateNearestNeighborEval -input glove.6B.300d.txt -index glove300-fw/ \
    -encoding fw -fw.q 60 -topics tools/topics-and-qrels/topics.robust04.txt -samples 100 -depth 100
 Loading model glove.6B.300d.txt
 Reading index at glove300-fw
@@ -89,7 +89,7 @@ avg query time: 344.67 ms
 Index:
 
 ```bash
-$ target/appassembler/bin/IndexVectors -input glove.6B.300d.txt -path glove300-ll -encoding lexlsh
+$ target/appassembler/bin/IndexVectors -input glove.6B.300d.txt -index glove300-ll -encoding lexlsh
 Loading model glove.6B.300d.txt
 Creating index at glove300-ll...
 100000 words added
@@ -105,7 +105,7 @@ Search:
 
 ```bash
 $ target/appassembler/bin/ApproximateNearestNeighborSearch -input glove.6B.300d.txt \
-   -path glove300-ll -encoding lexlsh -word italy
+   -index glove300-ll -encoding lexlsh -word italy
 Loading model glove.6B.300d.txt
 Reading index at glove300-ll
 10 nearest neighbors of 'italy':
@@ -125,7 +125,7 @@ Search time: 525ms
 Evaluate recall at retrieval depth=100:
 
 ```bash
-$ target/appassembler/bin/ApproximateNearestNeighborEval -input glove.6B.300d.txt -path glove300-ll/ \
+$ target/appassembler/bin/ApproximateNearestNeighborEval -input glove.6B.300d.txt -index glove300-ll/ \
    -encoding lexlsh -topics tools/topics-and-qrels/topics.robust04.txt -samples 100 -depth 100
 Loading model glove.6B.300d.txt
 Reading index at glove300-ll

--- a/src/main/java/io/anserini/analysis/lexlsh/LexicalLshAnalyzer.java
+++ b/src/main/java/io/anserini/analysis/lexlsh/LexicalLshAnalyzer.java
@@ -34,7 +34,9 @@ public class LexicalLshAnalyzer extends Analyzer {
 
   private static final int DEFAULT_SHINGLE_SIZE = 2;
   private static final int DEFAULT_DECIMALS = 1;
-
+  private static final int DEFAULT_HASH_COUNT = 1;
+  private static final int DEFAULT_BUCKET_COUNT = 300;
+  private static final int DEFAULT_HASH_SET_SIZE = 1;
   private final int min;
   private final int max;
   private final int hashCount;
@@ -53,8 +55,8 @@ public class LexicalLshAnalyzer extends Analyzer {
   }
 
   public LexicalLshAnalyzer() {
-    this(DEFAULT_SHINGLE_SIZE, DEFAULT_SHINGLE_SIZE, MinHashFilter.DEFAULT_HASH_COUNT, MinHashFilter.DEFAULT_BUCKET_COUNT,
-        MinHashFilter.DEFAULT_HASH_SET_SIZE, DEFAULT_DECIMALS);
+    this(DEFAULT_SHINGLE_SIZE, DEFAULT_SHINGLE_SIZE, DEFAULT_HASH_COUNT, DEFAULT_BUCKET_COUNT,
+        DEFAULT_HASH_SET_SIZE, DEFAULT_DECIMALS);
   }
 
   public LexicalLshAnalyzer(int decimals, int ngrams, int hashCount, int bucketCount, int hashSetSize) {

--- a/src/main/java/io/anserini/index/IndexInvertedDenseVectors.java
+++ b/src/main/java/io/anserini/index/IndexInvertedDenseVectors.java
@@ -16,19 +16,50 @@
 
 package io.anserini.index;
 
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
 import io.anserini.analysis.fw.FakeWordsEncoderAnalyzer;
 import io.anserini.analysis.lexlsh.LexicalLshAnalyzer;
+import io.anserini.collection.DocumentCollection;
+import io.anserini.collection.FileSegment;
+import io.anserini.collection.SourceDocument;
+import io.anserini.index.generator.EmptyDocumentException;
+import io.anserini.index.generator.InvalidDocumentException;
+import io.anserini.index.generator.LuceneDocumentGenerator;
+import io.anserini.index.generator.SkippedDocumentException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.miscellaneous.PerFieldAnalyzerWrapper;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.backward_codecs.lucene94.Lucene94Codec;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.ConcurrentMergeScheduler;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.kohsuke.args4j.CmdLineException;
@@ -36,38 +67,102 @@ import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.OptionHandlerFilter;
 import org.kohsuke.args4j.ParserProperties;
+import org.kohsuke.args4j.spi.StringArrayOptionHandler;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
-public class IndexInvertedDenseVectors {
+public final class IndexInvertedDenseVectors {
+
   public static final String FIELD_ID = "id";
   public static final String FIELD_VECTOR = "vector";
 
   public static final String FW = "fw";
   public static final String LEXLSH = "lexlsh";
 
-  public static final class Args {
-    @Option(name = "-input", metaVar = "[file]", required = true, usage = "vectors model")
-    public File input;
 
-    @Option(name = "-path", metaVar = "[path]", required = true, usage = "index path")
-    public Path path;
+  public static final class Args {
+
+    // This is the name of the field in the Lucene document where the docid is stored.
+    public static final String ID = "id";
+
+    // This is the name of the field in the Lucene document that should be searched by default.
+    public static final String CONTENTS = "contents";
+
+    // This is the name of the field in the Lucene document where the raw document is stored.
+    public static final String RAW = "raw";
+
+    @Option(name = "-input", metaVar = "[path]", required = true,
+        usage = "Location of input collection.")
+    public String input;
+
+    @Option(name = "-threads", metaVar = "[num]",
+        usage = "Number of indexing threads.")
+    public int threads = 1;
+
+    @Option(name = "-collection", metaVar = "[class]",
+        usage = "Collection class in package 'io.anserini.collection'.")
+    public String collectionClass;
+
+    @Option(name = "-generator", metaVar = "[class]",
+        usage = "Document generator class in package 'io.anserini.index.generator'.")
+    public String generatorClass = "InvertedDenseVectorDocumentGenerator";
+
+    // optional general arguments
+
+    @Option(name = "-verbose", forbids = {"-quiet"},
+        usage = "Enables verbose logging for each indexing thread; can be noisy if collection has many small file segments.")
+    public boolean verbose = false;
+
+    @Option(name = "-quiet", forbids = {"-verbose"},
+        usage = "Turns off all logging.")
+    public boolean quiet = false;
+
+    // optional arguments
+
+    @Option(name = "-index", metaVar = "[path]", usage = "Index path.", required = true)
+    public String index;
+
+    @Option(name = "-fields", handler = StringArrayOptionHandler.class,
+        usage = "List of fields to index (space separated), in addition to the default 'contents' field.")
+    public String[] fields = new String[]{};
+
+    @Option(name = "-storePositions",
+        usage = "Boolean switch to index store term positions; needed for phrase queries.")
+    public boolean storePositions = false;
+
+    @Option(name = "-storeDocvectors",
+        usage = "Boolean switch to store document vectors; needed for (pseudo) relevance feedback.")
+    public boolean storeDocvectors = false;
+
+    @Option(name = "-storeContents",
+        usage = "Boolean switch to store document contents.")
+    public boolean storeContents = false;
+
+    @Option(name = "-storeRaw",
+        usage = "Boolean switch to store raw source documents.")
+    public boolean storeRaw = false;
+
+    @Option(name = "-optimize",
+        usage = "Boolean switch to optimize index (i.e., force merge) into a single segment; costly for large collections.")
+    public boolean optimize = false;
+
+    @Option(name = "-uniqueDocid",
+        usage = "Removes duplicate documents with the same docid during indexing. This significantly slows indexing throughput " +
+            "but may be needed for tweet collections since the streaming API might deliver a tweet multiple times.")
+    public boolean uniqueDocid = false;
+
+    @Option(name = "-memorybuffer", metaVar = "[mb]",
+        usage = "Memory buffer size (in MB).")
+    public int memorybufferSize = 2048;
+
+    @Option(name = "-whitelist", metaVar = "[file]",
+        usage = "File containing list of docids, one per line; only these docids will be indexed.")
+    public String whitelist = null;
 
     @Option(name = "-encoding", metaVar = "[word]", required = true, usage = "encoding must be one of {fw, lexlsh}")
     public String encoding = FW;
 
-    @Option(name="-stored", metaVar = "[boolean]", usage = "store vectors")
-    public boolean stored;
+    @Option(name = "-stored", metaVar = "[boolean]", usage = "store vectors")
+    public boolean stored = false;
 
     @Option(name = "-lexlsh.n", metaVar = "[int]", usage = "ngrams")
     public int ngrams = 2;
@@ -86,90 +181,383 @@ public class IndexInvertedDenseVectors {
 
     @Option(name = "-fw.q", metaVar = "[int]", usage = "quantization factor")
     public int q = FakeWordsEncoderAnalyzer.DEFAULT_Q;
+    // Sharding options
+
+    @Option(name = "-shard.count", metaVar = "[n]",
+        usage = "Number of shards to partition the document collection into.")
+    public int shardCount = -1;
+
+    @Option(name = "-shard.current", metaVar = "[n]",
+        usage = "The current shard number to generate (indexed from 0).")
+    public int shardCurrent = -1;
   }
 
-  public static void main(String[] args) throws Exception {
-    IndexInvertedDenseVectors.Args indexArgs = new IndexInvertedDenseVectors.Args();
-    CmdLineParser parser = new CmdLineParser(indexArgs, ParserProperties.defaults().withUsageWidth(90));
+  private static final Logger LOG = LogManager.getLogger(IndexInvertedDenseVectors.class);
 
-    try {
-      parser.parseArgument(args);
-    } catch (CmdLineException e) {
-      System.err.println(e.getMessage());
-      parser.printUsage(System.err);
-      System.err.println("Example: " + IndexInvertedDenseVectors.class.getSimpleName() +
-          parser.printExample(OptionHandlerFilter.REQUIRED));
-      return;
+  // This is the default analyzer used, unless another stemming algorithm or language is specified.
+  public final class Counters {
+
+    /**
+     * Counter for successfully indexed documents.
+     */
+    public AtomicLong indexed = new AtomicLong();
+
+    /**
+     * Counter for empty documents that are not indexed. Empty documents are not necessary errors;
+     * it could be the case, for example, that a document is comprised solely of stopwords.
+     */
+    public AtomicLong empty = new AtomicLong();
+
+    /**
+     * Counter for unindexable documents. These are cases where {@link SourceDocument#indexable()}
+     * returns false.
+     */
+    public AtomicLong unindexable = new AtomicLong();
+
+    /**
+     * Counter for skipped documents. These are cases documents are skipped as part of normal
+     * processing logic, e.g., using a whitelist, not indexing retweets or deleted tweets.
+     */
+    public AtomicLong skipped = new AtomicLong();
+
+    /**
+     * Counter for unexpected errors.
+     */
+    public AtomicLong errors = new AtomicLong();
+  }
+
+  private final class LocalIndexerThread extends Thread {
+
+    final private Path inputFile;
+    final private IndexWriter writer;
+    final private DocumentCollection collection;
+    private FileSegment fileSegment;
+
+    private LocalIndexerThread(IndexWriter writer, DocumentCollection collection, Path inputFile) {
+      this.writer = writer;
+      this.collection = collection;
+      this.inputFile = inputFile;
+      setName(inputFile.getFileName().toString());
     }
-    Analyzer vectorAnalyzer;
-    if (indexArgs.encoding.equalsIgnoreCase(FW)) {
-      vectorAnalyzer = new FakeWordsEncoderAnalyzer(indexArgs.q);
-    } else if (indexArgs.encoding.equalsIgnoreCase(LEXLSH)) {
-      vectorAnalyzer = new LexicalLshAnalyzer(indexArgs.decimals, indexArgs.ngrams, indexArgs.hashCount,
-          indexArgs.bucketCount, indexArgs.hashSetSize);
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void run() {
+      try {
+        LuceneDocumentGenerator generator = (LuceneDocumentGenerator)
+            generatorClass.getDeclaredConstructor(Args.class).newInstance(args);
+
+        // We keep track of two separate counts: the total count of documents in this file segment (cnt),
+        // and the number of documents in this current "batch" (batch). We update the global counter every
+        // 10k documents: this is so that we get intermediate updates, which is informative if a collection
+        // has only one file segment; see https://github.com/castorini/anserini/issues/683
+        int cnt = 0;
+        int batch = 0;
+
+        FileSegment<SourceDocument> segment = collection.createFileSegment(inputFile);
+        // in order to call close() and clean up resources in case of exception
+        this.fileSegment = segment;
+
+        for (SourceDocument d : segment) {
+          if (!d.indexable()) {
+            counters.unindexable.incrementAndGet();
+            continue;
+          }
+
+          Document doc;
+          try {
+            doc = generator.createDocument(d);
+          } catch (EmptyDocumentException e1) {
+            counters.empty.incrementAndGet();
+            continue;
+          } catch (SkippedDocumentException e2) {
+            counters.skipped.incrementAndGet();
+            continue;
+          } catch (InvalidDocumentException e3) {
+            counters.errors.incrementAndGet();
+            continue;
+          }
+
+          if (whitelistDocids != null && !whitelistDocids.contains(d.id())) {
+            counters.skipped.incrementAndGet();
+            continue;
+          }
+
+          if (args.uniqueDocid) {
+            writer.updateDocument(new Term("id", d.id()), doc);
+          } else {
+            writer.addDocument(doc);
+          }
+          cnt++;
+          batch++;
+
+          // And the counts from this batch, reset batch counter.
+          if (batch % 10000 == 0) {
+            counters.indexed.addAndGet(batch);
+            batch = 0;
+          }
+        }
+
+        // Add the remaining documents.
+        counters.indexed.addAndGet(batch);
+
+        int skipped = segment.getSkippedCount();
+        if (skipped > 0) {
+          // When indexing tweets, this is normal, because there are delete messages that are skipped over.
+          counters.skipped.addAndGet(skipped);
+          LOG.warn(inputFile.getParent().getFileName().toString() + File.separator +
+                       inputFile.getFileName().toString() + ": " + skipped + " docs skipped.");
+        }
+
+        if (segment.getErrorStatus()) {
+          counters.errors.incrementAndGet();
+          LOG.error(inputFile.getParent().getFileName().toString() + File.separator +
+                        inputFile.getFileName().toString() + ": error iterating through segment.");
+        }
+
+        // Log at the debug level because this can be quite noisy if there are lots of file segments.
+        LOG.debug(inputFile.getParent().getFileName().toString() + File.separator +
+                      inputFile.getFileName().toString() + ": " + cnt + " docs added.");
+      } catch (Exception e) {
+        LOG.error(Thread.currentThread().getName() + ": Unexpected Exception:", e);
+      } finally {
+        if (fileSegment != null) {
+          fileSegment.close();
+        }
+      }
+    }
+  }
+
+  private final Args args;
+  private final Path collectionPath;
+  private final Set whitelistDocids;
+  private Class collectionClass;
+  private final Class generatorClass;
+  private DocumentCollection collection;
+  private final Counters counters;
+  private Path indexPath;
+
+  @SuppressWarnings("unchecked")
+  public IndexInvertedDenseVectors(Args args) throws Exception {
+    this.args = args;
+
+    if (args.verbose) {
+      // If verbose logging enabled, changed default log level to DEBUG so we get per-thread logging messages.
+      Configurator.setRootLevel(Level.DEBUG);
+      LOG.info("Setting log level to " + Level.DEBUG);
+    } else if (args.quiet) {
+      // If quiet mode enabled, only report warnings and above.
+      Configurator.setRootLevel(Level.WARN);
     } else {
-      parser.printUsage(System.err);
-      System.err.println("Example: " + IndexInvertedDenseVectors.class.getSimpleName() +
-          parser.printExample(OptionHandlerFilter.REQUIRED));
-      return;
+      // Otherwise, we get the standard set of log messages.
+      Configurator.setRootLevel(Level.INFO);
+      LOG.info("Setting log level to " + Level.INFO);
     }
 
+    LOG.info("Starting indexer...");
+    LOG.info("============ Loading Parameters ============");
+    LOG.info("DocumentCollection path: " + args.input);
+    LOG.info("CollectionClass: " + args.collectionClass);
+    LOG.info("Generator: " + args.generatorClass);
+    LOG.info("Threads: " + args.threads);
+    LOG.info("Store document \"contents\" field? " + args.storeContents);
+    LOG.info("Store document \"raw\" field? " + args.storeRaw);
+    LOG.info("Optimize (merge segments)? " + args.optimize);
+    LOG.info("Whitelist: " + args.whitelist);
+    LOG.info("Index path: " + args.index);
+
+    if (args.index != null) {
+      this.indexPath = Paths.get(args.index);
+      if (!Files.exists(this.indexPath)) {
+        Files.createDirectories(this.indexPath);
+      }
+    }
+
+    // Our documentation uses /path/to/foo as a convention: to make copy and paste of the commands work, we assume
+    // collections/ as the path location.
+    String pathStr = args.input;
+    if (pathStr.startsWith("/path/to")) {
+      pathStr = pathStr.replace("/path/to", "collections");
+    }
+    collectionPath = Paths.get(pathStr);
+    if (!Files.exists(collectionPath) || !Files.isReadable(collectionPath)) {
+      throw new RuntimeException("Document directory " + collectionPath + " does not exist or is not readable, please check the path");
+    }
+
+    if (Files.isDirectory(collectionPath) && args.collectionClass == null) {
+      throw new RuntimeException("Collection class must be defined, got `null` instead");
+    }
+
+    this.generatorClass = Class.forName("io.anserini.index.generator." + args.generatorClass);
+    if (args.collectionClass != null) {
+      this.collectionClass = Class.forName("io.anserini.collection." + args.collectionClass);
+      // Initialize the collection.
+      collection = (DocumentCollection) this.collectionClass.getConstructor(Path.class).newInstance(collectionPath);
+    }
+
+    if (args.whitelist != null) {
+      List<String> lines = FileUtils.readLines(new File(args.whitelist), "utf-8");
+      this.whitelistDocids = new HashSet<>(lines);
+    } else {
+      this.whitelistDocids = null;
+    }
+
+    this.counters = new Counters();
+  }
+
+  public Counters run() throws IOException {
     final long start = System.nanoTime();
-    System.out.println(String.format("Loading model %s", indexArgs.input));
 
-    Map<String, List<float[]>> vectors = readGloVe(indexArgs.input);
+    LOG.info("============ Indexing Collection ============");
 
-    Path indexDir = indexArgs.path;
-    if (!Files.exists(indexDir)) {
-      Files.createDirectories(indexDir);
+    int numThreads = args.threads;
+    IndexWriter writer = null;
+    Analyzer vectorAnalyzer;
+    if (args.encoding.equalsIgnoreCase(FW)) {
+      vectorAnalyzer = new FakeWordsEncoderAnalyzer(args.q);
+    } else if (args.encoding.equalsIgnoreCase(LEXLSH)) {
+      vectorAnalyzer = new LexicalLshAnalyzer(args.decimals, args.ngrams, args.hashCount,
+                                              args.bucketCount, args.hashSetSize);
+    } else {
+      vectorAnalyzer = null;
+      System.err.println("error!");
     }
-
-    System.out.println(String.format("Creating index at %s...", indexArgs.path));
-
-    Directory d = FSDirectory.open(indexDir);
     Map<String, Analyzer> map = new HashMap<>();
     map.put(FIELD_VECTOR, vectorAnalyzer);
     Analyzer analyzer = new PerFieldAnalyzerWrapper(new StandardAnalyzer(), map);
 
-    IndexWriterConfig conf = new IndexWriterConfig(analyzer);
-    IndexWriter indexWriter = new IndexWriter(d, conf);
-    final AtomicInteger cnt = new AtomicInteger();
-
-    for (Map.Entry<String, List<float[]>> entry : vectors.entrySet()) {
-      for (float[] vector: entry.getValue()) {
-        Document doc = new Document();
-        doc.add(new StringField(FIELD_ID, entry.getKey(), Field.Store.YES));
-        StringBuilder sb = new StringBuilder();
-        for (double fv : vector) {
-          if (sb.length() > 0) {
-            sb.append(' ');
-          }
-          sb.append(fv);
-        }
-        doc.add(new TextField(FIELD_VECTOR, sb.toString(), indexArgs.stored ? Field.Store.YES : Field.Store.NO));
-        try {
-          indexWriter.addDocument(doc);
-          int cur = cnt.incrementAndGet();
-          if (cur % 100000 == 0) {
-            System.out.println(String.format("%s docs added", cnt));
-          }
-        } catch (IOException e) {
-          System.err.println("Error while indexing: " + e.getLocalizedMessage());
-        }
-      }
+    // Used for LocalIndexThread
+    if (indexPath != null) {
+      final Directory dir = FSDirectory.open(indexPath);
+      final IndexWriterConfig config = new IndexWriterConfig(analyzer).setCodec(new Lucene94Codec());
+      config.setOpenMode(IndexWriterConfig.OpenMode.CREATE);
+      config.setRAMBufferSizeMB(args.memorybufferSize);
+      config.setUseCompoundFile(false);
+      config.setMergeScheduler(new ConcurrentMergeScheduler());
+      writer = new IndexWriter(dir, config);
     }
 
-    indexWriter.commit();
-    System.out.println(String.format("%s docs indexed", cnt.get()));
-    long space = FileUtils.sizeOfDirectory(indexDir.toFile()) / (1024L * 1024L);
-    System.out.println(String.format("Index size: %dMB", space));
-    indexWriter.close();
-    d.close();
+    if (Files.isDirectory(collectionPath)) {
+      final ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(numThreads);
+      LOG.info("Thread pool with " + numThreads + " threads initialized.");
 
-    final long durationMillis =
-        TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
-    System.out.println(String.format("Total time: %s",
-        DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss")));
+      LOG.info("Initializing collection in " + collectionPath);
+
+      List<?> segmentPaths = collection.getSegmentPaths();
+      // when we want sharding to be done
+      if (args.shardCount > 1) {
+        segmentPaths = collection.getSegmentPaths(args.shardCount, args.shardCurrent);
+      }
+      final int segmentCnt = segmentPaths.size();
+
+      LOG.info(String.format("%,d %s found", segmentCnt, (segmentCnt == 1 ? "file" : "files")));
+      LOG.info("Starting to index...");
+
+      for (Object segmentPath : segmentPaths) {
+        executor.execute(new LocalIndexerThread(writer, collection, (Path) segmentPath));
+      }
+
+      executor.shutdown();
+
+      try {
+        // Wait for existing tasks to terminate
+        while (!executor.awaitTermination(1, TimeUnit.MINUTES)) {
+          if (segmentCnt == 1) {
+            LOG.info(String.format("%,d documents indexed", counters.indexed.get()));
+          } else {
+            LOG.info(String.format("%.2f%% of files completed, %,d documents indexed",
+                                   (double) executor.getCompletedTaskCount() / segmentCnt * 100.0d, counters.indexed.get()));
+          }
+        }
+      } catch (InterruptedException ie) {
+        // (Re-)Cancel if current thread also interrupted
+        executor.shutdownNow();
+        // Preserve interrupt status
+        Thread.currentThread().interrupt();
+      }
+
+      if (segmentCnt != executor.getCompletedTaskCount()) {
+        throw new RuntimeException("totalFiles = " + segmentCnt +
+                                       " is not equal to completedTaskCount =  " + executor.getCompletedTaskCount());
+      }
+
+      long numIndexed = writer.getDocStats().maxDoc;
+
+      // Do a final commit
+      try {
+        if (writer != null) {
+          writer.commit();
+          if (args.optimize) {
+            writer.forceMerge(1);
+          }
+        }
+      } finally {
+        try {
+          if (writer != null) {
+            writer.close();
+          }
+        } catch (IOException e) {
+          // It is possible that this happens... but nothing much we can do at this point,
+          // so just log the error and move on.
+          LOG.error(e);
+        }
+      }
+
+      if (numIndexed != counters.indexed.get()) {
+        LOG.warn("Unexpected difference between number of indexed documents and index maxDoc.");
+      }
+
+      LOG.info(String.format("Indexing Complete! %,d documents indexed", numIndexed));
+      LOG.info("============ Final Counter Values ============");
+      LOG.info(String.format("indexed:     %,12d", counters.indexed.get()));
+      LOG.info(String.format("unindexable: %,12d", counters.unindexable.get()));
+      LOG.info(String.format("empty:       %,12d", counters.empty.get()));
+      LOG.info(String.format("skipped:     %,12d", counters.skipped.get()));
+      LOG.info(String.format("errors:      %,12d", counters.errors.get()));
+
+      final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+      LOG.info(String.format("Total %,d documents indexed in %s", numIndexed,
+                             DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss")));
+    } else {
+      Map<String, List<float[]>> vectors = readGloVe(new File(args.input));
+      for (Map.Entry<String, List<float[]>> entry : vectors.entrySet()) {
+        for (float[] vector: entry.getValue()) {
+          Document doc = new Document();
+          doc.add(new StringField(FIELD_ID, entry.getKey(), Field.Store.YES));
+          StringBuilder sb = new StringBuilder();
+          for (double fv : vector) {
+            if (sb.length() > 0) {
+              sb.append(' ');
+            }
+            sb.append(fv);
+          }
+          doc.add(new TextField(FIELD_VECTOR, sb.toString(), args.stored ? Field.Store.YES : Field.Store.NO));
+          try {
+            writer.addDocument(doc);
+            long cur = counters.indexed.incrementAndGet();
+            if (cur % 100000 == 0) {
+              System.out.println(String.format("%s docs added", counters.indexed.get()));
+            }
+          } catch (IOException e) {
+            System.err.println("Error while indexing: " + e.getLocalizedMessage());
+            counters.errors.incrementAndGet();
+          }
+        }
+      }
+
+      writer.commit();
+      System.out.println(String.format("%s docs indexed", counters.indexed.get()));
+      long space = FileUtils.sizeOfDirectory(indexPath.toFile()) / (1024L * 1024L);
+      System.out.println(String.format("Index size: %dMB", space));
+      writer.close();
+
+      final long durationMillis =
+          TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+      System.out.println(String.format("Total time: %s",
+                                       DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss")));
+    }
+
+    return counters;
   }
 
   public static Map<String, List<float[]>> readGloVe(File input) throws IOException {
@@ -199,5 +587,22 @@ public class IndexInvertedDenseVectors {
       }
     }
     return vectors;
+  }
+
+  public static void main(String[] args) throws Exception {
+    Args indexCollectionArgs = new Args();
+    CmdLineParser parser = new CmdLineParser(indexCollectionArgs, ParserProperties.defaults().withUsageWidth(100));
+
+    try {
+      parser.parseArgument(args);
+    } catch (CmdLineException e) {
+      System.err.println(e.getMessage());
+      parser.printUsage(System.err);
+      System.err.println("Example: " + IndexInvertedDenseVectors.class.getSimpleName() +
+                             parser.printExample(OptionHandlerFilter.REQUIRED));
+      return;
+    }
+
+    new IndexInvertedDenseVectors(indexCollectionArgs).run();
   }
 }

--- a/src/main/java/io/anserini/index/generator/InvertedDenseVectorDocumentGenerator.java
+++ b/src/main/java/io/anserini/index/generator/InvertedDenseVectorDocumentGenerator.java
@@ -1,0 +1,96 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.index.generator;
+
+import java.util.ArrayList;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.anserini.collection.SourceDocument;
+import io.anserini.index.IndexInvertedDenseVectors;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+
+import static io.anserini.index.IndexInvertedDenseVectors.Args.RAW;
+
+/**
+ * Converts a {@link SourceDocument} into a Lucene {@link Document}, ready to be indexed for ANN search.
+ *
+ * @param <T> type of the source document
+ */
+public class InvertedDenseVectorDocumentGenerator<T extends SourceDocument> implements LuceneDocumentGenerator<T> {
+
+  protected IndexInvertedDenseVectors.Args args;
+
+  protected InvertedDenseVectorDocumentGenerator() {
+  }
+
+  /**
+   * Constructor with config and counters
+   *
+   * @param args configuration arguments
+   */
+  public InvertedDenseVectorDocumentGenerator(IndexInvertedDenseVectors.Args args) {
+    this.args = args;
+  }
+
+  private float[] convertJsonArray(String vectorString) throws JsonMappingException, JsonProcessingException {
+    ObjectMapper mapper = new ObjectMapper();
+    ArrayList<Float> denseVector = mapper.readValue(vectorString, new TypeReference<ArrayList<Float>>(){});
+    int length = denseVector.size();
+    float[] vector = new float[length];
+    int i = 0;
+    for (Float f : denseVector) {
+      vector[i++] = f;
+    }
+    return vector;
+  }
+
+  @Override
+  public Document createDocument(T src) throws InvalidDocumentException {
+    String id = src.id();
+    float[] contents;
+
+    try {
+      contents = convertJsonArray(src.contents());
+    } catch (Exception e) {
+      throw new InvalidDocumentException();
+    }
+    StringBuilder sb = new StringBuilder();
+    for (double fv : contents) {
+      if (sb.length() > 0) {
+        sb.append(' ');
+      }
+      sb.append(fv);
+    }
+    // Make a new, empty document.
+    final Document document = new Document();
+
+    // Store the collection docid.
+    document.add(new StringField(IndexInvertedDenseVectors.FIELD_ID, id, Field.Store.YES));
+    document.add(new TextField(IndexInvertedDenseVectors.FIELD_VECTOR, sb.toString(), args.stored ? Field.Store.YES : Field.Store.NO));
+    if (args.storeRaw) {
+      document.add(new StoredField(RAW, src.raw()));
+    }
+    return document;
+  }
+}

--- a/src/main/java/io/anserini/search/EvaluateInvertedDenseVectors.java
+++ b/src/main/java/io/anserini/search/EvaluateInvertedDenseVectors.java
@@ -62,7 +62,7 @@ public class EvaluateInvertedDenseVectors {
     @Option(name = "-input", metaVar = "[file]", required = true, usage = "vectors model")
     public File input;
 
-    @Option(name = "-path", metaVar = "[path]", required = true, usage = "index path")
+    @Option(name = "-index", metaVar = "[path]", required = true, usage = "index path")
     public Path path;
 
     @Option(name = "-topics", metaVar = "[file]", required = true, usage = "path to TREC topics file")

--- a/src/main/java/io/anserini/search/SearchInvertedDenseVectors.java
+++ b/src/main/java/io/anserini/search/SearchInvertedDenseVectors.java
@@ -16,145 +16,452 @@
 
 package io.anserini.search;
 
-import io.anserini.analysis.AnalyzerUtils;
-import io.anserini.analysis.fw.FakeWordsEncoderAnalyzer;
-import io.anserini.analysis.lexlsh.LexicalLshAnalyzer;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import io.anserini.index.IndexInvertedDenseVectors;
-import org.apache.lucene.analysis.Analyzer;
+import io.anserini.rerank.ScoredDocuments;
+import io.anserini.search.query.InvertedDenseVectorQueryGenerator;
+import io.anserini.search.topicreader.TopicReader;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.queries.CommonTermsQuery;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopScoreDocCollector;
 import org.apache.lucene.search.similarities.ClassicSimilarity;
-import org.apache.lucene.store.Directory;
+import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.store.FSDirectory;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.OptionHandlerFilter;
 import org.kohsuke.args4j.ParserProperties;
+import org.kohsuke.args4j.spi.StringArrayOptionHandler;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import static io.anserini.index.IndexInvertedDenseVectors.FW;
 
-import static org.apache.lucene.search.BooleanClause.Occur.SHOULD;
+/**
+ * Main entry point for inverted dense vector search.
+ */
+public final class SearchInvertedDenseVectors implements Closeable {
 
-public class SearchInvertedDenseVectors {
-  private static final String FW = "fw";
-  private static final String LEXLSH = "lexlsh";
+  private static final Logger LOG = LogManager.getLogger(SearchInvertedDenseVectors.class);
 
-  public static final class Args {
+  public static class Args {
+
     @Option(name = "-input", metaVar = "[file]", usage = "vectors model")
     public File input;
-
-    @Option(name = "-path", metaVar = "[path]", required = true, usage = "index path")
-    public Path path;
 
     @Option(name = "-word", metaVar = "[word]", required = true, usage = "input word")
     public String word;
 
-    @Option(name="-stored", metaVar = "[boolean]", usage = "fetch stored vectors from index")
+    @Option(name = "-stored", metaVar = "[boolean]", usage = "fetch stored vectors from index")
     public boolean stored;
+
+    @Option(name = "-index", metaVar = "[path]", required = true, usage = "Path to Lucene index")
+    public String index;
+
+    @Option(name = "-topics", metaVar = "[file]", handler = StringArrayOptionHandler.class, usage = "topics file")
+    public String[] topics;
+
+    @Option(name = "-output", metaVar = "[file]", usage = "output file")
+    public String output;
+
+    @Option(name = "-topicreader", usage = "TopicReader to use.")
+    public String topicReader;
 
     @Option(name = "-encoding", metaVar = "[word]", required = true, usage = "encoding must be one of {fw, lexlsh}")
     public String encoding;
 
-    @Option(name = "-depth", metaVar = "[int]", usage = "retrieval depth")
-    public int depth = 10;
+    @Option(name = "-threads", metaVar = "[int]", usage = "Number of threads to use for running different parameter configurations.")
+    public int threads = 1;
 
-    @Option(name = "-lexlsh.n", metaVar = "[int]", usage = "n-grams")
-    public int ngrams = 2;
+    @Option(name = "-parallelism", metaVar = "[int]", usage = "Number of threads to use for each individual parameter configuration.")
+    public int parallelism = 8;
 
-    @Option(name = "-lexlsh.d", metaVar = "[int]", usage = "decimals")
-    public int decimals = 1;
+    @Option(name = "-threadsPerQuery", metaVar = "[int]", usage = "Number of threads used to execute each query.")
+    public int threadsPerQuery = 1;
 
-    @Option(name = "-lexlsh.hsize", metaVar = "[int]", usage = "hash set size")
-    public int hashSetSize = 1;
+    @Option(name = "-removeQuery", usage = "Remove docids that have the query id when writing final run output.")
+    public Boolean removeQuery = false;
 
-    @Option(name = "-lexlsh.h", metaVar = "[int]", usage = "hash count")
-    public int hashCount = 1;
+    // Note that this option is set to false by default because duplicate documents usually indicate some underlying
+    // indexing issues, and we don't want to just eat errors silently.
+    @Option(name = "-removedups", usage = "Remove duplicate docids when writing final run output.")
+    public Boolean removedups = false;
 
-    @Option(name = "-lexlsh.b", metaVar = "[int]", usage = "bucket count")
-    public int bucketCount = 300;
+    @Option(name = "-skipexists", usage = "When enabled, will skip if the run file exists")
+    public Boolean skipexists = false;
 
-    @Option(name = "-fw.q", metaVar = "[int]", usage = "quantization factor")
-    public int q = 60;
+    @Option(name = "-hits", metaVar = "[number]", required = false, usage = "max number of hits to return")
+    public int hits = 1000;
 
-    @Option(name = "-cutoff", metaVar = "[float]", usage = "tf cutoff factor")
-    public float cutoff = 0.999f;
+    @Option(name = "-inmem", usage = "Boolean switch to read index in memory")
+    public Boolean inmem = false;
 
-    @Option(name = "-msm", metaVar = "[float]", usage = "minimum should match")
-    public float msm = 0f;
+    @Option(name = "-topicfield", usage = "Which field of the query should be used, default \"title\"." +
+        " For TREC ad hoc topics, description or narrative can be used.")
+    public String topicfield = "title";
+
+    @Option(name = "-runtag", metaVar = "[tag]", usage = "runtag")
+    public String runtag = null;
+
+    @Option(name = "-format", metaVar = "[output format]", usage = "Output format, default \"trec\", alternative \"msmarco\".")
+    public String format = "trec";
+
+    // ---------------------------------------------
+    // Simple built-in support for passage retrieval
+    // ---------------------------------------------
+
+    // A simple approach to passage retrieval is to pre-segment documents in the corpus into passages and index those
+    // passages. At retrieval time, we retain only the max scoring passage from each document; this is often called MaxP,
+    // from Dai and Callan (SIGIR 2019) in the context of BERT, although the general approach dates back to Callan
+    // (SIGIR 1994), Hearst and Plaunt (SIGIR 1993), and lots of other papers from the 1990s and even earlier.
+    //
+    // One common convention is to label the passages of a docid as "docid.00000", "docid.00001", "docid.00002", ...
+    // We use this convention in CORD-19. Alternatively, in document expansion for the MS MARCO document corpus, we use
+    // '#' as the delimiter.
+    //
+    // The options below control various aspects of this behavior.
+
+    @Option(name = "-selectMaxPassage", usage = "Select and retain only the max scoring segment from each document.")
+    public Boolean selectMaxPassage = false;
+
+    @Option(name = "-selectMaxPassage.delimiter", metaVar = "[regexp]",
+        usage = "The delimiter (as a regular regression) for splitting the segment id from the doc id.")
+    public String selectMaxPassage_delimiter = "\\.";
+
+    @Option(name = "-selectMaxPassage.hits", metaVar = "[int]",
+        usage = "Maximum number of hits to return per topic after segment id removal. " +
+            "Note that this is different from '-hits', which specifies the number of hits including the segment id. ")
+    public int selectMaxPassage_hits = Integer.MAX_VALUE;
+  }
+
+  private final Args args;
+  private final IndexReader reader;
+
+  private InvertedDenseVectorQueryGenerator generator;
+
+  private final class SearcherThread<K> extends Thread {
+
+    final private IndexReader reader;
+    final private IndexSearcher searcher;
+    final private SortedMap<K, Map<String, String>> topics;
+    final private String outputPath;
+    final private String runTag;
+
+    private SearcherThread(IndexReader reader, SortedMap<K, Map<String, String>> topics, String outputPath, String runTag,
+                           ExecutorService executorService, Similarity similarity) {
+      this.reader = reader;
+      this.topics = topics;
+      this.runTag = runTag;
+      this.outputPath = outputPath;
+      this.searcher = executorService != null ? new IndexSearcher(this.reader, executorService) : new IndexSearcher(this.reader);
+      if (similarity != null) {
+        searcher.setSimilarity(similarity);
+      }
+      setName(outputPath);
+    }
+
+    @Override
+    public void run() {
+      try {
+        // A short descriptor of the ranking setup.
+        final String desc = String.format("ranker: kNN");
+        // ThreadPool for parallelizing the execution of individual queries:
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(args.parallelism);
+        // Data structure for holding the per-query results, with the qid as the key and the results (the lines that
+        // will go into the final run file) as the value.
+        ConcurrentSkipListMap<K, String> results = new ConcurrentSkipListMap<>();
+        AtomicInteger cnt = new AtomicInteger();
+
+        final long start = System.nanoTime();
+        for (Map.Entry<K, Map<String, String>> entry : topics.entrySet()) {
+          K qid = entry.getKey();
+
+          // This is the per-query execution, in parallel.
+          executor.execute(() -> {
+            // This is for holding the results.
+            StringBuilder out = new StringBuilder();
+            String queryString = entry.getValue().get(args.topicfield);
+            ScoredDocuments docs;
+            try {
+              docs = search(this.searcher, queryString);
+            } catch (IOException e) {
+              throw new CompletionException(e);
+            }
+
+            // For removing duplicate docids.
+            Set<String> docids = new HashSet<>();
+
+            int rank = 1;
+            for (int i = 0; i < docs.documents.length; i++) {
+              String docid = docs.documents[i].get(IndexInvertedDenseVectors.Args.ID);
+
+              if (args.selectMaxPassage) {
+                docid = docid.split(args.selectMaxPassage_delimiter)[0];
+              }
+
+              if (docids.contains(docid)) {
+                continue;
+              }
+
+              // Remove docids that are identical to the query id if flag is set.
+              if (args.removeQuery && docid.equals(qid)) {
+                continue;
+              }
+
+              if ("msmarco".equals(args.format)) {
+                // MS MARCO output format:
+                out.append(String.format(Locale.US, "%s\t%s\t%d\n", qid, docid, rank));
+              } else {
+                // Standard TREC format:
+                // + the first column is the topic number.
+                // + the second column is currently unused and should always be "Q0".
+                // + the third column is the official document identifier of the retrieved document.
+                // + the fourth column is the rank the document is retrieved.
+                // + the fifth column shows the score (integer or floating point) that generated the ranking.
+                // + the sixth column is called the "run tag" and should be a unique identifier for your
+                out.append(String.format(Locale.US, "%s Q0 %s %d %f %s\n",
+                                         qid, docid, rank, docs.scores[i], runTag));
+              }
+
+              // Note that this option is set to false by default because duplicate documents usually indicate some
+              // underlying indexing issues, and we don't want to just eat errors silently.
+              //
+              // However, we we're performing passage retrieval, i.e., with "selectMaxSegment", we *do* want to remove
+              // duplicates.
+              if (args.removedups || args.selectMaxPassage) {
+                docids.add(docid);
+              }
+
+              rank++;
+
+              if (args.selectMaxPassage && rank > args.selectMaxPassage_hits) {
+                break;
+              }
+            }
+
+            results.put(qid, out.toString());
+            int n = cnt.incrementAndGet();
+            if (n % 100 == 0) {
+              LOG.info(String.format("%s: %d queries processed", desc, n));
+            }
+          });
+        }
+
+        executor.shutdown();
+
+        try {
+          // Wait for existing tasks to terminate.
+          while (!executor.awaitTermination(1, TimeUnit.MINUTES)) ;
+        } catch (InterruptedException ie) {
+          // (Re-)Cancel if current thread also interrupted.
+          executor.shutdownNow();
+          // Preserve interrupt status.
+          Thread.currentThread().interrupt();
+        }
+        final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+
+        LOG.info(desc + ": " + topics.size() + " queries processed in " +
+                     DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss") +
+                     String.format(" = ~%.2f q/s", topics.size() / (durationMillis / 1000.0)));
+
+        // Now we write the results to a run file.
+        PrintWriter out = new PrintWriter(Files.newBufferedWriter(Paths.get(outputPath), StandardCharsets.UTF_8));
+
+        // This is the default case: just dump out the qids by their natural order.
+        for (K qid : results.keySet()) {
+          out.print(results.get(qid));
+        }
+        out.flush();
+        out.close();
+      } catch (Exception e) {
+        LOG.error(Thread.currentThread().getName() + ": Unexpected Exception: ", e);
+      }
+    }
+  }
+
+  public SearchInvertedDenseVectors(Args args) throws IOException {
+    this.args = args;
+    Path indexPath = Paths.get(args.index);
+
+    if (!Files.exists(indexPath) || !Files.isDirectory(indexPath) || !Files.isReadable(indexPath)) {
+      throw new IllegalArgumentException(String.format("Index path '%s' does not exist or is not a directory.", args.index));
+    }
+
+    LOG.info("============ Initializing Searcher ============");
+    LOG.info("Index: " + indexPath);
+    this.reader = DirectoryReader.open(FSDirectory.open(indexPath));
+    LOG.info("Vector Search:");
+    LOG.info("Number of threads for running different parameter configurations: " + args.threads);
+  }
+
+  @Override
+  public void close() throws IOException {
+    reader.close();
+  }
+
+  @SuppressWarnings("unchecked")
+  public <K> void runTopics() {
+    generator = new InvertedDenseVectorQueryGenerator(args.encoding, true);
+    TopicReader<K> tr;
+    SortedMap<K, Map<String, String>> topics = new TreeMap<>();
+    for (String singleTopicsFile : args.topics) {
+      Path topicsFilePath = Paths.get(singleTopicsFile);
+      if (!Files.exists(topicsFilePath) || !Files.isRegularFile(topicsFilePath) || !Files.isReadable(topicsFilePath)) {
+        throw new IllegalArgumentException("Topics file : " + topicsFilePath + " does not exist or is not a (readable) file.");
+      }
+      try {
+        tr = (TopicReader<K>) Class.forName("io.anserini.search.topicreader." + args.topicReader + "TopicReader")
+            .getConstructor(Path.class).newInstance(topicsFilePath);
+        topics.putAll(tr.read());
+      } catch (Exception e) {
+        e.printStackTrace();
+        throw new IllegalArgumentException("Unable to load topic reader: " + args.topicReader);
+      }
+    }
+
+    final String runTag = args.runtag == null ? "Anserini" : args.runtag;
+    LOG.info("runtag: " + runTag);
+
+    final ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(args.threads);
+
+    LOG.info("============ Launching Search Threads ============");
+
+    ExecutorService queryExecutor = null;
+    if (args.threadsPerQuery > 1) {
+      queryExecutor = Executors.newFixedThreadPool(args.threadsPerQuery);
+    }
+
+    Similarity similarity = null;
+    if (args.encoding.equalsIgnoreCase(FW)) {
+      similarity = new ClassicSimilarity();
+    }
+    String outputPath = args.output;
+    if (args.skipexists && new File(outputPath).exists()) {
+      LOG.info("Run already exists, skipping: " + outputPath);
+    } else {
+      executor.execute(new SearcherThread<>(reader, topics, outputPath, runTag, queryExecutor, similarity));
+      executor.shutdown();
+      if (queryExecutor != null) {
+        queryExecutor.shutdown();
+      }
+    }
+
+    try {
+      // Wait for existing tasks to terminate
+      while (!executor.awaitTermination(1, TimeUnit.MINUTES)) {
+      }
+      if (queryExecutor != null) {
+        while (!queryExecutor.awaitTermination(1, TimeUnit.MINUTES)) {
+        }
+      }
+    } catch (InterruptedException ie) {
+      // (Re-)Cancel if current thread also interrupted
+      executor.shutdownNow();
+      // Preserve interrupt status
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  public ScoredDocuments search(IndexSearcher searcher, String queryString) throws IOException {
+    // If fieldsMap isn't null, then it means that the -fields option is specified. In this case, we search across
+    // multiple fields with the associated boosts.
+    Query query = generator.buildQuery(queryString);
+
+    TopScoreDocCollector results = TopScoreDocCollector.create(args.hits, Integer.MAX_VALUE);
+    searcher.search(query, results);
+
+    return ScoredDocuments.fromTopDocs(results.topDocs(), searcher);
   }
 
   public static void main(String[] args) throws Exception {
-    SearchInvertedDenseVectors.Args indexArgs = new SearchInvertedDenseVectors.Args();
-    CmdLineParser parser = new CmdLineParser(indexArgs, ParserProperties.defaults().withUsageWidth(90));
+    Args searchArgs = new Args();
+    CmdLineParser parser = new CmdLineParser(searchArgs, ParserProperties.defaults().withUsageWidth(100));
 
     try {
       parser.parseArgument(args);
     } catch (CmdLineException e) {
       System.err.println(e.getMessage());
       parser.printUsage(System.err);
-      System.err.println("Example: " + SearchInvertedDenseVectors.class.getSimpleName() +
-          parser.printExample(OptionHandlerFilter.REQUIRED));
+      System.err.println("Example: SearchCollection" + parser.printExample(OptionHandlerFilter.REQUIRED));
       return;
     }
-    Analyzer vectorAnalyzer;
-    if (indexArgs.encoding.equalsIgnoreCase(FW)) {
-      vectorAnalyzer = new FakeWordsEncoderAnalyzer(indexArgs.q);
-    } else if (indexArgs.encoding.equalsIgnoreCase(LEXLSH)) {
-      vectorAnalyzer = new LexicalLshAnalyzer(indexArgs.decimals, indexArgs.ngrams, indexArgs.hashCount,
-          indexArgs.bucketCount, indexArgs.hashSetSize);
+
+    final long start = System.nanoTime();
+    SearchInvertedDenseVectors searcher;
+
+    // We're at top-level already inside a main; makes no sense to propagate exceptions further, so reformat the
+    // exception messages and display on console.
+    try {
+      searcher = new SearchInvertedDenseVectors(searchArgs);
+    } catch (IllegalArgumentException e) {
+      System.err.println(e.getMessage());
+      return;
+    }
+    if (searchArgs.topicReader != null && searchArgs.topics != null) {
+      searcher.runTopics();
+    } else if (searchArgs.word != null) {
+      searcher.runWord();
     } else {
-      parser.printUsage(System.err);
-      System.err.println("Example: " + SearchInvertedDenseVectors.class.getSimpleName() +
-          parser.printExample(OptionHandlerFilter.REQUIRED));
+      System.err.println("Either " + searchArgs.word + " or " + searchArgs.topicReader + " must be set");
       return;
     }
+    searcher.close();
+    final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+    LOG.info("Total run time: " + DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss"));
+  }
 
-    if (!indexArgs.stored && indexArgs.input == null) {
-      System.err.println("Either -path or -stored args must be set");
-      return;
-    }
-
-    Path indexDir = indexArgs.path;
-    if (!Files.exists(indexDir)) {
-      Files.createDirectories(indexDir);
-    }
-
-    System.out.println(String.format("Reading index at %s", indexArgs.path));
-
-    Directory d = FSDirectory.open(indexDir);
-    DirectoryReader reader = DirectoryReader.open(d);
+  private void runWord() throws IOException {
+    generator = new InvertedDenseVectorQueryGenerator(args.encoding, false);
+    Collection<String> vectorStrings = new LinkedList<>();
     IndexSearcher searcher = new IndexSearcher(reader);
-    if (indexArgs.encoding.equalsIgnoreCase(FW)) {
+    if (args.encoding.equalsIgnoreCase(FW)) {
       searcher.setSimilarity(new ClassicSimilarity());
     }
-
-    Collection<String> vectorStrings = new LinkedList<>();
-    if (indexArgs.stored) {
-      TopDocs topDocs = searcher.search(new TermQuery(new Term(IndexInvertedDenseVectors.FIELD_ID, indexArgs.word)), indexArgs.depth);
+    if (args.stored) {
+      TopDocs topDocs = searcher.search(new TermQuery(new Term(IndexInvertedDenseVectors.FIELD_ID, args.word)), args.hits);
       for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
         vectorStrings.add(reader.document(scoreDoc.doc).get(IndexInvertedDenseVectors.FIELD_VECTOR));
       }
     } else {
-      System.out.println(String.format("Loading model %s", indexArgs.input));
+      System.out.println(String.format("Loading model %s", args.input));
 
-      Map<String, List<float[]>> wordVectors = IndexInvertedDenseVectors.readGloVe(indexArgs.input);
+      Map<String, List<float[]>> wordVectors = IndexInvertedDenseVectors.readGloVe(args.input);
 
-      if (wordVectors.containsKey(indexArgs.word)) {
-        List<float[]> vectors = wordVectors.get(indexArgs.word);
+      if (wordVectors.containsKey(args.word)) {
+        List<float[]> vectors = wordVectors.get(args.word);
         for (float[] vector : vectors) {
           StringBuilder sb = new StringBuilder();
           for (double fv : vector) {
@@ -170,23 +477,14 @@ public class SearchInvertedDenseVectors {
     }
 
     for (String vectorString : vectorStrings) {
-      float msm = indexArgs.msm;
-      float cutoff = indexArgs.cutoff;
-      CommonTermsQuery simQuery = new CommonTermsQuery(SHOULD, SHOULD, cutoff);
-      for (String token : AnalyzerUtils.analyze(vectorAnalyzer, vectorString)) {
-        simQuery.add(new Term(IndexInvertedDenseVectors.FIELD_VECTOR, token));
-      }
-      if (msm > 0) {
-        simQuery.setHighFreqMinimumNumberShouldMatch(msm);
-        simQuery.setLowFreqMinimumNumberShouldMatch(msm);
-      }
+      Query query = generator.buildQuery(vectorString);
 
       long start = System.currentTimeMillis();
-      TopScoreDocCollector results = TopScoreDocCollector.create(indexArgs.depth, Integer.MAX_VALUE);
-      searcher.search(simQuery, results);
+      TopScoreDocCollector results = TopScoreDocCollector.create(args.hits, Integer.MAX_VALUE);
+      searcher.search(query, results);
       long time = System.currentTimeMillis() - start;
 
-      System.out.println(String.format("%d nearest neighbors of '%s':", indexArgs.depth, indexArgs.word));
+      System.out.println(String.format("%d nearest neighbors of '%s':", args.hits, args.word));
 
       int rank = 1;
       for (ScoreDoc sd : results.topDocs().scoreDocs) {
@@ -198,6 +496,5 @@ public class SearchInvertedDenseVectors {
       System.out.println(String.format("Search time: %dms", time));
     }
     reader.close();
-    d.close();
   }
 }

--- a/src/main/java/io/anserini/search/SearchInvertedDenseVectors.java
+++ b/src/main/java/io/anserini/search/SearchInvertedDenseVectors.java
@@ -82,7 +82,7 @@ public final class SearchInvertedDenseVectors implements Closeable {
     @Option(name = "-input", metaVar = "[file]", usage = "vectors model")
     public File input;
 
-    @Option(name = "-word", metaVar = "[word]", required = true, usage = "input word")
+    @Option(name = "-word", metaVar = "[word]", usage = "input word")
     public String word;
 
     @Option(name = "-stored", metaVar = "[boolean]", usage = "fetch stored vectors from index")

--- a/src/main/java/io/anserini/search/SearchInvertedDenseVectors.java
+++ b/src/main/java/io/anserini/search/SearchInvertedDenseVectors.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.anserini.analysis.fw.FakeWordsEncoderAnalyzer;
 import io.anserini.index.IndexInvertedDenseVectors;
 import io.anserini.rerank.ScoredDocuments;
 import io.anserini.search.query.InvertedDenseVectorQueryGenerator;
@@ -102,6 +103,24 @@ public final class SearchInvertedDenseVectors implements Closeable {
 
     @Option(name = "-encoding", metaVar = "[word]", required = true, usage = "encoding must be one of {fw, lexlsh}")
     public String encoding;
+
+    @Option(name = "-lexlsh.n", metaVar = "[int]", usage = "ngrams")
+    public int ngrams = 2;
+
+    @Option(name = "-lexlsh.d", metaVar = "[int]", usage = "decimals")
+    public int decimals = 1;
+
+    @Option(name = "-lexlsh.hsize", metaVar = "[int]", usage = "hash set size")
+    public int hashSetSize = 1;
+
+    @Option(name = "-lexlsh.h", metaVar = "[int]", usage = "hash count")
+    public int hashCount = 1;
+
+    @Option(name = "-lexlsh.b", metaVar = "[int]", usage = "bucket count")
+    public int bucketCount = 300;
+
+    @Option(name = "-fw.q", metaVar = "[int]", usage = "quantization factor")
+    public int q = FakeWordsEncoderAnalyzer.DEFAULT_Q;
 
     @Option(name = "-threads", metaVar = "[int]", usage = "Number of threads to use for running different parameter configurations.")
     public int threads = 1;
@@ -334,7 +353,7 @@ public final class SearchInvertedDenseVectors implements Closeable {
 
   @SuppressWarnings("unchecked")
   public <K> void runTopics() {
-    generator = new InvertedDenseVectorQueryGenerator(args.encoding, true);
+    generator = new InvertedDenseVectorQueryGenerator(args, true);
     TopicReader<K> tr;
     SortedMap<K, Map<String, String>> topics = new TreeMap<>();
     for (String singleTopicsFile : args.topics) {
@@ -444,7 +463,7 @@ public final class SearchInvertedDenseVectors implements Closeable {
   }
 
   private void runWord() throws IOException {
-    generator = new InvertedDenseVectorQueryGenerator(args.encoding, false);
+    generator = new InvertedDenseVectorQueryGenerator(args, false);
     Collection<String> vectorStrings = new LinkedList<>();
     IndexSearcher searcher = new IndexSearcher(reader);
     if (args.encoding.equalsIgnoreCase(FW)) {

--- a/src/main/java/io/anserini/search/query/InvertedDenseVectorQueryGenerator.java
+++ b/src/main/java/io/anserini/search/query/InvertedDenseVectorQueryGenerator.java
@@ -1,0 +1,80 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.search.query;
+
+import java.util.ArrayList;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.anserini.analysis.AnalyzerUtils;
+import io.anserini.analysis.fw.FakeWordsEncoderAnalyzer;
+import io.anserini.analysis.lexlsh.LexicalLshAnalyzer;
+import io.anserini.index.IndexInvertedDenseVectors;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.CommonTermsQuery;
+import org.apache.lucene.search.Query;
+
+import static io.anserini.index.IndexInvertedDenseVectors.FW;
+import static io.anserini.index.IndexInvertedDenseVectors.LEXLSH;
+import static org.apache.lucene.search.BooleanClause.Occur.SHOULD;
+
+public class InvertedDenseVectorQueryGenerator {
+
+  private final Analyzer vectorAnalyzer;
+  private final boolean jsonConversion;
+
+  public InvertedDenseVectorQueryGenerator(String encoding, boolean jsonConversion) {
+    this.jsonConversion = jsonConversion;
+    if (encoding.equalsIgnoreCase(FW)) {
+      vectorAnalyzer = new FakeWordsEncoderAnalyzer();
+    } else if (encoding.equalsIgnoreCase(LEXLSH)) {
+      vectorAnalyzer = new LexicalLshAnalyzer();
+    } else {
+      throw new RuntimeException("unrecognized encoding " + encoding);
+    }
+  }
+
+  private String convertJsonArray(String vectorString) throws JsonProcessingException {
+    ObjectMapper mapper = new ObjectMapper();
+    ArrayList<Float> denseVector = mapper.readValue(vectorString, new TypeReference<>() {});
+    StringBuilder sb = new StringBuilder();
+    for (float fv : denseVector) {
+      if (sb.length() > 0) {
+        sb.append(' ');
+      }
+      sb.append(fv);
+    }
+    return sb.toString();
+  }
+
+  public Query buildQuery(String queryString) throws JsonProcessingException {
+    String queryText;
+    if (jsonConversion) {
+      queryText = convertJsonArray(queryString);
+    } else {
+      queryText = queryString;
+    }
+    float cutoff = 0.999f;
+    CommonTermsQuery simQuery = new CommonTermsQuery(SHOULD, SHOULD, cutoff);
+    for (String token : AnalyzerUtils.analyze(vectorAnalyzer, queryText)) {
+      simQuery.add(new Term(IndexInvertedDenseVectors.FIELD_VECTOR, token));
+    }
+    return simQuery;
+  }
+}

--- a/src/main/java/io/anserini/search/query/InvertedDenseVectorQueryGenerator.java
+++ b/src/main/java/io/anserini/search/query/InvertedDenseVectorQueryGenerator.java
@@ -25,6 +25,7 @@ import io.anserini.analysis.AnalyzerUtils;
 import io.anserini.analysis.fw.FakeWordsEncoderAnalyzer;
 import io.anserini.analysis.lexlsh.LexicalLshAnalyzer;
 import io.anserini.index.IndexInvertedDenseVectors;
+import io.anserini.search.SearchInvertedDenseVectors;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.CommonTermsQuery;
@@ -39,14 +40,14 @@ public class InvertedDenseVectorQueryGenerator {
   private final Analyzer vectorAnalyzer;
   private final boolean jsonConversion;
 
-  public InvertedDenseVectorQueryGenerator(String encoding, boolean jsonConversion) {
+  public InvertedDenseVectorQueryGenerator(SearchInvertedDenseVectors.Args args, boolean jsonConversion) {
     this.jsonConversion = jsonConversion;
-    if (encoding.equalsIgnoreCase(FW)) {
-      vectorAnalyzer = new FakeWordsEncoderAnalyzer();
-    } else if (encoding.equalsIgnoreCase(LEXLSH)) {
-      vectorAnalyzer = new LexicalLshAnalyzer();
+    if (args.encoding.equalsIgnoreCase(FW)) {
+      vectorAnalyzer = new FakeWordsEncoderAnalyzer(args.q);
+    } else if (args.encoding.equalsIgnoreCase(LEXLSH)) {
+      vectorAnalyzer = new LexicalLshAnalyzer(args.decimals, args.ngrams, args.hashCount, args.bucketCount, args.hashSetSize);
     } else {
-      throw new RuntimeException("unrecognized encoding " + encoding);
+      throw new RuntimeException("unrecognized encoding " + args.encoding);
     }
   }
 

--- a/src/test/java/io/anserini/index/IndexInvertedDenseVectorsTest.java
+++ b/src/test/java/io/anserini/index/IndexInvertedDenseVectorsTest.java
@@ -16,7 +16,6 @@
 
 package io.anserini.index;
 
-import io.anserini.index.IndexInvertedDenseVectors;
 import org.junit.Test;
 
 import java.util.LinkedList;
@@ -47,13 +46,43 @@ public class IndexInvertedDenseVectorsTest {
     createIndex("target/idx-sample-ll" + System.currentTimeMillis(), "lexlsh", false);
   }
 
+  @Test
+  public void testLLCollection() throws Exception {
+    List<String> args = new LinkedList<>();
+    args.add("-collection");
+    args.add("JsonDenseVectorCollection");
+    args.add("-encoding");
+    args.add("lexlsh");
+    args.add("-input");
+    args.add("src/test/resources/sample_docs/json_vector/dense_collection1");
+    args.add("-index");
+    args.add("target/idx-sample-ll-vector" + System.currentTimeMillis());
+    args.add("-stored");
+    IndexInvertedDenseVectors.main(args.toArray(new String[0]));
+  }
+
+  @Test
+  public void testFWCollection() throws Exception {
+    List<String> args = new LinkedList<>();
+    args.add("-collection");
+    args.add("JsonDenseVectorCollection");
+    args.add("-encoding");
+    args.add("fw");
+    args.add("-input");
+    args.add("src/test/resources/sample_docs/json_vector/dense_collection1");
+    args.add("-index");
+    args.add("target/idx-sample-fw-vector" + System.currentTimeMillis());
+    args.add("-stored");
+    IndexInvertedDenseVectors.main(args.toArray(new String[0]));
+  }
+
   public static void createIndex(String path, String encoding, boolean stored) throws Exception {
     List<String> args = new LinkedList<>();
     args.add("-encoding");
     args.add(encoding);
     args.add("-input");
     args.add("src/test/resources/mini-word-vectors.txt");
-    args.add("-path");
+    args.add("-index");
     args.add(path);
     if (stored) {
       args.add("-stored");

--- a/src/test/java/io/anserini/search/SearchInvertedDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchInvertedDenseVectorsTest.java
@@ -30,7 +30,7 @@ public class SearchInvertedDenseVectorsTest {
     String path = "target/idx-sample-fw" + System.currentTimeMillis();
     String encoding = "fw";
     IndexInvertedDenseVectorsTest.createIndex(path, encoding, false);
-    String[] args = new String[]{"-encoding", encoding, "-input", "src/test/resources/mini-word-vectors.txt", "-path",
+    String[] args = new String[]{"-encoding", encoding, "-input", "src/test/resources/mini-word-vectors.txt", "-index",
         path, "-word", "foo"};
     SearchInvertedDenseVectors.main(args);
   }
@@ -40,7 +40,7 @@ public class SearchInvertedDenseVectorsTest {
     String path = "target/idx-sample-fw-stored" + System.currentTimeMillis();
     String encoding = "fw";
     IndexInvertedDenseVectorsTest.createIndex(path, encoding, true);
-    String[] args = new String[]{"-encoding", encoding, "-stored", "-path", path, "-word", "foo"};
+    String[] args = new String[]{"-encoding", encoding, "-stored", "-index", path, "-word", "foo"};
     SearchInvertedDenseVectors.main(args);
   }
 
@@ -49,7 +49,7 @@ public class SearchInvertedDenseVectorsTest {
     String path = "target/idx-sample-ll" + System.currentTimeMillis();
     String encoding = "lexlsh";
     IndexInvertedDenseVectorsTest.createIndex(path, encoding, false);
-    String[] args = new String[]{"-encoding", encoding, "-input", "src/test/resources/mini-word-vectors.txt", "-path",
+    String[] args = new String[]{"-encoding", encoding, "-input", "src/test/resources/mini-word-vectors.txt", "-index",
         path, "-word", "foo"};
     SearchInvertedDenseVectors.main(args);
   }
@@ -59,7 +59,7 @@ public class SearchInvertedDenseVectorsTest {
     String path = "target/idx-sample-ll" + System.currentTimeMillis();
     String encoding = "lexlsh";
     IndexInvertedDenseVectorsTest.createIndex(path, encoding, true);
-    String[] args = new String[]{"-encoding", encoding, "-stored", "-path", path, "-word", "foo"};
+    String[] args = new String[]{"-encoding", encoding, "-stored", "-index", path, "-word", "foo"};
     SearchInvertedDenseVectors.main(args);
   }
 

--- a/src/test/resources/sample_docs/json_vector/dense_collection1/doc1.json
+++ b/src/test/resources/sample_docs/json_vector/dense_collection1/doc1.json
@@ -1,0 +1,5 @@
+{
+  "docid": "doc1",
+  "contents": "this is the contents 1.",
+  "vector": [0.1, 0.2, 0.3]
+}

--- a/src/test/resources/sample_docs/json_vector/dense_collection1/doc2.json
+++ b/src/test/resources/sample_docs/json_vector/dense_collection1/doc2.json
@@ -1,0 +1,5 @@
+{
+  "docid": "doc2",
+  "contents": "this is the contents 2.",
+  "vector": [0.2, 0.3, 0.4]
+}


### PR DESCRIPTION
this extends `IndexInvertedDenseVectors` and `SearchInvertedDenseVectors`, InvertedDenseVectorsDocumentGenerator and `InvertedDenseVectorsQueryGenerator` to allow users to index MSMarco using LSH or FW analyzers.
Indexing command example:

```bash
./target/appassembler/bin/IndexInvertedDenseVectors -collection JsonDenseVectorCollection -generator InvertedDenseVectorsDocumentGenerator -threads 1 -index /path/to/fw-msmarco-passage/ -input /path/to/vector-cos-dpr-msmarco-passage -encoding fw 
```
Search command example:
```bash
./target/appassembler/bin/SearchInvertedDenseVectors  -index /path/to/index-cos-dpr-msmarco-passage/ \
 -topics /path/to/vector-cos-dpr-msmarco-passage-dev-query/encoded-query.jsonl \
 -topicreader JsonIntVector \
 -querygenerator InvertedDenseVectorsQueryGenerator \
 -output run.ann-cos-dpr-msmarco-dev.trec \
 -topicfield vector \
 -hits 100 
```