### PR TITLE
Tweak 'name' in regression yaml files to make more unique

### DIFF
--- a/docs/regressions/regressions-dl19-doc-hgf-wp.md
+++ b/docs/regressions/regressions-dl19-doc-hgf-wp.md
@@ -50,7 +50,7 @@ target/appassembler/bin/SearchCollection \
   -topics tools/topics-and-qrels/topics.dl19-doc.txt \
   -topicReader TsvInt \
   -output runs/run.msmarco-doc.bm25-default.topics.dl19-doc.txt \
-  -bm25 -analyzeWithHuggingFaceTokenizer  bert-base-uncased &
+  -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions/regressions-dl19-doc-segmented-unicoil-noexp.md
+++ b/docs/regressions/regressions-dl19-doc-segmented-unicoil-noexp.md
@@ -82,41 +82,41 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil-noexp/ \
   -topics tools/topics-and-qrels/topics.dl19-doc.unicoil-noexp.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.dl19-doc.unicoil-noexp.0shot.txt \
+  -output runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q.topics.dl19-doc.unicoil-noexp.0shot.txt \
   -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil-noexp/ \
   -topics tools/topics-and-qrels/topics.dl19-doc.unicoil-noexp.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil-noexp.rm3.topics.dl19-doc.unicoil-noexp.0shot.txt \
+  -output runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-cached_q+rm3.topics.dl19-doc.unicoil-noexp.0shot.txt \
   -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil-noexp/ \
   -topics tools/topics-and-qrels/topics.dl19-doc.unicoil-noexp.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil-noexp.rocchio.topics.dl19-doc.unicoil-noexp.0shot.txt \
+  -output runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-cached_q+rocchio.topics.dl19-doc.unicoil-noexp.0shot.txt \
   -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.dl19-doc.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.dl19-doc.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.dl19-doc.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.dl19-doc.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q.topics.dl19-doc.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q.topics.dl19-doc.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q.topics.dl19-doc.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q.topics.dl19-doc.unicoil-noexp.0shot.txt
 
-target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rm3.topics.dl19-doc.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rm3.topics.dl19-doc.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rm3.topics.dl19-doc.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rm3.topics.dl19-doc.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-cached_q+rm3.topics.dl19-doc.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-cached_q+rm3.topics.dl19-doc.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-cached_q+rm3.topics.dl19-doc.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-cached_q+rm3.topics.dl19-doc.unicoil-noexp.0shot.txt
 
-target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rocchio.topics.dl19-doc.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rocchio.topics.dl19-doc.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rocchio.topics.dl19-doc.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rocchio.topics.dl19-doc.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-cached_q+rocchio.topics.dl19-doc.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-cached_q+rocchio.topics.dl19-doc.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-cached_q+rocchio.topics.dl19-doc.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-cached_q+rocchio.topics.dl19-doc.unicoil-noexp.0shot.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-doc-segmented-unicoil.md
+++ b/docs/regressions/regressions-dl19-doc-segmented-unicoil.md
@@ -82,41 +82,41 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
   -topics tools/topics-and-qrels/topics.dl19-doc.unicoil.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl19-doc.unicoil.0shot.txt \
+  -output runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q.topics.dl19-doc.unicoil.0shot.txt \
   -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
   -topics tools/topics-and-qrels/topics.dl19-doc.unicoil.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil.rm3.topics.dl19-doc.unicoil.0shot.txt \
+  -output runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rm3.topics.dl19-doc.unicoil.0shot.txt \
   -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
   -topics tools/topics-and-qrels/topics.dl19-doc.unicoil.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil.rocchio.topics.dl19-doc.unicoil.0shot.txt \
+  -output runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rocchio.topics.dl19-doc.unicoil.0shot.txt \
   -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl19-doc.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl19-doc.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl19-doc.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl19-doc.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q.topics.dl19-doc.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q.topics.dl19-doc.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q.topics.dl19-doc.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q.topics.dl19-doc.unicoil.0shot.txt
 
-target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.rm3.topics.dl19-doc.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.rm3.topics.dl19-doc.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.rm3.topics.dl19-doc.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.rm3.topics.dl19-doc.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rm3.topics.dl19-doc.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rm3.topics.dl19-doc.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rm3.topics.dl19-doc.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rm3.topics.dl19-doc.unicoil.0shot.txt
 
-target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.rocchio.topics.dl19-doc.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.rocchio.topics.dl19-doc.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.rocchio.topics.dl19-doc.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.rocchio.topics.dl19-doc.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rocchio.topics.dl19-doc.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rocchio.topics.dl19-doc.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rocchio.topics.dl19-doc.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl19-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rocchio.topics.dl19-doc.unicoil.0shot.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-passage-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-dl19-passage-bge-base-en-v1.5-hnsw-int8.md
@@ -82,17 +82,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-bge-base-en-v1.5-int8/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.bge-base-en-v1.5.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt \
+  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-passage-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-dl19-passage-bge-base-en-v1.5-hnsw.md
@@ -80,17 +80,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-bge-base-en-v1.5/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.bge-base-en-v1.5.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt \
+  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl19-passage.bge-base-en-v1.5.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-passage-cohere-embed-english-v3.0-hnsw-int8.md
+++ b/docs/regressions/regressions-dl19-passage-cohere-embed-english-v3.0-hnsw-int8.md
@@ -75,17 +75,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-cohere-embed-english-v3.0-int8/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.cohere-embed-english-v3.0.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt \
+  -output runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-passage-cohere-embed-english-v3.0-hnsw.md
+++ b/docs/regressions/regressions-dl19-passage-cohere-embed-english-v3.0-hnsw.md
@@ -75,17 +75,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-cohere-embed-english-v3.0/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.cohere-embed-english-v3.0.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt \
+  -output runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl19-passage.cohere-embed-english-v3.0.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-passage-cos-dpr-distil-fw.md
+++ b/docs/regressions/regressions-dl19-passage-cos-dpr-distil-fw.md
@@ -75,17 +75,17 @@ target/appassembler/bin/SearchInvertedDenseVectors \
   -index indexes/lucene-index.msmarco-passage-cos-dpr-distil.fw-40/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.cos-dpr-distil.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40.topics.dl19-passage.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt \
   -topicField vector -threads 16 -encoding fw -fw.q 40 -hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-passage-cos-dpr-distil-hnsw-int8.md
+++ b/docs/regressions/regressions-dl19-passage-cos-dpr-distil-hnsw-int8.md
@@ -82,17 +82,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil-int8/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.cos-dpr-distil.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl19-passage.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-passage-cos-dpr-distil-hnsw.md
+++ b/docs/regressions/regressions-dl19-passage-cos-dpr-distil-hnsw.md
@@ -80,17 +80,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.cos-dpr-distil.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl19-passage.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-passage-cos-dpr-distil-lexlsh.md
+++ b/docs/regressions/regressions-dl19-passage-cos-dpr-distil-lexlsh.md
@@ -75,17 +75,17 @@ target/appassembler/bin/SearchInvertedDenseVectors \
   -index indexes/lucene-index.msmarco-passage-cos-dpr-distil.lexlsh-600/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.cos-dpr-distil.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600.topics.dl19-passage.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt \
   -topicField vector -threads 16 -encoding lexlsh -lexlsh.b 600 -hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-passage-hgf-wp.md
+++ b/docs/regressions/regressions-dl19-passage-hgf-wp.md
@@ -50,7 +50,7 @@ target/appassembler/bin/SearchCollection \
   -topics tools/topics-and-qrels/topics.dl19-passage.txt \
   -topicReader TsvInt \
   -output runs/run.msmarco-passage.bm25-default.topics.dl19-passage.txt \
-  -bm25 -analyzeWithHuggingFaceTokenizer  bert-base-uncased &
+  -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions/regressions-dl19-passage-openai-ada2-int8.md
+++ b/docs/regressions/regressions-dl19-passage-openai-ada2-int8.md
@@ -84,17 +84,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-openai-ada2-int8/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.openai-ada2.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl19-passage.openai-ada2.jsonl.txt \
+  -output runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl19-passage.openai-ada2.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl19-passage.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl19-passage.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl19-passage.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl19-passage.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl19-passage.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl19-passage.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl19-passage.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl19-passage.openai-ada2.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-passage-openai-ada2.md
+++ b/docs/regressions/regressions-dl19-passage-openai-ada2.md
@@ -80,17 +80,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-openai-ada2/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.openai-ada2.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl19-passage.openai-ada2.jsonl.txt \
+  -output runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl19-passage.openai-ada2.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl19-passage.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl19-passage.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl19-passage.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl19-passage.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl19-passage.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl19-passage.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl19-passage.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl19-passage.openai-ada2.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions/regressions-dl19-passage-splade-pp-ed-onnx.md
@@ -81,41 +81,41 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.txt \
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx.topics.dl19-passage.txt \
   -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.txt \
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rm3.topics.dl19-passage.txt \
   -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.txt \
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rocchio.topics.dl19-passage.txt \
   -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil -rocchio &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx.topics.dl19-passage.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rm3.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rm3.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rm3.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rm3.topics.dl19-passage.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rocchio.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rocchio.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rocchio.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rocchio.topics.dl19-passage.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-passage-splade-pp-ed.md
+++ b/docs/regressions/regressions-dl19-passage-splade-pp-ed.md
@@ -81,41 +81,41 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.splade-pp-ed.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.splade-pp-ed.txt \
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q.topics.dl19-passage.splade-pp-ed.txt \
   -impact -pretokenized &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.splade-pp-ed.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.splade-pp-ed.txt \
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rm3.topics.dl19-passage.splade-pp-ed.txt \
   -impact -pretokenized -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.splade-pp-ed.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.splade-pp-ed.txt \
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rocchio.topics.dl19-passage.splade-pp-ed.txt \
   -impact -pretokenized -rocchio &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl19-passage.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q.topics.dl19-passage.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q.topics.dl19-passage.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q.topics.dl19-passage.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q.topics.dl19-passage.splade-pp-ed.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl19-passage.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rm3.topics.dl19-passage.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rm3.topics.dl19-passage.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rm3.topics.dl19-passage.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rm3.topics.dl19-passage.splade-pp-ed.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl19-passage.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rocchio.topics.dl19-passage.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rocchio.topics.dl19-passage.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rocchio.topics.dl19-passage.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rocchio.topics.dl19-passage.splade-pp-ed.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions/regressions-dl19-passage-splade-pp-sd-onnx.md
@@ -81,41 +81,41 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.txt \
+  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx.topics.dl19-passage.txt \
   -impact -pretokenized -encoder SpladePlusPlusSelfDistil &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.txt \
+  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rm3.topics.dl19-passage.txt \
   -impact -pretokenized -rm3 -encoder SpladePlusPlusSelfDistil &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.txt \
+  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rocchio.topics.dl19-passage.txt \
   -impact -pretokenized -rocchio -encoder SpladePlusPlusSelfDistil &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx.topics.dl19-passage.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rm3.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rm3.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rm3.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rm3.topics.dl19-passage.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rocchio.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rocchio.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rocchio.topics.dl19-passage.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rocchio.topics.dl19-passage.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-passage-splade-pp-sd.md
+++ b/docs/regressions/regressions-dl19-passage-splade-pp-sd.md
@@ -81,41 +81,41 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.splade-pp-sd.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.splade-pp-sd.txt \
+  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q.topics.dl19-passage.splade-pp-sd.txt \
   -impact -pretokenized &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.splade-pp-sd.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.splade-pp-sd.txt \
+  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rm3.topics.dl19-passage.splade-pp-sd.txt \
   -impact -pretokenized -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.splade-pp-sd.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.splade-pp-sd.txt \
+  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rocchio.topics.dl19-passage.splade-pp-sd.txt \
   -impact -pretokenized -rocchio &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl19-passage.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q.topics.dl19-passage.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q.topics.dl19-passage.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q.topics.dl19-passage.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q.topics.dl19-passage.splade-pp-sd.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl19-passage.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rm3.topics.dl19-passage.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rm3.topics.dl19-passage.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rm3.topics.dl19-passage.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rm3.topics.dl19-passage.splade-pp-sd.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl19-passage.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rocchio.topics.dl19-passage.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rocchio.topics.dl19-passage.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rocchio.topics.dl19-passage.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rocchio.topics.dl19-passage.splade-pp-sd.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-passage-unicoil-noexp.md
+++ b/docs/regressions/regressions-dl19-passage-unicoil-noexp.md
@@ -84,41 +84,41 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil-noexp/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.unicoil-noexp.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.dl19-passage.unicoil-noexp.0shot.txt \
+  -output runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q.topics.dl19-passage.unicoil-noexp.0shot.txt \
   -impact -pretokenized &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil-noexp/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.unicoil-noexp.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-unicoil-noexp.rm3.topics.dl19-passage.unicoil-noexp.0shot.txt \
+  -output runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rm3.topics.dl19-passage.unicoil-noexp.0shot.txt \
   -impact -pretokenized -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil-noexp/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.unicoil-noexp.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-unicoil-noexp.rocchio.topics.dl19-passage.unicoil-noexp.0shot.txt \
+  -output runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rocchio.topics.dl19-passage.unicoil-noexp.0shot.txt \
   -impact -pretokenized -rocchio &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.dl19-passage.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.dl19-passage.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.dl19-passage.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.dl19-passage.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q.topics.dl19-passage.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q.topics.dl19-passage.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q.topics.dl19-passage.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q.topics.dl19-passage.unicoil-noexp.0shot.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.rm3.topics.dl19-passage.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.rm3.topics.dl19-passage.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.rm3.topics.dl19-passage.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.rm3.topics.dl19-passage.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rm3.topics.dl19-passage.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rm3.topics.dl19-passage.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rm3.topics.dl19-passage.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rm3.topics.dl19-passage.unicoil-noexp.0shot.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.rocchio.topics.dl19-passage.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.rocchio.topics.dl19-passage.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.rocchio.topics.dl19-passage.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.rocchio.topics.dl19-passage.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rocchio.topics.dl19-passage.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rocchio.topics.dl19-passage.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rocchio.topics.dl19-passage.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rocchio.topics.dl19-passage.unicoil-noexp.0shot.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl19-passage-unicoil.md
+++ b/docs/regressions/regressions-dl19-passage-unicoil.md
@@ -84,41 +84,41 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.unicoil.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-unicoil.unicoil.topics.dl19-passage.unicoil.0shot.txt \
+  -output runs/run.msmarco-passage-unicoil.unicoil-cached_q.topics.dl19-passage.unicoil.0shot.txt \
   -impact -pretokenized &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.unicoil.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-unicoil.rm3.topics.dl19-passage.unicoil.0shot.txt \
+  -output runs/run.msmarco-passage-unicoil.unicoil-cached_q+rm3.topics.dl19-passage.unicoil.0shot.txt \
   -impact -pretokenized -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil/ \
   -topics tools/topics-and-qrels/topics.dl19-passage.unicoil.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-unicoil.rocchio.topics.dl19-passage.unicoil.0shot.txt \
+  -output runs/run.msmarco-passage-unicoil.unicoil-cached_q+rocchio.topics.dl19-passage.unicoil.0shot.txt \
   -impact -pretokenized -rocchio &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl19-passage.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl19-passage.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl19-passage.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl19-passage.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q.topics.dl19-passage.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q.topics.dl19-passage.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q.topics.dl19-passage.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q.topics.dl19-passage.unicoil.0shot.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.rm3.topics.dl19-passage.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.rm3.topics.dl19-passage.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.rm3.topics.dl19-passage.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.rm3.topics.dl19-passage.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q+rm3.topics.dl19-passage.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q+rm3.topics.dl19-passage.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q+rm3.topics.dl19-passage.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q+rm3.topics.dl19-passage.unicoil.0shot.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.rocchio.topics.dl19-passage.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.rocchio.topics.dl19-passage.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.rocchio.topics.dl19-passage.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.rocchio.topics.dl19-passage.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q+rocchio.topics.dl19-passage.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q+rocchio.topics.dl19-passage.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q+rocchio.topics.dl19-passage.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q+rocchio.topics.dl19-passage.unicoil.0shot.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-doc-hgf-wp.md
+++ b/docs/regressions/regressions-dl20-doc-hgf-wp.md
@@ -50,7 +50,7 @@ target/appassembler/bin/SearchCollection \
   -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicReader TsvInt \
   -output runs/run.msmarco-doc.bm25-default.topics.dl20.txt \
-  -bm25 -analyzeWithHuggingFaceTokenizer  bert-base-uncased &
+  -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions/regressions-dl20-doc-segmented-unicoil-noexp.md
+++ b/docs/regressions/regressions-dl20-doc-segmented-unicoil-noexp.md
@@ -82,41 +82,41 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil-noexp/ \
   -topics tools/topics-and-qrels/topics.dl20.unicoil-noexp.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.dl20.unicoil-noexp.0shot.txt \
+  -output runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q.topics.dl20.unicoil-noexp.0shot.txt \
   -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil-noexp/ \
   -topics tools/topics-and-qrels/topics.dl20.unicoil-noexp.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil-noexp.rm3.topics.dl20.unicoil-noexp.0shot.txt \
+  -output runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q+rm3.topics.dl20.unicoil-noexp.0shot.txt \
   -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil-noexp/ \
   -topics tools/topics-and-qrels/topics.dl20.unicoil-noexp.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil-noexp.rocchio.topics.dl20.unicoil-noexp.0shot.txt \
+  -output runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q+rocchio.topics.dl20.unicoil-noexp.0shot.txt \
   -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q.topics.dl20.unicoil-noexp.0shot.txt
 
-target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rm3.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rm3.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rm3.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rm3.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q+rm3.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q+rm3.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q+rm3.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q+rm3.topics.dl20.unicoil-noexp.0shot.txt
 
-target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rocchio.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rocchio.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rocchio.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.rocchio.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q+rocchio.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q+rocchio.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q+rocchio.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q+rocchio.topics.dl20.unicoil-noexp.0shot.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-doc-segmented-unicoil.md
+++ b/docs/regressions/regressions-dl20-doc-segmented-unicoil.md
@@ -82,41 +82,41 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
   -topics tools/topics-and-qrels/topics.dl20.unicoil.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl20.unicoil.0shot.txt \
+  -output runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q.topics.dl20.unicoil.0shot.txt \
   -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
   -topics tools/topics-and-qrels/topics.dl20.unicoil.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil.rm3.topics.dl20.unicoil.0shot.txt \
+  -output runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rm3.topics.dl20.unicoil.0shot.txt \
   -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
   -topics tools/topics-and-qrels/topics.dl20.unicoil.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil.rocchio.topics.dl20.unicoil.0shot.txt \
+  -output runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rocchio.topics.dl20.unicoil.0shot.txt \
   -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q.topics.dl20.unicoil.0shot.txt
 
-target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.rm3.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.rm3.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.rm3.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.rm3.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rm3.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rm3.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rm3.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rm3.topics.dl20.unicoil.0shot.txt
 
-target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.rocchio.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.rocchio.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.rocchio.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.rocchio.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -M 100 -m map tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rocchio.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rocchio.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rocchio.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.dl20-doc.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q+rocchio.topics.dl20.unicoil.0shot.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-dl20-passage-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -82,17 +82,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-bge-base-en-v1.5-int8/ \
   -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.txt \
+  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.dl20.txt \
   -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.dl20.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-dl20-passage-bge-base-en-v1.5-hnsw-int8.md
@@ -82,17 +82,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-bge-base-en-v1.5-int8/ \
   -topics tools/topics-and-qrels/topics.dl20.bge-base-en-v1.5.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.bge-base-en-v1.5.jsonl.txt \
+  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl20.bge-base-en-v1.5.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl20.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl20.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl20.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl20.bge-base-en-v1.5.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-dl20-passage-bge-base-en-v1.5-hnsw-onnx.md
@@ -80,17 +80,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-bge-base-en-v1.5/ \
   -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.txt \
+  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.dl20.txt \
   -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.dl20.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-dl20-passage-bge-base-en-v1.5-hnsw.md
@@ -80,17 +80,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-bge-base-en-v1.5/ \
   -topics tools/topics-and-qrels/topics.dl20.bge-base-en-v1.5.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.bge-base-en-v1.5.jsonl.txt \
+  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl20.bge-base-en-v1.5.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.dl20.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl20.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl20.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl20.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.dl20.bge-base-en-v1.5.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-cohere-embed-english-v3.0-hnsw-int8.md
+++ b/docs/regressions/regressions-dl20-passage-cohere-embed-english-v3.0-hnsw-int8.md
@@ -75,17 +75,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-cohere-embed-english-v3.0-int8/ \
   -topics tools/topics-and-qrels/topics.dl20.cohere-embed-english-v3.0.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl20.cohere-embed-english-v3.0.jsonl.txt \
+  -output runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl20.cohere-embed-english-v3.0.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl20.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl20.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl20.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl20.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl20.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl20.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl20.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl20.cohere-embed-english-v3.0.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-cohere-embed-english-v3.0-hnsw.md
+++ b/docs/regressions/regressions-dl20-passage-cohere-embed-english-v3.0-hnsw.md
@@ -75,17 +75,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-cohere-embed-english-v3.0/ \
   -topics tools/topics-and-qrels/topics.dl20.cohere-embed-english-v3.0.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl20.cohere-embed-english-v3.0.jsonl.txt \
+  -output runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl20.cohere-embed-english-v3.0.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl20.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl20.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl20.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.dl20.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl20.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl20.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl20.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.dl20.cohere-embed-english-v3.0.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-cos-dpr-distil-fw.md
+++ b/docs/regressions/regressions-dl20-passage-cos-dpr-distil-fw.md
@@ -75,17 +75,17 @@ target/appassembler/bin/SearchInvertedDenseVectors \
   -index indexes/lucene-index.msmarco-passage-cos-dpr-distil.fw-40/ \
   -topics tools/topics-and-qrels/topics.dl20.cos-dpr-distil.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40.topics.dl20.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt \
   -topicField vector -threads 16 -encoding fw -fw.q 40 -hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40.topics.dl20.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40.topics.dl20.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40.topics.dl20.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40.topics.dl20.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-cos-dpr-distil-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-dl20-passage-cos-dpr-distil-hnsw-int8-onnx.md
@@ -82,7 +82,7 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil-int8/ \
   -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.dl20.txt \
   -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder CosDprDistil &
 ```
 
@@ -91,10 +91,10 @@ Note that we are performing query inference "on-the-fly" with ONNX in these expe
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.dl20.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-cos-dpr-distil-hnsw-int8.md
+++ b/docs/regressions/regressions-dl20-passage-cos-dpr-distil-hnsw-int8.md
@@ -82,17 +82,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil-int8/ \
   -topics tools/topics-and-qrels/topics.dl20.cos-dpr-distil.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-cos-dpr-distil-hnsw-onnx.md
+++ b/docs/regressions/regressions-dl20-passage-cos-dpr-distil-hnsw-onnx.md
@@ -80,7 +80,7 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil/ \
   -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.dl20.txt \
   -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder CosDprDistil &
 ```
 
@@ -89,10 +89,10 @@ Note that we are performing query inference "on-the-fly" with ONNX in these expe
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.dl20.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-cos-dpr-distil-hnsw.md
+++ b/docs/regressions/regressions-dl20-passage-cos-dpr-distil-hnsw.md
@@ -80,17 +80,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil/ \
   -topics tools/topics-and-qrels/topics.dl20.cos-dpr-distil.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.dl20.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-cos-dpr-distil-lexlsh.md
+++ b/docs/regressions/regressions-dl20-passage-cos-dpr-distil-lexlsh.md
@@ -75,17 +75,17 @@ target/appassembler/bin/SearchInvertedDenseVectors \
   -index indexes/lucene-index.msmarco-passage-cos-dpr-distil.lexlsh-600/ \
   -topics tools/topics-and-qrels/topics.dl20.cos-dpr-distil.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600.topics.dl20.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt \
   -topicField vector -threads 16 -encoding lexlsh -lexlsh.b 600 -hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600.topics.dl20.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600.topics.dl20.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600.topics.dl20.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600.topics.dl20.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-hgf-wp.md
+++ b/docs/regressions/regressions-dl20-passage-hgf-wp.md
@@ -50,7 +50,7 @@ target/appassembler/bin/SearchCollection \
   -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicReader TsvInt \
   -output runs/run.msmarco-passage.bm25-default.topics.dl20.txt \
-  -bm25 -analyzeWithHuggingFaceTokenizer  bert-base-uncased &
+  -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions/regressions-dl20-passage-openai-ada2-int8.md
+++ b/docs/regressions/regressions-dl20-passage-openai-ada2-int8.md
@@ -84,17 +84,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-openai-ada2-int8/ \
   -topics tools/topics-and-qrels/topics.dl20.openai-ada2.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl20.openai-ada2.jsonl.txt \
+  -output runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl20.openai-ada2.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl20.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl20.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl20.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl20.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl20.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl20.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl20.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl20.openai-ada2.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-openai-ada2.md
+++ b/docs/regressions/regressions-dl20-passage-openai-ada2.md
@@ -80,17 +80,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-openai-ada2/ \
   -topics tools/topics-and-qrels/topics.dl20.openai-ada2.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl20.openai-ada2.jsonl.txt \
+  -output runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl20.openai-ada2.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl20.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl20.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl20.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.dl20.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl20.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl20.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl20.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.dl20.openai-ada2.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions/regressions-dl20-passage-splade-pp-ed-onnx.md
@@ -81,41 +81,41 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
   -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.txt \
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx.topics.dl20.txt \
   -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
   -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.txt \
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rm3.topics.dl20.txt \
   -impact -pretokenized -rm3 -encoder SpladePlusPlusEnsembleDistil &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
   -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.txt \
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rocchio.topics.dl20.txt \
   -impact -pretokenized -rocchio -encoder SpladePlusPlusEnsembleDistil &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx.topics.dl20.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rm3.topics.dl20.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rm3.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rm3.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rm3.topics.dl20.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rocchio.topics.dl20.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rocchio.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rocchio.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx+rocchio.topics.dl20.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-splade-pp-ed.md
+++ b/docs/regressions/regressions-dl20-passage-splade-pp-ed.md
@@ -81,41 +81,41 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
   -topics tools/topics-and-qrels/topics.dl20.splade-pp-ed.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.splade-pp-ed.txt \
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q.topics.dl20.splade-pp-ed.txt \
   -impact -pretokenized &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
   -topics tools/topics-and-qrels/topics.dl20.splade-pp-ed.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.splade-pp-ed.txt \
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rm3.topics.dl20.splade-pp-ed.txt \
   -impact -pretokenized -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
   -topics tools/topics-and-qrels/topics.dl20.splade-pp-ed.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.splade-pp-ed.txt \
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rocchio.topics.dl20.splade-pp-ed.txt \
   -impact -pretokenized -rocchio &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.dl20.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q.topics.dl20.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q.topics.dl20.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q.topics.dl20.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q.topics.dl20.splade-pp-ed.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rm3.topics.dl20.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rm3.topics.dl20.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rm3.topics.dl20.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rm3.topics.dl20.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rm3.topics.dl20.splade-pp-ed.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.rocchio.topics.dl20.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rocchio.topics.dl20.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rocchio.topics.dl20.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rocchio.topics.dl20.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q+rocchio.topics.dl20.splade-pp-ed.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions/regressions-dl20-passage-splade-pp-sd-onnx.md
@@ -81,41 +81,41 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
   -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.txt \
+  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx.topics.dl20.txt \
   -impact -pretokenized -encoder SpladePlusPlusSelfDistil &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
   -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.txt \
+  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rm3.topics.dl20.txt \
   -impact -pretokenized -rm3 -encoder SpladePlusPlusSelfDistil &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
   -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.txt \
+  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rocchio.topics.dl20.txt \
   -impact -pretokenized -rocchio -encoder SpladePlusPlusSelfDistil &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx.topics.dl20.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rm3.topics.dl20.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rm3.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rm3.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rm3.topics.dl20.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rocchio.topics.dl20.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rocchio.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rocchio.topics.dl20.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx+rocchio.topics.dl20.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-splade-pp-sd.md
+++ b/docs/regressions/regressions-dl20-passage-splade-pp-sd.md
@@ -81,41 +81,41 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
   -topics tools/topics-and-qrels/topics.dl20.splade-pp-sd.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.splade-pp-sd.txt \
+  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q.topics.dl20.splade-pp-sd.txt \
   -impact -pretokenized &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
   -topics tools/topics-and-qrels/topics.dl20.splade-pp-sd.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.splade-pp-sd.txt \
+  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rm3.topics.dl20.splade-pp-sd.txt \
   -impact -pretokenized -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
   -topics tools/topics-and-qrels/topics.dl20.splade-pp-sd.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.splade-pp-sd.txt \
+  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rocchio.topics.dl20.splade-pp-sd.txt \
   -impact -pretokenized -rocchio &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.dl20.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q.topics.dl20.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q.topics.dl20.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q.topics.dl20.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q.topics.dl20.splade-pp-sd.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rm3.topics.dl20.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rm3.topics.dl20.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rm3.topics.dl20.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rm3.topics.dl20.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rm3.topics.dl20.splade-pp-sd.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.rocchio.topics.dl20.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rocchio.topics.dl20.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rocchio.topics.dl20.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rocchio.topics.dl20.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q+rocchio.topics.dl20.splade-pp-sd.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-unicoil-noexp.md
+++ b/docs/regressions/regressions-dl20-passage-unicoil-noexp.md
@@ -84,41 +84,41 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil-noexp/ \
   -topics tools/topics-and-qrels/topics.dl20.unicoil-noexp.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.dl20.unicoil-noexp.0shot.txt \
+  -output runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q.topics.dl20.unicoil-noexp.0shot.txt \
   -impact -pretokenized &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil-noexp/ \
   -topics tools/topics-and-qrels/topics.dl20.unicoil-noexp.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-unicoil-noexp.rm3.topics.dl20.unicoil-noexp.0shot.txt \
+  -output runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rm3.topics.dl20.unicoil-noexp.0shot.txt \
   -impact -pretokenized -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil-noexp/ \
   -topics tools/topics-and-qrels/topics.dl20.unicoil-noexp.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-unicoil-noexp.rocchio.topics.dl20.unicoil-noexp.0shot.txt \
+  -output runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rocchio.topics.dl20.unicoil-noexp.0shot.txt \
   -impact -pretokenized -rocchio &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q.topics.dl20.unicoil-noexp.0shot.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.rm3.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.rm3.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.rm3.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.rm3.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rm3.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rm3.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rm3.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rm3.topics.dl20.unicoil-noexp.0shot.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.rocchio.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.rocchio.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.rocchio.topics.dl20.unicoil-noexp.0shot.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.rocchio.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rocchio.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rocchio.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rocchio.topics.dl20.unicoil-noexp.0shot.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q+rocchio.topics.dl20.unicoil-noexp.0shot.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-dl20-passage-unicoil.md
+++ b/docs/regressions/regressions-dl20-passage-unicoil.md
@@ -84,41 +84,41 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil/ \
   -topics tools/topics-and-qrels/topics.dl20.unicoil.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-unicoil.unicoil.topics.dl20.unicoil.0shot.txt \
+  -output runs/run.msmarco-passage-unicoil.unicoil-cached_q.topics.dl20.unicoil.0shot.txt \
   -impact -pretokenized &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil/ \
   -topics tools/topics-and-qrels/topics.dl20.unicoil.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-unicoil.rm3.topics.dl20.unicoil.0shot.txt \
+  -output runs/run.msmarco-passage-unicoil.unicoil-cached_q+rm3.topics.dl20.unicoil.0shot.txt \
   -impact -pretokenized -rm3 &
 
 target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil/ \
   -topics tools/topics-and-qrels/topics.dl20.unicoil.0shot.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-unicoil.rocchio.topics.dl20.unicoil.0shot.txt \
+  -output runs/run.msmarco-passage-unicoil.unicoil-cached_q+rocchio.topics.dl20.unicoil.0shot.txt \
   -impact -pretokenized -rocchio &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q.topics.dl20.unicoil.0shot.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.rm3.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.rm3.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.rm3.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.rm3.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q+rm3.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q+rm3.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q+rm3.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q+rm3.topics.dl20.unicoil.0shot.txt
 
-target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.rocchio.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.rocchio.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.rocchio.topics.dl20.unicoil.0shot.txt
-target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.rocchio.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q+rocchio.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q+rocchio.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q+rocchio.topics.dl20.unicoil.0shot.txt
+target/appassembler/bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q+rocchio.topics.dl20.unicoil.0shot.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-doc-hgf-wp.md
+++ b/docs/regressions/regressions-msmarco-doc-hgf-wp.md
@@ -47,7 +47,7 @@ target/appassembler/bin/SearchCollection \
   -topics tools/topics-and-qrels/topics.msmarco-doc.dev.txt \
   -topicReader TsvInt \
   -output runs/run.msmarco-doc.bm25-default.topics.msmarco-doc.dev.txt \
-  -bm25 -analyzeWithHuggingFaceTokenizer  bert-base-uncased &
+  -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions/regressions-msmarco-doc-segmented-unicoil-noexp.md
+++ b/docs/regressions/regressions-msmarco-doc-segmented-unicoil-noexp.md
@@ -81,17 +81,17 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil-noexp/ \
   -topics tools/topics-and-qrels/topics.msmarco-doc.dev.unicoil-noexp.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.msmarco-doc.dev.unicoil-noexp.txt \
+  -output runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q.topics.msmarco-doc.dev.unicoil-noexp.txt \
   -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.msmarco-doc.dev.unicoil-noexp.txt
-target/appassembler/bin/trec_eval -c -M 100 -m recip_rank tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.msmarco-doc.dev.unicoil-noexp.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.msmarco-doc.dev.unicoil-noexp.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil.topics.msmarco-doc.dev.unicoil-noexp.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q.topics.msmarco-doc.dev.unicoil-noexp.txt
+target/appassembler/bin/trec_eval -c -M 100 -m recip_rank tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q.topics.msmarco-doc.dev.unicoil-noexp.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q.topics.msmarco-doc.dev.unicoil-noexp.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil-noexp.unicoil-noexp-cached_q.topics.msmarco-doc.dev.unicoil-noexp.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-doc-segmented-unicoil.md
+++ b/docs/regressions/regressions-msmarco-doc-segmented-unicoil.md
@@ -81,17 +81,17 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-doc-segmented-unicoil/ \
   -topics tools/topics-and-qrels/topics.msmarco-doc.dev.unicoil.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.msmarco-doc.dev.unicoil.txt \
+  -output runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q.topics.msmarco-doc.dev.unicoil.txt \
   -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.msmarco-doc.dev.unicoil.txt
-target/appassembler/bin/trec_eval -c -M 100 -m recip_rank tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.msmarco-doc.dev.unicoil.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.msmarco-doc.dev.unicoil.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.unicoil.topics.msmarco-doc.dev.unicoil.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q.topics.msmarco-doc.dev.unicoil.txt
+target/appassembler/bin/trec_eval -c -M 100 -m recip_rank tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q.topics.msmarco-doc.dev.unicoil.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q.topics.msmarco-doc.dev.unicoil.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-doc.dev.txt runs/run.msmarco-doc-segmented-unicoil.unicoil-cached_q.topics.msmarco-doc.dev.unicoil.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-msmarco-passage-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -78,17 +78,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-bge-base-en-v1.5-int8/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.txt \
+  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.msmarco-passage.dev-subset.txt \
   -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.msmarco-passage.dev-subset.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-msmarco-passage-bge-base-en-v1.5-hnsw-int8.md
@@ -78,17 +78,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-bge-base-en-v1.5-int8/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt \
+  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-msmarco-passage-bge-base-en-v1.5-hnsw-onnx.md
@@ -76,17 +76,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-bge-base-en-v1.5/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.txt \
+  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.msmarco-passage.dev-subset.txt \
   -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-onnx.topics.msmarco-passage.dev-subset.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-msmarco-passage-bge-base-en-v1.5-hnsw.md
@@ -76,17 +76,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-bge-base-en-v1.5/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt \
+  -output runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-bge-base-en-v1.5.bge-hnsw-cached_q.topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-cohere-embed-english-v3.0-hnsw-int8.md
+++ b/docs/regressions/regressions-msmarco-passage-cohere-embed-english-v3.0-hnsw-int8.md
@@ -76,17 +76,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-cohere-embed-english-v3.0-int8/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt \
+  -output runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-cohere-embed-english-v3.0-hnsw.md
+++ b/docs/regressions/regressions-msmarco-passage-cohere-embed-english-v3.0-hnsw.md
@@ -74,17 +74,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-cohere-embed-english-v3.0/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt \
+  -output runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cohere-embed-english-v3.0.cohere-embed-english-v3.0-cached_q.topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-cos-dpr-distil-fw.md
+++ b/docs/regressions/regressions-msmarco-passage-cos-dpr-distil-fw.md
@@ -71,17 +71,17 @@ target/appassembler/bin/SearchInvertedDenseVectors \
   -index indexes/lucene-index.msmarco-passage-cos-dpr-distil.fw-40/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt \
   -topicField vector -threads 16 -encoding fw -fw.q 40 -hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-fw-40-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-cos-dpr-distil-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-msmarco-passage-cos-dpr-distil-hnsw-int8-onnx.md
@@ -78,7 +78,7 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil-int8/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.msmarco-passage.dev-subset.txt \
   -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder CosDprDistil &
 ```
 
@@ -87,10 +87,10 @@ Note that we are performing query inference "on-the-fly" with ONNX in these expe
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.msmarco-passage.dev-subset.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-cos-dpr-distil-hnsw-int8.md
+++ b/docs/regressions/regressions-msmarco-passage-cos-dpr-distil-hnsw-int8.md
@@ -78,17 +78,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil-int8/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-cos-dpr-distil-hnsw-onnx.md
+++ b/docs/regressions/regressions-msmarco-passage-cos-dpr-distil-hnsw-onnx.md
@@ -76,7 +76,7 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.msmarco-passage.dev-subset.txt \
   -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder CosDprDistil &
 ```
 
@@ -85,10 +85,10 @@ Note that we are performing query inference "on-the-fly" with ONNX in these expe
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-onnx.topics.msmarco-passage.dev-subset.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-cos-dpr-distil-hnsw.md
+++ b/docs/regressions/regressions-msmarco-passage-cos-dpr-distil-hnsw.md
@@ -76,17 +76,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-cos-dpr-distil/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-hnsw-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-cos-dpr-distil-lexlsh.md
+++ b/docs/regressions/regressions-msmarco-passage-cos-dpr-distil-lexlsh.md
@@ -71,17 +71,17 @@ target/appassembler/bin/SearchInvertedDenseVectors \
   -index indexes/lucene-index.msmarco-passage-cos-dpr-distil.lexlsh-600/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt \
   -topicField vector -threads 16 -encoding lexlsh -lexlsh.b 600 -hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-cos-dpr-distil.cos-dpr-distil-lexlsh-600-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-deepimpact.md
+++ b/docs/regressions/regressions-msmarco-passage-deepimpact.md
@@ -76,17 +76,17 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-deepimpact/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.deepimpact.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-deepimpact.deepimpact.topics.msmarco-passage.dev-subset.deepimpact.txt \
+  -output runs/run.msmarco-passage-deepimpact.deepimpact-cached_q.topics.msmarco-passage.dev-subset.deepimpact.txt \
   -impact -pretokenized &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-deepimpact.deepimpact.topics.msmarco-passage.dev-subset.deepimpact.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-deepimpact.deepimpact.topics.msmarco-passage.dev-subset.deepimpact.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-deepimpact.deepimpact.topics.msmarco-passage.dev-subset.deepimpact.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-deepimpact.deepimpact.topics.msmarco-passage.dev-subset.deepimpact.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-deepimpact.deepimpact-cached_q.topics.msmarco-passage.dev-subset.deepimpact.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-deepimpact.deepimpact-cached_q.topics.msmarco-passage.dev-subset.deepimpact.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-deepimpact.deepimpact-cached_q.topics.msmarco-passage.dev-subset.deepimpact.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-deepimpact.deepimpact-cached_q.topics.msmarco-passage.dev-subset.deepimpact.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-distill-splade-max.md
+++ b/docs/regressions/regressions-msmarco-passage-distill-splade-max.md
@@ -77,17 +77,17 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-distill-splade-max/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.distill-splade-max.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-distill-splade-max.distill-splade-max.topics.msmarco-passage.dev-subset.distill-splade-max.txt \
+  -output runs/run.msmarco-passage-distill-splade-max.distill-splade-max-cached_q.topics.msmarco-passage.dev-subset.distill-splade-max.txt \
   -impact -pretokenized &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-distill-splade-max.distill-splade-max.topics.msmarco-passage.dev-subset.distill-splade-max.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-distill-splade-max.distill-splade-max.topics.msmarco-passage.dev-subset.distill-splade-max.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-distill-splade-max.distill-splade-max.topics.msmarco-passage.dev-subset.distill-splade-max.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-distill-splade-max.distill-splade-max.topics.msmarco-passage.dev-subset.distill-splade-max.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-distill-splade-max.distill-splade-max-cached_q.topics.msmarco-passage.dev-subset.distill-splade-max.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-distill-splade-max.distill-splade-max-cached_q.topics.msmarco-passage.dev-subset.distill-splade-max.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-distill-splade-max.distill-splade-max-cached_q.topics.msmarco-passage.dev-subset.distill-splade-max.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-distill-splade-max.distill-splade-max-cached_q.topics.msmarco-passage.dev-subset.distill-splade-max.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-hgf-wp.md
+++ b/docs/regressions/regressions-msmarco-passage-hgf-wp.md
@@ -47,7 +47,7 @@ target/appassembler/bin/SearchCollection \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
   -topicReader TsvInt \
   -output runs/run.msmarco-passage.bm25-default.topics.msmarco-passage.dev-subset.txt \
-  -bm25 -analyzeWithHuggingFaceTokenizer  bert-base-uncased &
+  -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased &
 ```
 
 Evaluation can be performed using `trec_eval`:

--- a/docs/regressions/regressions-msmarco-passage-openai-ada2-int8.md
+++ b/docs/regressions/regressions-msmarco-passage-openai-ada2-int8.md
@@ -80,17 +80,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-openai-ada2-int8/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.openai-ada2.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt \
+  -output runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-openai-ada2.md
+++ b/docs/regressions/regressions-msmarco-passage-openai-ada2.md
@@ -76,17 +76,17 @@ target/appassembler/bin/SearchHnswDenseVectors \
   -index indexes/lucene-hnsw.msmarco-passage-openai-ada2/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.openai-ada2.jsonl.gz \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt \
+  -output runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt \
   -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-openai-ada2.openai-ada2.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-openai-ada2.openai-ada2-cached_q.topics.msmarco-passage.dev-subset.openai-ada2.jsonl.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-splade-pp-ed-onnx.md
+++ b/docs/regressions/regressions-msmarco-passage-splade-pp-ed-onnx.md
@@ -77,17 +77,17 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.txt \
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx.topics.msmarco-passage.dev-subset.txt \
   -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-onnx.topics.msmarco-passage.dev-subset.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-splade-pp-ed.md
+++ b/docs/regressions/regressions-msmarco-passage-splade-pp-ed.md
@@ -77,17 +77,17 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-ed/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.splade-pp-ed.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.splade-pp-ed.txt \
+  -output runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q.topics.msmarco-passage.dev-subset.splade-pp-ed.txt \
   -impact -pretokenized &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-ed.splade-pp-ed-cached_q.topics.msmarco-passage.dev-subset.splade-pp-ed.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-splade-pp-sd-onnx.md
+++ b/docs/regressions/regressions-msmarco-passage-splade-pp-sd-onnx.md
@@ -77,17 +77,17 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.msmarco-passage.dev-subset.txt \
+  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx.topics.msmarco-passage.dev-subset.txt \
   -impact -pretokenized -encoder SpladePlusPlusSelfDistil &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.msmarco-passage.dev-subset.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx.topics.msmarco-passage.dev-subset.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-onnx.topics.msmarco-passage.dev-subset.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-splade-pp-sd.md
+++ b/docs/regressions/regressions-msmarco-passage-splade-pp-sd.md
@@ -77,17 +77,17 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-splade-pp-sd/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.splade-pp-sd.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.msmarco-passage.dev-subset.splade-pp-sd.txt \
+  -output runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q.topics.msmarco-passage.dev-subset.splade-pp-sd.txt \
   -impact -pretokenized &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-pp-sd.splade-pp-sd-cached_q.topics.msmarco-passage.dev-subset.splade-pp-sd.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-unicoil-noexp.md
+++ b/docs/regressions/regressions-msmarco-passage-unicoil-noexp.md
@@ -80,17 +80,17 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil-noexp/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.unicoil-noexp.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp.topics.msmarco-passage.dev-subset.unicoil-noexp.txt \
+  -output runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q.topics.msmarco-passage.dev-subset.unicoil-noexp.txt \
   -impact -pretokenized &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-noexp.unicoil-noexp-cached_q.topics.msmarco-passage.dev-subset.unicoil-noexp.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-unicoil-tilde-expansion.md
+++ b/docs/regressions/regressions-msmarco-passage-unicoil-tilde-expansion.md
@@ -77,17 +77,17 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil-tilde-expansion/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-unicoil-tilde-expansion.unicoil-tilde-expansion.topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.txt \
+  -output runs/run.msmarco-passage-unicoil-tilde-expansion.unicoil-tilde-expansion-cached_q.topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.txt \
   -impact -pretokenized &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-tilde-expansion.unicoil-tilde-expansion.topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-tilde-expansion.unicoil-tilde-expansion.topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-tilde-expansion.unicoil-tilde-expansion.topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-tilde-expansion.unicoil-tilde-expansion.topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-tilde-expansion.unicoil-tilde-expansion-cached_q.topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-tilde-expansion.unicoil-tilde-expansion-cached_q.topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-tilde-expansion.unicoil-tilde-expansion-cached_q.topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil-tilde-expansion.unicoil-tilde-expansion-cached_q.topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.txt
 ```
 
 ## Effectiveness

--- a/docs/regressions/regressions-msmarco-passage-unicoil.md
+++ b/docs/regressions/regressions-msmarco-passage-unicoil.md
@@ -77,17 +77,17 @@ target/appassembler/bin/SearchCollection \
   -index indexes/lucene-index.msmarco-passage-unicoil/ \
   -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.unicoil.tsv.gz \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.txt \
+  -output runs/run.msmarco-passage-unicoil.unicoil-cached_q.topics.msmarco-passage.dev-subset.unicoil.txt \
   -impact -pretokenized &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.txt
-target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.txt
-target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.txt
-target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.unicoil.topics.msmarco-passage.dev-subset.unicoil.txt
+target/appassembler/bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q.topics.msmarco-passage.dev-subset.unicoil.txt
+target/appassembler/bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q.topics.msmarco-passage.dev-subset.unicoil.txt
+target/appassembler/bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q.topics.msmarco-passage.dev-subset.unicoil.txt
+target/appassembler/bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-unicoil.unicoil-cached_q.topics.msmarco-passage.dev-subset.unicoil.txt
 ```
 
 ## Effectiveness

--- a/src/main/python/regressions-batch03.txt
+++ b/src/main/python/regressions-batch03.txt
@@ -1,3 +1,4 @@
+# MS MARCO V1 passage
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-cohere-embed-english-v3.0-hnsw > logs/log.msmarco-passage-cohere-embed-english-v3.0-hnsw 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-cohere-embed-english-v3.0-hnsw-int8 > logs/log.msmarco-passage-cohere-embed-english-v3.0-hnsw-int8 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-bge-base-en-v1.5-hnsw > logs/log.msmarco-passage-bge-base-en-v1.5-hnsw 2>&1
@@ -6,7 +7,6 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-cos-dpr-distil-hnsw-int8 > logs/log.msmarco-passage-cos-dpr-distil-hnsw-int8 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-openai-ada2 > logs/log.msmarco-passage-openai-ada2 2>&1
 
-# MS MARCO V1 passage
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-pp-ed > logs/log.msmarco-passage-splade-pp-ed 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-splade-pp-sd > logs/log.msmarco-passage-splade-pp-sd 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-cos-dpr-distil-fw > logs/log.msmarco-passage-cos-dpr-distil-fw 2>&1
@@ -25,12 +25,6 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-unicoil-tilde-expansion > logs/log.msmarco-passage-unicoil-tilde-expansion 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-passage-distill-splade-max > logs/log.msmarco-passage-distill-splade-max 2>&1
 
-# HNSW search-only
-python src/main/python/run_regression.py --search --regression msmarco-passage-cos-dpr-distil-hnsw-onnx > logs/log.msmarco-passage-cos-dpr-distil-hnsw-onnx 2>&1
-python src/main/python/run_regression.py --search --regression msmarco-passage-cos-dpr-distil-hnsw-int8-onnx > logs/log.msmarco-passage-cos-dpr-distil-hnsw-int8-onnx 2>&1
-python src/main/python/run_regression.py --search --regression msmarco-passage-bge-base-en-v1.5-hnsw-onnx > logs/log.msmarco-passage-bge-base-en-v1.5-hnsw-onnx 2>&1
-python src/main/python/run_regression.py --search --regression msmarco-passage-bge-base-en-v1.5-hnsw-int8-onnx > logs/log.msmarco-passage-bge-base-en-v1.5-hnsw-int8-onnx 2>&1
-
 # MS MARCO V1 doc
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc > logs/log.msmarco-doc 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc-wp > logs/log.msmarco-doc-wp 2>&1
@@ -43,45 +37,6 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc-segmented-docTTTTTquery > logs/log.msmarco-doc-segmented-docTTTTTquery 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc-segmented-unicoil > logs/log.msmarco-doc-segmented-unicoil 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-doc-segmented-unicoil-noexp > logs/log.msmarco-doc-segmented-unicoil-noexp 2>&1
-
-# MS MARCO V1 passage ONNX runs - uses same index, so need to make sure previous runs finish
-python src/main/python/run_regression.py --search --regression msmarco-passage-splade-pp-ed-onnx > logs/log.msmarco-passage-splade-pp-ed-onnx 2>&1
-python src/main/python/run_regression.py --search --regression msmarco-passage-splade-pp-sd-onnx > logs/log.msmarco-passage-splade-pp-sd-onnx 2>&1
-
-# MIRACL
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ar > logs/log.miracl-v1.0-ar 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-bn > logs/log.miracl-v1.0-bn 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-en > logs/log.miracl-v1.0-en 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-es > logs/log.miracl-v1.0-es 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-fa > logs/log.miracl-v1.0-fa 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-fi > logs/log.miracl-v1.0-fi 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-fr > logs/log.miracl-v1.0-fr 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-hi > logs/log.miracl-v1.0-hi 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-id > logs/log.miracl-v1.0-id 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ja > logs/log.miracl-v1.0-ja 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ko > logs/log.miracl-v1.0-ko 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ru > logs/log.miracl-v1.0-ru 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-sw > logs/log.miracl-v1.0-sw 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-te > logs/log.miracl-v1.0-te 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-th > logs/log.miracl-v1.0-th 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-zh > logs/log.miracl-v1.0-zh 2>&1
-
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ar-aca > logs/log.miracl-v1.0-ar-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-bn-aca > logs/log.miracl-v1.0-bn-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-en-aca > logs/log.miracl-v1.0-en-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-es-aca > logs/log.miracl-v1.0-es-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-fa-aca > logs/log.miracl-v1.0-fa-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-fi-aca > logs/log.miracl-v1.0-fi-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-fr-aca > logs/log.miracl-v1.0-fr-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-hi-aca > logs/log.miracl-v1.0-hi-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-id-aca > logs/log.miracl-v1.0-id-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ja-aca > logs/log.miracl-v1.0-ja-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ko-aca > logs/log.miracl-v1.0-ko-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ru-aca > logs/log.miracl-v1.0-ru-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-sw-aca > logs/log.miracl-v1.0-sw-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-te-aca > logs/log.miracl-v1.0-te-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-th-aca > logs/log.miracl-v1.0-th-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-zh-aca > logs/log.miracl-v1.0-zh-aca 2>&1
 
 # MS MARCO V2 passage
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v2-passage-splade-pp-ed > logs/log.msmarco-v2-passage-splade-pp-ed 2>&1
@@ -106,30 +61,13 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v2-doc-segmented-unicoil-0shot > logs/log.msmarco-v2-doc-segmented-unicoil-0shot 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v2-doc-segmented-unicoil-0shot-v2 > logs/log.msmarco-v2-doc-segmented-unicoil-0shot-v2 2>&1
 
-# Mr.TyDi
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-ar > logs/log.mrtydi-v1.1-ar 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-bn > logs/log.mrtydi-v1.1-bn 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-en > logs/log.mrtydi-v1.1-en 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-fi > logs/log.mrtydi-v1.1-fi 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-id > logs/log.mrtydi-v1.1-id 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-ja > logs/log.mrtydi-v1.1-ja 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-ko > logs/log.mrtydi-v1.1-ko 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-ru > logs/log.mrtydi-v1.1-ru 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-sw > logs/log.mrtydi-v1.1-sw 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-te > logs/log.mrtydi-v1.1-te 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-th > logs/log.mrtydi-v1.1-th 2>&1
-
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-ar-aca > logs/log.mrtydi-v1.1-ar-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-bn-aca > logs/log.mrtydi-v1.1-bn-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-en-aca > logs/log.mrtydi-v1.1-en-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-fi-aca > logs/log.mrtydi-v1.1-fi-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-id-aca > logs/log.mrtydi-v1.1-id-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-ja-aca > logs/log.mrtydi-v1.1-ja-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-ko-aca > logs/log.mrtydi-v1.1-ko-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-ru-aca > logs/log.mrtydi-v1.1-ru-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-sw-aca > logs/log.mrtydi-v1.1-sw-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-te-aca > logs/log.mrtydi-v1.1-te-aca 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-th-aca > logs/log.mrtydi-v1.1-th-aca 2>&1
+# MS MARCO V1 passage search-only
+python src/main/python/run_regression.py --search --regression msmarco-passage-cos-dpr-distil-hnsw-onnx > logs/log.msmarco-passage-cos-dpr-distil-hnsw-onnx 2>&1
+python src/main/python/run_regression.py --search --regression msmarco-passage-cos-dpr-distil-hnsw-int8-onnx > logs/log.msmarco-passage-cos-dpr-distil-hnsw-int8-onnx 2>&1
+python src/main/python/run_regression.py --search --regression msmarco-passage-bge-base-en-v1.5-hnsw-onnx > logs/log.msmarco-passage-bge-base-en-v1.5-hnsw-onnx 2>&1
+python src/main/python/run_regression.py --search --regression msmarco-passage-bge-base-en-v1.5-hnsw-int8-onnx > logs/log.msmarco-passage-bge-base-en-v1.5-hnsw-int8-onnx 2>&1
+python src/main/python/run_regression.py --search --regression msmarco-passage-splade-pp-ed-onnx > logs/log.msmarco-passage-splade-pp-ed-onnx 2>&1
+python src/main/python/run_regression.py --search --regression msmarco-passage-splade-pp-sd-onnx > logs/log.msmarco-passage-splade-pp-sd-onnx 2>&1
 
 # DL19
 python src/main/python/run_regression.py --search --regression dl19-passage > logs/log.dl19-passage 2>&1
@@ -155,6 +93,12 @@ python src/main/python/run_regression.py --search --regression dl19-passage-unic
 python src/main/python/run_regression.py --search --regression dl19-passage-unicoil-noexp > logs/log.dl19-passage-unicoil-noexp 2>&1
 python src/main/python/run_regression.py --search --regression dl19-passage-splade-pp-ed > logs/log.dl19-passage-splade-pp-ed 2>&1
 python src/main/python/run_regression.py --search --regression dl19-passage-splade-pp-sd > logs/log.dl19-passage-splade-pp-sd 2>&1
+
+python src/main/python/run_regression.py --search --regression dl19-passage-cos-dpr-distil-hnsw-onnx > logs/log.dl19-passage-cos-dpr-distil-hnsw-onnx 2>&1
+python src/main/python/run_regression.py --search --regression dl19-passage-cos-dpr-distil-hnsw-int8-onnx > logs/log.dl19-passage-cos-dpr-distil-hnsw-int8-onnx 2>&1
+
+python src/main/python/run_regression.py --search --regression dl19-passage-bge-base-en-v1.5-hnsw-onnx > logs/log.dl19-passage-bge-base-en-v1.5-hnsw-onnx 2>&1
+python src/main/python/run_regression.py --search --regression dl19-passage-bge-base-en-v1.5-hnsw-int8-onnx > logs/log.dl19-passage-bge-base-en-v1.5-hnsw-int8-onnx 2>&1
 
 python src/main/python/run_regression.py --search --regression dl19-doc > logs/log.dl19-doc 2>&1
 python src/main/python/run_regression.py --search --regression dl19-doc-ca > logs/log.dl19-doc-ca 2>&1
@@ -194,6 +138,12 @@ python src/main/python/run_regression.py --search --regression dl20-passage-unic
 python src/main/python/run_regression.py --search --regression dl20-passage-splade-pp-ed > logs/log.dl20-passage-splade-pp-ed 2>&1
 python src/main/python/run_regression.py --search --regression dl20-passage-splade-pp-sd > logs/log.dl20-passage-splade-pp-sd 2>&1
 
+python src/main/python/run_regression.py --search --regression dl20-passage-cos-dpr-distil-hnsw-onnx > logs/log.dl20-passage-cos-dpr-distil-hnsw-onnx 2>&1
+python src/main/python/run_regression.py --search --regression dl20-passage-cos-dpr-distil-hnsw-int8-onnx > logs/log.dl20-passage-cos-dpr-distil-hnsw-int8-onnx 2>&1
+
+python src/main/python/run_regression.py --search --regression dl20-passage-bge-base-en-v1.5-hnsw-onnx > logs/log.dl20-passage-bge-base-en-v1.5-hnsw-onnx 2>&1
+python src/main/python/run_regression.py --search --regression dl20-passage-bge-base-en-v1.5-hnsw-int8-onnx > logs/log.dl20-passage-bge-base-en-v1.5-hnsw-int8-onnx 2>&1
+
 python src/main/python/run_regression.py --search --regression dl20-doc > logs/log.dl20-doc 2>&1
 python src/main/python/run_regression.py --search --regression dl20-doc-ca > logs/log.dl20-doc-ca 2>&1
 python src/main/python/run_regression.py --search --regression dl20-doc-wp > logs/log.dl20-doc-wp 2>&1
@@ -206,17 +156,6 @@ python src/main/python/run_regression.py --search --regression dl20-doc-segmente
 python src/main/python/run_regression.py --search --regression dl20-doc-segmented-docTTTTTquery > logs/log.dl20-doc-segmented-docTTTTTquery 2>&1
 python src/main/python/run_regression.py --search --regression dl20-doc-segmented-unicoil > logs/log.dl20-doc-segmented-unicoil 2>&1
 python src/main/python/run_regression.py --search --regression dl20-doc-segmented-unicoil-noexp > logs/log.dl20-doc-segmented-unicoil-noexp 2>&1
-
-# We need to offset the ONNX runs since they write to the same run files.
-python src/main/python/run_regression.py --search --regression dl19-passage-cos-dpr-distil-hnsw-onnx > logs/log.dl19-passage-cos-dpr-distil-hnsw-onnx 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage-cos-dpr-distil-hnsw-int8-onnx > logs/log.dl19-passage-cos-dpr-distil-hnsw-int8-onnx 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage-cos-dpr-distil-hnsw-onnx > logs/log.dl20-passage-cos-dpr-distil-hnsw-onnx 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage-cos-dpr-distil-hnsw-int8-onnx > logs/log.dl20-passage-cos-dpr-distil-hnsw-int8-onnx 2>&1
-
-python src/main/python/run_regression.py --search --regression dl19-passage-bge-base-en-v1.5-hnsw-onnx > logs/log.dl19-passage-bge-base-en-v1.5-hnsw-onnx 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage-bge-base-en-v1.5-hnsw-int8-onnx > logs/log.dl19-passage-bge-base-en-v1.5-hnsw-int8-onnx 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage-bge-base-en-v1.5-hnsw-onnx > logs/log.dl20-passage-bge-base-en-v1.5-hnsw-onnx 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage-bge-base-en-v1.5-hnsw-int8-onnx > logs/log.dl20-passage-bge-base-en-v1.5-hnsw-int8-onnx 2>&1
 
 # DL21/22
 python src/main/python/run_regression.py --search --regression dl21-passage > logs/log.dl21-passage 2>&1
@@ -262,14 +201,3 @@ python src/main/python/run_regression.py --search --regression dl23-doc > logs/l
 python src/main/python/run_regression.py --search --regression dl23-doc-d2q-t5 > logs/log.dl23-doc-d2q-t5 2>&1
 python src/main/python/run_regression.py --search --regression dl23-doc-segmented > logs/log.dl23-doc-segmented 2>&1
 python src/main/python/run_regression.py --search --regression dl23-doc-segmented-d2q-t5 > logs/log.dl23-doc-segmented-d2q-t5 2>&1
-
-# CIRAL
-python src/main/python/run_regression.py --index --verify --search --regression ciral-v1.0-ha > logs/log.ciral-v1.0-ha 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression ciral-v1.0-so > logs/log.ciral-v1.0-so 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression ciral-v1.0-sw > logs/log.ciral-v1.0-sw 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression ciral-v1.0-yo > logs/log.ciral-v1.0-yo 2>&1
-
-python src/main/python/run_regression.py --index --verify --search --regression ciral-v1.0-ha-en > logs/log.ciral-v1.0-ha-en 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression ciral-v1.0-so-en > logs/log.ciral-v1.0-so-en 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression ciral-v1.0-sw-en > logs/log.ciral-v1.0-sw-en 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression ciral-v1.0-yo-en > logs/log.ciral-v1.0-yo-en 2>&1

--- a/src/main/python/regressions-batch04.txt
+++ b/src/main/python/regressions-batch04.txt
@@ -298,6 +298,77 @@ python src/main/python/run_regression.py --search --regression beir-v1.0.0-fever
 python src/main/python/run_regression.py --search --regression beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw-int8 > logs/log.beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw-int8 2>&1
 python src/main/python/run_regression.py --search --regression beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw-int8 > logs/log.beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw-int8 2>&1
 
+# MIRACL
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ar > logs/log.miracl-v1.0-ar 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-bn > logs/log.miracl-v1.0-bn 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-en > logs/log.miracl-v1.0-en 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-es > logs/log.miracl-v1.0-es 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-fa > logs/log.miracl-v1.0-fa 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-fi > logs/log.miracl-v1.0-fi 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-fr > logs/log.miracl-v1.0-fr 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-hi > logs/log.miracl-v1.0-hi 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-id > logs/log.miracl-v1.0-id 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ja > logs/log.miracl-v1.0-ja 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ko > logs/log.miracl-v1.0-ko 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ru > logs/log.miracl-v1.0-ru 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-sw > logs/log.miracl-v1.0-sw 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-te > logs/log.miracl-v1.0-te 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-th > logs/log.miracl-v1.0-th 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-zh > logs/log.miracl-v1.0-zh 2>&1
+
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ar-aca > logs/log.miracl-v1.0-ar-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-bn-aca > logs/log.miracl-v1.0-bn-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-en-aca > logs/log.miracl-v1.0-en-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-es-aca > logs/log.miracl-v1.0-es-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-fa-aca > logs/log.miracl-v1.0-fa-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-fi-aca > logs/log.miracl-v1.0-fi-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-fr-aca > logs/log.miracl-v1.0-fr-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-hi-aca > logs/log.miracl-v1.0-hi-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-id-aca > logs/log.miracl-v1.0-id-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ja-aca > logs/log.miracl-v1.0-ja-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ko-aca > logs/log.miracl-v1.0-ko-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ru-aca > logs/log.miracl-v1.0-ru-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-sw-aca > logs/log.miracl-v1.0-sw-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-te-aca > logs/log.miracl-v1.0-te-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-th-aca > logs/log.miracl-v1.0-th-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-zh-aca > logs/log.miracl-v1.0-zh-aca 2>&1
+
+# Mr.TyDi
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-ar > logs/log.mrtydi-v1.1-ar 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-bn > logs/log.mrtydi-v1.1-bn 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-en > logs/log.mrtydi-v1.1-en 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-fi > logs/log.mrtydi-v1.1-fi 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-id > logs/log.mrtydi-v1.1-id 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-ja > logs/log.mrtydi-v1.1-ja 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-ko > logs/log.mrtydi-v1.1-ko 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-ru > logs/log.mrtydi-v1.1-ru 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-sw > logs/log.mrtydi-v1.1-sw 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-te > logs/log.mrtydi-v1.1-te 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-th > logs/log.mrtydi-v1.1-th 2>&1
+
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-ar-aca > logs/log.mrtydi-v1.1-ar-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-bn-aca > logs/log.mrtydi-v1.1-bn-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-en-aca > logs/log.mrtydi-v1.1-en-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-fi-aca > logs/log.mrtydi-v1.1-fi-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-id-aca > logs/log.mrtydi-v1.1-id-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-ja-aca > logs/log.mrtydi-v1.1-ja-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-ko-aca > logs/log.mrtydi-v1.1-ko-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-ru-aca > logs/log.mrtydi-v1.1-ru-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-sw-aca > logs/log.mrtydi-v1.1-sw-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-te-aca > logs/log.mrtydi-v1.1-te-aca 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression mrtydi-v1.1-th-aca > logs/log.mrtydi-v1.1-th-aca 2>&1
+
+# CIRAL
+python src/main/python/run_regression.py --index --verify --search --regression ciral-v1.0-ha > logs/log.ciral-v1.0-ha 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression ciral-v1.0-so > logs/log.ciral-v1.0-so 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression ciral-v1.0-sw > logs/log.ciral-v1.0-sw 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression ciral-v1.0-yo > logs/log.ciral-v1.0-yo 2>&1
+
+python src/main/python/run_regression.py --index --verify --search --regression ciral-v1.0-ha-en > logs/log.ciral-v1.0-ha-en 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression ciral-v1.0-so-en > logs/log.ciral-v1.0-so-en 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression ciral-v1.0-sw-en > logs/log.ciral-v1.0-sw-en 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression ciral-v1.0-yo-en > logs/log.ciral-v1.0-yo-en 2>&1
+
 # CAR: start with these because the first two are single-threaded and super slow
 python src/main/python/run_regression.py --index --verify --search --regression car17v1.5 > logs/log.car17v1.5 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression car17v2.0 > logs/log.car17v2.0 2>&1

--- a/src/main/python/run_regression.py
+++ b/src/main/python/run_regression.py
@@ -140,7 +140,7 @@ def construct_indexing_command(yaml_data, args):
 
 def construct_runfile_path(index, id, model_name):
     # If the index is 'indexes/lucene-index.msmarco-passage-ca/', we pull out 'msmarco-passage-ca'.
-    # Be careful, for 'indexes/lucene-index.mrtydi-v1.1-arabic/', we want to pull out 'lucene-index.mrtydi-v1.1-arabic'.
+    # Be careful, for 'indexes/lucene-index.mrtydi-v1.1-arabic/', we want to pull out 'mrtydi-v1.1-arabic'.
     index_part = index.split('/')[1].split('.', 1)[1]
     return os.path.join('runs/', 'run.{0}.{1}.{2}'.format(index_part, id, model_name))
 

--- a/src/main/resources/regression/dl19-doc-hgf-wp.yaml
+++ b/src/main/resources/regression/dl19-doc-hgf-wp.yaml
@@ -52,7 +52,7 @@ topics:
 models:
   - name: bm25-default
     display: BM25 (default)
-    params: -bm25 -analyzeWithHuggingFaceTokenizer  bert-base-uncased
+    params: -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased
     results:
       AP@100:
         - 0.1947

--- a/src/main/resources/regression/dl19-doc-segmented-unicoil-noexp.yaml
+++ b/src/main/resources/regression/dl19-doc-segmented-unicoil-noexp.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.dl19-doc.txt
 
 models:
-  - name: unicoil
+  - name: unicoil-noexp-cached_q
     display: uniCOIL (no expansions)
     params: -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:
@@ -65,7 +65,7 @@ models:
         - 0.3943
       R@1000:
         - 0.6391
-  - name: rm3
+  - name: unicoil-cached_q+rm3
     display: +RM3
     params: -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:
@@ -77,7 +77,7 @@ models:
         - 0.4347
       R@1000:
         - 0.6909
-  - name: rocchio
+  - name: unicoil-cached_q+rocchio
     display: +Rocchio
     params: -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:

--- a/src/main/resources/regression/dl19-doc-segmented-unicoil.yaml
+++ b/src/main/resources/regression/dl19-doc-segmented-unicoil.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.dl19-doc.txt
 
 models:
-  - name: unicoil
+  - name: unicoil-cached_q
     display: uniCOIL (with doc2query-T5 expansions)
     params: -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:
@@ -65,7 +65,7 @@ models:
         - 0.4099
       R@1000:
         - 0.6652
-  - name: rm3
+  - name: unicoil-cached_q+rm3
     display: +RM3
     params: -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:
@@ -77,7 +77,7 @@ models:
         - 0.4501
       R@1000:
         - 0.7275
-  - name: rocchio
+  - name: unicoil-cached_q+rocchio
     display: +Rocchio
     params: -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:

--- a/src/main/resources/regression/dl19-passage-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/dl19-passage-bge-base-en-v1.5-hnsw-int8.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl19-passage.txt
 
 models:
-  - name: bge-hnsw
+  - name: bge-hnsw-cached_q
     display: BGE-base-en-v1.5
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/dl19-passage-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/dl19-passage-bge-base-en-v1.5-hnsw.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl19-passage.txt
 
 models:
-  - name: bge-hnsw
+  - name: bge-hnsw-cached_q
     display: BGE-base-en-v1.5
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/dl19-passage-cohere-embed-english-v3.0-hnsw-int8.yaml
+++ b/src/main/resources/regression/dl19-passage-cohere-embed-english-v3.0-hnsw-int8.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl19-passage.txt
 
 models:
-  - name: cohere-embed-english-v3.0
+  - name: cohere-embed-english-v3.0-cached_q
     display: cohere-embed-english-v3.0
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/dl19-passage-cohere-embed-english-v3.0-hnsw.yaml
+++ b/src/main/resources/regression/dl19-passage-cohere-embed-english-v3.0-hnsw.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl19-passage.txt
 
 models:
-  - name: cohere-embed-english-v3.0
+  - name: cohere-embed-english-v3.0-cached_q
     display: cohere-embed-english-v3.0
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/dl19-passage-cos-dpr-distil-fw.yaml
+++ b/src/main/resources/regression/dl19-passage-cos-dpr-distil-fw.yaml
@@ -54,7 +54,7 @@ topics:
     qrel: qrels.dl19-passage.txt
 
 models:
-  - name: cos-dpr-distil-fw-40
+  - name: cos-dpr-distil-fw-40-cached_q
     display: cosDPR-distill
     type: inverted-dense
     params: -topicField vector -threads 16 -encoding fw -fw.q 40 -hits 1000

--- a/src/main/resources/regression/dl19-passage-cos-dpr-distil-hnsw-int8.yaml
+++ b/src/main/resources/regression/dl19-passage-cos-dpr-distil-hnsw-int8.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl19-passage.txt
 
 models:
-  - name: cos-dpr-distil-hnsw
+  - name: cos-dpr-distil-hnsw-cached_q
     display: cosDPR-distil
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/dl19-passage-cos-dpr-distil-hnsw.yaml
+++ b/src/main/resources/regression/dl19-passage-cos-dpr-distil-hnsw.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl19-passage.txt
 
 models:
-  - name: cos-dpr-distil-hnsw
+  - name: cos-dpr-distil-hnsw-cached_q
     display: cosDPR-distil
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/dl19-passage-cos-dpr-distil-lexlsh.yaml
+++ b/src/main/resources/regression/dl19-passage-cos-dpr-distil-lexlsh.yaml
@@ -54,7 +54,7 @@ topics:
     qrel: qrels.dl19-passage.txt
 
 models:
-  - name: cos-dpr-distil-lexlsh-600
+  - name: cos-dpr-distil-lexlsh-600-cached_q
     display: cosDPR-distill
     type: inverted-dense
     params: -topicField vector -threads 16 -encoding lexlsh -lexlsh.b 600 -hits 1000

--- a/src/main/resources/regression/dl19-passage-hgf-wp.yaml
+++ b/src/main/resources/regression/dl19-passage-hgf-wp.yaml
@@ -52,7 +52,7 @@ topics:
 models:
   - name: bm25-default
     display: BM25 (default)
-    params: -bm25 -analyzeWithHuggingFaceTokenizer  bert-base-uncased
+    params: -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased
     results:
       AP@1000:
         - 0.2367

--- a/src/main/resources/regression/dl19-passage-openai-ada2-int8.yaml
+++ b/src/main/resources/regression/dl19-passage-openai-ada2-int8.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl19-passage.txt
 
 models:
-  - name: openai-ada2
+  - name: openai-ada2-cached_q
     display: OpenAI-ada2
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/dl19-passage-openai-ada2.yaml
+++ b/src/main/resources/regression/dl19-passage-openai-ada2.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl19-passage.txt
 
 models:
-  - name: openai-ada2
+  - name: openai-ada2-cached_q
     display: OpenAI-ada2
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/dl19-passage-splade-pp-ed-onnx.yaml
+++ b/src/main/resources/regression/dl19-passage-splade-pp-ed-onnx.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.dl19-passage.txt
 
 models:
-  - name: splade-pp-ed
+  - name: splade-pp-ed-onnx
     display: SPLADE++ CoCondenser-EnsembleDistil
     params: -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil
     results:
@@ -65,7 +65,7 @@ models:
         - 0.6390
       R@1000:
         - 0.8728
-  - name: rm3
+  - name: splade-pp-ed-onnx+rm3
     display: +RM3
     params: -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil -rm3
     results:
@@ -77,7 +77,7 @@ models:
         - 0.6427
       R@1000:
         - 0.8684
-  - name: rocchio
+  - name: splade-pp-ed-onnx+rocchio
     display: +Rocchio
     params: -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil -rocchio
     results:

--- a/src/main/resources/regression/dl19-passage-splade-pp-ed.yaml
+++ b/src/main/resources/regression/dl19-passage-splade-pp-ed.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.dl19-passage.txt
 
 models:
-  - name: splade-pp-ed
+  - name: splade-pp-ed-cached_q
     display: SPLADE++ CoCondenser-EnsembleDistil
     params: -impact -pretokenized
     results:
@@ -65,7 +65,7 @@ models:
         - 0.6390
       R@1000:
         - 0.8726
-  - name: rm3
+  - name: splade-pp-ed-cached_q+rm3
     display: +RM3
     params: -impact -pretokenized -rm3
     results:
@@ -77,7 +77,7 @@ models:
         - 0.6425
       R@1000:
         - 0.8684
-  - name: rocchio
+  - name: splade-pp-ed-cached_q+rocchio
     display: +Rocchio
     params: -impact -pretokenized -rocchio
     results:

--- a/src/main/resources/regression/dl19-passage-splade-pp-sd-onnx.yaml
+++ b/src/main/resources/regression/dl19-passage-splade-pp-sd-onnx.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.dl19-passage.txt
 
 models:
-  - name: splade-pp-sd
+  - name: splade-pp-sd-onnx
     display: SPLADE++ CoCondenser-SelfDistil
     params: -impact -pretokenized -encoder SpladePlusPlusSelfDistil
     results:
@@ -65,7 +65,7 @@ models:
         - 0.6370
       R@1000:
         - 0.8761
-  - name: rm3
+  - name: splade-pp-sd-onnx+rm3
     display: +RM3
     params: -impact -pretokenized -rm3 -encoder SpladePlusPlusSelfDistil
     results:
@@ -77,7 +77,7 @@ models:
         - 0.6456
       R@1000:
         - 0.8793
-  - name: rocchio
+  - name: splade-pp-sd-onnx+rocchio
     display: +Rocchio
     params: -impact -pretokenized -rocchio -encoder SpladePlusPlusSelfDistil
     results:

--- a/src/main/resources/regression/dl19-passage-splade-pp-sd.yaml
+++ b/src/main/resources/regression/dl19-passage-splade-pp-sd.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.dl19-passage.txt
 
 models:
-  - name: splade-pp-sd
+  - name: splade-pp-sd-cached_q
     display: SPLADE++ CoCondenser-SelfDistil
     params: -impact -pretokenized
     results:
@@ -65,7 +65,7 @@ models:
         - 0.6353
       R@1000:
         - 0.8758
-  - name: rm3
+  - name: splade-pp-sd-cached_q+rm3
     display: +RM3
     params: -impact -pretokenized -rm3
     results:
@@ -77,7 +77,7 @@ models:
         - 0.6456
       R@1000:
         - 0.8793
-  - name: rocchio
+  - name: splade-pp-sd-cached_q+rocchio
     display: +Rocchio
     params: -impact -pretokenized -rocchio
     results:

--- a/src/main/resources/regression/dl19-passage-unicoil-noexp.yaml
+++ b/src/main/resources/regression/dl19-passage-unicoil-noexp.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.dl19-passage.txt
 
 models:
-  - name: unicoil
+  - name: unicoil-noexp-cached_q
     display: uniCOIL (no expansions)
     params: -impact -pretokenized
     results:
@@ -65,7 +65,7 @@ models:
         - 0.5629
       R@1000:
         - 0.7752
-  - name: rm3
+  - name: unicoil-noexp-cached_q+rm3
     display: +RM3
     params: -impact -pretokenized -rm3
     results:
@@ -77,7 +77,7 @@ models:
         - 0.5915
       R@1000:
         - 0.8019
-  - name: rocchio
+  - name: unicoil-noexp-cached_q+rocchio
     display: +Rocchio
     params: -impact -pretokenized -rocchio
     results:

--- a/src/main/resources/regression/dl19-passage-unicoil.yaml
+++ b/src/main/resources/regression/dl19-passage-unicoil.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.dl19-passage.txt
 
 models:
-  - name: unicoil
+  - name: unicoil-cached_q
     display: uniCOIL (with doc2query-T5 expansions)
     params: -impact -pretokenized
     results:
@@ -65,7 +65,7 @@ models:
         - 0.6054
       R@1000:
         - 0.8292
-  - name: rm3
+  - name: unicoil-cached_q+rm3
     display: +RM3
     params: -impact -pretokenized -rm3
     results:
@@ -77,7 +77,7 @@ models:
         - 0.6207
       R@1000:
         - 0.8598
-  - name: rocchio
+  - name: unicoil-cached_q+rocchio
     display: +Rocchio
     params: -impact -pretokenized -rocchio
     results:

--- a/src/main/resources/regression/dl20-doc-hgf-wp.yaml
+++ b/src/main/resources/regression/dl20-doc-hgf-wp.yaml
@@ -52,7 +52,7 @@ topics:
 models:
   - name: bm25-default
     display: BM25 (default)
-    params: -bm25 -analyzeWithHuggingFaceTokenizer  bert-base-uncased
+    params: -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased
     results:
       AP@100:
         - 0.3258

--- a/src/main/resources/regression/dl20-doc-segmented-unicoil-noexp.yaml
+++ b/src/main/resources/regression/dl20-doc-segmented-unicoil-noexp.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.dl20-doc.txt
 
 models:
-  - name: unicoil
+  - name: unicoil-noexp-cached_q
     display: uniCOIL w/ doc2query-T5 expansion
     params: -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:
@@ -65,7 +65,7 @@ models:
         - 0.5872
       R@1000:
         - 0.7623
-  - name: rm3
+  - name: unicoil-noexp-cached_q+rm3
     display: +RM3
     params: -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:
@@ -77,7 +77,7 @@ models:
         - 0.6381
       R@1000:
         - 0.8117
-  - name: rocchio
+  - name: unicoil-noexp-cached_q+rocchio
     display: +Rocchio
     params: -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:

--- a/src/main/resources/regression/dl20-doc-segmented-unicoil.yaml
+++ b/src/main/resources/regression/dl20-doc-segmented-unicoil.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.dl20-doc.txt
 
 models:
-  - name: unicoil
+  - name: unicoil-cached_q
     display: uniCOIL w/ doc2query-T5 expansion
     params: -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:
@@ -65,7 +65,7 @@ models:
         - 0.6210
       R@1000:
         - 0.7869
-  - name: rm3
+  - name: unicoil-cached_q+rm3
     display: +RM3
     params: -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:
@@ -77,7 +77,7 @@ models:
         - 0.6499
       R@1000:
         - 0.8229
-  - name: rocchio
+  - name: unicoil-cached_q+rocchio
     display: +Rocchio
     params: -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:

--- a/src/main/resources/regression/dl20-passage-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/dl20-passage-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: bge-hnsw
+  - name: bge-hnsw-onnx
     display: BGE-base-en-v1.5
     type: hnsw
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15

--- a/src/main/resources/regression/dl20-passage-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/dl20-passage-bge-base-en-v1.5-hnsw-int8.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: bge-hnsw
+  - name: bge-hnsw-cached_q
     display: BGE-base-en-v1.5
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/dl20-passage-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/dl20-passage-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: bge-hnsw
+  - name: bge-hnsw-onnx
     display: BGE-base-en-v1.5
     type: hnsw
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15

--- a/src/main/resources/regression/dl20-passage-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/dl20-passage-bge-base-en-v1.5-hnsw.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: bge-hnsw
+  - name: bge-hnsw-cached_q
     display: BGE-base-en-v1.5
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/dl20-passage-cohere-embed-english-v3.0-hnsw-int8.yaml
+++ b/src/main/resources/regression/dl20-passage-cohere-embed-english-v3.0-hnsw-int8.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: cohere-embed-english-v3.0
+  - name: cohere-embed-english-v3.0-cached_q
     display: cohere-embed-english-v3.0
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/dl20-passage-cohere-embed-english-v3.0-hnsw.yaml
+++ b/src/main/resources/regression/dl20-passage-cohere-embed-english-v3.0-hnsw.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: cohere-embed-english-v3.0
+  - name: cohere-embed-english-v3.0-cached_q
     display: cohere-embed-english-v3.0
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/dl20-passage-cos-dpr-distil-fw.yaml
+++ b/src/main/resources/regression/dl20-passage-cos-dpr-distil-fw.yaml
@@ -54,7 +54,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: cos-dpr-distil-fw-40
+  - name: cos-dpr-distil-fw-40-cached_q
     display: cosDPR-distill
     type: inverted-dense
     params: -topicField vector -threads 16 -encoding fw -fw.q 40 -hits 1000

--- a/src/main/resources/regression/dl20-passage-cos-dpr-distil-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/dl20-passage-cos-dpr-distil-hnsw-int8-onnx.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: cos-dpr-distil-hnsw
+  - name: cos-dpr-distil-hnsw-onnx
     display: cosDPR-distil
     type: hnsw
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder CosDprDistil

--- a/src/main/resources/regression/dl20-passage-cos-dpr-distil-hnsw-int8.yaml
+++ b/src/main/resources/regression/dl20-passage-cos-dpr-distil-hnsw-int8.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: cos-dpr-distil-hnsw
+  - name: cos-dpr-distil-hnsw-cached_q
     display: cosDPR-distil
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/dl20-passage-cos-dpr-distil-hnsw-onnx.yaml
+++ b/src/main/resources/regression/dl20-passage-cos-dpr-distil-hnsw-onnx.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: cos-dpr-distil-hnsw
+  - name: cos-dpr-distil-hnsw-onnx
     display: cosDPR-distil
     type: hnsw
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder CosDprDistil

--- a/src/main/resources/regression/dl20-passage-cos-dpr-distil-hnsw.yaml
+++ b/src/main/resources/regression/dl20-passage-cos-dpr-distil-hnsw.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: cos-dpr-distil-hnsw
+  - name: cos-dpr-distil-hnsw-cached_q
     display: cosDPR-distil
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/dl20-passage-cos-dpr-distil-lexlsh.yaml
+++ b/src/main/resources/regression/dl20-passage-cos-dpr-distil-lexlsh.yaml
@@ -54,7 +54,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: cos-dpr-distil-lexlsh-600
+  - name: cos-dpr-distil-lexlsh-600-cached_q
     display: cosDPR-distill
     type: inverted-dense
     params: -topicField vector -threads 16 -encoding lexlsh -lexlsh.b 600 -hits 1000

--- a/src/main/resources/regression/dl20-passage-hgf-wp.yaml
+++ b/src/main/resources/regression/dl20-passage-hgf-wp.yaml
@@ -52,7 +52,7 @@ topics:
 models:
   - name: bm25-default
     display: BM25 (default)
-    params: -bm25 -analyzeWithHuggingFaceTokenizer  bert-base-uncased
+    params: -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased
     results:
       AP@1000:
         - 0.2606

--- a/src/main/resources/regression/dl20-passage-openai-ada2-int8.yaml
+++ b/src/main/resources/regression/dl20-passage-openai-ada2-int8.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: openai-ada2
+  - name: openai-ada2-cached_q
     display: OpenAI-ada2
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/dl20-passage-openai-ada2.yaml
+++ b/src/main/resources/regression/dl20-passage-openai-ada2.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: openai-ada2
+  - name: openai-ada2-cached_q
     display: OpenAI-ada2
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/dl20-passage-splade-pp-ed-onnx.yaml
+++ b/src/main/resources/regression/dl20-passage-splade-pp-ed-onnx.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: splade-pp-ed
+  - name: splade-pp-ed-onnx
     display: SPLADE++ CoCondenser-EnsembleDistil
     params: -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil
     results:
@@ -65,7 +65,7 @@ models:
         - 0.7653
       R@1000:
         - 0.8998
-  - name: rm3
+  - name: splade-pp-ed-onnx+rm3
     display: +RM3
     params: -impact -pretokenized -rm3 -encoder SpladePlusPlusEnsembleDistil
     results:
@@ -77,7 +77,7 @@ models:
         - 0.7555
       R@1000:
         - 0.9046
-  - name: rocchio
+  - name: splade-pp-ed-onnx+rocchio
     display: +Rocchio
     params: -impact -pretokenized -rocchio -encoder SpladePlusPlusEnsembleDistil
     results:

--- a/src/main/resources/regression/dl20-passage-splade-pp-ed.yaml
+++ b/src/main/resources/regression/dl20-passage-splade-pp-ed.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: splade-pp-ed
+  - name: splade-pp-ed-cached_q
     display: SPLADE++ CoCondenser-EnsembleDistil
     params: -impact -pretokenized
     results:
@@ -65,7 +65,7 @@ models:
         - 0.7653
       R@1000:
         - 0.8995
-  - name: rm3
+  - name: splade-pp-ed-cached_q+rm3
     display: +RM3
     params: -impact -pretokenized -rm3
     results:
@@ -77,7 +77,7 @@ models:
         - 0.7553
       R@1000:
         - 0.9046
-  - name: rocchio
+  - name: splade-pp-ed-cached_q+rocchio
     display: +Rocchio
     params: -impact -pretokenized -rocchio
     results:

--- a/src/main/resources/regression/dl20-passage-splade-pp-sd-onnx.yaml
+++ b/src/main/resources/regression/dl20-passage-splade-pp-sd-onnx.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: splade-pp-sd
+  - name: splade-pp-sd-onnx
     display: SPLADE++ CoCondenser-SelfDistil
     params: -impact -pretokenized -encoder SpladePlusPlusSelfDistil
     results:
@@ -65,7 +65,7 @@ models:
         - 0.7512
       R@1000:
         - 0.9024
-  - name: rm3
+  - name: splade-pp-sd-onnx+rm3
     display: +RM3
     params: -impact -pretokenized -rm3 -encoder SpladePlusPlusSelfDistil
     results:
@@ -77,7 +77,7 @@ models:
         - 0.7648
       R@1000:
         - 0.9174
-  - name: rocchio
+  - name: splade-pp-sd-onnx+rocchio
     display: +Rocchio
     params: -impact -pretokenized -rocchio -encoder SpladePlusPlusSelfDistil
     results:

--- a/src/main/resources/regression/dl20-passage-splade-pp-sd.yaml
+++ b/src/main/resources/regression/dl20-passage-splade-pp-sd.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: splade-pp-sd
+  - name: splade-pp-sd-cached_q
     display: SPLADE++ CoCondenser-SelfDistil
     params: -impact -pretokenized
     results:
@@ -65,7 +65,7 @@ models:
         - 0.7512
       R@1000:
         - 0.9023
-  - name: rm3
+  - name: splade-pp-sd-cached_q+rm3
     display: +RM3
     params: -impact -pretokenized -rm3
     results:
@@ -77,7 +77,7 @@ models:
         - 0.7631
       R@1000:
         - 0.9174
-  - name: rocchio
+  - name: splade-pp-sd-cached_q+rocchio
     display: +Rocchio
     params: -impact -pretokenized -rocchio
     results:

--- a/src/main/resources/regression/dl20-passage-unicoil-noexp.yaml
+++ b/src/main/resources/regression/dl20-passage-unicoil-noexp.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: unicoil
+  - name: unicoil-noexp-cached_q
     display: uniCOIL (no expansions)
     params: -impact -pretokenized
     results:
@@ -67,7 +67,7 @@ models:
         - 0.6658
       R@1000:
         - 0.7861
-  - name: rm3
+  - name: unicoil-noexp-cached_q+rm3
     display: +RM3
     params: -impact -pretokenized -rm3
     results:
@@ -79,7 +79,7 @@ models:
         - 0.6629
       R@1000:
         - 0.8091
-  - name: rocchio
+  - name: unicoil-noexp-cached_q+rocchio
     display: +Rocchio
     params: -impact -pretokenized -rocchio
     results:

--- a/src/main/resources/regression/dl20-passage-unicoil.yaml
+++ b/src/main/resources/regression/dl20-passage-unicoil.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.dl20-passage.txt
 
 models:
-  - name: unicoil
+  - name: unicoil-cached_q
     display: uniCOIL (with doc2query-T5 expansions)
     params: -impact -pretokenized
     results:
@@ -65,7 +65,7 @@ models:
         - 0.7006
       R@1000:
         - 0.8430
-  - name: rm3
+  - name: unicoil-cached_q+rm3
     display: +RM3
     params: -impact -pretokenized -rm3
     results:
@@ -77,7 +77,7 @@ models:
         - 0.6822
       R@1000:
         - 0.8417
-  - name: rocchio
+  - name: unicoil-cached_q+rocchio
     display: +Rocchio
     params: -impact -pretokenized -rocchio
     results:

--- a/src/main/resources/regression/msmarco-doc-hgf-wp.yaml
+++ b/src/main/resources/regression/msmarco-doc-hgf-wp.yaml
@@ -52,7 +52,7 @@ topics:
 models:
   - name: bm25-default
     display: BM25 (default)
-    params: -bm25 -analyzeWithHuggingFaceTokenizer  bert-base-uncased
+    params: -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased
     results:
       AP@1000:
         - 0.2234

--- a/src/main/resources/regression/msmarco-doc-segmented-unicoil-noexp.yaml
+++ b/src/main/resources/regression/msmarco-doc-segmented-unicoil-noexp.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.msmarco-doc.dev.txt
 
 models:
-  - name: unicoil
+  - name: unicoil-noexp-cached_q
     display: uniCOIL (no expansions)
     params: -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:
@@ -68,7 +68,7 @@ models:
 # PRF regressions are no longer maintained for sparse judgments to reduce running times.
 # (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
 #
-#  - name: rm3
+#  - name: unicoil-noexp-cached_q+rm3
 #    display: +RM3
 #    params: -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
 #    results:
@@ -80,7 +80,7 @@ models:
 #        - 0.8600
 #      R@1000:
 #        - 0.9495
-#  - name: rocchio
+#  - name: unicoil-noexp-cached_q+rocchio
 #    display: +Rocchio
 #    params: -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
 #    results:

--- a/src/main/resources/regression/msmarco-doc-segmented-unicoil.yaml
+++ b/src/main/resources/regression/msmarco-doc-segmented-unicoil.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.msmarco-doc.dev.txt
 
 models:
-  - name: unicoil
+  - name: unicoil-cached_q
     display: uniCOIL (with doc2query-T5 expansions)
     params: -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
     results:
@@ -68,7 +68,7 @@ models:
 # PRF regressions are no longer maintained for sparse judgments to reduce running times.
 # (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
 #
-#  - name: rm3
+#  - name: unicoil-cached_q+rm3
 #    display: +RM3
 #    params: -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
 #    results:
@@ -80,7 +80,7 @@ models:
 #        - 0.8800
 #      R@1000:
 #        - 0.9615
-#  - name: rocchio
+#  - name: unicoil-cached_q+rocchio
 #    display: +Rocchio
 #    params: -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
 #    results:

--- a/src/main/resources/regression/msmarco-passage-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/msmarco-passage-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: bge-hnsw
+  - name: bge-hnsw-onnx
     display: BGE-base-en-v1.5
     type: hnsw
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15

--- a/src/main/resources/regression/msmarco-passage-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/msmarco-passage-bge-base-en-v1.5-hnsw-int8.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: bge-hnsw
+  - name: bge-hnsw-cached_q
     display: BGE-base-en-v1.5
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/msmarco-passage-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/msmarco-passage-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: bge-hnsw
+  - name: bge-hnsw-onnx
     display: BGE-base-en-v1.5
     type: hnsw
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15

--- a/src/main/resources/regression/msmarco-passage-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/msmarco-passage-bge-base-en-v1.5-hnsw.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: bge-hnsw
+  - name: bge-hnsw-cached_q
     display: BGE-base-en-v1.5
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/msmarco-passage-cohere-embed-english-v3.0-hnsw-int8.yaml
+++ b/src/main/resources/regression/msmarco-passage-cohere-embed-english-v3.0-hnsw-int8.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: cohere-embed-english-v3.0
+  - name: cohere-embed-english-v3.0-cached_q
     display: cohere-embed-english-v3.0
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/msmarco-passage-cohere-embed-english-v3.0-hnsw.yaml
+++ b/src/main/resources/regression/msmarco-passage-cohere-embed-english-v3.0-hnsw.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: cohere-embed-english-v3.0
+  - name: cohere-embed-english-v3.0-cached_q
     display: cohere-embed-english-v3.0
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/msmarco-passage-cos-dpr-distil-fw.yaml
+++ b/src/main/resources/regression/msmarco-passage-cos-dpr-distil-fw.yaml
@@ -54,7 +54,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: cos-dpr-distil-fw-40
+  - name: cos-dpr-distil-fw-40-cached_q
     display: cosDPR-distill
     type: inverted-dense
     params: -topicField vector -threads 16 -encoding fw -fw.q 40 -hits 1000

--- a/src/main/resources/regression/msmarco-passage-cos-dpr-distil-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/msmarco-passage-cos-dpr-distil-hnsw-int8-onnx.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: cos-dpr-distil-hnsw
+  - name: cos-dpr-distil-hnsw-onnx
     display: cosDPR-distil
     type: hnsw
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder CosDprDistil

--- a/src/main/resources/regression/msmarco-passage-cos-dpr-distil-hnsw-int8.yaml
+++ b/src/main/resources/regression/msmarco-passage-cos-dpr-distil-hnsw-int8.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: cos-dpr-distil-hnsw
+  - name: cos-dpr-distil-hnsw-cached_q
     display: cosDPR-distil
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/msmarco-passage-cos-dpr-distil-hnsw-onnx.yaml
+++ b/src/main/resources/regression/msmarco-passage-cos-dpr-distil-hnsw-onnx.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: cos-dpr-distil-hnsw
+  - name: cos-dpr-distil-hnsw-onnx
     display: cosDPR-distil
     type: hnsw
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder CosDprDistil

--- a/src/main/resources/regression/msmarco-passage-cos-dpr-distil-hnsw.yaml
+++ b/src/main/resources/regression/msmarco-passage-cos-dpr-distil-hnsw.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: cos-dpr-distil-hnsw
+  - name: cos-dpr-distil-hnsw-cached_q
     display: cosDPR-distil
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/msmarco-passage-cos-dpr-distil-lexlsh.yaml
+++ b/src/main/resources/regression/msmarco-passage-cos-dpr-distil-lexlsh.yaml
@@ -54,7 +54,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: cos-dpr-distil-lexlsh-600
+  - name: cos-dpr-distil-lexlsh-600-cached_q
     display: cosDPR-distill
     type: inverted-dense
     params: -topicField vector -threads 16 -encoding lexlsh -lexlsh.b 600 -hits 1000

--- a/src/main/resources/regression/msmarco-passage-deepimpact.yaml
+++ b/src/main/resources/regression/msmarco-passage-deepimpact.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: deepimpact
+  - name: deepimpact-cached_q
     display: DeepImpact
     params: -impact -pretokenized
     results:

--- a/src/main/resources/regression/msmarco-passage-distill-splade-max.yaml
+++ b/src/main/resources/regression/msmarco-passage-distill-splade-max.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: distill-splade-max
+  - name: distill-splade-max-cached_q
     display: DistilSPLADE-max
     params: -impact -pretokenized
     results:

--- a/src/main/resources/regression/msmarco-passage-hgf-wp.yaml
+++ b/src/main/resources/regression/msmarco-passage-hgf-wp.yaml
@@ -52,7 +52,7 @@ topics:
 models:
   - name: bm25-default
     display: BM25 (default)
-    params: -bm25 -analyzeWithHuggingFaceTokenizer  bert-base-uncased
+    params: -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased
     results:
       AP@1000:
         - 0.1836

--- a/src/main/resources/regression/msmarco-passage-openai-ada2-int8.yaml
+++ b/src/main/resources/regression/msmarco-passage-openai-ada2-int8.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: openai-ada2
+  - name: openai-ada2-cached_q
     display: OpenAI-ada2
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/msmarco-passage-openai-ada2.yaml
+++ b/src/main/resources/regression/msmarco-passage-openai-ada2.yaml
@@ -50,7 +50,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: openai-ada2
+  - name: openai-ada2-cached_q
     display: OpenAI-ada2
     type: hnsw
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000

--- a/src/main/resources/regression/msmarco-passage-splade-pp-ed-onnx.yaml
+++ b/src/main/resources/regression/msmarco-passage-splade-pp-ed-onnx.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: splade-pp-ed
+  - name: splade-pp-ed-onnx
     display: SPLADE++ CoCondenser-EnsembleDistil
     params: -impact -pretokenized -encoder SpladePlusPlusEnsembleDistil
     results:

--- a/src/main/resources/regression/msmarco-passage-splade-pp-ed.yaml
+++ b/src/main/resources/regression/msmarco-passage-splade-pp-ed.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: splade-pp-ed
+  - name: splade-pp-ed-cached_q
     display: SPLADE++ CoCondenser-EnsembleDistil
     params: -impact -pretokenized
     results:
@@ -68,7 +68,7 @@ models:
 # PRF regressions are no longer maintained for sparse judgments to reduce running times.
 # (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
 #
-#  - name: rm3
+#  - name: splade-pp-ed-cached_q+rm3
 #    display: +RM3
 #    params: -impact -pretokenized -rm3
 #    results:
@@ -80,7 +80,7 @@ models:
 #        - 0.8728
 #      R@1000:
 #        - 0.9744
-#  - name: rocchio
+#  - name: splade-pp-ed-cached_q+rocchio
 #    display: +Rocchio
 #    params: -impact -pretokenized -rocchio
 #    results:

--- a/src/main/resources/regression/msmarco-passage-splade-pp-sd-onnx.yaml
+++ b/src/main/resources/regression/msmarco-passage-splade-pp-sd-onnx.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: splade-pp-sd
+  - name: splade-pp-sd-onnx
     display: SPLADE++ CoCondenser-SelfDistil
     params: -impact -pretokenized -encoder SpladePlusPlusSelfDistil
     results:

--- a/src/main/resources/regression/msmarco-passage-splade-pp-sd.yaml
+++ b/src/main/resources/regression/msmarco-passage-splade-pp-sd.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: splade-pp-sd
+  - name: splade-pp-sd-cached_q
     display: SPLADE++ CoCondenser-SelfDistil
     params: -impact -pretokenized
     results:
@@ -68,7 +68,7 @@ models:
 # PRF regressions are no longer maintained for sparse judgments to reduce running times.
 # (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
 #
-#  - name: rm3
+#  - name: splade-pp-sd-cached_q+rm3
 #    display: +RM3
 #    params: -impact -pretokenized -rm3
 #    results:
@@ -80,7 +80,7 @@ models:
 #        - 0.8681
 #      R@1000:
 #        - 0.9739
-#  - name: rocchio
+#  - name: splade-pp-sd-cached_q+rocchio
 #    display: +Rocchio
 #    params: -impact -pretokenized -rocchio
 #    results:

--- a/src/main/resources/regression/msmarco-passage-unicoil-noexp.yaml
+++ b/src/main/resources/regression/msmarco-passage-unicoil-noexp.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: unicoil-noexp
+  - name: unicoil-noexp-cached_q
     display: uniCOIL (no expansions)
     params: -impact -pretokenized
     results:
@@ -68,7 +68,7 @@ models:
 # PRF regressions are no longer maintained for sparse judgments to reduce running times.
 # (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
 #
-#  - name: rm3
+#  - name: unicoil-noexp-cached_q+rm3
 #    display: +RM3
 #    params: -impact -pretokenized -rm3
 #    results:
@@ -80,7 +80,7 @@ models:
 #        - 0.7953
 #      R@1000:
 #        - 0.9296
-#  - name: rocchio
+#  - name: unicoil-noexp-cached_q+rocchio
 #    display: +Rocchio
 #    params: -impact -pretokenized -rocchio
 #    results:

--- a/src/main/resources/regression/msmarco-passage-unicoil-tilde-expansion.yaml
+++ b/src/main/resources/regression/msmarco-passage-unicoil-tilde-expansion.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: unicoil-tilde-expansion
+  - name: unicoil-tilde-expansion-cached_q
     display: uniCOIL (with TILDE expansions)
     params: -impact -pretokenized
     results:

--- a/src/main/resources/regression/msmarco-passage-unicoil.yaml
+++ b/src/main/resources/regression/msmarco-passage-unicoil.yaml
@@ -53,7 +53,7 @@ topics:
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
-  - name: unicoil
+  - name: unicoil-cached_q
     display: uniCOIL (with doc2query-T5 expansions)
     params: -impact -pretokenized
     results:
@@ -68,7 +68,7 @@ models:
 # PRF regressions are no longer maintained for sparse judgments to reduce running times.
 # (commenting out instead of removing; in case these numbers are needed, just uncomment and rerun.)
 #
-#  - name: rm3
+#  - name: unicoil-cached_q+rm3
 #    display: +RM3
 #    params: -impact -pretokenized -rm3
 #    results:
@@ -80,7 +80,7 @@ models:
 #        - 0.8425
 #      R@1000:
 #        - 0.9603
-#  - name: rocchio
+#  - name: unicoil-cached_q+rocchio
 #    display: +Rocchio
 #    params: -impact -pretokenized -rocchio
 #    results:


### PR DESCRIPTION
This avoids output runfile collisions, enabling regressions to run concurrently without clobbering each other.