### PR TITLE
Follow up: add bindings for CIRAL's dev qrels

### DIFF
--- a/src/main/java/io/anserini/eval/Qrels.java
+++ b/src/main/java/io/anserini/eval/Qrels.java
@@ -163,7 +163,11 @@ public enum Qrels {
   MIRACL_V10_DE_DEV("qrels.miracl-v1.0-de-dev.tsv"),
   MIRACL_V10_YO_DEV("qrels.miracl-v1.0-yo-dev.tsv"),
   ATOMIC_VAL_T2I("qrels.atomic.validation.t2i.trec"),
-  ATOMIC_VAL_I2T("qrels.atomic.validation.i2t.trec");
+  ATOMIC_VAL_I2T("qrels.atomic.validation.i2t.trec"),
+  CIRAL_V10_HA_DEV("qrels.ciral-v1.0-ha-dev.tsv"),
+  CIRAL_V10_SO_DEV("qrels.ciral-v1.0-so-dev.tsv"),
+  CIRAL_V10_SW_DEV("qrels.ciral-v1.0-sw-dev.tsv"),
+  CIRAL_V10_YO_DEV("qrels.ciral-v1.0-yo-dev.tsv");
 
   public final String path;
 

--- a/src/test/java/io/anserini/eval/RelevanceJudgmentsTest.java
+++ b/src/test/java/io/anserini/eval/RelevanceJudgmentsTest.java
@@ -1297,4 +1297,29 @@ public class RelevanceJudgmentsTest{
     assertEquals(393, qrels.getQids().size());
     assertEquals(3928, getQrelsCount(qrels));
   }
+
+  @Test
+  public void testsCIRAL() throws IOException{
+    RelevanceJudgments qrels;
+
+    qrels = RelevanceJudgments.fromQrels(Qrels.CIRAL_V10_HA_DEV);
+    assertNotNull(qrels);
+    assertEquals(10, qrels.getQids().size());
+    assertEquals(165, getQrelsCount(qrels));
+
+    qrels = RelevanceJudgments.fromQrels(Qrels.CIRAL_V10_SO_DEV);
+    assertNotNull(qrels);
+    assertEquals(10, qrels.getQids().size());
+    assertEquals(187, getQrelsCount(qrels));
+
+    qrels = RelevanceJudgments.fromQrels(Qrels.CIRAL_V10_SW_DEV);
+    assertNotNull(qrels);
+    assertEquals(10, qrels.getQids().size());
+    assertEquals(196, getQrelsCount(qrels));
+
+    qrels = RelevanceJudgments.fromQrels(Qrels.CIRAL_V10_YO_DEV);
+    assertNotNull(qrels);
+    assertEquals(10, qrels.getQids().size());
+    assertEquals(185, getQrelsCount(qrels));
+  }
 }

--- a/src/test/java/io/anserini/eval/RelevanceJudgmentsTest.java
+++ b/src/test/java/io/anserini/eval/RelevanceJudgmentsTest.java
@@ -1299,7 +1299,7 @@ public class RelevanceJudgmentsTest{
   }
 
   @Test
-  public void testsCIRAL() throws IOException{
+  public void testCIRAL() throws IOException{
     RelevanceJudgments qrels;
 
     qrels = RelevanceJudgments.fromQrels(Qrels.CIRAL_V10_HA_DEV);


### PR DESCRIPTION
Follow up to [castorini/anserini/pull/2258](https://github.com/castorini/anserini/pull/2258) as branch was deleted. 
Including bindings for dev qrels.