### PR TITLE
Tweak regression docs and ONNX cosDPR-distil scores

### DIFF
--- a/docs/regressions/regressions-dl19-passage-cos-dpr-distil-onnx.md
+++ b/docs/regressions/regressions-dl19-passage-cos-dpr-distil-onnx.md
@@ -97,13 +97,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cosDPR-distil**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.463     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.458     |
 | **nDCG@10**                                                                                                  | **cosDPR-distil**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.725     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.717     |
 | **R@100**                                                                                                    | **cosDPR-distil**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.615     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.605     |
 | **R@1000**                                                                                                   | **cosDPR-distil**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.813     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.805     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage-cos-dpr-distil-onnx.yaml).

--- a/docs/regressions/regressions-dl19-passage-cos-dpr-distil-onnx.md
+++ b/docs/regressions/regressions-dl19-passage-cos-dpr-distil-onnx.md
@@ -1,10 +1,10 @@
 # Anserini Regressions: TREC 2019 Deep Learning Track (Passage)
 
-**Model**: cosDPR-distil-onnx (encode on-the-fly) with HNSW indexes
+**Model**: cosDPR-distil with HNSW indexes (using ONNX for on-the-fly query encoding)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the cosDPR-distil model on the [TREC 2019 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
-> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://arxiv.org/abs/2304.12139) _arXiv:2304.12139_, 2023.
+> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://dl.acm.org/doi/10.1145/3583780.3615112) _Proceedings of the 32nd International Conference on Information and Knowledge Management (CIKM 2023)_, October 2023, pages 5366–5370, Birmingham, the United Kingdom.
 
 In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
@@ -65,8 +65,6 @@ The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus d
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -108,7 +106,7 @@ With the above commands, you should be able to reproduce the following results:
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.813     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage-cos-dpr-distil-onnx.yaml).
 
 Also note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl19-passage-cos-dpr-distil.md
+++ b/docs/regressions/regressions-dl19-passage-cos-dpr-distil.md
@@ -1,10 +1,10 @@
 # Anserini Regressions: TREC 2019 Deep Learning Track (Passage)
 
-**Model**: cosDPR-distil (using pre-encoded queries) with HNSW indexes
+**Model**: cosDPR-distil with HNSW indexes (using pre-encoded queries)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the cosDPR-distil model on the [TREC 2019 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
-> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://arxiv.org/abs/2304.12139) _arXiv:2304.12139_, 2023.
+> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://dl.acm.org/doi/10.1145/3583780.3615112) _Proceedings of the 32nd International Conference on Information and Knowledge Management (CIKM 2023)_, October 2023, pages 5366–5370, Birmingham, the United Kingdom.
 
 In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
@@ -65,8 +65,6 @@ The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus d
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -108,7 +106,7 @@ With the above commands, you should be able to reproduce the following results:
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.805     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage-cos-dpr-distil.yaml).
 
 Also note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl19-passage-openai-ada2.md
+++ b/docs/regressions/regressions-dl19-passage-openai-ada2.md
@@ -65,8 +65,6 @@ The path `/path/to/msmarco-passage-openai-ada2/` should point to the corpus down
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -108,7 +106,7 @@ With the above commands, you should be able to reproduce the following results:
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.857     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage-openai-ada2.yaml).
 
 Also note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl20-passage-cos-dpr-distil-onnx.md
+++ b/docs/regressions/regressions-dl20-passage-cos-dpr-distil-onnx.md
@@ -97,13 +97,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cosDPR-distil**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.481     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.482     |
 | **nDCG@10**                                                                                                  | **cosDPR-distil**|
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.701     |
 | **R@100**                                                                                                    | **cosDPR-distil**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.707     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.712     |
 | **R@1000**                                                                                                   | **cosDPR-distil**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.837     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.843     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage-cos-dpr-distil-onnx.yaml).

--- a/docs/regressions/regressions-dl20-passage-cos-dpr-distil-onnx.md
+++ b/docs/regressions/regressions-dl20-passage-cos-dpr-distil-onnx.md
@@ -1,10 +1,10 @@
 # Anserini Regressions: TREC 2020 Deep Learning Track (Passage)
 
-**Model**: cosDPR-distil-onnx (encode on-the-fly) with HNSW indexes
+**Model**: cosDPR-distil with HNSW indexes (using ONNX for on-the-fly query encoding)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the cosDPR-distil model on the [TREC 2020 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
-> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://arxiv.org/abs/2304.12139) _arXiv:2304.12139_, 2023.
+> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://dl.acm.org/doi/10.1145/3583780.3615112) _Proceedings of the 32nd International Conference on Information and Knowledge Management (CIKM 2023)_, October 2023, pages 5366–5370, Birmingham, the United Kingdom.
 
 In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
@@ -65,8 +65,6 @@ The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus d
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -108,7 +106,7 @@ With the above commands, you should be able to reproduce the following results:
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.837     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage-cos-dpr-distil-onnx.yaml).
 
 Also note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl20-passage-cos-dpr-distil.md
+++ b/docs/regressions/regressions-dl20-passage-cos-dpr-distil.md
@@ -1,10 +1,10 @@
 # Anserini Regressions: TREC 2020 Deep Learning Track (Passage)
 
-**Model**: cosDPR-distil (using pre-encoded queries) with HNSW indexes
+**Model**: cosDPR-distil with HNSW indexes (using pre-encoded queries)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the cosDPR-distil model on the [TREC 2020 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
-> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://arxiv.org/abs/2304.12139) _arXiv:2304.12139_, 2023.
+> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://dl.acm.org/doi/10.1145/3583780.3615112) _Proceedings of the 32nd International Conference on Information and Knowledge Management (CIKM 2023)_, October 2023, pages 5366–5370, Birmingham, the United Kingdom.
 
 In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
@@ -65,8 +65,6 @@ The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus d
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -108,7 +106,7 @@ With the above commands, you should be able to reproduce the following results:
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.843     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage-cos-dpr-distil.yaml).
 
 Also note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl20-passage-openai-ada2.md
+++ b/docs/regressions/regressions-dl20-passage-openai-ada2.md
@@ -65,8 +65,6 @@ The path `/path/to/msmarco-passage-openai-ada2/` should point to the corpus down
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -108,7 +106,7 @@ With the above commands, you should be able to reproduce the following results:
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.867     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage-openai-ada2.yaml).
 
 Also note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-msmarco-passage-cos-dpr-distil-onnx.md
+++ b/docs/regressions/regressions-msmarco-passage-cos-dpr-distil-onnx.md
@@ -1,10 +1,10 @@
 # Anserini Regressions: MS MARCO Passage Ranking
 
-**Model**: cosDPR-distil-onnx (encode on-the-fly) with HNSW indexes
+**Model**: cosDPR-distil with HNSW indexes (using ONNX for on-the-fly query encoding)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the cosDPR-distil model on the [MS MARCO passage ranking task](https://github.com/microsoft/MSMARCO-Passage-Ranking), as described in the following paper:
 
-> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://arxiv.org/abs/2304.12139) _arXiv:2304.12139_, 2023.
+> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://dl.acm.org/doi/10.1145/3583780.3615112) _Proceedings of the 32nd International Conference on Information and Knowledge Management (CIKM 2023)_, October 2023, pages 5366–5370, Birmingham, the United Kingdom.
 
 In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
@@ -62,8 +62,6 @@ The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus d
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -104,10 +102,8 @@ With the above commands, you should be able to reproduce the following results:
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.974     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-passage-cos-dpr-distil-onnx.yaml).
 
 ## Reproduction Log[*](../../docs/reproducibility.md)
 
 To add to this reproduction log, modify [this template](../../src/main/resources/docgen/templates/msmarco-passage-cos-dpr-distil-onnx.template) and run `bin/build.sh` to rebuild the documentation.
-
-+ Results reproduced by [@yilinjz](https://github.com/yilinjz) on 2023-09-01 (commit [`4ae518b`](https://github.com/castorini/anserini/commit/4ae518bb284ebcba0b273a473bc8774735cb7d19))

--- a/docs/regressions/regressions-msmarco-passage-cos-dpr-distil.md
+++ b/docs/regressions/regressions-msmarco-passage-cos-dpr-distil.md
@@ -1,10 +1,10 @@
 # Anserini Regressions: MS MARCO Passage Ranking
 
-**Model**: cosDPR-distil (using pre-encoded queries) with HNSW indexes
+**Model**: cosDPR-distil with HNSW indexes (using pre-encoded queries)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the cosDPR-distil model on the [MS MARCO passage ranking task](https://github.com/microsoft/MSMARCO-Passage-Ranking), as described in the following paper:
 
-> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://arxiv.org/abs/2304.12139) _arXiv:2304.12139_, 2023.
+> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://dl.acm.org/doi/10.1145/3583780.3615112) _Proceedings of the 32nd International Conference on Information and Knowledge Management (CIKM 2023)_, October 2023, pages 5366–5370, Birmingham, the United Kingdom.
 
 In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
@@ -62,8 +62,6 @@ The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus d
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -104,7 +102,7 @@ With the above commands, you should be able to reproduce the following results:
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.974     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-passage-cos-dpr-distil.yaml).
 
 ## Reproduction Log[*](../../docs/reproducibility.md)
 

--- a/docs/regressions/regressions-msmarco-passage-openai-ada2.md
+++ b/docs/regressions/regressions-msmarco-passage-openai-ada2.md
@@ -62,8 +62,6 @@ The path `/path/to/msmarco-passage-openai-ada2/` should point to the corpus down
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -104,7 +102,7 @@ With the above commands, you should be able to reproduce the following results:
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.985     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-passage-openai-ada2.yaml).
 
 ## Reproduction Log[*](../../docs/reproducibility.md)
 

--- a/src/main/resources/docgen/templates/dl19-passage-cos-dpr-distil-onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage-cos-dpr-distil-onnx.template
@@ -1,10 +1,10 @@
 # Anserini Regressions: TREC 2019 Deep Learning Track (Passage)
 
-**Model**: cosDPR-distil-onnx (encode on-the-fly) with HNSW indexes
+**Model**: cosDPR-distil with HNSW indexes (using ONNX for on-the-fly query encoding)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the cosDPR-distil model on the [TREC 2019 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
-> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://arxiv.org/abs/2304.12139) _arXiv:2304.12139_, 2023.
+> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://dl.acm.org/doi/10.1145/3583780.3615112) _Proceedings of the 32nd International Conference on Information and Knowledge Management (CIKM 2023)_, October 2023, pages 5366–5370, Birmingham, the United Kingdom.
 
 In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
@@ -59,8 +59,6 @@ The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -86,7 +84,7 @@ With the above commands, you should be able to reproduce the following results:
 ${effectiveness}
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
 
 Also note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl19-passage-cos-dpr-distil.template
+++ b/src/main/resources/docgen/templates/dl19-passage-cos-dpr-distil.template
@@ -1,10 +1,10 @@
 # Anserini Regressions: TREC 2019 Deep Learning Track (Passage)
 
-**Model**: cosDPR-distil (using pre-encoded queries) with HNSW indexes
+**Model**: cosDPR-distil with HNSW indexes (using pre-encoded queries)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the cosDPR-distil model on the [TREC 2019 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
-> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://arxiv.org/abs/2304.12139) _arXiv:2304.12139_, 2023.
+> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://dl.acm.org/doi/10.1145/3583780.3615112) _Proceedings of the 32nd International Conference on Information and Knowledge Management (CIKM 2023)_, October 2023, pages 5366–5370, Birmingham, the United Kingdom.
 
 In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
@@ -59,8 +59,6 @@ The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -86,7 +84,7 @@ With the above commands, you should be able to reproduce the following results:
 ${effectiveness}
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
 
 Also note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl19-passage-openai-ada2.template
+++ b/src/main/resources/docgen/templates/dl19-passage-openai-ada2.template
@@ -59,8 +59,6 @@ The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -86,7 +84,7 @@ With the above commands, you should be able to reproduce the following results:
 ${effectiveness}
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
 
 Also note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl20-passage-cos-dpr-distil-onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage-cos-dpr-distil-onnx.template
@@ -1,10 +1,10 @@
 # Anserini Regressions: TREC 2020 Deep Learning Track (Passage)
 
-**Model**: cosDPR-distil-onnx (encode on-the-fly) with HNSW indexes
+**Model**: cosDPR-distil with HNSW indexes (using ONNX for on-the-fly query encoding)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the cosDPR-distil model on the [TREC 2020 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
-> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://arxiv.org/abs/2304.12139) _arXiv:2304.12139_, 2023.
+> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://dl.acm.org/doi/10.1145/3583780.3615112) _Proceedings of the 32nd International Conference on Information and Knowledge Management (CIKM 2023)_, October 2023, pages 5366–5370, Birmingham, the United Kingdom.
 
 In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
@@ -59,8 +59,6 @@ The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -86,7 +84,7 @@ With the above commands, you should be able to reproduce the following results:
 ${effectiveness}
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
 
 Also note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl20-passage-cos-dpr-distil.template
+++ b/src/main/resources/docgen/templates/dl20-passage-cos-dpr-distil.template
@@ -1,10 +1,10 @@
 # Anserini Regressions: TREC 2020 Deep Learning Track (Passage)
 
-**Model**: cosDPR-distil (using pre-encoded queries) with HNSW indexes
+**Model**: cosDPR-distil with HNSW indexes (using pre-encoded queries)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the cosDPR-distil model on the [TREC 2020 Deep Learning Track passage ranking task](https://trec.nist.gov/data/deep2019.html), as described in the following paper:
 
-> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://arxiv.org/abs/2304.12139) _arXiv:2304.12139_, 2023.
+> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://dl.acm.org/doi/10.1145/3583780.3615112) _Proceedings of the 32nd International Conference on Information and Knowledge Management (CIKM 2023)_, October 2023, pages 5366–5370, Birmingham, the United Kingdom.
 
 In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
@@ -59,8 +59,6 @@ The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -86,7 +84,7 @@ With the above commands, you should be able to reproduce the following results:
 ${effectiveness}
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
 
 Also note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl20-passage-openai-ada2.template
+++ b/src/main/resources/docgen/templates/dl20-passage-openai-ada2.template
@@ -59,8 +59,6 @@ The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -86,7 +84,7 @@ With the above commands, you should be able to reproduce the following results:
 ${effectiveness}
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
 
 Also note that retrieval metrics are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 Also, for computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/msmarco-passage-cos-dpr-distil-onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-cos-dpr-distil-onnx.template
@@ -1,10 +1,10 @@
 # Anserini Regressions: MS MARCO Passage Ranking
 
-**Model**: cosDPR-distil-onnx (encode on-the-fly) with HNSW indexes
+**Model**: cosDPR-distil with HNSW indexes (using ONNX for on-the-fly query encoding)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the cosDPR-distil model on the [MS MARCO passage ranking task](https://github.com/microsoft/MSMARCO-Passage-Ranking), as described in the following paper:
 
-> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://arxiv.org/abs/2304.12139) _arXiv:2304.12139_, 2023.
+> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://dl.acm.org/doi/10.1145/3583780.3615112) _Proceedings of the 32nd International Conference on Information and Knowledge Management (CIKM 2023)_, October 2023, pages 5366–5370, Birmingham, the United Kingdom.
 
 In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
@@ -56,8 +56,6 @@ The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -82,10 +80,8 @@ With the above commands, you should be able to reproduce the following results:
 ${effectiveness}
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
 
 ## Reproduction Log[*](${root_path}/docs/reproducibility.md)
 
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
-
-+ Results reproduced by [@yilinjz](https://github.com/yilinjz) on 2023-09-01 (commit [`4ae518b`](https://github.com/castorini/anserini/commit/4ae518bb284ebcba0b273a473bc8774735cb7d19))

--- a/src/main/resources/docgen/templates/msmarco-passage-cos-dpr-distil.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-cos-dpr-distil.template
@@ -1,10 +1,10 @@
 # Anserini Regressions: MS MARCO Passage Ranking
 
-**Model**: cosDPR-distil (using pre-encoded queries) with HNSW indexes
+**Model**: cosDPR-distil with HNSW indexes (using pre-encoded queries)
 
 This page describes regression experiments, integrated into Anserini's regression testing framework, using the cosDPR-distil model on the [MS MARCO passage ranking task](https://github.com/microsoft/MSMARCO-Passage-Ranking), as described in the following paper:
 
-> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://arxiv.org/abs/2304.12139) _arXiv:2304.12139_, 2023.
+> Xueguang Ma, Tommaso Teofili, and Jimmy Lin. [Anserini Gets Dense Retrieval: Integration of Lucene's HNSW Indexes.](https://dl.acm.org/doi/10.1145/3583780.3615112) _Proceedings of the 32nd International Conference on Information and Knowledge Management (CIKM 2023)_, October 2023, pages 5366–5370, Birmingham, the United Kingdom.
 
 In these experiments, we are using pre-encoded queries (i.e., cached results of query encoding).
 
@@ -56,8 +56,6 @@ The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -82,7 +80,7 @@ With the above commands, you should be able to reproduce the following results:
 ${effectiveness}
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
 
 ## Reproduction Log[*](${root_path}/docs/reproducibility.md)
 

--- a/src/main/resources/docgen/templates/msmarco-passage-openai-ada2.template
+++ b/src/main/resources/docgen/templates/msmarco-passage-openai-ada2.template
@@ -56,8 +56,6 @@ The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 
 Upon completion, we should have an index with 8,841,823 documents.
 
-<!-- For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md). -->
-
 ## Retrieval
 
 Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
@@ -82,7 +80,7 @@ With the above commands, you should be able to reproduce the following results:
 ${effectiveness}
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally stable to the third digit after the decimal point.
+Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
 
 ## Reproduction Log[*](${root_path}/docs/reproducibility.md)
 

--- a/src/main/resources/regression/dl19-passage-cos-dpr-distil-onnx.yaml
+++ b/src/main/resources/regression/dl19-passage-cos-dpr-distil-onnx.yaml
@@ -54,10 +54,10 @@ models:
     params: -querygenerator VectorQueryGenerator -topicfield title -threads 16 -hits 1000 -efSearch 1000 -encoder CosDprDistil
     results:
       AP@1000:
-        - 0.463
+        - 0.458
       nDCG@10:
-        - 0.725
+        - 0.717
       R@100:
-        - 0.615
+        - 0.605
       R@1000:
-        - 0.813
+        - 0.805

--- a/src/main/resources/regression/dl20-passage-cos-dpr-distil-onnx.yaml
+++ b/src/main/resources/regression/dl20-passage-cos-dpr-distil-onnx.yaml
@@ -54,10 +54,10 @@ models:
     params: -querygenerator VectorQueryGenerator -topicfield title -threads 16 -hits 1000 -efSearch 1000 -encoder CosDprDistil
     results:
       AP@1000:
-        - 0.481
+        - 0.482
       nDCG@10:
         - 0.701
       R@100:
-        - 0.707
+        - 0.712
       R@1000:
-        - 0.837
+        - 0.843


### PR DESCRIPTION
Also aligns ONNX and non-ONNX versions of cosDPR-distil scores; cf. https://github.com/castorini/anserini/pull/2231