### PR TITLE
Add an entry in the Passage Ranking Experiment Reproduction Log for ugrad onboarding

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -422,3 +422,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@pratyushpal](https://github.com/pratyushpal) on 2023-07-14 (commit [`17d5fc7`](https://github.com/castorini/anserini/commit/17d5fc7f338b511c4dc49de88e9b2ab7ea27f8aa))
 + Results reproduced by [@sahel-sh](https://github.com/sahel-sh) on 2023-07-22 (commit [`4b8f051`](https://github.com/castorini/anserini/commit/4b8f051c25992a5d87ecf8d30d45a93aff17abc4))
 + Results reproduced by [@Mofetoluwa](https://github.com/Mofetoluwa) on 2023-08-03 (commit [`7314128`](https://github.com/castorini/anserini/commit/73141282b62979e189ac3c87d9a902064f34a1c5))
++ Results reproduced by [@yilinjz](https://github.com/yilinjz) on 2023-08-24 (commit [`d4cb6fd`](https://github.com/castorini/anserini/commit/d4cb6fd1c0b5ed0a7eac4747af919823acc939fa))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -227,7 +227,7 @@ the fourth colum provides the relevance judgment itself.
 In this case, 0 means "not relevant" and 1 means "relevant".
 So, this entry says that the document with id 7187158 is relevant to the query with id 1048585.
 
-Well, how do we get the actual contents of document 1048585?
+Well, how do we get the actual contents of document 7187158?
 The simplest way is to grep through the collection itself:
 
 ```bash


### PR DESCRIPTION
**OS**: macOS Ventura Version 13.5
**Hardware**: M2 MacBook Pro (2023), 16 GB RAM
 
**Java**: 20.0.2
**Maven**: 3.9.4
**Python**: 3.11.4

**Result**: I was able to replicate the Indexing, Retrieval & Evaluation steps on my machine with the above settings. Outputs are the same as listed in the document. I also repeat the steps for two other queries (one with MRR@10=0.33 and the other with MRR@10=0.00) and their MRR@10 scores agree with the ranking lists.

**Additional Comment**: There might be a typo in the start-here.md file. Given the context, it seems 1048585 is the query id rather than the document id. 