### PR TITLE
Dial down -maxThreadMemoryBeforeFlush for indexing OpenAI Ada2 embeddings

### DIFF
--- a/docs/regressions/regressions-dl19-passage-openai-ada2.md
+++ b/docs/regressions/regressions-dl19-passage-openai-ada2.md
@@ -57,7 +57,7 @@ target/appassembler/bin/IndexHnswDenseVectors \
   -input /path/to/msmarco-passage-openai-ada2 \
   -generator HnswDenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.msmarco-passage-openai-ada2/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -maxThreadMemoryBeforeFlush 1945 \
   >& logs/log.msmarco-passage-openai-ada2 &
 ```
 

--- a/docs/regressions/regressions-dl20-passage-openai-ada2.md
+++ b/docs/regressions/regressions-dl20-passage-openai-ada2.md
@@ -57,7 +57,7 @@ target/appassembler/bin/IndexHnswDenseVectors \
   -input /path/to/msmarco-passage-openai-ada2 \
   -generator HnswDenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.msmarco-passage-openai-ada2/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -maxThreadMemoryBeforeFlush 1945 \
   >& logs/log.msmarco-passage-openai-ada2 &
 ```
 

--- a/docs/regressions/regressions-msmarco-passage-openai-ada2.md
+++ b/docs/regressions/regressions-msmarco-passage-openai-ada2.md
@@ -54,7 +54,7 @@ target/appassembler/bin/IndexHnswDenseVectors \
   -input /path/to/msmarco-passage-openai-ada2 \
   -generator HnswDenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.msmarco-passage-openai-ada2/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -maxThreadMemoryBeforeFlush 1945 \
   >& logs/log.msmarco-passage-openai-ada2 &
 ```
 

--- a/src/main/resources/regression/dl19-passage-openai-ada2.yaml
+++ b/src/main/resources/regression/dl19-passage-openai-ada2.yaml
@@ -10,7 +10,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: HnswDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -maxThreadMemoryBeforeFlush 1945
 
 metrics:
   - metric: AP@1000

--- a/src/main/resources/regression/dl20-passage-openai-ada2.yaml
+++ b/src/main/resources/regression/dl20-passage-openai-ada2.yaml
@@ -10,7 +10,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: HnswDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -maxThreadMemoryBeforeFlush 1945
 
 metrics:
   - metric: AP@1000

--- a/src/main/resources/regression/msmarco-passage-openai-ada2.yaml
+++ b/src/main/resources/regression/msmarco-passage-openai-ada2.yaml
@@ -10,7 +10,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: HnswDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -maxThreadMemoryBeforeFlush 1945
 
 metrics:
   - metric: AP@1000


### PR DESCRIPTION
default of 2047 seems to be too aggressive for `hops`, getting OOM errors.