### PR TITLE
Modify CIRAL's regression documentation to mention dev set

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,8 @@ See individual pages for details!
 + Regressions for [NTCIR-8 ACLIA (IR4QA subtask, Monolingual Chinese)](docs/regressions/regressions-ntcir8-zh.md)
 + Regressions for [CLEF 2006 Monolingual French](docs/regressions/regressions-clef06-fr.md)
 + Regressions for [TREC 2002 Monolingual Arabic](docs/regressions/regressions-trec02-ar.md)
-+ Regressions for FIRE 2012: [Monolingual Bengali](docs/regressions/regressions-fire12-bn.md), [Monolingual Hindi](docs/regressions/regressions-fire12-hi.md), [Monolingual English](docs/regressions/regressions-fire12-en.md)
-+ Regressions for CIRAL (v1.0) baselines: [Monolingual Hausa](docs/regressions/regressions-ciral-v1.0-ha.md), [Monolingual Somali](docs/regressions/regressions-ciral-v1.0-so.md), [Monolingual Swahili](docs/regressions/regressions-ciral-v1.0-sw.md), [Monolingual Yoruba](docs/regressions/regressions-ciral-v1.0-yo.md)
++ Regressions for FIRE 2012 monolingual baselines: [Bengali](docs/regressions/regressions-fire12-bn.md), [Hindi](docs/regressions/regressions-fire12-hi.md), [English](docs/regressions/regressions-fire12-en.md)
++ Regressions for CIRAL (v1.0) monolingual baselines on dev set: [Hausa](docs/regressions/regressions-ciral-v1.0-ha.md), [Somali](docs/regressions/regressions-ciral-v1.0-so.md), [Swahili](docs/regressions/regressions-ciral-v1.0-sw.md), [Yoruba](docs/regressions/regressions-ciral-v1.0-yo.md)
 
 </details>
 <details>

--- a/docs/regressions/regressions-ciral-v1.0-ha.md
+++ b/docs/regressions/regressions-ciral-v1.0-ha.md
@@ -1,6 +1,6 @@
 # Anserini Regressions: CIRAL (v1.0) &mdash; Hausa
 
-This page documents BM25 monolingual regression experiments for [CIRAL (v1.0) &mdash; Hausa](https://github.com/ciralproject/ciral).
+This page documents BM25 monolingual regression experiments on the dev set of [CIRAL (v1.0) &mdash; Hausa](https://github.com/ciralproject/ciral).
 
 The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/ciral-v1.0-ha.yaml).
 Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/ciral-v1.0-ha.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.

--- a/docs/regressions/regressions-ciral-v1.0-so.md
+++ b/docs/regressions/regressions-ciral-v1.0-so.md
@@ -1,6 +1,6 @@
 # Anserini Regressions: CIRAL (v1.0) &mdash; Somali
 
-This page documents BM25 monolingual regression experiments for [CIRAL (v1.0) &mdash; Somali](https://github.com/ciralproject/ciral).
+This page documents BM25 monolingual regression experiments on the dev set of [CIRAL (v1.0) &mdash; Somali](https://github.com/ciralproject/ciral).
 
 The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/ciral-v1.0-so.yaml).
 Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/ciral-v1.0-so.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.

--- a/docs/regressions/regressions-ciral-v1.0-sw.md
+++ b/docs/regressions/regressions-ciral-v1.0-sw.md
@@ -1,6 +1,6 @@
 # Anserini Regressions: CIRAL (v1.0) &mdash; Swahili
 
-This page documents BM25 monolingual regression experiments for [CIRAL (v1.0) &mdash; Swahili](https://github.com/ciralproject/ciral).
+This page documents BM25 monolingual regression experiments on the dev set of [CIRAL (v1.0) &mdash; Swahili](https://github.com/ciralproject/ciral).
 
 The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/ciral-v1.0-sw.yaml).
 Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/ciral-v1.0-sw.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.

--- a/docs/regressions/regressions-ciral-v1.0-yo.md
+++ b/docs/regressions/regressions-ciral-v1.0-yo.md
@@ -1,6 +1,6 @@
 # Anserini Regressions: CIRAL (v1.0) &mdash; Yoruba
 
-This page documents BM25 monolingual regression experiments for [CIRAL (v1.0) &mdash; Yoruba](https://github.com/ciralproject/ciral).
+This page documents BM25 monolingual regression experiments on the dev set of [CIRAL (v1.0) &mdash; Yoruba](https://github.com/ciralproject/ciral).
 
 The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/ciral-v1.0-yo.yaml).
 Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/ciral-v1.0-yo.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.

--- a/src/main/resources/docgen/templates/ciral-v1.0-ha.template
+++ b/src/main/resources/docgen/templates/ciral-v1.0-ha.template
@@ -1,6 +1,6 @@
 # Anserini Regressions: CIRAL (v1.0) &mdash; Hausa
 
-This page documents BM25 monolingual regression experiments for [CIRAL (v1.0) &mdash; Hausa](https://github.com/ciralproject/ciral).
+This page documents BM25 monolingual regression experiments on the dev set of [CIRAL (v1.0) &mdash; Hausa](https://github.com/ciralproject/ciral).
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
 Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.

--- a/src/main/resources/docgen/templates/ciral-v1.0-so.template
+++ b/src/main/resources/docgen/templates/ciral-v1.0-so.template
@@ -1,6 +1,6 @@
 # Anserini Regressions: CIRAL (v1.0) &mdash; Somali
 
-This page documents BM25 monolingual regression experiments for [CIRAL (v1.0) &mdash; Somali](https://github.com/ciralproject/ciral).
+This page documents BM25 monolingual regression experiments on the dev set of [CIRAL (v1.0) &mdash; Somali](https://github.com/ciralproject/ciral).
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
 Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.

--- a/src/main/resources/docgen/templates/ciral-v1.0-sw.template
+++ b/src/main/resources/docgen/templates/ciral-v1.0-sw.template
@@ -1,6 +1,6 @@
 # Anserini Regressions: CIRAL (v1.0) &mdash; Swahili
 
-This page documents BM25 monolingual regression experiments for [CIRAL (v1.0) &mdash; Swahili](https://github.com/ciralproject/ciral).
+This page documents BM25 monolingual regression experiments on the dev set of [CIRAL (v1.0) &mdash; Swahili](https://github.com/ciralproject/ciral).
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
 Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.

--- a/src/main/resources/docgen/templates/ciral-v1.0-yo.template
+++ b/src/main/resources/docgen/templates/ciral-v1.0-yo.template
@@ -1,6 +1,6 @@
 # Anserini Regressions: CIRAL (v1.0) &mdash; Yoruba
 
-This page documents BM25 monolingual regression experiments for [CIRAL (v1.0) &mdash; Yoruba](https://github.com/ciralproject/ciral).
+This page documents BM25 monolingual regression experiments on the dev set of [CIRAL (v1.0) &mdash; Yoruba](https://github.com/ciralproject/ciral).
 
 The exact configurations for these regressions are stored in [this YAML file](${yaml}).
 Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.


### PR DESCRIPTION
This PR modifies CIRAL's monolingual regressions to mention dev in the documentation. 

Also modifies FIRE's regression documentation in Anserini's README.