### PR TITLE
Refactor ONNX encoders

### DIFF
--- a/src/main/java/io/anserini/encoder/SparseEncoder.java
+++ b/src/main/java/io/anserini/encoder/SparseEncoder.java
@@ -1,19 +1,39 @@
-package io.anserini.search.query;
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.encoder;
 
 import ai.djl.modality.nlp.DefaultVocabulary;
 import ai.djl.modality.nlp.Vocabulary;
 import ai.djl.modality.nlp.bert.BertFullTokenizer;
 import ai.onnxruntime.OrtException;
+import org.apache.commons.io.FileUtils;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
-import org.apache.commons.io.FileUtils;
-
-public abstract class QueryEncoder {
+public abstract class SparseEncoder {
   static private final String CACHE_DIR = Paths.get(System.getProperty("user.home"), "/.cache/anserini/encoders").toString();
 
   protected int weightRange;
@@ -50,7 +70,7 @@ public abstract class QueryEncoder {
     return cacheDir.getPath();
   }
 
-  public QueryEncoder(int weightRange, int quantRange) {
+  public SparseEncoder(int weightRange, int quantRange) {
     this.weightRange = weightRange;
     this.quantRange = quantRange;
   }

--- a/src/main/java/io/anserini/encoder/SpladePlusPlusEnsembleDistilEncoder.java
+++ b/src/main/java/io/anserini/encoder/SpladePlusPlusEnsembleDistilEncoder.java
@@ -1,4 +1,20 @@
-package io.anserini.search.query;
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.encoder;
 
 import ai.djl.modality.nlp.DefaultVocabulary;
 import ai.djl.modality.nlp.bert.BertFullTokenizer;
@@ -7,10 +23,14 @@ import ai.onnxruntime.OrtEnvironment;
 import ai.onnxruntime.OrtException;
 import ai.onnxruntime.OrtSession;
 
-import java.io.*;
-import java.util.*;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-public class SpladePlusPlusEnsembleDistilQueryEncoder extends QueryEncoder {
+public class SpladePlusPlusEnsembleDistilEncoder extends SparseEncoder {
   static private final String MODEL_URL = "https://rgw.cs.uwaterloo.ca/pyserini/data/splade-pp-ed-optimized.onnx";
 
   static private final String VOCAB_URL = "https://rgw.cs.uwaterloo.ca/pyserini/data/wordpiece-vocab.txt";
@@ -27,7 +47,7 @@ public class SpladePlusPlusEnsembleDistilQueryEncoder extends QueryEncoder {
 
   private final OrtSession session;
 
-  public SpladePlusPlusEnsembleDistilQueryEncoder() throws IOException, OrtException {
+  public SpladePlusPlusEnsembleDistilEncoder() throws IOException, OrtException {
     super(5, 256);
     this.vocab = DefaultVocabulary.builder()
         .addFromTextFile(getVocabPath(VOCAB_NAME, VOCAB_URL))

--- a/src/main/java/io/anserini/encoder/SpladePlusPlusSelfDistilEncoder.java
+++ b/src/main/java/io/anserini/encoder/SpladePlusPlusSelfDistilEncoder.java
@@ -1,4 +1,20 @@
-package io.anserini.search.query;
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.encoder;
 
 import ai.djl.modality.nlp.DefaultVocabulary;
 import ai.djl.modality.nlp.bert.BertFullTokenizer;
@@ -7,10 +23,14 @@ import ai.onnxruntime.OrtEnvironment;
 import ai.onnxruntime.OrtException;
 import ai.onnxruntime.OrtSession;
 
-import java.io.*;
-import java.util.*;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-public class SpladePlusPlusSelfDistilQueryEncoder extends QueryEncoder {
+public class SpladePlusPlusSelfDistilEncoder extends SparseEncoder {
   static private final String MODEL_URL = "https://rgw.cs.uwaterloo.ca/pyserini/data/splade-pp-sd-optimized.onnx";
 
   static private final String VOCAB_URL = "https://rgw.cs.uwaterloo.ca/pyserini/data/wordpiece-vocab.txt";
@@ -26,7 +46,7 @@ public class SpladePlusPlusSelfDistilQueryEncoder extends QueryEncoder {
   private final OrtEnvironment environment;
 
   private final OrtSession session;
-  public SpladePlusPlusSelfDistilQueryEncoder() throws IOException, OrtException {
+  public SpladePlusPlusSelfDistilEncoder() throws IOException, OrtException {
     super(5, 256);
     this.vocab = DefaultVocabulary.builder()
         .addFromTextFile(getVocabPath(VOCAB_NAME, VOCAB_URL))

--- a/src/main/java/io/anserini/encoder/UniCoilEncoder.java
+++ b/src/main/java/io/anserini/encoder/UniCoilEncoder.java
@@ -1,4 +1,20 @@
-package io.anserini.search.query;
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.encoder;
 
 import ai.djl.modality.nlp.DefaultVocabulary;
 import ai.djl.modality.nlp.bert.BertFullTokenizer;
@@ -7,10 +23,14 @@ import ai.onnxruntime.OrtEnvironment;
 import ai.onnxruntime.OrtException;
 import ai.onnxruntime.OrtSession;
 
-import java.io.*;
-import java.util.*;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
-public class UniCoilQueryEncoder extends QueryEncoder {
+public class UniCoilEncoder extends SparseEncoder {
   static private final String MODEL_URL = "https://rgw.cs.uwaterloo.ca/pyserini/data/unicoil.onnx";
 
   static private final String VOCAB_URL = "https://rgw.cs.uwaterloo.ca/pyserini/data/wordpiece-vocab.txt";
@@ -27,7 +47,7 @@ public class UniCoilQueryEncoder extends QueryEncoder {
 
   private final OrtSession session;
 
-  public UniCoilQueryEncoder() throws IOException, OrtException {
+  public UniCoilEncoder() throws IOException, OrtException {
     super(5, 256);
     this.vocab = DefaultVocabulary.builder()
         .addFromTextFile(getVocabPath(VOCAB_NAME, VOCAB_URL))

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -18,11 +18,12 @@ package io.anserini.search;
 
 import io.anserini.analysis.AnalyzerMap;
 import io.anserini.analysis.AnalyzerUtils;
+import io.anserini.analysis.AutoCompositeAnalyzer;
 import io.anserini.analysis.CompositeAnalyzer;
 import io.anserini.analysis.DefaultEnglishAnalyzer;
 import io.anserini.analysis.HuggingFaceTokenizerAnalyzer;
-import io.anserini.analysis.AutoCompositeAnalyzer;
 import io.anserini.analysis.TweetAnalyzer;
+import io.anserini.encoder.SparseEncoder;
 import io.anserini.index.Constants;
 import io.anserini.index.generator.TweetGenerator;
 import io.anserini.index.generator.WashingtonPostGenerator;
@@ -35,7 +36,6 @@ import io.anserini.rerank.lib.NewsBackgroundLinkingReranker;
 import io.anserini.rerank.lib.Rm3Reranker;
 import io.anserini.rerank.lib.RocchioReranker;
 import io.anserini.rerank.lib.ScoreTiesAdjusterReranker;
-import io.anserini.search.query.QueryEncoder;
 import io.anserini.search.query.QueryGenerator;
 import io.anserini.search.query.SdmQueryGenerator;
 import io.anserini.search.similarity.AccurateBM25Similarity;
@@ -752,10 +752,11 @@ public final class SearchCollection implements Closeable {
         AtomicInteger cnt = new AtomicInteger();
 
         // Initialize query encoder if specified
-        QueryEncoder queryEncoder;
+        SparseEncoder queryEncoder;
         if (args.encoder != null) {
-          queryEncoder = (QueryEncoder) Class.forName("io.anserini.search.query." + args.encoder + "QueryEncoder")
-                  .getConstructor().newInstance();
+          queryEncoder = (SparseEncoder) Class
+              .forName(String.format("io.anserini.encoder.%sEncoder", args.encoder))
+              .getConstructor().newInstance();
         } else {
           queryEncoder = null;
         }

--- a/src/test/java/io/anserini/encoder/SpladeEncoderTokenizationTest.java
+++ b/src/test/java/io/anserini/encoder/SpladeEncoderTokenizationTest.java
@@ -1,4 +1,20 @@
-package io.anserini.search.query;
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.encoder;
 
 import ai.djl.modality.nlp.DefaultVocabulary;
 import ai.djl.modality.nlp.bert.BertFullTokenizer;
@@ -14,7 +30,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
 
-public class UniCoilEncoderQueryTokenizationTest {
+public class SpladeEncoderTokenizationTest {
   static private final String VOCAB_URL = "https://rgw.cs.uwaterloo.ca/pyserini/data/wordpiece-vocab.txt";
 
   Object[][] examples = new Object[][] {
@@ -68,7 +84,7 @@ public class UniCoilEncoderQueryTokenizationTest {
   }
 
   static private Path getVocabPath() throws IOException {
-    File vocabFile = new File(getCacheDir(), "unicoil-vocab.txt");
+    File vocabFile = new File(getCacheDir(), "UnicoilVocab.txt");
     FileUtils.copyURLToFile(new URL(VOCAB_URL), vocabFile);
     return vocabFile.toPath();
   }

--- a/src/test/java/io/anserini/encoder/SpladePlusPlusEncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/SpladePlusPlusEncoderInferenceTest.java
@@ -1,6 +1,27 @@
-package io.anserini.search.query;
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import static org.junit.Assert.assertArrayEquals;
+package io.anserini.encoder;
+
+import ai.onnxruntime.OnnxTensor;
+import ai.onnxruntime.OrtEnvironment;
+import ai.onnxruntime.OrtException;
+import ai.onnxruntime.OrtSession;
+import ai.onnxruntime.OrtSession.Result;
+import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,21 +31,14 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.io.FileUtils;
+import static org.junit.Assert.assertArrayEquals;
 
-import ai.onnxruntime.OrtEnvironment;
-import ai.onnxruntime.OrtException;
-import ai.onnxruntime.OrtSession;
-import ai.onnxruntime.OrtSession.Result;
-import ai.onnxruntime.OnnxTensor;
-
-
-abstract class SpladePlusPlusEncoderQueryInferenceTest {
+abstract class SpladePlusPlusEncoderInferenceTest {
   private final String MODEL_NAME;
   private final String MODEL_URL;
   private final Object[][] EXAMPLES;
 
-  public SpladePlusPlusEncoderQueryInferenceTest(String modelName, String modelUrl, Object[][] examples) {
+  public SpladePlusPlusEncoderInferenceTest(String modelName, String modelUrl, Object[][] examples) {
     this.MODEL_NAME = modelName;
     this.MODEL_URL = modelUrl;
     this.EXAMPLES = examples;

--- a/src/test/java/io/anserini/encoder/SpladePlusPlusEnsembleDistilEncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/SpladePlusPlusEnsembleDistilEncoderInferenceTest.java
@@ -1,12 +1,27 @@
-package io.anserini.search.query;
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import ai.onnxruntime.*;
+package io.anserini.encoder;
 
+import ai.onnxruntime.OrtException;
 import org.junit.Test;
 
 import java.io.IOException;
 
-public class SpladePlusPlusEnsembleDistilEncoderQueryInferenceTest extends SpladePlusPlusEncoderQueryInferenceTest {
+public class SpladePlusPlusEnsembleDistilEncoderInferenceTest extends SpladePlusPlusEncoderInferenceTest {
 
   static private final String MODEL_URL = "https://rgw.cs.uwaterloo.ca/pyserini/data/splade-pp-ed-optimized.onnx";
   static private final String MODEL_NAME = "splade-pp-ed-optimized.onnx";
@@ -201,7 +216,7 @@ public class SpladePlusPlusEnsembleDistilEncoderQueryInferenceTest extends Splad
               0.060074817f } },
   };
 
-  public SpladePlusPlusEnsembleDistilEncoderQueryInferenceTest() {
+  public SpladePlusPlusEnsembleDistilEncoderInferenceTest() {
     super(MODEL_NAME, MODEL_URL, EXAMPLES);
   }
 

--- a/src/test/java/io/anserini/encoder/SpladePlusPlusSelfDistilEncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/SpladePlusPlusSelfDistilEncoderInferenceTest.java
@@ -1,10 +1,27 @@
-package io.anserini.search.query;
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import ai.onnxruntime.*;
+package io.anserini.encoder;
+
+import ai.onnxruntime.OrtException;
 import org.junit.Test;
+
 import java.io.IOException;
 
-public class SpladePlusPlusSelfDistilEncoderQueryInferenceTest extends SpladePlusPlusEncoderQueryInferenceTest {
+public class SpladePlusPlusSelfDistilEncoderInferenceTest extends SpladePlusPlusEncoderInferenceTest {
 
   static private final String MODEL_URL = "https://rgw.cs.uwaterloo.ca/pyserini/data/splade-pp-sd-optimized.onnx";
   static private final String MODEL_NAME = "splade-pp-sd-optimized.onnx";
@@ -201,7 +218,7 @@ public class SpladePlusPlusSelfDistilEncoderQueryInferenceTest extends SpladePlu
               0.2994387f, 0.3522259f, 0.15532349f, 1.4914014f, 0.7453375f } }
   };
 
-  public SpladePlusPlusSelfDistilEncoderQueryInferenceTest() {
+  public SpladePlusPlusSelfDistilEncoderInferenceTest() {
     super(MODEL_NAME, MODEL_URL, EXAMPLES);
   }
 

--- a/src/test/java/io/anserini/encoder/UniCoilEncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/UniCoilEncoderInferenceTest.java
@@ -1,6 +1,25 @@
-package io.anserini.search.query;
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import ai.onnxruntime.*;
+package io.anserini.encoder;
+
+import ai.onnxruntime.OnnxTensor;
+import ai.onnxruntime.OrtEnvironment;
+import ai.onnxruntime.OrtException;
+import ai.onnxruntime.OrtSession;
 import ai.onnxruntime.OrtSession.Result;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
@@ -16,7 +35,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertArrayEquals;
 
-public class UniCoilEncoderQueryInferenceTest {
+public class UniCoilEncoderInferenceTest {
   static private final String MODEL_URL = "https://rgw.cs.uwaterloo.ca/pyserini/data/unicoil.onnx";
 
   Object[][] examples = new Object[][] {

--- a/src/test/java/io/anserini/encoder/UniCoilEncoderTokenizationTest.java
+++ b/src/test/java/io/anserini/encoder/UniCoilEncoderTokenizationTest.java
@@ -1,4 +1,20 @@
-package io.anserini.search.query;
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.encoder;
 
 import ai.djl.modality.nlp.DefaultVocabulary;
 import ai.djl.modality.nlp.bert.BertFullTokenizer;
@@ -14,7 +30,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
 
-public class SpladeEncoderQueryTokenizationTest {
+public class UniCoilEncoderTokenizationTest {
   static private final String VOCAB_URL = "https://rgw.cs.uwaterloo.ca/pyserini/data/wordpiece-vocab.txt";
 
   Object[][] examples = new Object[][] {
@@ -68,7 +84,7 @@ public class SpladeEncoderQueryTokenizationTest {
   }
 
   static private Path getVocabPath() throws IOException {
-    File vocabFile = new File(getCacheDir(), "UnicoilVocab.txt");
+    File vocabFile = new File(getCacheDir(), "unicoil-vocab.txt");
     FileUtils.copyURLToFile(new URL(VOCAB_URL), vocabFile);
     return vocabFile.toPath();
   }


### PR DESCRIPTION
+ `QueryEncoder` -> just `Encoder`, because in theory they can encode documents.
+ move encoders into their own package; not limited to searching.
+ `SparseEncoder`, because we'll implement _dense_ encoders soon.