### PR TITLE
use encoders cache directory instead of test

### DIFF
--- a/src/test/java/io/anserini/encoder/EncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/EncoderInferenceTest.java
@@ -14,7 +14,7 @@ public abstract class EncoderInferenceTest {
     protected Object[][] longExamples;
 
     protected String getCacheDir() {
-        File cacheDir = new File(System.getProperty("user.home") + "/.cache/anserini/test");
+        File cacheDir = new File(System.getProperty("user.home") + "/.cache/anserini/encoders");
         if (!cacheDir.exists()) {
             cacheDir.mkdir();
         }

--- a/src/test/java/io/anserini/encoder/SpladeEncoderTokenizationTest.java
+++ b/src/test/java/io/anserini/encoder/SpladeEncoderTokenizationTest.java
@@ -76,7 +76,7 @@ public class SpladeEncoderTokenizationTest {
   };
 
   static private String getCacheDir() {
-    File cacheDir = new File(System.getProperty("user.home") + "/.cache/anserini/test");
+    File cacheDir = new File(System.getProperty("user.home") + "/.cache/anserini/encoders");
     if (!cacheDir.exists()) {
       cacheDir.mkdir();
     }

--- a/src/test/java/io/anserini/encoder/UniCoilEncoderTokenizationTest.java
+++ b/src/test/java/io/anserini/encoder/UniCoilEncoderTokenizationTest.java
@@ -76,7 +76,7 @@ public class UniCoilEncoderTokenizationTest {
   };
 
   static private String getCacheDir() {
-    File cacheDir = new File(System.getProperty("user.home") + "/.cache/anserini/test");
+    File cacheDir = new File(System.getProperty("user.home") + "/.cache/anserini/encoders");
     if (!cacheDir.exists()) {
       cacheDir.mkdir();
     }


### PR DESCRIPTION
resolve #2417
Use `~/.cache/anserini/encoders` instead of making duplicates in `~/.cache/anserini/test` for test cases