### PR TITLE
Fix MS MARCO V2.1 repo experiments on segmented doc collection

### DIFF
--- a/src/main/java/io/anserini/reproduce/RunRepro.java
+++ b/src/main/java/io/anserini/reproduce/RunRepro.java
@@ -117,12 +117,11 @@ public class RunRepro {
               else {
                 System.out.println(String.format("    %7s: %.4f [OK]", metric, score));
               }
-            }
-            else {
+            } else {
               System.out.println("Evaluation command failed for metric: " + metric);
             }
-            System.out.println("");
           }
+          System.out.println("");
         }
       }
     }

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -1024,6 +1024,13 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
       }
     }
 
+    LOG.info("MaxPassage: " + args.selectMaxPassage);
+    if (args.selectMaxPassage) {
+      LOG.info("MaxPassage delimiter: " + args.selectMaxPassageDelimiter);
+      LOG.info("MaxPassage hits: " + args.selectMaxPassageHits);
+    }
+    LOG.info("Hits: " + args.hits);
+
     // get collection class if available
     if (args.collectionClass != null) {
       try {
@@ -1035,6 +1042,7 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
     } else {
       this.collectionClass = null;
     }
+    LOG.info("Collection class: " + this.collectionClass);
 
     this.isRerank = args.rm3 || args.axiom || args.bm25prf || args.rocchio;
     this.analyzer = getAnalyzer();

--- a/src/main/resources/reproduce/msmarco-v2.1-doc.yaml
+++ b/src/main/resources/reproduce/msmarco-v2.1-doc.yaml
@@ -1,7 +1,7 @@
 conditions:
   - name: bm25
-    display: "BM25 v2.1 (k1=0.9, b=0.4)"
-    display_html: "BM25 v2.1 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)"
+    display: "BM25 doc (k1=0.9, b=0.4)"
+    display_html: "BM25 doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)"
     display_row: ""
     command: java -cp $fatjar io.anserini.search.SearchCollection -threads $threads -index msmarco-v2.1-doc -topics $topics -output $output -hits 1000 -bm25
     topics:
@@ -38,10 +38,10 @@ conditions:
             R@100: 0.2604
             R@1K: 0.5383
   - name: bm25-segmented
-    display: "BM25 v2.1 Segmented Corpus (k1=0.9, b=0.4)"
-    display_html: "BM25 v2.1 Segmented Corpus (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)"
+    display: "BM25 segmented doc (k1=0.9, b=0.4)"
+    display_html: "BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)"
     display_row: ""
-    command: java -cp $fatjar io.anserini.search.SearchCollection -threads $threads -index msmarco-v2.1-doc-segmented -topics $topics -output $output -hits 1000 -bm25 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+    command: java -cp $fatjar io.anserini.search.SearchCollection -threads $threads -index msmarco-v2.1-doc-segmented -topics $topics -output $output -hits 10000 -bm25 -selectMaxPassage -selectMaxPassage.delimiter \# -selectMaxPassage.hits 1000
     topics:
       - topic_key: msmarco-v2-doc-dev
         eval_key: msmarco-v2.1-doc.dev


### PR DESCRIPTION
Proposed fix to https://github.com/castorini/anserini/issues/2480#issuecomment-2085063194

The issue is that '#' may get interpreted as a comment; WSL and Mac might also different on how interpolation, escaping, etc. is handled with `ProcessBuilder`. This works on my Mac.
