### PR TITLE
Add simple script to analyze reproductions

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -360,10 +360,8 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@justinborromeo](https://github.com/justinborromeo) on 2020-06-10 (commit [`7954eab`](https://github.com/castorini/anserini/commit/7954eab43f17bb8d254987d5873933c0b9596bb4))
 + Results reproduced by [@yxzhu16](https://github.com/yxzhu16) on 2020-07-03 (commit [`68ace26`](https://github.com/castorini/anserini/commit/68ace26d0418a769df3d2b21e946495e54d462f6))
 + Results reproduced by [@LizzyZhang-tutu](https://github.com/LizzyZhang-tutu) on 2020-07-13 (commit [`8c98d5b`](https://github.com/castorini/anserini/commit/8c98d5ba0795bbea01bcef1e21abb153fe4c3da1))
-+ Results reproduced by [@estella98](https://github.com/estella98) on 2020-07-29 
-(commit [`99092a8`](https://github.com/castorini/anserini/commit/99092a82179d7efd38fc0b8c7c967137a40cd96f))
-+ Results reproduced by [@tangsaidi](https://github.com/tangsaidi) on 2020-08-19 
-(commit [`aba846`](https://github.com/castorini/anserini/commit/aba846aa07d6f319fb3dc9cb591c20b4ae69f9ef))
++ Results reproduced by [@estella98](https://github.com/estella98) on 2020-07-29 (commit [`99092a8`](https://github.com/castorini/anserini/commit/99092a82179d7efd38fc0b8c7c967137a40cd96f))
++ Results reproduced by [@tangsaidi](https://github.com/tangsaidi) on 2020-08-19 (commit [`aba846`](https://github.com/castorini/anserini/commit/aba846aa07d6f319fb3dc9cb591c20b4ae69f9ef))
 + Results reproduced by [@qguo96](https://github.com/qguo96) on 2020-09-07 (commit [`e16b3c1`](https://github.com/castorini/anserini/commit/e16b3c160664057d4e00f2b4030cb6cb0d32fabd))
 + Results reproduced by [@yuxuan-ji](https://github.com/yuxuan-ji) on 2020-09-08 (commit [`0f9a8ec`](https://github.com/castorini/anserini/commit/0f9a8ec4f335fb49c9387351745d1c755afc0e84))
 + Results reproduced by [@wiltan-uw](https://github.com/wiltan-uw) on 2020-09-09 (commit [`93d913f`](https://github.com/castorini/anserini/commit/93d913f2619c44451be3d46816c7b9c44cbeb091))

--- a/src/main/python/analyze_reproductions.py
+++ b/src/main/python/analyze_reproductions.py
@@ -1,0 +1,54 @@
+#
+# Anserini: A Lucene toolkit for reproducible information retrieval research
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from datetime import datetime
+import re
+import subprocess
+
+
+def run_command(cmd):
+    try:
+        output = subprocess.check_output(cmd, shell=True, universal_newlines=True)
+        return output
+    except subprocess.CalledProcessError as e:
+        print(f"Error executing the command: {e}")
+
+
+def analyze_page(page):
+    print(f'Analyzing {page}')
+    output = run_command(f"grep 'Results reproduced by' {page}")
+    lines = output.rstrip().split('\n')
+    cnt = len(lines)
+    print(f' + count: {cnt}')
+
+    start_date_str = re.search(r'\d\d\d\d-\d\d-\d\d', lines[0]).group()
+    end_date_str = re.search(r'\d\d\d\d-\d\d-\d\d', lines[-1]).group()
+
+    print(f' + start: {start_date_str}')
+    print(f' + end:   {end_date_str}')
+
+    date_format = '%Y-%m-%d'
+    start_date = datetime.strptime(start_date_str, date_format)
+    end_date = datetime.strptime(end_date_str, date_format)
+
+    time_difference = end_date - start_date
+    print(f' + total: {time_difference.days} days')
+    print(f' + ratel: {time_difference.days/cnt:0.2f}')
+    print('')
+
+
+analyze_page('docs/start-here.md')
+analyze_page('docs/experiments-msmarco-passage.md')

--- a/src/main/python/analyze_reproductions.py
+++ b/src/main/python/analyze_reproductions.py
@@ -46,7 +46,7 @@ def analyze_page(page):
 
     time_difference = end_date - start_date
     print(f' + total: {time_difference.days} days')
-    print(f' + ratel: {time_difference.days/cnt:0.2f}')
+    print(f' + freq:  {time_difference.days/cnt:0.2f} days between reproductions (on avg)')
     print('')
 
 


### PR DESCRIPTION
Simple script to analyze reproduction logs:

```
% python src/main/python/analyze_reproductions.py
Analyzing docs/start-here.md
 + count: 19
 + start: 2023-07-21
 + end:   2023-11-01
 + total: 103 days
 + ratel: 5.42

Analyzing docs/experiments-msmarco-passage.md
 + count: 108
 + start: 2019-08-12
 + end:   2023-11-03
 + total: 1544 days
 + ratel: 14.30
```
