### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -363,3 +363,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@charlie-liuu](https://github.com/charlie-liuu) on 2024-01-22 (commit [`ba472b8`](https://github.com/castorini/anserini/commit/ba472b801889acdc371c1dad78b2156c1620ce32))
 + Results reproduced by [@dannychn11](https://github.com/dannychn11) on 2024-01-27 (commit [`f02e6f1`](https://github.com/castorini/anserini/commit/f02e6f1dd6375d2f513656a7f70aeaf63cf67f4e))
 + Results reproduced by [@chloeqxq](https://github.com/chloeqxq) on 2024-01-28 (commit [`3f2d7fa`](https://github.com/castorini/anserini/commit/3f2d7fa91118b71d75d9f547d19ff19858f96523))
++ Results reproduced by [@stephen-ics](https://github.com/stephen-ics) on 2024-01-28 (commit [`5c110dc`](https://github.com/castorini/anserini/commit/5c110dcf970f14e1ee271699ba972ded588d822c))


### PR DESCRIPTION
Reproduced on Apple M1 Pro

System Environment
- Operating System: macOS 12.7.2
- Java Version: openjdk 21.0.2
- Python Version: Python 3.11.7
- Maven Version: Apache Maven 3.9.6

The setup was successfully reproduced. The first link to the data yielded 404 not found errors, but the mirror link worked fine.
