### PR TITLE
Add cos-dpr-distill regressions for TREC DL 19/20

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See individual pages for details!
 | SPLADE++ CoCondenser-SelfDistil             |          [✓](docs/regressions/regressions-msmarco-passage-splade-pp-sd.md)           |          [✓](docs/regressions/regressions-dl19-passage-splade-pp-sd.md)           |          [✓](docs/regressions/regressions-dl20-passage-splade-pp-sd.md)           |
 | SPLADE++ CoCondenser-SelfDistil (ONNX)      |        [✓](docs/regressions/regressions-msmarco-passage-splade-pp-sd-onnx.md)        |        [✓](docs/regressions/regressions-dl19-passage-splade-pp-sd-onnx.md)        |        [✓](docs/regressions/regressions-dl20-passage-splade-pp-sd-onnx.md)        |
 | **Learned Dense**                           |                                                                                      |                                                                                   |                                                                                   |
-| cosDPR-distil                               |         [✓](docs/regressions/regressions-msmarco-passage-cos-dpr-distil.md)          |                                                                                   |                                                                                   |                                                                       |
+| cosDPR-distil                               |         [✓](docs/regressions/regressions-msmarco-passage-cos-dpr-distil.md)          |         [✓](docs/regressions/regressions-dl19-passage-cos-dpr-distil.md)          |         [✓](docs/regressions/regressions-dl20-passage-cos-dpr-distil.md)          |  
 
 ### Available Corpora for Download
 

--- a/docs/regressions.md
+++ b/docs/regressions.md
@@ -77,9 +77,9 @@ nohup python src/main/python/run_regression.py --index --verify --search --regre
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-distil-cocodenser-medium >& logs/log.dl19-passage-splade-distil-cocodenser-medium &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-pp-ed >& logs/log.dl19-passage-splade-pp-ed &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-pp-sd >& logs/log.dl19-passage-splade-pp-sd &
-nohup python src/main/python/run_regression.py --search-pool 1 --index --verify --search --regression dl19-passage-splade-pp-ed-onnx >& logs/log.dl19-passage-splade-pp-ed-onnx
-nohup python src/main/python/run_regression.py --search-pool 1 --index --verify --search --regression dl19-passage-splade-pp-sd-onnx >& logs/log.dl19-passage-splade-pp-sd-onnx
-nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-cos-dpr-distil >& logs/log.msmarco-passage-cos-dpr-distil &
+nohup python src/main/python/run_regression.py --search-pool 1 --index --verify --search --regression dl19-passage-splade-pp-ed-onnx >& logs/log.dl19-passage-splade-pp-ed-onnx &
+nohup python src/main/python/run_regression.py --search-pool 1 --index --verify --search --regression dl19-passage-splade-pp-sd-onnx >& logs/log.dl19-passage-splade-pp-sd-onnx &
+nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-cos-dpr-distil >& logs/log.dl19-passage-cos-dpr-distil &
 
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-doc >& logs/log.dl19-doc &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-doc-wp >& logs/log.dl19-doc-wp &
@@ -104,9 +104,9 @@ nohup python src/main/python/run_regression.py --index --verify --search --regre
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-distil-cocodenser-medium >& logs/log.dl20-passage-splade-distil-cocodenser-medium &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-pp-ed >& logs/log.dl20-passage-splade-pp-ed &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-pp-sd >& logs/log.dl20-passage-splade-pp-sd &
-nohup python src/main/python/run_regression.py --search-pool 1 --index --verify --search --regression dl20-passage-splade-pp-ed-onnx >& logs/log.dl20-passage-splade-pp-ed-onnx
-nohup python src/main/python/run_regression.py --search-pool 1 --index --verify --search --regression dl20-passage-splade-pp-sd-onnx >& logs/log.dl20-passage-splade-pp-sd-onnx
-nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-cos-dpr-distil >& logs/log.msmarco-passage-cos-dpr-distil &
+nohup python src/main/python/run_regression.py --search-pool 1 --index --verify --search --regression dl20-passage-splade-pp-ed-onnx >& logs/log.dl20-passage-splade-pp-ed-onnx &
+nohup python src/main/python/run_regression.py --search-pool 1 --index --verify --search --regression dl20-passage-splade-pp-sd-onnx >& logs/log.dl20-passage-splade-pp-sd-onnx &
+nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-cos-dpr-distil >& logs/log.dl20-passage-cos-dpr-distil &
 
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-doc >& logs/log.dl20-doc &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-doc-wp >& logs/log.dl20-doc-wp &

--- a/docs/regressions.md
+++ b/docs/regressions.md
@@ -79,6 +79,7 @@ nohup python src/main/python/run_regression.py --index --verify --search --regre
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-splade-pp-sd >& logs/log.dl19-passage-splade-pp-sd &
 nohup python src/main/python/run_regression.py --search-pool 1 --index --verify --search --regression dl19-passage-splade-pp-ed-onnx >& logs/log.dl19-passage-splade-pp-ed-onnx
 nohup python src/main/python/run_regression.py --search-pool 1 --index --verify --search --regression dl19-passage-splade-pp-sd-onnx >& logs/log.dl19-passage-splade-pp-sd-onnx
+nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-cos-dpr-distil >& logs/log.msmarco-passage-cos-dpr-distil &
 
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-doc >& logs/log.dl19-doc &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl19-doc-wp >& logs/log.dl19-doc-wp &
@@ -105,6 +106,7 @@ nohup python src/main/python/run_regression.py --index --verify --search --regre
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-splade-pp-sd >& logs/log.dl20-passage-splade-pp-sd &
 nohup python src/main/python/run_regression.py --search-pool 1 --index --verify --search --regression dl20-passage-splade-pp-ed-onnx >& logs/log.dl20-passage-splade-pp-ed-onnx
 nohup python src/main/python/run_regression.py --search-pool 1 --index --verify --search --regression dl20-passage-splade-pp-sd-onnx >& logs/log.dl20-passage-splade-pp-sd-onnx
+nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-cos-dpr-distil >& logs/log.msmarco-passage-cos-dpr-distil &
 
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-doc >& logs/log.dl20-doc &
 nohup python src/main/python/run_regression.py --index --verify --search --regression dl20-doc-wp >& logs/log.dl20-doc-wp &

--- a/docs/regressions/regressions-dl19-passage-cos-dpr-distil.md
+++ b/docs/regressions/regressions-dl19-passage-cos-dpr-distil.md
@@ -49,7 +49,7 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Indexing
 
-Sample indexing command:
+Sample indexing command, building HNSW indexes:
 
 ```bash
 target/appassembler/bin/IndexHnswDenseVectors \

--- a/docs/regressions/regressions-dl19-passage-cos-dpr-distil.md
+++ b/docs/regressions/regressions-dl19-passage-cos-dpr-distil.md
@@ -1,0 +1,119 @@
+# Anserini Regressions: TREC 2019 Deep Learning Track (Passage)
+
+**Model**: cosDPR-distil (using pre-encoded queries) with HNSW indexes
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using the cosDPR-distil model on the [TREC 2019 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
+
+> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://arxiv.org/abs/2304.12139) _arXiv:2304.12139_, 2023.
+
+In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
+
+Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
+For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/dl19-passage-cos-dpr-distil.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/dl19-passage-cos-dpr-distil.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```bash
+python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-cos-dpr-distil
+```
+
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with cosDPR-distil.
+
+From any machine, the following command will download the corpus and perform the complete regression, end to end:
+
+```bash
+python src/main/python/run_regression.py --download --index --verify --search --regression dl19-passage-cos-dpr-distil
+```
+
+The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
+
+## Corpus Download
+
+Download the corpus and unpack into `collections/`:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-cos-dpr-distil.tar -P collections/
+tar xvf collections/msmarco-passage-cos-dpr-distil.tar -C collections/
+```
+
+To confirm, `msmarco-passage-cos-dpr-distil.tar` is 57 GB and has MD5 checksum `e20ffbc8b5e7f760af31298aefeaebbd`.
+With the corpus downloaded, the following command will perform the remaining steps below:
+
+```bash
+python src/main/python/run_regression.py --index --verify --search --regression dl19-passage-cos-dpr-distil \
+  --corpus-path collections/msmarco-passage-cos-dpr-distil
+```
+
+## Indexing
+
+Sample indexing command:
+
+```bash
+target/appassembler/bin/IndexHnswDenseVectors \
+  -collection JsonDenseVectorCollection \
+  -input /path/to/msmarco-passage-cos-dpr-distil \
+  -index indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil/ \
+  -generator LuceneDenseVectorDocumentGenerator \
+  -threads 16 -M 16 -efC 100 \
+  >& logs/log.msmarco-passage-cos-dpr-distil &
+```
+
+The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus downloaded above.
+
+Upon completion, we should have an index with 8,841,823 documents.
+
+<!-- For additional details, see explanation of [common indexing options](common-indexing-options.md). -->
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+The regression experiments here evaluate on the 43 topics for which NIST has provided judgments as part of the TREC 2019 Deep Learning Track.
+The original data can be found [here](https://trec.nist.gov/data/deep2019.html).
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```bash
+target/appassembler/bin/SearchHnswDenseVectors \
+  -index indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil/ \
+  -topics tools/topics-and-qrels/topics.dl19-passage.cos-dpr-distil.jsonl.gz \
+  -topicreader JsonIntVector \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil.topics.dl19-passage.cos-dpr-distil.jsonl.txt \
+  -querygenerator VectorQueryGenerator -topicfield vector -threads 16 -hits 1000 -efSearch 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```bash
+tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **AP@1000**                                                                                                  | **cosDPR-distil**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.460     |
+| **nDCG@10**                                                                                                  | **cosDPR-distil**|
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.722     |
+| **R@100**                                                                                                    | **cosDPR-distil**|
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.609     |
+| **R@1000**                                                                                                   | **cosDPR-distil**|
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.807     |
+
+Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
+Nevertheless, scores are generally stable to the third digit after the decimal point.
+
+Also note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
+Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).
+The experimental results reported here are directly comparable to the results reported in the [track overview paper](https://arxiv.org/abs/2003.07820).
+
+## Reproduction Log[*](reproducibility.md)
+
+To add to this reproduction log, modify [this template](../../src/main/resources/docgen/templates/dl19-passage-cos-dpr-distil.template) and run `bin/build.sh` to rebuild the documentation.

--- a/docs/regressions/regressions-dl20-passage-cos-dpr-distil.md
+++ b/docs/regressions/regressions-dl20-passage-cos-dpr-distil.md
@@ -49,7 +49,7 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Indexing
 
-Sample indexing command:
+Sample indexing command, building HNSW indexes:
 
 ```bash
 target/appassembler/bin/IndexHnswDenseVectors \

--- a/docs/regressions/regressions-dl20-passage-cos-dpr-distil.md
+++ b/docs/regressions/regressions-dl20-passage-cos-dpr-distil.md
@@ -1,0 +1,119 @@
+# Anserini Regressions: TREC 2020 Deep Learning Track (Passage)
+
+**Model**: cosDPR-distil (using pre-encoded queries) with HNSW indexes
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using the cosDPR-distil model on the [TREC 2020 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
+
+> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://arxiv.org/abs/2304.12139) _arXiv:2304.12139_, 2023.
+
+In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
+
+Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
+For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/dl20-passage-cos-dpr-distil.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/dl20-passage-cos-dpr-distil.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```bash
+python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-cos-dpr-distil
+```
+
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with cosDPR-distil.
+
+From any machine, the following command will download the corpus and perform the complete regression, end to end:
+
+```bash
+python src/main/python/run_regression.py --download --index --verify --search --regression dl20-passage-cos-dpr-distil
+```
+
+The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
+
+## Corpus Download
+
+Download the corpus and unpack into `collections/`:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-cos-dpr-distil.tar -P collections/
+tar xvf collections/msmarco-passage-cos-dpr-distil.tar -C collections/
+```
+
+To confirm, `msmarco-passage-cos-dpr-distil.tar` is 57 GB and has MD5 checksum `e20ffbc8b5e7f760af31298aefeaebbd`.
+With the corpus downloaded, the following command will perform the remaining steps below:
+
+```bash
+python src/main/python/run_regression.py --index --verify --search --regression dl20-passage-cos-dpr-distil \
+  --corpus-path collections/msmarco-passage-cos-dpr-distil
+```
+
+## Indexing
+
+Sample indexing command:
+
+```bash
+target/appassembler/bin/IndexHnswDenseVectors \
+  -collection JsonDenseVectorCollection \
+  -input /path/to/msmarco-passage-cos-dpr-distil \
+  -index indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil/ \
+  -generator LuceneDenseVectorDocumentGenerator \
+  -threads 16 -M 16 -efC 100 \
+  >& logs/log.msmarco-passage-cos-dpr-distil &
+```
+
+The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus downloaded above.
+
+Upon completion, we should have an index with 8,841,823 documents.
+
+<!-- For additional details, see explanation of [common indexing options](common-indexing-options.md). -->
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+The regression experiments here evaluate on the 54 topics for which NIST has provided judgments as part of the TREC 2020 Deep Learning Track.
+The original data can be found [here](https://trec.nist.gov/data/deep2020.html).
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```bash
+target/appassembler/bin/SearchHnswDenseVectors \
+  -index indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil/ \
+  -topics tools/topics-and-qrels/topics.dl20.cos-dpr-distil.jsonl.gz \
+  -topicreader JsonIntVector \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil.topics.dl20.cos-dpr-distil.jsonl.txt \
+  -querygenerator VectorQueryGenerator -topicfield vector -threads 16 -hits 1000 -efSearch 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```bash
+tools/eval/trec_eval.9.0.4/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil.topics.dl20.cos-dpr-distil.jsonl.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil.topics.dl20.cos-dpr-distil.jsonl.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil.topics.dl20.cos-dpr-distil.jsonl.txt
+tools/eval/trec_eval.9.0.4/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil.topics.dl20.cos-dpr-distil.jsonl.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **AP@1000**                                                                                                  | **cosDPR-distil**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.482     |
+| **nDCG@10**                                                                                                  | **cosDPR-distil**|
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.701     |
+| **R@100**                                                                                                    | **cosDPR-distil**|
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.714     |
+| **R@1000**                                                                                                   | **cosDPR-distil**|
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.844     |
+
+Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
+Nevertheless, scores are generally stable to the third digit after the decimal point.
+
+Also note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
+Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).
+The experimental results reported here are directly comparable to the results reported in the [track overview paper](https://arxiv.org/abs/2003.07820).
+
+## Reproduction Log[*](reproducibility.md)
+
+To add to this reproduction log, modify [this template](../../src/main/resources/docgen/templates/dl20-passage-cos-dpr-distil.template) and run `bin/build.sh` to rebuild the documentation.

--- a/src/main/python/regressions-batch03.txt
+++ b/src/main/python/regressions-batch03.txt
@@ -1,7 +1,3 @@
-
-python src/main/python/run_regression.py --index --verify --search --regression msmarco-v2-passage-splade-pp-ed > logs/log.msmarco-v2-passage-splade-pp-ed 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression msmarco-v2-passage-splade-pp-sd > logs/log.msmarco-v2-passage-splade-pp-sd 2>&1
-
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-cos-dpr-distil > logs/log.msmarco-passage-cos-dpr-distil 2>&1
 
 # ONNX runs write to the same indexes as the encoded queries, so we need to spread out
@@ -20,6 +16,9 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc-segmented-docTTTTTquery > logs/log.msmarco-doc-segmented-docTTTTTquery 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc-segmented-unicoil > logs/log.msmarco-doc-segmented-unicoil 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc-segmented-unicoil-noexp > logs/log.msmarco-doc-segmented-unicoil-noexp 2>&1
+
+python src/main/python/run_regression.py --verify --search --regression dl19-passage-cos-dpr-distil > logs/log.dl19-passage-cos-dpr-distil 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage-cos-dpr-distil > logs/log.dl20-passage-cos-dpr-distil 2>&1
 
 python src/main/python/run_regression.py --search-pool 1 --verify --search --regression dl19-passage-splade-pp-ed-onnx > logs/log.dl19-passage-splade-pp-ed-onnx 2>&1
 python src/main/python/run_regression.py --search-pool 1 --verify --search --regression dl19-passage-splade-pp-sd-onnx > logs/log.dl19-passage-splade-pp-sd-onnx 2>&1
@@ -52,8 +51,12 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v2-doc-segmented-unicoil-0shot > logs/log.msmarco-v2-doc-segmented-unicoil-0shot 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v2-doc-segmented-unicoil-0shot-v2 > logs/log.msmarco-v2-doc-segmented-unicoil-0shot-v2 2>&1
 
+# spread out wrt ONNX version
 python src/main/python/run_regression.py --verify --search --regression msmarco-passage-splade-pp-ed > logs/log.msmarco-passage-splade-pp-ed 2>&1
 python src/main/python/run_regression.py --verify --search --regression msmarco-passage-splade-pp-sd > logs/log.msmarco-passage-splade-pp-sd 2>&1
+
+python src/main/python/run_regression.py --index --verify --search --regression msmarco-v2-passage-splade-pp-ed > logs/log.msmarco-v2-passage-splade-pp-ed 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression msmarco-v2-passage-splade-pp-sd > logs/log.msmarco-v2-passage-splade-pp-sd 2>&1
 
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v2-passage > logs/log.msmarco-v2-passage 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v2-passage-d2q-t5 > logs/log.msmarco-v2-passage-d2q-t5 2>&1

--- a/src/main/python/run_regression.py
+++ b/src/main/python/run_regression.py
@@ -204,9 +204,11 @@ def evaluate_and_verify(yaml_data, dry_run):
                         expected, actual, metric['metric'], model['name'], topic_set['id'])
 
                 # For inverted indexes, we expect scores to match precisely.
-                # For HNSW, be more tolerant.
+                # For HNSW, be more tolerant, but as long as the actual score is higher than the expected score,
+                # let the test pass.
                 if is_close(expected, actual) or \
-                        ('VectorQueryGenerator' in model['params'] and is_close(expected, actual, abs_tol=0.006)):
+                        ('VectorQueryGenerator' in model['params'] and is_close(expected, actual, abs_tol=0.006)) or \
+                        ('VectorQueryGenerator' in model['params'] and actual > expected):
                     logger.info(ok_str + result_str)
                 else:
                     if args.lucene8 and is_close_lucene8(expected, actual):

--- a/src/main/resources/docgen/templates/dl19-passage-cos-dpr-distil.template
+++ b/src/main/resources/docgen/templates/dl19-passage-cos-dpr-distil.template
@@ -1,0 +1,97 @@
+# Anserini Regressions: TREC 2019 Deep Learning Track (Passage)
+
+**Model**: cosDPR-distil (using pre-encoded queries) with HNSW indexes
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using the cosDPR-distil model on the [TREC 2019 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
+
+> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://arxiv.org/abs/2304.12139) _arXiv:2304.12139_, 2023.
+
+In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
+
+Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
+For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```bash
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with cosDPR-distil.
+
+From any machine, the following command will download the corpus and perform the complete regression, end to end:
+
+```bash
+python src/main/python/run_regression.py --download --index --verify --search --regression ${test_name}
+```
+
+The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
+
+## Corpus Download
+
+Download the corpus and unpack into `collections/`:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-cos-dpr-distil.tar -P collections/
+tar xvf collections/msmarco-passage-cos-dpr-distil.tar -C collections/
+```
+
+To confirm, `msmarco-passage-cos-dpr-distil.tar` is 57 GB and has MD5 checksum `e20ffbc8b5e7f760af31298aefeaebbd`.
+With the corpus downloaded, the following command will perform the remaining steps below:
+
+```bash
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
+  --corpus-path collections/${corpus}
+```
+
+## Indexing
+
+Sample indexing command:
+
+```bash
+${index_cmds}
+```
+
+The path `/path/to/${corpus}/` should point to the corpus downloaded above.
+
+Upon completion, we should have an index with 8,841,823 documents.
+
+<!-- For additional details, see explanation of [common indexing options](common-indexing-options.md). -->
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+The regression experiments here evaluate on the 43 topics for which NIST has provided judgments as part of the TREC 2019 Deep Learning Track.
+The original data can be found [here](https://trec.nist.gov/data/deep2019.html).
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```bash
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```bash
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}
+
+Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
+Nevertheless, scores are generally stable to the third digit after the decimal point.
+
+Also note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
+Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).
+The experimental results reported here are directly comparable to the results reported in the [track overview paper](https://arxiv.org/abs/2003.07820).
+
+## Reproduction Log[*](reproducibility.md)
+
+To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.

--- a/src/main/resources/docgen/templates/dl19-passage-cos-dpr-distil.template
+++ b/src/main/resources/docgen/templates/dl19-passage-cos-dpr-distil.template
@@ -49,7 +49,7 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Indexing
 
-Sample indexing command:
+Sample indexing command, building HNSW indexes:
 
 ```bash
 ${index_cmds}

--- a/src/main/resources/docgen/templates/dl20-passage-cos-dpr-distil.template
+++ b/src/main/resources/docgen/templates/dl20-passage-cos-dpr-distil.template
@@ -49,7 +49,7 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 
 ## Indexing
 
-Sample indexing command:
+Sample indexing command, building HNSW indexes:
 
 ```bash
 ${index_cmds}

--- a/src/main/resources/docgen/templates/dl20-passage-cos-dpr-distil.template
+++ b/src/main/resources/docgen/templates/dl20-passage-cos-dpr-distil.template
@@ -1,0 +1,97 @@
+# Anserini Regressions: TREC 2020 Deep Learning Track (Passage)
+
+**Model**: cosDPR-distil (using pre-encoded queries) with HNSW indexes
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using the cosDPR-distil model on the [TREC 2020 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
+
+> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://arxiv.org/abs/2304.12139) _arXiv:2304.12139_, 2023.
+
+In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
+
+Note that the NIST relevance judgments provide far more relevant passages per topic, unlike the "sparse" judgments provided by Microsoft (these are sometimes called "dense" judgments to emphasize this contrast).
+For additional instructions on working with MS MARCO passage collection, refer to [this page](experiments-msmarco-passage.md).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```bash
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+We make available a version of the MS MARCO Passage Corpus that has already been encoded with cosDPR-distil.
+
+From any machine, the following command will download the corpus and perform the complete regression, end to end:
+
+```bash
+python src/main/python/run_regression.py --download --index --verify --search --regression ${test_name}
+```
+
+The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
+
+## Corpus Download
+
+Download the corpus and unpack into `collections/`:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-cos-dpr-distil.tar -P collections/
+tar xvf collections/msmarco-passage-cos-dpr-distil.tar -C collections/
+```
+
+To confirm, `msmarco-passage-cos-dpr-distil.tar` is 57 GB and has MD5 checksum `e20ffbc8b5e7f760af31298aefeaebbd`.
+With the corpus downloaded, the following command will perform the remaining steps below:
+
+```bash
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
+  --corpus-path collections/${corpus}
+```
+
+## Indexing
+
+Sample indexing command:
+
+```bash
+${index_cmds}
+```
+
+The path `/path/to/${corpus}/` should point to the corpus downloaded above.
+
+Upon completion, we should have an index with 8,841,823 documents.
+
+<!-- For additional details, see explanation of [common indexing options](common-indexing-options.md). -->
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+The regression experiments here evaluate on the 54 topics for which NIST has provided judgments as part of the TREC 2020 Deep Learning Track.
+The original data can be found [here](https://trec.nist.gov/data/deep2020.html).
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```bash
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```bash
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}
+
+Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
+Nevertheless, scores are generally stable to the third digit after the decimal point.
+
+Also note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
+Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).
+The experimental results reported here are directly comparable to the results reported in the [track overview paper](https://arxiv.org/abs/2003.07820).
+
+## Reproduction Log[*](reproducibility.md)
+
+To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.

--- a/src/main/resources/regression/dl19-passage-cos-dpr-distil.yaml
+++ b/src/main/resources/regression/dl19-passage-cos-dpr-distil.yaml
@@ -1,0 +1,63 @@
+---
+corpus: msmarco-passage-cos-dpr-distil
+corpus_path: collections/msmarco/msmarco-passage-cos-dpr-distil/
+
+download_url: https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-cos-dpr-distil.tar
+download_checksum: e20ffbc8b5e7f760af31298aefeaebbd
+
+index_path: indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil/
+collection_class: JsonDenseVectorCollection
+generator_class: LuceneDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100
+
+metrics:
+  - metric: AP@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m map -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@10
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m ndcg_cut.10 -c
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m recall.100 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m recall.1000 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonIntVector
+topics:
+  - name: "[DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)"
+    id: dl19
+    path: topics.dl19-passage.cos-dpr-distil.jsonl.gz
+    qrel: qrels.dl19-passage.txt
+
+models:
+  - name: cos-dpr-distil
+    display: cosDPR-distil
+    params: -querygenerator VectorQueryGenerator -topicfield vector -threads 16 -hits 1000 -efSearch 1000
+    results:
+      AP@1000:
+        - 0.460
+      nDCG@10:
+        - 0.722
+      R@100:
+        - 0.609
+      R@1000:
+        - 0.807

--- a/src/main/resources/regression/dl20-passage-cos-dpr-distil.yaml
+++ b/src/main/resources/regression/dl20-passage-cos-dpr-distil.yaml
@@ -1,0 +1,63 @@
+---
+corpus: msmarco-passage-cos-dpr-distil
+corpus_path: collections/msmarco/msmarco-passage-cos-dpr-distil/
+
+download_url: https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco-passage-cos-dpr-distil.tar
+download_checksum: e20ffbc8b5e7f760af31298aefeaebbd
+
+index_path: indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil/
+collection_class: JsonDenseVectorCollection
+generator_class: LuceneDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100
+
+metrics:
+  - metric: AP@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m map -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@10
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m ndcg_cut.10 -c
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m recall.100 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: tools/eval/trec_eval.9.0.4/trec_eval
+    params: -m recall.1000 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonIntVector
+topics:
+  - name: "[DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)"
+    id: dl20
+    path: topics.dl20.cos-dpr-distil.jsonl.gz
+    qrel: qrels.dl20-passage.txt
+
+models:
+  - name: cos-dpr-distil
+    display: cosDPR-distil
+    params: -querygenerator VectorQueryGenerator -topicfield vector -threads 16 -hits 1000 -efSearch 1000
+    results:
+      AP@1000:
+        - 0.482
+      nDCG@10:
+        - 0.701
+      R@100:
+        - 0.714
+      R@1000:
+        - 0.844


### PR DESCRIPTION
Current scores:

```
% python src/main/python/run_regression.py --search --regression dl19-passage-cos-dpr-distil
2023-09-23 13:27:10,105 INFO  [python] ========== Ranking ==========
2023-09-23 13:27:10,216 INFO  [python] target/appassembler/bin/SearchHnswDenseVectors -index indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil/ -topics tools/topics-and-qrels/topics.dl19-passage.cos-dpr-distil.jsonl.gz -topicreader JsonIntVector -output runs/run.msmarco-passage-cos-dpr-distil.dl19.cos-dpr-distil -querygenerator VectorQueryGenerator -topicfield vector -threads 16 -hits 1000 -efSearch 1000
2023-09-23 13:27:11,202 INFO  [main] search.SearchHnswDenseVectors (SearchHnswDenseVectors.java:305) - ============ Initializing Searcher ============
2023-09-23 13:27:11,205 INFO  [main] search.SearchHnswDenseVectors (SearchHnswDenseVectors.java:306) - Index: indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil
2023-09-23 13:27:11,409 INFO  [main] search.SearchHnswDenseVectors (SearchHnswDenseVectors.java:309) - Vector Search:
2023-09-23 13:27:11,409 INFO  [main] search.SearchHnswDenseVectors (SearchHnswDenseVectors.java:310) - Number of threads for running different parameter configurations: 16
2023-09-23 13:27:11,627 INFO  [main] search.SearchHnswDenseVectors (SearchHnswDenseVectors.java:338) - runtag: Anserini
2023-09-23 13:27:11,628 INFO  [main] search.SearchHnswDenseVectors (SearchHnswDenseVectors.java:343) - ============ Launching Search Threads ============
2023-09-23 13:27:16,051 INFO  [pool-2-thread-1] search.SearchHnswDenseVectors$SearcherThread (SearchHnswDenseVectors.java:277) - ranker: kNN: 43 queries processed in 00:00:04 = ~9.77 q/s
2023-09-23 13:27:16,479 INFO  [main] search.SearchHnswDenseVectors (SearchHnswDenseVectors.java:417) - Total run time: 00:00:05
2023-09-23 13:27:16,520 INFO  [python] ========== Verifying Results: msmarco-passage-cos-dpr-distil ==========
2023-09-23 13:27:16,568 INFO  [python]    [OK] expected: 0.460 actual: 0.460 - metric: AP@1000  model: cos-dpr-distil topics: dl19
2023-09-23 13:27:16,616 INFO  [python]    [OK] expected: 0.722 actual: 0.722 - metric: nDCG@10  model: cos-dpr-distil topics: dl19
2023-09-23 13:27:16,664 INFO  [python]    [OK] expected: 0.609 actual: 0.609 - metric: R@100    model: cos-dpr-distil topics: dl19
2023-09-23 13:27:16,712 INFO  [python]    [OK] expected: 0.807 actual: 0.807 - metric: R@1000   model: cos-dpr-distil topics: dl19
2023-09-23 13:27:16,712 INFO  [python] All Tests Passed! Total elapsed time: 7s
```

And:

```
% python src/main/python/run_regression.py --search --regression dl20-passage-cos-dpr-distil
2023-09-23 13:31:12,145 INFO  [python] ========== Ranking ==========
2023-09-23 13:31:12,265 INFO  [python] target/appassembler/bin/SearchHnswDenseVectors -index indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil/ -topics tools/topics-and-qrels/topics.dl20.cos-dpr-distil.jsonl.gz -topicreader JsonIntVector -output runs/run.msmarco-passage-cos-dpr-distil.dl20.cos-dpr-distil -querygenerator VectorQueryGenerator -topicfield vector -threads 16 -hits 1000 -efSearch 1000
2023-09-23 13:31:12,817 INFO  [main] search.SearchHnswDenseVectors (SearchHnswDenseVectors.java:305) - ============ Initializing Searcher ============
2023-09-23 13:31:12,819 INFO  [main] search.SearchHnswDenseVectors (SearchHnswDenseVectors.java:306) - Index: indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil
2023-09-23 13:31:13,009 INFO  [main] search.SearchHnswDenseVectors (SearchHnswDenseVectors.java:309) - Vector Search:
2023-09-23 13:31:13,010 INFO  [main] search.SearchHnswDenseVectors (SearchHnswDenseVectors.java:310) - Number of threads for running different parameter configurations: 16
2023-09-23 13:31:13,402 INFO  [main] search.SearchHnswDenseVectors (SearchHnswDenseVectors.java:338) - runtag: Anserini
2023-09-23 13:31:13,402 INFO  [main] search.SearchHnswDenseVectors (SearchHnswDenseVectors.java:343) - ============ Launching Search Threads ============
2023-09-23 13:31:20,740 INFO  [pool-3-thread-6] search.SearchHnswDenseVectors$SearcherThread (SearchHnswDenseVectors.java:259) - ranker: kNN: 100 queries processed
2023-09-23 13:31:25,716 INFO  [pool-3-thread-6] search.SearchHnswDenseVectors$SearcherThread (SearchHnswDenseVectors.java:259) - ranker: kNN: 200 queries processed
2023-09-23 13:31:25,730 INFO  [pool-2-thread-1] search.SearchHnswDenseVectors$SearcherThread (SearchHnswDenseVectors.java:277) - ranker: kNN: 200 queries processed in 00:00:12 = ~16.25 q/s
2023-09-23 13:31:26,267 INFO  [main] search.SearchHnswDenseVectors (SearchHnswDenseVectors.java:417) - Total run time: 00:00:13
2023-09-23 13:31:26,320 INFO  [python] ========== Verifying Results: msmarco-passage-cos-dpr-distil ==========
2023-09-23 13:31:26,469 INFO  [python]    [OK] expected: 0.482 actual: 0.482 - metric: AP@1000  model: cos-dpr-distil topics: dl20
2023-09-23 13:31:26,614 INFO  [python]    [OK] expected: 0.701 actual: 0.701 - metric: nDCG@10  model: cos-dpr-distil topics: dl20
2023-09-23 13:31:26,758 INFO  [python]    [OK] expected: 0.714 actual: 0.714 - metric: R@100    model: cos-dpr-distil topics: dl20
2023-09-23 13:31:26,902 INFO  [python]    [OK] expected: 0.844 actual: 0.844 - metric: R@1000   model: cos-dpr-distil topics: dl20
2023-09-23 13:31:26,902 INFO  [python] All Tests Passed! Total elapsed time: 15s
```