### PR TITLE
Update Reproduction Log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ tools/topics-and-qrels/qrels.mb13.all.txt
 # vscode related files
 .settings
 .factorypath
-.vscode
+.vscode/
 
 # elastirini and solrini installation
 solrini/

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ tools/topics-and-qrels/qrels.mb13.all.txt
 # vscode related files
 .settings
 .factorypath
+.vscode
 
 # elastirini and solrini installation
 solrini/

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -471,3 +471,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@ASChampOmega](https://github.com/ASChampOmega) on 2024-02-23 (commit [`f0b37dd`](https://github.com/castorini/anserini/commit/f0b37dd28ffec543a9ef107a52297b30199b69f1))
 + Results reproduced by [@17Melissa](https://github.com/17Melissa) on 2024-02-23 (commit [`084deb9`](https://github.com/castorini/anserini/commit/084deb97fe886b9062d005edcdc3982b2e65ce3f))
 + Results reproduced by [@HaeriAmin](https://github.com/haeriamin) on 2024-02-26 (commit [`e91cd20`](https://github.com/castorini/anserini/commit/e91cd205230cbb04c14f71eee276511ea1f1316a))
++ Results reproduced by [@xpbowler](https://github.com/xpbowler) on 2024-03-11 (commit [`5c110dc`](https://github.com/castorini/anserini/commit/5c110dcf970f14e1ee271699ba972ded588d822c))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -472,6 +472,6 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@17Melissa](https://github.com/17Melissa) on 2024-02-23 (commit [`084deb9`](https://github.com/castorini/anserini/commit/084deb97fe886b9062d005edcdc3982b2e65ce3f))
 + Results reproduced by [@HaeriAmin](https://github.com/haeriamin) on 2024-02-26 (commit [`e91cd20`](https://github.com/castorini/anserini/commit/e91cd205230cbb04c14f71eee276511ea1f1316a))
 + Results reproduced by [@devesh-002](https://github.com/devesh-002) on 2024-03-05 (commit [`d674915`](https://github.com/castorini/anserini/commit/d674915ccd837f304380e84f17b9925f4eeb0e18))
-+ Results reproduced by [@xpbowler](https://github.com/xpbowler) on 2024-03-11 (commit [`5c110dc`](https://github.com/castorini/anserini/commit/5c110dcf970f14e1ee271699ba972ded588d822c))
++ Results reproduced by [@xpbowler](https://github.com/xpbowler) on 2024-03-11 (commit [`80c3bf9`](https://github.com/castorini/anserini/commit/80c3bf9a2d374c56b574ad7758f71ae597705cd5))
 + Results reproduced by [@jodyz0203](https://github.com/jodyz0203) on 2024-03-12 (commit [`f681d65`](https://github.com/castorini/anserini/commit/f681d6504b9f89f65697878c6c984840456f5d53))
 + Results reproduced by [@kxwtan](https://github.com/kxwtan) on 2024-03-12 (commit [`f681d65`](https://github.com/castorini/anserini/commit/f681d6504b9f89f65697878c6c984840456f5d53))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -369,7 +369,7 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@17Melissa](https://github.com/17Melissa) on 2024-02-23 (commit [`084deb9`](https://github.com/castorini/anserini/commit/084deb97fe886b9062d005edcdc3982b2e65ce3f))
 + Results reproduced by [@HaeriAmin](https://github.com/haeriamin) on 2024-02-26 (commit [`e91cd20`](https://github.com/castorini/anserini/commit/e91cd205230cbb04c14f71eee276511ea1f1316a))
 + Results reproduced by [@devesh-002](https://github.com/devesh-002) on 2024-03-05 (commit [`f86a65f`](https://github.com/castorini/anserini/commit/f86a65f43eb15d88b7a003a1edf541d9d60c3056))
-+ Results reproduced by [@xpbowler](https://github.com/xpbowler) on 2024-03-11 (commit [`5c110dc`](https://github.com/castorini/anserini/commit/5c110dcf970f14e1ee271699ba972ded588d822c))
++ Results reproduced by [@xpbowler](https://github.com/xpbowler) on 2024-03-11 (commit [`80c3bf9`](https://github.com/castorini/anserini/commit/80c3bf9a2d374c56b574ad7758f71ae597705cd5))
 + Results reproduced by [@jodyz0203](https://github.com/jodyz0203) on 2024-03-12 (commit [`f681d65`](https://github.com/castorini/anserini/commit/f681d6504b9f89f65697878c6c984840456f5d53))
 + Results reproduced by [@kxwtan](https://github.com/kxwtan) on 2024-03-12 (commit [`f681d65`](https://github.com/castorini/anserini/commit/f681d6504b9f89f65697878c6c984840456f5d53))
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -368,3 +368,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@ASChampOmega](https://github.com/ASChampOmega) on 2024-02-23 (commit [`f0b37dd`](https://github.com/castorini/anserini/commit/f0b37dd28ffec543a9ef107a52297b30199b69f1))
 + Results reproduced by [@17Melissa](https://github.com/17Melissa) on 2024-02-23 (commit [`084deb9`](https://github.com/castorini/anserini/commit/084deb97fe886b9062d005edcdc3982b2e65ce3f))
 + Results reproduced by [@HaeriAmin](https://github.com/haeriamin) on 2024-02-26 (commit [`e91cd20`](https://github.com/castorini/anserini/commit/e91cd205230cbb04c14f71eee276511ea1f1316a))
++ Results reproduced by [@xpbowler](https://github.com/xpbowler) on 2024-03-11 (commit [`5c110dc`](https://github.com/castorini/anserini/commit/5c110dcf970f14e1ee271699ba972ded588d822c))


### PR DESCRIPTION
Hardware:
CPU: Apple M2 Pro
RAM: 32GB

Environment:

- Operating System: macOS 14.2.1
- Python Version: Python 3.10.10
- Java Version: openjdk 11.0.11
- Maven Version: Apache Maven 3.9.6

The setup was successfully reproduced. Working in vscode auto-generated a .vscode/settings.json, which should be added to the .gitignore for future VSCode users.

<img width="1327" alt="Screenshot 2024-03-11 at 12 13 07 AM" src="https://github.com/castorini/anserini/assets/96593302/4c211186-e9e1-4c93-8fc3-cc3d781bdbf8">