### PR TITLE
Upgrade to Jacoco 0.8.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.7</version>
+        <version>0.8.11</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
This commit upgrades to Jacoco 0.8.11 (from 0.8.7). Recent Jacoco versions have added support for Java 20+ versions. 

The motivation for this change is to allow to run and test with more recent Java versions, specifically Java 20 and Java 21.
This allows to enable Lucene's faster SIMD-ized implementations of the vector distance computations.