### PR TITLE
Add v0.36.1-SNAPSHOT docs; fixed typos in existing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ java -cp anserini-0.36.0-fatjar.jar trec_eval -c -M 10 -m recip_rank msmarco-pas
 
 See [detailed instructions](docs/fatjar-regressions/fatjar-regressions-v0.36.0.md) for the current fatjar release of Anserini (v0.36.0) to reproduce regression experiments on the MS MARCO V2.1 corpora for TREC 2024 RAG, on MS MARCO V1 Passage, and on BEIR, all directly from the fatjar!
 
-<!-- We also have [forthcoming instructions](docs/fatjar-regressions/fatjar-regressions-v0.36.1-SNAPSHOT.md) for the next release (v0.36.1-SNAPSHOT) if you're interested. -->
+We also have [forthcoming instructions](docs/fatjar-regressions/fatjar-regressions-v0.36.1-SNAPSHOT.md) for the next release (v0.36.1-SNAPSHOT) if you're interested.
 
 <details>
 <summary>Older instructions</summary>

--- a/docs/fatjar-regressions/fatjar-regressions-v0.35.1.md
+++ b/docs/fatjar-regressions/fatjar-regressions-v0.35.1.md
@@ -18,7 +18,7 @@ If you want to change the download location, the current workaround is to use sy
 ## TREC 2024 RAG
 
 Warning: The `msmarco-v2.1-doc` prebuilt index is 63 GB uncompressed.
-The `msmarco-v2.1-doc-segmented` prebuilt index is 84 GB uncompresed.
+The `msmarco-v2.1-doc-segmented` prebuilt index is 84 GB uncompressed.
 
 Here are the instructions for reproducing runs on the MS MARCO V2.1 document corpus with prebuilt indexes (adjust number of threads based on available resources):
 

--- a/docs/fatjar-regressions/fatjar-regressions-v0.36.1-SNAPSHOT.md
+++ b/docs/fatjar-regressions/fatjar-regressions-v0.36.1-SNAPSHOT.md
@@ -1,8 +1,9 @@
-# Anserini Fatjar Regresions (v0.36.0)
+# Anserini Fatjar Regresions (v0.36.1-SNAPSHOT)
 
 Fetch the fatjar:
 
 ```bash
+# Update once artifact has been published
 wget https://repo1.maven.org/maven2/io/anserini/anserini/0.36.0/anserini-0.36.0-fatjar.jar
 ```
 
@@ -13,8 +14,8 @@ If you want to change the download location, the current workaround is to use sy
 Let's start out by setting the `ANSERINI_JAR` and the `OUTPUT_DIR`:
 
 ```bash
-export ANSERINI_JAR="anserini-0.36.0-fatjar.jar"
-export OUTPUT_DIR="."
+export ANSERINI_JAR=`ls target/*-fatjar.jar`
+export OUTPUT_DIR="runs"
 ```
 
 ## TREC 2024 RAG


### PR DESCRIPTION
Copied the existing v0.36.0 docs to v0.36.1-SNAPSHOT in anticipation of documenting new features, e.g., @16BitNarwhal and @wu-ming233 are working on.