### PR TITLE
Aligned doc output format with repro scripts

### DIFF
--- a/docs/fatjar-regressions/fatjar-regressions-v0.36.1-SNAPSHOT.md
+++ b/docs/fatjar-regressions/fatjar-regressions-v0.36.1-SNAPSHOT.md
@@ -102,7 +102,7 @@ Here are the instructions for reproducing runs on the MS MARCO V2.1 segmented do
 ```bash
 TOPICS=(msmarco-v2-doc-dev msmarco-v2-doc-dev2 trec2021-dl trec2022-dl trec2023-dl rag24-raggy-dev); for t in "${TOPICS[@]}"
 do
-    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index msmarco-v2.1-doc-segmented -topics $t -output $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.${t}.txt -threads 16 -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index msmarco-v2.1-doc-segmented -topics $t -output $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.${t}.txt -threads 16 -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
 done
 ```
 
@@ -112,28 +112,28 @@ done
 Run these commands for evaluation:
 
 ```
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.msmarco-v2-doc-dev.txt
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev2 $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.msmarco-v2-doc-dev2.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.msmarco-v2-doc-dev.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev2 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.msmarco-v2-doc-dev2.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.trec2021-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.trec2021-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.trec2021-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.trec2021-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2021-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2021-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2021-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2021-dl.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.trec2022-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.trec2022-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.trec2022-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.trec2022-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2022-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2022-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2022-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2022-dl.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.trec2023-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.trec2023-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.trec2023-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.trec2023-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2023-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2023-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2023-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2023-dl.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.rag24-raggy-dev.txt
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.rag24-raggy-dev.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.100 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.rag24-raggy-dev.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1-doc-segmented.bm25.rag24-raggy-dev.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.rag24-raggy-dev.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.rag24-raggy-dev.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.100 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.rag24-raggy-dev.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.rag24-raggy-dev.txt
 ```
 
 And these are the expected scores:
@@ -235,51 +235,51 @@ The following snippet will generate the complete set of results for MS MARCO V1 
 # BM25
 TOPICS=(msmarco-v1-passage.dev dl19-passage dl20-passage); for t in "${TOPICS[@]}"
 do
-    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index msmarco-v1-passage -topics ${t} -output $OUTPUT_DIR/run.${t}.bm25.txt -threads 16 -bm25
+    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index msmarco-v1-passage -topics ${t} -output $OUTPUT_DIR/run.msmarco-v1-passage.bm25.${t}.txt -threads 16 -bm25
 done
 
 # SPLADE++ ED
 TOPICS=(msmarco-v1-passage.dev dl19-passage dl20-passage); for t in "${TOPICS[@]}"
 do
     # Using cached queries
-    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index msmarco-v1-passage.splade-pp-ed -topics ${t}.splade-pp-ed -output $OUTPUT_DIR/run.${t}.splade-pp-ed.cached_q.txt -threads 16 -impact -pretokenized
+    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index msmarco-v1-passage.splade-pp-ed -topics ${t}.splade-pp-ed -output $OUTPUT_DIR/run.msmarco-v1-passage.splade-pp-ed.cached_q.${t}.txt -threads 16 -impact -pretokenized
     # Using ONNX
-    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index msmarco-v1-passage.splade-pp-ed -topics ${t} -encoder SpladePlusPlusEnsembleDistil -output $OUTPUT_DIR/run.${t}.splade-pp-ed.onnx.txt -threads 16 -impact -pretokenized
+    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index msmarco-v1-passage.splade-pp-ed -topics ${t} -encoder SpladePlusPlusEnsembleDistil -output $OUTPUT_DIR/run.msmarco-v1-passage.splade-pp-ed.onnx.${t}.txt -threads 16 -impact -pretokenized
 done
 
 # cosDPR-distil
 TOPICS=(msmarco-v1-passage.dev dl19-passage dl20-passage); for t in "${TOPICS[@]}"
 do
     # Using fp32 index, cached queries
-    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.cos-dpr-distil -topics ${t}.cos-dpr-distil -output $OUTPUT_DIR/run.${t}.cos-dpr-distil.fp32.cached_q.txt -threads 16 -efSearch 1000
+    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.cos-dpr-distil -topics ${t}.cos-dpr-distil -output $OUTPUT_DIR/run.msmarco-v1-passage.cos-dpr-distil.fp32.cached_q.${t}.txt -threads 16 -efSearch 1000
     # Using fp32 index, ONNX
-    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.cos-dpr-distil -topics ${t} -encoder CosDprDistil -output $OUTPUT_DIR/run.${t}.cos-dpr-distil.fp32.onnx.txt -threads 16 -efSearch 1000
+    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.cos-dpr-distil -topics ${t} -encoder CosDprDistil -output $OUTPUT_DIR/run.msmarco-v1-passage.cos-dpr-distil.fp32.onnx.${t}.txt -threads 16 -efSearch 1000
     # Using int8 index, cached queries
-    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.cos-dpr-distil.quantized -topics ${t}.cos-dpr-distil -output $OUTPUT_DIR/run.${t}.cos-dpr-distil.int8.cached_q.txt -threads 16 -efSearch 1000
+    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.cos-dpr-distil.quantized -topics ${t}.cos-dpr-distil -output $OUTPUT_DIR/run.msmarco-v1-passage.cos-dpr-distil.int8.cached_q.${t}.txt -threads 16 -efSearch 1000
     # Using int8 index, ONNX
-    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.cos-dpr-distil.quantized -topics ${t} -encoder CosDprDistil -output $OUTPUT_DIR/run.${t}.cos-dpr-distil.int8.onnx.txt -threads 16 -efSearch 1000
+    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.cos-dpr-distil.quantized -topics ${t} -encoder CosDprDistil -output $OUTPUT_DIR/run.msmarco-v1-passage.cos-dpr-distil.int8.onnx.${t}.txt -threads 16 -efSearch 1000
 done
 
 # bge-base-en-v1.5
 TOPICS=(msmarco-v1-passage.dev dl19-passage dl20-passage); for t in "${TOPICS[@]}"
 do
     # Using fp32 index, cached queries
-    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.bge-base-en-v1.5 -topics ${t}.bge-base-en-v1.5 -output $OUTPUT_DIR/run.${t}.bge-base-en-v1.5.fp32.cached_q.txt -threads 16 -efSearch 1000
+    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.bge-base-en-v1.5 -topics ${t}.bge-base-en-v1.5 -output $OUTPUT_DIR/run.msmarco-v1-passage.bge-base-en-v1.5.fp32.cached_q.${t}.txt -threads 16 -efSearch 1000
     # Using fp32 index, ONNX
-    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.bge-base-en-v1.5 -topics ${t} -encoder BgeBaseEn15 -output $OUTPUT_DIR/run.${t}.bge-base-en-v1.5.fp32.onnx.txt -threads 16 -efSearch 1000
+    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.bge-base-en-v1.5 -topics ${t} -encoder BgeBaseEn15 -output $OUTPUT_DIR/run.msmarco-v1-passage.bge-base-en-v1.5.fp32.onnx.${t}.txt -threads 16 -efSearch 1000
     # Using int8 index, cached queries
-    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.bge-base-en-v1.5.quantized -topics ${t}.bge-base-en-v1.5 -output $OUTPUT_DIR/run.${t}.bge-base-en-v1.5.int8.cached_q.txt -threads 16 -efSearch 1000
+    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.bge-base-en-v1.5.quantized -topics ${t}.bge-base-en-v1.5 -output $OUTPUT_DIR/run.msmarco-v1-passage.bge-base-en-v1.5.int8.cached_q.${t}.txt -threads 16 -efSearch 1000
     # Using int8 index, ONNX
-    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.bge-base-en-v1.5.quantized -topics ${t} -encoder BgeBaseEn15 -output $OUTPUT_DIR/run.${t}.bge-base-en-v1.5.int8.onnx.txt -threads 16 -efSearch 1000
+    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.bge-base-en-v1.5.quantized -topics ${t} -encoder BgeBaseEn15 -output $OUTPUT_DIR/run.msmarco-v1-passage.bge-base-en-v1.5.int8.onnx.${t}.txt -threads 16 -efSearch 1000
 done
 
 # cohere-embed-english-v3.0
 TOPICS=(msmarco-v1-passage.dev dl19-passage dl20-passage); for t in "${TOPICS[@]}"
 do
     # Using fp32 index, cached queries
-    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.cohere-embed-english-v3.0 -topics ${t}.cohere-embed-english-v3.0 -output $OUTPUT_DIR/run.${t}.cohere-embed-english-v3.0.fp32.cached_q.txt -threads 16 -efSearch 1000
+    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.cohere-embed-english-v3.0 -topics ${t}.cohere-embed-english-v3.0 -output $OUTPUT_DIR/run.msmarco-v1-passage.cohere-embed-english-v3.0.fp32.cached_q.${t}.txt -threads 16 -efSearch 1000
     # Using int8 index, cached queries
-    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.cohere-embed-english-v3.0.quantized -topics ${t}.cohere-embed-english-v3.0 -output $OUTPUT_DIR/run.${t}.cohere-embed-english-v3.0.int8.cached_q.txt -threads 16 -efSearch 1000
+    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index msmarco-v1-passage.cohere-embed-english-v3.0.quantized -topics ${t}.cohere-embed-english-v3.0 -output $OUTPUT_DIR/run.msmarco-v1-passage.cohere-embed-english-v3.0.int8.cached_q.${t}.txt -threads 16 -efSearch 1000
 done
 
 ```
@@ -307,57 +307,57 @@ Here are the expected scores (dev using MRR@10, DL19 and DL20 using nDCG@10):
 And here's the snippet of code to perform the evaluation (which will yield the results above):
 
 ```bash
-java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.dev.bm25.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.dl19-passage.bm25.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.dl20-passage.bm25.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.bm25.msmarco-v1-passage.dev.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.bm25.dl19-passage.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.bm25.dl20-passage.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.dev.splade-pp-ed.cached_q.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.dl19-passage.splade-pp-ed.cached_q.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.dl20-passage.splade-pp-ed.cached_q.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.splade-pp-ed.cached_q.msmarco-v1-passage.dev.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.splade-pp-ed.cached_q.dl19-passage.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.splade-pp-ed.cached_q.dl20-passage.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.dev.splade-pp-ed.onnx.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.dl19-passage.splade-pp-ed.onnx.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.dl20-passage.splade-pp-ed.onnx.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.splade-pp-ed.onnx.msmarco-v1-passage.dev.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.splade-pp-ed.onnx.dl19-passage.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.splade-pp-ed.onnx.dl20-passage.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.dev.cos-dpr-distil.fp32.cached_q.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.dl19-passage.cos-dpr-distil.fp32.cached_q.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.dl20-passage.cos-dpr-distil.fp32.cached_q.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.cos-dpr-distil.fp32.cached_q.msmarco-v1-passage.dev.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.cos-dpr-distil.fp32.cached_q.dl19-passage.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.cos-dpr-distil.fp32.cached_q.dl20-passage.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.dev.cos-dpr-distil.fp32.onnx.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.dl19-passage.cos-dpr-distil.fp32.onnx.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.dl20-passage.cos-dpr-distil.fp32.onnx.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.cos-dpr-distil.fp32.onnx.msmarco-v1-passage.dev.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.cos-dpr-distil.fp32.onnx.dl19-passage.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.cos-dpr-distil.fp32.onnx.dl20-passage.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.dev.cos-dpr-distil.int8.cached_q.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.dl19-passage.cos-dpr-distil.int8.cached_q.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.dl20-passage.cos-dpr-distil.int8.cached_q.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.cos-dpr-distil.int8.cached_q.msmarco-v1-passage.dev.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.cos-dpr-distil.int8.cached_q.dl19-passage.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.cos-dpr-distil.int8.cached_q.dl20-passage.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.dev.cos-dpr-distil.int8.onnx.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.dl19-passage.cos-dpr-distil.int8.onnx.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.dl20-passage.cos-dpr-distil.int8.onnx.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.cos-dpr-distil.int8.onnx.msmarco-v1-passage.dev.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.cos-dpr-distil.int8.onnx.dl19-passage.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.cos-dpr-distil.int8.onnx.dl20-passage.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.dev.bge-base-en-v1.5.fp32.cached_q.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.dl19-passage.bge-base-en-v1.5.fp32.cached_q.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.dl20-passage.bge-base-en-v1.5.fp32.cached_q.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.bge-base-en-v1.5.fp32.cached_q.msmarco-v1-passage.dev.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.bge-base-en-v1.5.fp32.cached_q.dl19-passage.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.bge-base-en-v1.5.fp32.cached_q.dl20-passage.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.dev.bge-base-en-v1.5.fp32.onnx.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.dl19-passage.bge-base-en-v1.5.fp32.onnx.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.dl20-passage.bge-base-en-v1.5.fp32.onnx.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.bge-base-en-v1.5.fp32.onnx.msmarco-v1-passage.dev.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.bge-base-en-v1.5.fp32.onnx.dl19-passage.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.bge-base-en-v1.5.fp32.onnx.dl20-passage.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.dev.bge-base-en-v1.5.int8.cached_q.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.dl19-passage.bge-base-en-v1.5.int8.cached_q.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.dl20-passage.bge-base-en-v1.5.int8.cached_q.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.bge-base-en-v1.5.int8.cached_q.msmarco-v1-passage.dev.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.bge-base-en-v1.5.int8.cached_q.dl19-passage.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.bge-base-en-v1.5.int8.cached_q.dl20-passage.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.dev.bge-base-en-v1.5.int8.onnx.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.dl19-passage.bge-base-en-v1.5.int8.onnx.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.dl20-passage.bge-base-en-v1.5.int8.onnx.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.bge-base-en-v1.5.int8.onnx.msmarco-v1-passage.dev.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.bge-base-en-v1.5.int8.onnx.dl19-passage.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.bge-base-en-v1.5.int8.onnx.dl20-passage.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.dev.cohere-embed-english-v3.0.fp32.cached_q.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.dl19-passage.cohere-embed-english-v3.0.fp32.cached_q.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.dl20-passage.cohere-embed-english-v3.0.fp32.cached_q.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.cohere-embed-english-v3.0.fp32.cached_q.msmarco-v1-passage.dev.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.cohere-embed-english-v3.0.fp32.cached_q.dl19-passage.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.cohere-embed-english-v3.0.fp32.cached_q.dl20-passage.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.dev.cohere-embed-english-v3.0.int8.cached_q.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.dl19-passage.cohere-embed-english-v3.0.int8.cached_q.txt
-java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.dl20-passage.cohere-embed-english-v3.0.int8.cached_q.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset $OUTPUT_DIR/run.msmarco-v1-passage.cohere-embed-english-v3.0.int8.cached_q.msmarco-v1-passage.dev.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl19-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.cohere-embed-english-v3.0.int8.cached_q.dl19-passage.txt
+java -cp $ANSERINI_JAR trec_eval -m ndcg_cut.10 -c dl20-passage                    $OUTPUT_DIR/run.msmarco-v1-passage.cohere-embed-english-v3.0.int8.cached_q.dl20-passage.txt
 ```
 
 </details>
@@ -383,17 +383,17 @@ The following snippet will generate the complete set of results for BEIR:
 CORPORA=(trec-covid bioasq nfcorpus nq hotpotqa fiqa signal1m trec-news robust04 arguana webis-touche2020 cqadupstack-android cqadupstack-english cqadupstack-gaming cqadupstack-gis cqadupstack-mathematica cqadupstack-physics cqadupstack-programmers cqadupstack-stats cqadupstack-tex cqadupstack-unix cqadupstack-webmasters cqadupstack-wordpress quora dbpedia-entity scidocs fever climate-fever scifact); for c in "${CORPORA[@]}"
 do
     # "flat" indexes
-    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.flat -topics beir-${c} -output $OUTPUT_DIR/run.beir.${c}.flat.txt -bm25 -removeQuery
+    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.flat -topics beir-${c} -output $OUTPUT_DIR/run.beir.flat.${c}.txt -bm25 -removeQuery
     # "multifield" indexes
-    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.multifield -topics beir-${c} -output $OUTPUT_DIR/run.beir.${c}.multifield.txt -bm25 -removeQuery -fields contents=1.0 title=1.0
+    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.multifield -topics beir-${c} -output $OUTPUT_DIR/run.beir.multifield.${c}.txt -bm25 -removeQuery -fields contents=1.0 title=1.0
     # SPLADE++ ED, cached queries
-    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.splade-pp-ed -topics beir-${c}.splade-pp-ed -output $OUTPUT_DIR/run.beir.${c}.splade-pp-ed.cached_q.txt -impact -pretokenized -removeQuery
+    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.splade-pp-ed -topics beir-${c}.splade-pp-ed -output $OUTPUT_DIR/run.beir.splade-pp-ed.cached_q.${c}.txt -impact -pretokenized -removeQuery
     # SPLADE++ ED, ONNX
-    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.splade-pp-ed -topics beir-${c} -encoder SpladePlusPlusEnsembleDistil -output $OUTPUT_DIR/run.beir.${c}.splade-pp-ed.onnx.txt -impact -pretokenized -removeQuery
+    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.splade-pp-ed -topics beir-${c} -encoder SpladePlusPlusEnsembleDistil -output $OUTPUT_DIR/run.beir.splade-pp-ed.onnx.${c}.txt -impact -pretokenized -removeQuery
     # BGE-base-en-v1.5, cached queries
-    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index beir-v1.0.0-${c}.bge-base-en-v1.5 -topics beir-${c}.bge-base-en-v1.5 -output $OUTPUT_DIR/run.beir.${c}.bge.cached_q.txt -threads 16 -efSearch 1000 -removeQuery
+    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index beir-v1.0.0-${c}.bge-base-en-v1.5 -topics beir-${c}.bge-base-en-v1.5 -output $OUTPUT_DIR/run.beir.bge.cached_q.${c}.txt -threads 16 -efSearch 1000 -removeQuery
     # BGE-base-en-v1.5, ONNX
-    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index beir-v1.0.0-${c}.bge-base-en-v1.5 -topics beir-${c} -encoder BgeBaseEn15 -output $OUTPUT_DIR/run.beir.${c}.bge.onnx.txt -threads 16 -efSearch 1000 -removeQuery
+    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index beir-v1.0.0-${c}.bge-base-en-v1.5 -topics beir-${c} -encoder BgeBaseEn15 -output $OUTPUT_DIR/run.beir.bge.onnx.${c}.txt -threads 16 -efSearch 1000 -removeQuery
 done
 ```
 
@@ -440,12 +440,12 @@ And here's the snippet of code to perform the evaluation (which will yield the r
 CORPORA=(trec-covid bioasq nfcorpus nq hotpotqa fiqa signal1m trec-news robust04 arguana webis-touche2020 cqadupstack-android cqadupstack-english cqadupstack-gaming cqadupstack-gis cqadupstack-mathematica cqadupstack-physics cqadupstack-programmers cqadupstack-stats cqadupstack-tex cqadupstack-unix cqadupstack-webmasters cqadupstack-wordpress quora dbpedia-entity scidocs fever climate-fever scifact); for c in "${CORPORA[@]}"
 do
     echo $c
-    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.${c}.flat.txt
-    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.${c}.multifield.txt
-    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.${c}.splade-pp-ed.cached_q.txt
-    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.${c}.splade-pp-ed.onnx.txt
-    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.${c}.bge.cached_q.txt
-    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.${c}.bge.onnx.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.flat.${c}.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.multifield.${c}.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.splade-pp-ed.cached_q.${c}.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.splade-pp-ed.onnx.${c}.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.bge.cached_q.${c}.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.bge.onnx.${c}.txt
 done
 ```
 

--- a/docs/fatjar-regressions/fatjar-regressions-v0.36.1-SNAPSHOT.md
+++ b/docs/fatjar-regressions/fatjar-regressions-v0.36.1-SNAPSHOT.md
@@ -30,7 +30,7 @@ Here are the instructions for reproducing runs on the MS MARCO V2.1 document cor
 ```bash
 TOPICS=(msmarco-v2-doc-dev msmarco-v2-doc-dev2 trec2021-dl trec2022-dl trec2023-dl rag24-raggy-dev); for t in "${TOPICS[@]}"
 do
-    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index msmarco-v2.1-doc -topics $t -output $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.${t}.txt -threads 16 -bm25
+    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index msmarco-v2.1-doc -topics $t -output $OUTPUT_DIR/run.msmarco-v2.1.doc.${t}.txt -threads 16 -bm25
 done
 ```
 
@@ -40,28 +40,28 @@ done
 Run these commands for evaluation:
 
 ```
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.msmarco-v2-doc-dev.txt
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev2 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.msmarco-v2-doc-dev2.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev $OUTPUT_DIR/run.msmarco-v2.1.doc.msmarco-v2-doc-dev.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev2 $OUTPUT_DIR/run.msmarco-v2.1.doc.msmarco-v2-doc-dev2.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.trec2021-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.trec2021-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.trec2021-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.trec2021-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc.trec2021-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc.trec2021-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc.trec2021-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc.trec2021-dl.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.trec2022-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.trec2022-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.trec2022-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.trec2022-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc.trec2022-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc.trec2022-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc.trec2022-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc.trec2022-dl.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.trec2023-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.trec2023-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.trec2023-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.trec2023-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc.trec2023-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc.trec2023-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc.trec2023-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc.trec2023-dl.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.rag24-raggy-dev.txt
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.rag24-raggy-dev.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.100 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.rag24-raggy-dev.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25.rag24-raggy-dev.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1.doc.rag24-raggy-dev.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1.doc.rag24-raggy-dev.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.100 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1.doc.rag24-raggy-dev.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1.doc.rag24-raggy-dev.txt
 ```
 
 And these are the expected scores:
@@ -102,7 +102,7 @@ Here are the instructions for reproducing runs on the MS MARCO V2.1 segmented do
 ```bash
 TOPICS=(msmarco-v2-doc-dev msmarco-v2-doc-dev2 trec2021-dl trec2022-dl trec2023-dl rag24-raggy-dev); for t in "${TOPICS[@]}"
 do
-    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index msmarco-v2.1-doc-segmented -topics $t -output $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.${t}.txt -threads 16 -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
+    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index msmarco-v2.1-doc-segmented -topics $t -output $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.${t}.txt -threads 16 -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000
 done
 ```
 
@@ -112,28 +112,28 @@ done
 Run these commands for evaluation:
 
 ```
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.msmarco-v2-doc-dev.txt
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev2 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.msmarco-v2-doc-dev2.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.msmarco-v2-doc-dev.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev2 $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.msmarco-v2-doc-dev2.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2021-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2021-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2021-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2021-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.trec2021-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.trec2021-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.trec2021-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl21-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.trec2021-dl.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2022-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2022-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2022-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2022-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.trec2022-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.trec2022-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.trec2022-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl22-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.trec2022-dl.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2023-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2023-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2023-dl.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.trec2023-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.trec2023-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.trec2023-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.100 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.trec2023-dl.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 dl23-doc-msmarco-v2.1 $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.trec2023-dl.txt
 echo ''
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.rag24-raggy-dev.txt
-java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.rag24-raggy-dev.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.100 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.rag24-raggy-dev.txt
-java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1-doc.bm25-segmented.rag24-raggy-dev.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m map rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.rag24-raggy-dev.txt
+java -cp $ANSERINI_JAR trec_eval -c -M 100 -m recip_rank -c -m ndcg_cut.10 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.rag24-raggy-dev.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.100 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.rag24-raggy-dev.txt
+java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 rag24.raggy-dev $OUTPUT_DIR/run.msmarco-v2.1.doc-segmented.rag24-raggy-dev.txt
 ```
 
 And these are the expected scores:
@@ -383,17 +383,17 @@ The following snippet will generate the complete set of results for BEIR:
 CORPORA=(trec-covid bioasq nfcorpus nq hotpotqa fiqa signal1m trec-news robust04 arguana webis-touche2020 cqadupstack-android cqadupstack-english cqadupstack-gaming cqadupstack-gis cqadupstack-mathematica cqadupstack-physics cqadupstack-programmers cqadupstack-stats cqadupstack-tex cqadupstack-unix cqadupstack-webmasters cqadupstack-wordpress quora dbpedia-entity scidocs fever climate-fever scifact); for c in "${CORPORA[@]}"
 do
     # "flat" indexes
-    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.flat -topics beir-${c} -output $OUTPUT_DIR/run.beir.flat.${c}.txt -bm25 -removeQuery
+    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.flat -topics beir-${c} -output $OUTPUT_DIR/run.beir.${c}.flat.txt -bm25 -removeQuery
     # "multifield" indexes
-    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.multifield -topics beir-${c} -output $OUTPUT_DIR/run.beir.multifield.${c}.txt -bm25 -removeQuery -fields contents=1.0 title=1.0
+    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.multifield -topics beir-${c} -output $OUTPUT_DIR/run.beir.${c}.multifield.txt -bm25 -removeQuery -fields contents=1.0 title=1.0
     # SPLADE++ ED, cached queries
-    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.splade-pp-ed -topics beir-${c}.splade-pp-ed -output $OUTPUT_DIR/run.beir.splade-pp-ed.cached_q.${c}.txt -impact -pretokenized -removeQuery
+    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.splade-pp-ed -topics beir-${c}.splade-pp-ed -output $OUTPUT_DIR/run.beir.${c}.splade-pp-ed.cached_q.txt -impact -pretokenized -removeQuery
     # SPLADE++ ED, ONNX
-    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.splade-pp-ed -topics beir-${c} -encoder SpladePlusPlusEnsembleDistil -output $OUTPUT_DIR/run.beir.splade-pp-ed.onnx.${c}.txt -impact -pretokenized -removeQuery
+    java -cp $ANSERINI_JAR io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.splade-pp-ed -topics beir-${c} -encoder SpladePlusPlusEnsembleDistil -output $OUTPUT_DIR/run.beir.${c}.splade-pp-ed.onnx.txt -impact -pretokenized -removeQuery
     # BGE-base-en-v1.5, cached queries
-    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index beir-v1.0.0-${c}.bge-base-en-v1.5 -topics beir-${c}.bge-base-en-v1.5 -output $OUTPUT_DIR/run.beir.bge.cached_q.${c}.txt -threads 16 -efSearch 1000 -removeQuery
+    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index beir-v1.0.0-${c}.bge-base-en-v1.5 -topics beir-${c}.bge-base-en-v1.5 -output $OUTPUT_DIR/run.beir.${c}.bge.cached_q.txt -threads 16 -efSearch 1000 -removeQuery
     # BGE-base-en-v1.5, ONNX
-    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index beir-v1.0.0-${c}.bge-base-en-v1.5 -topics beir-${c} -encoder BgeBaseEn15 -output $OUTPUT_DIR/run.beir.bge.onnx.${c}.txt -threads 16 -efSearch 1000 -removeQuery
+    java -cp $ANSERINI_JAR io.anserini.search.SearchHnswDenseVectors -index beir-v1.0.0-${c}.bge-base-en-v1.5 -topics beir-${c} -encoder BgeBaseEn15 -output $OUTPUT_DIR/run.beir.${c}.bge.onnx.txt -threads 16 -efSearch 1000 -removeQuery
 done
 ```
 
@@ -440,12 +440,12 @@ And here's the snippet of code to perform the evaluation (which will yield the r
 CORPORA=(trec-covid bioasq nfcorpus nq hotpotqa fiqa signal1m trec-news robust04 arguana webis-touche2020 cqadupstack-android cqadupstack-english cqadupstack-gaming cqadupstack-gis cqadupstack-mathematica cqadupstack-physics cqadupstack-programmers cqadupstack-stats cqadupstack-tex cqadupstack-unix cqadupstack-webmasters cqadupstack-wordpress quora dbpedia-entity scidocs fever climate-fever scifact); for c in "${CORPORA[@]}"
 do
     echo $c
-    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.flat.${c}.txt
-    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.multifield.${c}.txt
-    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.splade-pp-ed.cached_q.${c}.txt
-    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.splade-pp-ed.onnx.${c}.txt
-    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.bge.cached_q.${c}.txt
-    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.bge.onnx.${c}.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.${c}.flat.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.${c}.multifield.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.${c}.splade-pp-ed.cached_q.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.${c}.splade-pp-ed.onnx.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.${c}.bge.cached_q.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/run.beir.${c}.bge.onnx.txt
 done
 ```
 

--- a/docs/reproduce/msmarco-v1-passage.html
+++ b/docs/reproduce/msmarco-v1-passage.html
@@ -178,16 +178,16 @@ Instructions for programmatic execution are shown at the bottom of this page (sc
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)</td>
-<td>0.3013</td>
+<td>null</td>
 <td>0.5058</td>
-<td>0.7501</td>
+<td>null</td>
 <td></td>
-<td>0.2856</td>
+<td>null</td>
 <td>0.4796</td>
-<td>0.7863</td>
+<td>null</td>
 <td></td>
 <td>0.1840</td>
-<td>0.8526</td>
+<td>null</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -218,18 +218,14 @@ Command to generate run on TREC 2019 queries:
   -threads 16 \
   -index msmarco-v1-passage \
   -topics dl19-passage \
-  -output runs/run.msmarco.bm25-default.dl19.txt \
+  -output runs/run.msmarco.bm25.dl19.txt \
   -hits 1000 -bm25
 </code></pre></blockquote>
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
-  runs/run.msmarco.bm25-default.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
-  runs/run.msmarco.bm25-default.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
-  runs/run.msmarco.bm25-default.dl19.txt
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+  runs/run.msmarco.bm25.dl19.txt
 </code></pre>
   </blockquote>
 
@@ -242,18 +238,14 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   -threads 16 \
   -index msmarco-v1-passage \
   -topics dl20-passage \
-  -output runs/run.msmarco.bm25-default.dl20.txt \
+  -output runs/run.msmarco.bm25.dl20.txt \
   -hits 1000 -bm25
 </code></pre></blockquote>
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
-  runs/run.msmarco.bm25-default.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
-  runs/run.msmarco.bm25-default.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
-  runs/run.msmarco.bm25-default.dl20.txt
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+  runs/run.msmarco.bm25.dl20.txt
 </code></pre>
   </blockquote>
 
@@ -266,16 +258,14 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   -threads 16 \
   -index msmarco-v1-passage \
   -topics msmarco-v1-passage.dev \
-  -output runs/run.msmarco.bm25-default.dev.txt \
+  -output runs/run.msmarco.bm25.dev.txt \
   -hits 1000 -bm25
 </code></pre></blockquote>
 Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
-  runs/run.msmarco.bm25-default.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
-  runs/run.msmarco.bm25-default.dev.txt
+  runs/run.msmarco.bm25.dev.txt
 </code></pre>
   </blockquote>
 
@@ -290,16 +280,16 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subse
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">SPLADE++ EnsembleDistil (cached queries)</td>
-<td>0.5053</td>
+<td>null</td>
 <td>0.7317</td>
-<td>0.8726</td>
+<td>null</td>
 <td></td>
-<td>0.5001</td>
+<td>null</td>
 <td>0.7198</td>
-<td>0.8995</td>
+<td>null</td>
 <td></td>
 <td>0.3830</td>
-<td>0.9831</td>
+<td>null</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -336,11 +326,7 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
-  runs/run.msmarco.splade-pp-ed.cached_q.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
-  runs/run.msmarco.splade-pp-ed.cached_q.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.splade-pp-ed.cached_q.dl19.txt
 </code></pre>
   </blockquote>
@@ -360,11 +346,7 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
-  runs/run.msmarco.splade-pp-ed.cached_q.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
-  runs/run.msmarco.splade-pp-ed.cached_q.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.splade-pp-ed.cached_q.dl20.txt
 </code></pre>
   </blockquote>
@@ -386,8 +368,6 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.splade-pp-ed.cached_q.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
-  runs/run.msmarco.splade-pp-ed.cached_q.dev.txt
 </code></pre>
   </blockquote>
 
@@ -402,16 +382,16 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subse
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">SPLADE++ EnsembleDistil (ONNX)</td>
-<td>0.5050</td>
+<td>null</td>
 <td>0.7308</td>
-<td>0.8728</td>
+<td>null</td>
 <td></td>
-<td>0.4999</td>
+<td>null</td>
 <td>0.7197</td>
-<td>0.8998</td>
+<td>null</td>
 <td></td>
 <td>0.3828</td>
-<td>0.9831</td>
+<td>null</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -449,11 +429,7 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
-  runs/run.msmarco.splade-pp-ed.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
-  runs/run.msmarco.splade-pp-ed.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.splade-pp-ed.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -474,11 +450,7 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
-  runs/run.msmarco.splade-pp-ed.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
-  runs/run.msmarco.splade-pp-ed.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.splade-pp-ed.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -501,8 +473,6 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.splade-pp-ed.onnx.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
-  runs/run.msmarco.splade-pp-ed.onnx.dev.txt
 </code></pre>
   </blockquote>
 
@@ -517,16 +487,16 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subse
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">cosDPR-distil w/ HNSW fp32 (cached queries)</td>
-<td>0.4660</td>
+<td>null</td>
 <td>0.7250</td>
-<td>0.8222</td>
+<td>null</td>
 <td></td>
-<td>0.4876</td>
+<td>null</td>
 <td>0.7025</td>
-<td>0.8540</td>
+<td>null</td>
 <td></td>
 <td>0.3887</td>
-<td>0.9764</td>
+<td>null</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -563,11 +533,7 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
-  runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
-  runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl19.txt
 </code></pre>
   </blockquote>
@@ -587,11 +553,7 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
-  runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
-  runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl20.txt
 </code></pre>
   </blockquote>
@@ -613,8 +575,6 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
-  runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dev.txt
 </code></pre>
   </blockquote>
 
@@ -629,16 +589,16 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subse
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">cosDPR-distil w/ HNSW fp32 (ONNX)</td>
-<td>0.4660</td>
+<td>null</td>
 <td>0.7250</td>
-<td>0.8222</td>
+<td>null</td>
 <td></td>
-<td>0.4876</td>
+<td>null</td>
 <td>0.7025</td>
-<td>0.8540</td>
+<td>null</td>
 <td></td>
 <td>0.3887</td>
-<td>0.9765</td>
+<td>null</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -676,11 +636,7 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
-  runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
-  runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -701,11 +657,7 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
-  runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
-  runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -728,8 +680,6 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.cos-dpr-distil.fp32.onnx.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
-  runs/run.msmarco.cos-dpr-distil.fp32.onnx.dev.txt
 </code></pre>
   </blockquote>
 
@@ -744,16 +694,16 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subse
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">cosDPR-distil w/ HNSW int8 (cached queries)</td>
-<td>0.4662</td>
+<td>null</td>
 <td>0.7240</td>
-<td>0.8219</td>
+<td>null</td>
 <td></td>
-<td>0.4872</td>
+<td>null</td>
 <td>0.7004</td>
-<td>0.8538</td>
+<td>null</td>
 <td></td>
 <td>0.3897</td>
-<td>0.9764</td>
+<td>null</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -790,11 +740,7 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
-  runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
-  runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl19.txt
 </code></pre>
   </blockquote>
@@ -814,11 +760,7 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
-  runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
-  runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl20.txt
 </code></pre>
   </blockquote>
@@ -840,8 +782,6 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.cos-dpr-distil.int8.cached_q.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
-  runs/run.msmarco.cos-dpr-distil.int8.cached_q.dev.txt
 </code></pre>
   </blockquote>
 
@@ -856,16 +796,16 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subse
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">cosDPR-distil w/ HNSW int8 (ONNX)</td>
-<td>0.4664</td>
+<td>null</td>
 <td>0.7247</td>
-<td>0.8218</td>
+<td>null</td>
 <td></td>
-<td>0.4871</td>
+<td>null</td>
 <td>0.6996</td>
-<td>0.8538</td>
+<td>null</td>
 <td></td>
 <td>0.3899</td>
-<td>0.9764</td>
+<td>null</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -903,11 +843,7 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
-  runs/run.msmarco.cos-dpr-distil.int8.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
-  runs/run.msmarco.cos-dpr-distil.int8.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.cos-dpr-distil.int8.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -928,11 +864,7 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
-  runs/run.msmarco.cos-dpr-distil.int8.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
-  runs/run.msmarco.cos-dpr-distil.int8.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.cos-dpr-distil.int8.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -955,8 +887,6 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.cos-dpr-distil.int8.onnx.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
-  runs/run.msmarco.cos-dpr-distil.int8.onnx.dev.txt
 </code></pre>
   </blockquote>
 
@@ -971,16 +901,16 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subse
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">bge-base-en-v1.5 w/ HNSW fp32 (cached queries)</td>
-<td>0.4436</td>
+<td>null</td>
 <td>0.7065</td>
-<td>0.8481</td>
+<td>null</td>
 <td></td>
-<td>0.4648</td>
+<td>null</td>
 <td>0.6780</td>
-<td>0.8483</td>
+<td>null</td>
 <td></td>
 <td>0.3574</td>
-<td>0.9788</td>
+<td>null</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -1017,11 +947,7 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
-  runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
-  runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl19.txt
 </code></pre>
   </blockquote>
@@ -1041,11 +967,7 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
-  runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
-  runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl20.txt
 </code></pre>
   </blockquote>
@@ -1067,8 +989,6 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.bge-base-en-15.fp32.cached_q.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
-  runs/run.msmarco.bge-base-en-15.fp32.cached_q.dev.txt
 </code></pre>
   </blockquote>
 
@@ -1083,16 +1003,16 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subse
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">bge-base-en-v1.5 w/ HNSW fp32 (ONNX)</td>
-<td>0.4486</td>
+<td>null</td>
 <td>0.7016</td>
-<td>0.8441</td>
+<td>null</td>
 <td></td>
-<td>0.4626</td>
+<td>null</td>
 <td>0.6768</td>
-<td>0.8526</td>
+<td>null</td>
 <td></td>
 <td>0.3575</td>
-<td>0.9788</td>
+<td>null</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -1130,11 +1050,7 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
-  runs/run.msmarco.bge-base-en-15.fp32.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
-  runs/run.msmarco.bge-base-en-15.fp32.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.bge-base-en-15.fp32.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -1155,11 +1071,7 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
-  runs/run.msmarco.bge-base-en-15.fp32.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
-  runs/run.msmarco.bge-base-en-15.fp32.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.bge-base-en-15.fp32.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -1182,8 +1094,6 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.bge-base-en-15.fp32.onnx.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
-  runs/run.msmarco.bge-base-en-15.fp32.onnx.dev.txt
 </code></pre>
   </blockquote>
 
@@ -1198,16 +1108,16 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subse
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">bge-base-en-v1.5 w/ HNSW int8 (cached queries)</td>
-<td>0.4400</td>
+<td>null</td>
 <td>0.7016</td>
-<td>0.8481</td>
+<td>null</td>
 <td></td>
-<td>0.4623</td>
+<td>null</td>
 <td>0.6738</td>
-<td>0.8420</td>
+<td>null</td>
 <td></td>
 <td>0.3572</td>
-<td>0.9774</td>
+<td>null</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -1244,11 +1154,7 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
-  runs/run.msmarco.bge-base-en-15.int8.cached_q.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
-  runs/run.msmarco.bge-base-en-15.int8.cached_q.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.bge-base-en-15.int8.cached_q.dl19.txt
 </code></pre>
   </blockquote>
@@ -1268,11 +1174,7 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
-  runs/run.msmarco.bge-base-en-15.int8.cached_q.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
-  runs/run.msmarco.bge-base-en-15.int8.cached_q.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.bge-base-en-15.int8.cached_q.dl20.txt
 </code></pre>
   </blockquote>
@@ -1294,8 +1196,6 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.bge-base-en-15.int8.cached_q.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
-  runs/run.msmarco.bge-base-en-15.int8.cached_q.dev.txt
 </code></pre>
   </blockquote>
 
@@ -1310,16 +1210,16 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subse
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">bge-base-en-v1.5 w/ HNSW int8 (ONNX)</td>
-<td>0.4454</td>
+<td>null</td>
 <td>0.7017</td>
-<td>0.8436</td>
+<td>null</td>
 <td></td>
-<td>0.4596</td>
+<td>null</td>
 <td>0.6767</td>
-<td>0.8468</td>
+<td>null</td>
 <td></td>
 <td>0.3575</td>
-<td>0.9772</td>
+<td>null</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -1357,11 +1257,7 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
-  runs/run.msmarco.bge-base-en-15.int8.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
-  runs/run.msmarco.bge-base-en-15.int8.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.bge-base-en-15.int8.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -1382,11 +1278,7 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
-  runs/run.msmarco.bge-base-en-15.int8.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
-  runs/run.msmarco.bge-base-en-15.int8.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.bge-base-en-15.int8.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -1408,8 +1300,6 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
-  runs/run.msmarco.bge-base-en-15.int8.onnx.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
   runs/run.msmarco.bge-base-en-15.int8.onnx.dev.txt
 </code></pre>
   </blockquote>

--- a/docs/reproduce/msmarco-v1-passage.html
+++ b/docs/reproduce/msmarco-v1-passage.html
@@ -224,11 +224,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.bm25.dl19.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.bm25.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.bm25.dl19.txt
 </code></pre>
   </blockquote>
@@ -248,11 +248,11 @@ tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.bm25.dl20.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.bm25.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.bm25.dl20.txt
 </code></pre>
   </blockquote>
@@ -274,7 +274,7 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.bm25.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
   runs/run.msmarco.bm25.dev.txt
 </code></pre>
   </blockquote>
@@ -336,11 +336,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.splade-pp-ed.cached_q.dl19.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.splade-pp-ed.cached_q.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.splade-pp-ed.cached_q.dl19.txt
 </code></pre>
   </blockquote>
@@ -360,11 +360,11 @@ tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.splade-pp-ed.cached_q.dl20.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.splade-pp-ed.cached_q.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.splade-pp-ed.cached_q.dl20.txt
 </code></pre>
   </blockquote>
@@ -386,7 +386,7 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.splade-pp-ed.cached_q.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
   runs/run.msmarco.splade-pp-ed.cached_q.dev.txt
 </code></pre>
   </blockquote>
@@ -449,11 +449,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.splade-pp-ed.onnx.dl19.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.splade-pp-ed.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.splade-pp-ed.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -474,11 +474,11 @@ tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.splade-pp-ed.onnx.dl20.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.splade-pp-ed.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.splade-pp-ed.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -501,7 +501,7 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.splade-pp-ed.onnx.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
   runs/run.msmarco.splade-pp-ed.onnx.dev.txt
 </code></pre>
   </blockquote>
@@ -563,11 +563,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl19.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl19.txt
 </code></pre>
   </blockquote>
@@ -587,11 +587,11 @@ tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl20.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl20.txt
 </code></pre>
   </blockquote>
@@ -613,7 +613,7 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
   runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dev.txt
 </code></pre>
   </blockquote>
@@ -676,11 +676,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl19.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -701,11 +701,11 @@ tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl20.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -728,7 +728,7 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.cos-dpr-distil.fp32.onnx.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
   runs/run.msmarco.cos-dpr-distil.fp32.onnx.dev.txt
 </code></pre>
   </blockquote>
@@ -790,11 +790,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl19.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl19.txt
 </code></pre>
   </blockquote>
@@ -814,11 +814,11 @@ tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl20.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl20.txt
 </code></pre>
   </blockquote>
@@ -840,7 +840,7 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.cos-dpr-distil.int8.cached_q.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
   runs/run.msmarco.cos-dpr-distil.int8.cached_q.dev.txt
 </code></pre>
   </blockquote>
@@ -903,11 +903,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.cos-dpr-distil.int8.onnx.dl19.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.cos-dpr-distil.int8.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.cos-dpr-distil.int8.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -928,11 +928,11 @@ tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.cos-dpr-distil.int8.onnx.dl20.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.cos-dpr-distil.int8.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.cos-dpr-distil.int8.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -955,7 +955,7 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.cos-dpr-distil.int8.onnx.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
   runs/run.msmarco.cos-dpr-distil.int8.onnx.dev.txt
 </code></pre>
   </blockquote>
@@ -1017,11 +1017,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl19.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl19.txt
 </code></pre>
   </blockquote>
@@ -1041,11 +1041,11 @@ tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl20.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl20.txt
 </code></pre>
   </blockquote>
@@ -1067,7 +1067,7 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.bge-base-en-15.fp32.cached_q.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
   runs/run.msmarco.bge-base-en-15.fp32.cached_q.dev.txt
 </code></pre>
   </blockquote>
@@ -1130,11 +1130,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.bge-base-en-15.fp32.onnx.dl19.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.bge-base-en-15.fp32.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.bge-base-en-15.fp32.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -1155,11 +1155,11 @@ tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.bge-base-en-15.fp32.onnx.dl20.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.bge-base-en-15.fp32.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.bge-base-en-15.fp32.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -1182,7 +1182,7 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.bge-base-en-15.fp32.onnx.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
   runs/run.msmarco.bge-base-en-15.fp32.onnx.dev.txt
 </code></pre>
   </blockquote>
@@ -1244,11 +1244,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.bge-base-en-15.int8.cached_q.dl19.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.bge-base-en-15.int8.cached_q.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.bge-base-en-15.int8.cached_q.dl19.txt
 </code></pre>
   </blockquote>
@@ -1268,11 +1268,11 @@ tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.bge-base-en-15.int8.cached_q.dl20.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.bge-base-en-15.int8.cached_q.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.bge-base-en-15.int8.cached_q.dl20.txt
 </code></pre>
   </blockquote>
@@ -1294,7 +1294,7 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.bge-base-en-15.int8.cached_q.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
   runs/run.msmarco.bge-base-en-15.int8.cached_q.dev.txt
 </code></pre>
   </blockquote>
@@ -1357,11 +1357,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.bge-base-en-15.int8.onnx.dl19.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.bge-base-en-15.int8.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.bge-base-en-15.int8.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -1382,11 +1382,11 @@ tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.bge-base-en-15.int8.onnx.dl20.txt
 tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.bge-base-en-15.int8.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.bge-base-en-15.int8.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -1409,7 +1409,7 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.bge-base-en-15.int8.onnx.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev-subset \
   runs/run.msmarco.bge-base-en-15.int8.onnx.dev.txt
 </code></pre>
   </blockquote>

--- a/docs/reproduce/msmarco-v1-passage.html
+++ b/docs/reproduce/msmarco-v1-passage.html
@@ -178,16 +178,16 @@ Instructions for programmatic execution are shown at the bottom of this page (sc
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)</td>
-<td>null</td>
+<td>0.3013</td>
 <td>0.5058</td>
-<td>null</td>
+<td>0.7501</td>
 <td></td>
-<td>null</td>
+<td>0.2856</td>
 <td>0.4796</td>
-<td>null</td>
+<td>0.7863</td>
 <td></td>
 <td>0.1840</td>
-<td>null</td>
+<td>0.8526</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -224,7 +224,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+  runs/run.msmarco.bm25.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+  runs/run.msmarco.bm25.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
   runs/run.msmarco.bm25.dl19.txt
 </code></pre>
   </blockquote>
@@ -244,7 +248,11 @@ Evaluation commands:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+  runs/run.msmarco.bm25.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+  runs/run.msmarco.bm25.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
   runs/run.msmarco.bm25.dl20.txt
 </code></pre>
   </blockquote>
@@ -266,6 +274,8 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.bm25.dev.txt
+tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+  runs/run.msmarco.bm25.dev.txt
 </code></pre>
   </blockquote>
 
@@ -280,16 +290,16 @@ Evaluation commands:
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">SPLADE++ EnsembleDistil (cached queries)</td>
-<td>null</td>
+<td>0.5053</td>
 <td>0.7317</td>
-<td>null</td>
+<td>0.8726</td>
 <td></td>
-<td>null</td>
+<td>0.5001</td>
 <td>0.7198</td>
-<td>null</td>
+<td>0.8995</td>
 <td></td>
 <td>0.3830</td>
-<td>null</td>
+<td>0.9831</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -326,7 +336,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+  runs/run.msmarco.splade-pp-ed.cached_q.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+  runs/run.msmarco.splade-pp-ed.cached_q.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
   runs/run.msmarco.splade-pp-ed.cached_q.dl19.txt
 </code></pre>
   </blockquote>
@@ -346,7 +360,11 @@ Evaluation commands:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+  runs/run.msmarco.splade-pp-ed.cached_q.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+  runs/run.msmarco.splade-pp-ed.cached_q.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
   runs/run.msmarco.splade-pp-ed.cached_q.dl20.txt
 </code></pre>
   </blockquote>
@@ -368,6 +386,8 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.splade-pp-ed.cached_q.dev.txt
+tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+  runs/run.msmarco.splade-pp-ed.cached_q.dev.txt
 </code></pre>
   </blockquote>
 
@@ -382,16 +402,16 @@ Evaluation commands:
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">SPLADE++ EnsembleDistil (ONNX)</td>
-<td>null</td>
+<td>0.5050</td>
 <td>0.7308</td>
-<td>null</td>
+<td>0.8728</td>
 <td></td>
-<td>null</td>
+<td>0.4999</td>
 <td>0.7197</td>
-<td>null</td>
+<td>0.8998</td>
 <td></td>
 <td>0.3828</td>
-<td>null</td>
+<td>0.9831</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -429,7 +449,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+  runs/run.msmarco.splade-pp-ed.onnx.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+  runs/run.msmarco.splade-pp-ed.onnx.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
   runs/run.msmarco.splade-pp-ed.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -450,7 +474,11 @@ Evaluation commands:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+  runs/run.msmarco.splade-pp-ed.onnx.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+  runs/run.msmarco.splade-pp-ed.onnx.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
   runs/run.msmarco.splade-pp-ed.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -473,6 +501,8 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.splade-pp-ed.onnx.dev.txt
+tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+  runs/run.msmarco.splade-pp-ed.onnx.dev.txt
 </code></pre>
   </blockquote>
 
@@ -487,16 +517,16 @@ Evaluation commands:
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">cosDPR-distil w/ HNSW fp32 (cached queries)</td>
-<td>null</td>
+<td>0.4660</td>
 <td>0.7250</td>
-<td>null</td>
+<td>0.8222</td>
 <td></td>
-<td>null</td>
+<td>0.4876</td>
 <td>0.7025</td>
-<td>null</td>
+<td>0.8540</td>
 <td></td>
 <td>0.3887</td>
-<td>null</td>
+<td>0.9764</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -533,7 +563,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+  runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+  runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl19.txt
 </code></pre>
   </blockquote>
@@ -553,7 +587,11 @@ Evaluation commands:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+  runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+  runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dl20.txt
 </code></pre>
   </blockquote>
@@ -575,6 +613,8 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dev.txt
+tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+  runs/run.msmarco.cos-dpr-distil.fp32.cached_q.dev.txt
 </code></pre>
   </blockquote>
 
@@ -589,16 +629,16 @@ Evaluation commands:
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">cosDPR-distil w/ HNSW fp32 (ONNX)</td>
-<td>null</td>
+<td>0.4660</td>
 <td>0.7250</td>
-<td>null</td>
+<td>0.8222</td>
 <td></td>
-<td>null</td>
+<td>0.4876</td>
 <td>0.7025</td>
-<td>null</td>
+<td>0.8540</td>
 <td></td>
 <td>0.3887</td>
-<td>null</td>
+<td>0.9765</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -636,7 +676,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+  runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+  runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -657,7 +701,11 @@ Evaluation commands:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+  runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+  runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
   runs/run.msmarco.cos-dpr-distil.fp32.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -680,6 +728,8 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.cos-dpr-distil.fp32.onnx.dev.txt
+tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+  runs/run.msmarco.cos-dpr-distil.fp32.onnx.dev.txt
 </code></pre>
   </blockquote>
 
@@ -694,16 +744,16 @@ Evaluation commands:
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">cosDPR-distil w/ HNSW int8 (cached queries)</td>
-<td>null</td>
+<td>0.4662</td>
 <td>0.7240</td>
-<td>null</td>
+<td>0.8219</td>
 <td></td>
-<td>null</td>
+<td>0.4872</td>
 <td>0.7004</td>
-<td>null</td>
+<td>0.8538</td>
 <td></td>
 <td>0.3897</td>
-<td>null</td>
+<td>0.9764</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -740,7 +790,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+  runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+  runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
   runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl19.txt
 </code></pre>
   </blockquote>
@@ -760,7 +814,11 @@ Evaluation commands:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+  runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+  runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
   runs/run.msmarco.cos-dpr-distil.int8.cached_q.dl20.txt
 </code></pre>
   </blockquote>
@@ -782,6 +840,8 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.cos-dpr-distil.int8.cached_q.dev.txt
+tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+  runs/run.msmarco.cos-dpr-distil.int8.cached_q.dev.txt
 </code></pre>
   </blockquote>
 
@@ -796,16 +856,16 @@ Evaluation commands:
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">cosDPR-distil w/ HNSW int8 (ONNX)</td>
-<td>null</td>
+<td>0.4664</td>
 <td>0.7247</td>
-<td>null</td>
+<td>0.8218</td>
 <td></td>
-<td>null</td>
+<td>0.4871</td>
 <td>0.6996</td>
-<td>null</td>
+<td>0.8538</td>
 <td></td>
 <td>0.3899</td>
-<td>null</td>
+<td>0.9764</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -843,7 +903,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+  runs/run.msmarco.cos-dpr-distil.int8.onnx.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+  runs/run.msmarco.cos-dpr-distil.int8.onnx.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
   runs/run.msmarco.cos-dpr-distil.int8.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -864,7 +928,11 @@ Evaluation commands:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+  runs/run.msmarco.cos-dpr-distil.int8.onnx.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+  runs/run.msmarco.cos-dpr-distil.int8.onnx.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
   runs/run.msmarco.cos-dpr-distil.int8.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -887,6 +955,8 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.cos-dpr-distil.int8.onnx.dev.txt
+tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+  runs/run.msmarco.cos-dpr-distil.int8.onnx.dev.txt
 </code></pre>
   </blockquote>
 
@@ -901,16 +971,16 @@ Evaluation commands:
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">bge-base-en-v1.5 w/ HNSW fp32 (cached queries)</td>
-<td>null</td>
+<td>0.4436</td>
 <td>0.7065</td>
-<td>null</td>
+<td>0.8481</td>
 <td></td>
-<td>null</td>
+<td>0.4648</td>
 <td>0.6780</td>
-<td>null</td>
+<td>0.8483</td>
 <td></td>
 <td>0.3574</td>
-<td>null</td>
+<td>0.9788</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -947,7 +1017,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+  runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+  runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
   runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl19.txt
 </code></pre>
   </blockquote>
@@ -967,7 +1041,11 @@ Evaluation commands:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+  runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+  runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
   runs/run.msmarco.bge-base-en-15.fp32.cached_q.dl20.txt
 </code></pre>
   </blockquote>
@@ -989,6 +1067,8 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.bge-base-en-15.fp32.cached_q.dev.txt
+tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+  runs/run.msmarco.bge-base-en-15.fp32.cached_q.dev.txt
 </code></pre>
   </blockquote>
 
@@ -1003,16 +1083,16 @@ Evaluation commands:
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">bge-base-en-v1.5 w/ HNSW fp32 (ONNX)</td>
-<td>null</td>
+<td>0.4486</td>
 <td>0.7016</td>
-<td>null</td>
+<td>0.8441</td>
 <td></td>
-<td>null</td>
+<td>0.4626</td>
 <td>0.6768</td>
-<td>null</td>
+<td>0.8526</td>
 <td></td>
 <td>0.3575</td>
-<td>null</td>
+<td>0.9788</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -1050,7 +1130,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+  runs/run.msmarco.bge-base-en-15.fp32.onnx.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+  runs/run.msmarco.bge-base-en-15.fp32.onnx.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
   runs/run.msmarco.bge-base-en-15.fp32.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -1071,7 +1155,11 @@ Evaluation commands:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+  runs/run.msmarco.bge-base-en-15.fp32.onnx.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+  runs/run.msmarco.bge-base-en-15.fp32.onnx.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
   runs/run.msmarco.bge-base-en-15.fp32.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -1094,6 +1182,8 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.bge-base-en-15.fp32.onnx.dev.txt
+tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+  runs/run.msmarco.bge-base-en-15.fp32.onnx.dev.txt
 </code></pre>
   </blockquote>
 
@@ -1108,16 +1198,16 @@ Evaluation commands:
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">bge-base-en-v1.5 w/ HNSW int8 (cached queries)</td>
-<td>null</td>
+<td>0.4400</td>
 <td>0.7016</td>
-<td>null</td>
+<td>0.8481</td>
 <td></td>
-<td>null</td>
+<td>0.4623</td>
 <td>0.6738</td>
-<td>null</td>
+<td>0.8420</td>
 <td></td>
 <td>0.3572</td>
-<td>null</td>
+<td>0.9774</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -1154,7 +1244,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+  runs/run.msmarco.bge-base-en-15.int8.cached_q.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+  runs/run.msmarco.bge-base-en-15.int8.cached_q.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
   runs/run.msmarco.bge-base-en-15.int8.cached_q.dl19.txt
 </code></pre>
   </blockquote>
@@ -1174,7 +1268,11 @@ Evaluation commands:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+  runs/run.msmarco.bge-base-en-15.int8.cached_q.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+  runs/run.msmarco.bge-base-en-15.int8.cached_q.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
   runs/run.msmarco.bge-base-en-15.int8.cached_q.dl20.txt
 </code></pre>
   </blockquote>
@@ -1196,6 +1294,8 @@ Evaluation commands:
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
   runs/run.msmarco.bge-base-en-15.int8.cached_q.dev.txt
+tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
+  runs/run.msmarco.bge-base-en-15.int8.cached_q.dev.txt
 </code></pre>
   </blockquote>
 
@@ -1210,16 +1310,16 @@ Evaluation commands:
 <td class="expand-button"></td>
 <td style="min-width: 85px"></td>
 <td style="min-width: 400px">bge-base-en-v1.5 w/ HNSW int8 (ONNX)</td>
-<td>null</td>
+<td>0.4454</td>
 <td>0.7017</td>
-<td>null</td>
+<td>0.8436</td>
 <td></td>
-<td>null</td>
+<td>0.4596</td>
 <td>0.6767</td>
-<td>null</td>
+<td>0.8468</td>
 <td></td>
 <td>0.3575</td>
-<td>null</td>
+<td>0.9772</td>
 </tr>
 <tr class="hide-table-padding">
 <td></td>
@@ -1257,7 +1357,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
+  runs/run.msmarco.bge-base-en-15.int8.onnx.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+  runs/run.msmarco.bge-base-en-15.int8.onnx.dl19.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl19-passage \
   runs/run.msmarco.bge-base-en-15.int8.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -1278,7 +1382,11 @@ Evaluation commands:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
+  runs/run.msmarco.bge-base-en-15.int8.onnx.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+  runs/run.msmarco.bge-base-en-15.int8.onnx.dl20.txt
+tools/eval/trec_eval.9.0.4/trec_eval null dl20-passage \
   runs/run.msmarco.bge-base-en-15.int8.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -1300,6 +1408,8 @@ Evaluation commands:
 
   <blockquote class="mycode">
 <pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset \
+  runs/run.msmarco.bge-base-en-15.int8.onnx.dev.txt
+tools/eval/trec_eval.9.0.4/trec_eval null msmarco-passage.dev-subset \
   runs/run.msmarco.bge-base-en-15.int8.onnx.dev.txt
 </code></pre>
   </blockquote>

--- a/src/main/java/io/anserini/reproduce/RunBeir.java
+++ b/src/main/java/io/anserini/reproduce/RunBeir.java
@@ -24,7 +24,7 @@ import io.anserini.reproduce.RunRepro.TrecEvalMetricDefinitions;
 public class RunBeir {
 
   public static void main(String[] args) throws Exception {
-    RunRepro repro = new RunRepro("beir", new BeirMetricDefinitions());
+    RunRepro repro = new RunRepro("beir", new BeirMetricDefinitions(), false);
     repro.run();
   }
 

--- a/src/main/java/io/anserini/reproduce/RunMsMarco.java
+++ b/src/main/java/io/anserini/reproduce/RunMsMarco.java
@@ -17,9 +17,12 @@
 package io.anserini.reproduce;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
@@ -32,14 +35,13 @@ public class RunMsMarco {
   public static class Args {
     @Option(name = "-options", usage = "Print information about options.")
     public Boolean options = false;
-    @Option(name = "-v", metaVar = "[int]", usage = "MsMarco Version (1/2), where 2 is for V2.1. Default 1.")
-    public int MsMarcoVersion = 1;
+    @Option(name = "-v", usage = "MsMarco Version (msmarco-v2.1 / msmarco-v1-passage). Default: msmarco-v1-passage.")
+    public String MsMarcoVersion = "msmarco-v1-passage";
   }
 
   public static void main(String[] args) throws Exception {
 
     // check for cmd option
-    String COLLECTION = "msmarco-v1-passage";
     Args MsMarcoArgs = new Args();
     CmdLineParser parser = new CmdLineParser(MsMarcoArgs, ParserProperties.defaults().withUsageWidth(120));
 
@@ -64,16 +66,14 @@ public class RunMsMarco {
 
       return;
     }
-    switch (MsMarcoArgs.MsMarcoVersion) {
-        case 2:
-            COLLECTION = "msmarco-v2.1";
-            break;
-        default: // MsMarcoVersion == 1
-            COLLECTION = "msmarco-v1-passage";
-            break;
+
+    Set<String> allowedVersions = new HashSet<>(Arrays.asList("msmarco-v2.1", "msmarco-v1-passage"));
+    if (!allowedVersions.contains(MsMarcoArgs.MsMarcoVersion)) {
+        System.err.println("Invalid MsMarco version: " + MsMarcoArgs.MsMarcoVersion);
+        System.exit(1);
     }
 
-    RunRepro repro = new RunRepro(COLLECTION, new MsMarcoMetricDefinitions(), true);
+    RunRepro repro = new RunRepro(MsMarcoArgs.MsMarcoVersion, new MsMarcoMetricDefinitions(), true);
     repro.run();
   }
 

--- a/src/main/java/io/anserini/reproduce/RunMsMarco.java
+++ b/src/main/java/io/anserini/reproduce/RunMsMarco.java
@@ -66,14 +66,14 @@ public class RunMsMarco {
     }
     switch (MsMarcoArgs.MsMarcoVersion) {
         case 2:
-            COLLECTION = "msmarco-v2.1-doc";
+            COLLECTION = "msmarco-v2.1";
             break;
         default: // MsMarcoVersion == 1
             COLLECTION = "msmarco-v1-passage";
             break;
     }
 
-    RunRepro repro = new RunRepro(COLLECTION, new MsMarcoMetricDefinitions());
+    RunRepro repro = new RunRepro(COLLECTION, new MsMarcoMetricDefinitions(), true);
     repro.run();
   }
 
@@ -136,7 +136,7 @@ public class RunMsMarco {
       dl23PassageMetrics.put("R@1K", "-c -m recall.1000");
       msmarcoV2Passage.put("dl23-doc-msmarco-v2.1", dl23PassageMetrics);
   
-      metricDefinitions.put("msmarco-v2.1-doc", msmarcoV2Passage);
+      metricDefinitions.put("msmarco-v2.1", msmarcoV2Passage);
     }
   }
 

--- a/src/main/java/io/anserini/reproduce/RunMsMarco.java
+++ b/src/main/java/io/anserini/reproduce/RunMsMarco.java
@@ -86,20 +86,15 @@ public class RunMsMarco {
       // msmarco-v1-passage definitions
       Map<String, String> msmarcoDevSubsetMetrics = new HashMap<>();
       msmarcoDevSubsetMetrics.put("MRR@10", "-c -M 10 -m recip_rank");
-      msmarcoDevSubsetMetrics.put("R@1K", "-c -m recall.1000");
       msmarcoV1Passage.put("msmarco-passage.dev-subset",
           msmarcoDevSubsetMetrics);
   
       Map<String, String> dl19PassageMetrics = new HashMap<>();
-      dl19PassageMetrics.put("MAP", "-c -l 2 -m map");
       dl19PassageMetrics.put("nDCG@10", "-c -m ndcg_cut.10");
-      dl19PassageMetrics.put("R@1K", "-c -l 2 -m recall.1000");
       msmarcoV1Passage.put("dl19-passage", dl19PassageMetrics);
 
       Map<String, String> dl20PassageMetrics = new HashMap<>();
-      dl20PassageMetrics.put("MAP", "-c -l 2 -m map");
       dl20PassageMetrics.put("nDCG@10", "-c -m ndcg_cut.10");
-      dl20PassageMetrics.put("R@1K", "-c -l 2 -m recall.1000");
       msmarcoV1Passage.put("dl20-passage", dl20PassageMetrics);
 
       metricDefinitions.put("msmarco-v1-passage", msmarcoV1Passage);

--- a/src/main/java/io/anserini/reproduce/RunMsMarco.java
+++ b/src/main/java/io/anserini/reproduce/RunMsMarco.java
@@ -86,15 +86,20 @@ public class RunMsMarco {
       // msmarco-v1-passage definitions
       Map<String, String> msmarcoDevSubsetMetrics = new HashMap<>();
       msmarcoDevSubsetMetrics.put("MRR@10", "-c -M 10 -m recip_rank");
+      msmarcoDevSubsetMetrics.put("R@1K", "-c -m recall.1000");
       msmarcoV1Passage.put("msmarco-passage.dev-subset",
           msmarcoDevSubsetMetrics);
   
       Map<String, String> dl19PassageMetrics = new HashMap<>();
+      dl19PassageMetrics.put("MAP", "-c -l 2 -m map");
       dl19PassageMetrics.put("nDCG@10", "-c -m ndcg_cut.10");
+      dl19PassageMetrics.put("R@1K", "-c -l 2 -m recall.1000");
       msmarcoV1Passage.put("dl19-passage", dl19PassageMetrics);
 
       Map<String, String> dl20PassageMetrics = new HashMap<>();
+      dl20PassageMetrics.put("MAP", "-c -l 2 -m map");
       dl20PassageMetrics.put("nDCG@10", "-c -m ndcg_cut.10");
+      dl20PassageMetrics.put("R@1K", "-c -l 2 -m recall.1000");
       msmarcoV1Passage.put("dl20-passage", dl20PassageMetrics);
 
       metricDefinitions.put("msmarco-v1-passage", msmarcoV1Passage);

--- a/src/main/java/io/anserini/reproduce/RunRepro.java
+++ b/src/main/java/io/anserini/reproduce/RunRepro.java
@@ -40,11 +40,13 @@ public class RunRepro {
 
   private String COLLECTION;
   private TrecEvalMetricDefinitions metricDefinitions;
+  private boolean sortByCondition;
 
-  public RunRepro(String collection, TrecEvalMetricDefinitions metrics)
+  public RunRepro(String collection, TrecEvalMetricDefinitions metrics, boolean sortCondition)
       throws IOException, InterruptedException {
     COLLECTION = collection;
     metricDefinitions = metrics;
+    sortByCondition = sortCondition;
   }
 
   public void run() throws StreamReadException, DatabindException, IOException, InterruptedException, URISyntaxException {
@@ -64,8 +66,15 @@ public class RunRepro {
       for (Topic topic : condition.topics) {
         System.out.println("  - topic_key: " + topic.topic_key + "\n");
 
-        final String output = String.format("runs/run.%s.%s.%s.txt", COLLECTION, condition.name,
-            topic.topic_key);
+        final String output;
+        if (sortByCondition) {
+          output = String.format("runs/run.%s.%s.%s.txt", COLLECTION, condition.name,
+          topic.topic_key);
+        }
+        else {
+          output = String.format("runs/run.%s.%s.%s.txt", COLLECTION, topic.topic_key,
+          condition.name);
+        }
 
         final String command = condition.command
             .replace("$fatjar", fatjarPath)
@@ -93,6 +102,9 @@ public class RunRepro {
         for (Map<String, Double> expected : topic.scores) {
           for (String metric : expected.keySet()) {
             String evalKey = topic.eval_key;
+            if (!evalCommands.get(evalKey).containsKey(metric)) {
+              continue; // skip metric unintended to test
+            }
             String evalCmd = "java -cp $fatjarPath trec_eval $metric $evalKey $output"
             .replace("$fatjarPath", fatjarPath)
             .replace("$metric", evalCommands.get(evalKey).get(metric))

--- a/src/main/java/io/anserini/reproduce/RunRepro.java
+++ b/src/main/java/io/anserini/reproduce/RunRepro.java
@@ -70,8 +70,7 @@ public class RunRepro {
         if (sortByCondition) {
           output = String.format("runs/run.%s.%s.%s.txt", COLLECTION, condition.name,
           topic.topic_key);
-        }
-        else {
+        } else {
           output = String.format("runs/run.%s.%s.%s.txt", COLLECTION, topic.topic_key,
           condition.name);
         }
@@ -125,8 +124,7 @@ public class RunRepro {
               if (delta > 0.00005) {
                 System.out.println(String.format("    %7s: %.4f %s expected %.4f", metric, score, FAIL,
                     expected.get(metric)));
-              }
-              else {
+              } else {
                 System.out.println(String.format("    %7s: %.4f [OK]", metric, score));
               }
             } else {

--- a/src/main/resources/reproduce/beir.yaml
+++ b/src/main/resources/reproduce/beir.yaml
@@ -491,7 +491,7 @@ conditions:
     display: "bge-base-en-v1.5 cached queries"
     display_html: "bge-base-en-v1.5 cached queries"
     display_row: ""
-    command: java -cp $fatjar io.anserini.search.SearchCollection -threads $threads -index beir-v1.0.0-$topics.bge-base-en-v1.5 -topics beir-$topics.bge-base-en-v1.5 -output $output -threads 16 -efSearch 1000 -removeQuery
+    command: java -cp $fatjar io.anserini.search.SearchHnswDenseVectors -threads $threads -index beir-v1.0.0-$topics.bge-base-en-v1.5 -topics beir-$topics.bge-base-en-v1.5 -output $output -threads 16 -efSearch 1000 -removeQuery
     topics:
     - topic_key: trec-covid
       eval_key: beir-v1.0.0-trec-covid.test
@@ -613,7 +613,7 @@ conditions:
     display: "bge-base-en-v1.5 ONNX query encoding"
     display_html: "bge-base-en-v1.5 ONNX query encoding"
     display_row: ""
-    command: java -cp $fatjar io.anserini.search.SearchCollection -threads $threads -index beir-v1.0.0-$topics.bge-base-en-v1.5 -topics beir-$topics -encoder BgeBaseEn15 -output $output -threads 16 -efSearch 1000 -removeQuery
+    command: java -cp $fatjar io.anserini.search.SearchHnswDenseVectors -threads $threads -index beir-v1.0.0-$topics.bge-base-en-v1.5 -topics beir-$topics -encoder BgeBaseEn15 -output $output -threads 16 -efSearch 1000 -removeQuery
     topics:
     - topic_key: trec-covid
       eval_key: beir-v1.0.0-trec-covid.test

--- a/src/main/resources/reproduce/msmarco-v1-passage.yaml
+++ b/src/main/resources/reproduce/msmarco-v1-passage.yaml
@@ -1,5 +1,5 @@
 conditions:
-  - name: bm25-default
+  - name: bm25
     display: "BM25 (k1=0.9, b=0.4)"
     display_html: "BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)"
     display_row: ""
@@ -9,19 +9,14 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.1840
-            R@1K: 0.8526
       - topic_key: dl19-passage
         eval_key: dl19-passage
         scores:
-          - MAP: 0.3013
-            nDCG@10: 0.5058
-            R@1K: 0.7501
+          - nDCG@10: 0.5058
       - topic_key: dl20-passage
         eval_key: dl20-passage
         scores:
-          - MAP: 0.2856
-            nDCG@10: 0.4796
-            R@1K: 0.7863
+          - nDCG@10: 0.4796
   - name: splade-pp-ed.cached_q
     display: "SPLADE++ EnsembleDistil (cached queries)"
     display_html: "SPLADE++ EnsembleDistil (cached queries)"
@@ -32,19 +27,14 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3830
-            R@1K: 0.9831
       - topic_key: dl19-passage.splade-pp-ed
         eval_key: dl19-passage
         scores:
-          - MAP: 0.5053
-            nDCG@10: 0.7317
-            R@1K: 0.8726
+          - nDCG@10: 0.7317
       - topic_key: dl20-passage.splade-pp-ed
         eval_key: dl20-passage
         scores:
-          - MAP: 0.5001
-            nDCG@10: 0.7198
-            R@1K: 0.8995
+          - nDCG@10: 0.7198
   - name: splade-pp-ed.onnx
     display: "SPLADE++ EnsembleDistil (ONNX)"
     display_html: "SPLADE++ EnsembleDistil (ONNX)"
@@ -55,19 +45,14 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3828
-            R@1K: 0.9831
       - topic_key: dl19-passage
         eval_key: dl19-passage
         scores:
-          - MAP: 0.5050
-            nDCG@10: 0.7308
-            R@1K: 0.8728
+          - nDCG@10: 0.7308
       - topic_key: dl20-passage
         eval_key: dl20-passage
         scores:
-          - MAP: 0.4999
-            nDCG@10: 0.7197
-            R@1K: 0.8998
+          - nDCG@10: 0.7197
   - name: cos-dpr-distil.fp32.cached_q
     display: "cosDPR-distil w/ HNSW fp32 (cached queries)"
     display_html: "cosDPR-distil w/ HNSW fp32 (cached queries)"
@@ -78,19 +63,14 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3887
-            R@1K: 0.9764
       - topic_key: dl19-passage.cos-dpr-distil
         eval_key: dl19-passage
         scores:
-          - MAP: 0.4660
-            nDCG@10: 0.7250
-            R@1K: 0.8222
+          - nDCG@10: 0.7250
       - topic_key: dl20-passage.cos-dpr-distil
         eval_key: dl20-passage
         scores:
-          - MAP: 0.4876
-            nDCG@10: 0.7025
-            R@1K: 0.8540
+          - nDCG@10: 0.7025
   - name: cos-dpr-distil.fp32.onnx
     display: "cosDPR-distil w/ HNSW fp32 (ONNX)"
     display_html: "cosDPR-distil w/ HNSW fp32 (ONNX)"
@@ -101,19 +81,14 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3887
-            R@1K: 0.9765
       - topic_key: dl19-passage
         eval_key: dl19-passage
         scores:
-          - MAP: 0.4660
-            nDCG@10: 0.7250
-            R@1K: 0.8222
+          - nDCG@10: 0.7250
       - topic_key: dl20-passage
         eval_key: dl20-passage
         scores:
-          - MAP: 0.4876
-            nDCG@10: 0.7025
-            R@1K: 0.8540
+          - nDCG@10: 0.7025
   - name: cos-dpr-distil.int8.cached_q
     display: "cosDPR-distil w/ HNSW int8 (cached queries)"
     display_html: "cosDPR-distil w/ HNSW int8 (cached queries)"
@@ -124,19 +99,14 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3897
-            R@1K: 0.9764
       - topic_key: dl19-passage.cos-dpr-distil
         eval_key: dl19-passage
         scores:
-          - MAP: 0.4662
-            nDCG@10: 0.7240
-            R@1K: 0.8219
+          - nDCG@10: 0.7240
       - topic_key: dl20-passage.cos-dpr-distil
         eval_key: dl20-passage
         scores:
-          - MAP: 0.4872
-            nDCG@10: 0.7004
-            R@1K: 0.8538
+          - nDCG@10: 0.7004
   - name: cos-dpr-distil.int8.onnx
     display: "cosDPR-distil w/ HNSW int8 (ONNX)"
     display_html: "cosDPR-distil w/ HNSW int8 (ONNX)"
@@ -147,19 +117,14 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3899
-            R@1K: 0.9764
       - topic_key: dl19-passage
         eval_key: dl19-passage
         scores:
-          - MAP: 0.4664
-            nDCG@10: 0.7247
-            R@1K: 0.8218
+          - nDCG@10: 0.7247
       - topic_key: dl20-passage
         eval_key: dl20-passage
         scores:
-          - MAP: 0.4871
-            nDCG@10: 0.6996
-            R@1K: 0.8538
+          - nDCG@10: 0.6996
   - name: bge-base-en-15.fp32.cached_q
     display: "bge-base-en-v1.5 w/ HNSW fp32 (cached queries)"
     display_html: "bge-base-en-v1.5 w/ HNSW fp32 (cached queries)"
@@ -170,19 +135,14 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3574
-            R@1K: 0.9788
       - topic_key: dl19-passage.bge-base-en-v1.5
         eval_key: dl19-passage
         scores:
-          - MAP: 0.4436
-            nDCG@10: 0.7065
-            R@1K: 0.8481
+          - nDCG@10: 0.7065
       - topic_key: dl20-passage.bge-base-en-v1.5
         eval_key: dl20-passage
         scores:
-          - MAP: 0.4648
-            nDCG@10: 0.6780
-            R@1K: 0.8483
+          - nDCG@10: 0.6780
   - name: bge-base-en-15.fp32.onnx
     display: "bge-base-en-v1.5 w/ HNSW fp32 (ONNX)"
     display_html: "bge-base-en-v1.5 w/ HNSW fp32 (ONNX)"
@@ -193,19 +153,14 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3575
-            R@1K: 0.9788
       - topic_key: dl19-passage
         eval_key: dl19-passage
         scores:
-          - MAP: 0.4486
-            nDCG@10: 0.7016
-            R@1K: 0.8441
+          - nDCG@10: 0.7016
       - topic_key: dl20-passage
         eval_key: dl20-passage
         scores:
-          - MAP: 0.4626
-            nDCG@10: 0.6768
-            R@1K: 0.8526
+          - nDCG@10: 0.6768
   - name: bge-base-en-15.int8.cached_q
     display: "bge-base-en-v1.5 w/ HNSW int8 (cached queries)"
     display_html: "bge-base-en-v1.5 w/ HNSW int8 (cached queries)"
@@ -216,19 +171,14 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3572
-            R@1K: 0.9774
       - topic_key: dl19-passage.bge-base-en-v1.5
         eval_key: dl19-passage
         scores:
-          - MAP: 0.4400
-            nDCG@10: 0.7016
-            R@1K: 0.8481
+          - nDCG@10: 0.7016
       - topic_key: dl20-passage.bge-base-en-v1.5
         eval_key: dl20-passage
         scores:
-          - MAP: 0.4623
-            nDCG@10: 0.6738
-            R@1K: 0.8420
+          - nDCG@10: 0.6738
   - name: bge-base-en-15.int8.onnx
     display: "bge-base-en-v1.5 w/ HNSW int8 (ONNX)"
     display_html: "bge-base-en-v1.5 w/ HNSW int8 (ONNX)"
@@ -239,19 +189,14 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3575
-            R@1K: 0.9772
       - topic_key: dl19-passage
         eval_key: dl19-passage
         scores:
-          - MAP: 0.4454
-            nDCG@10: 0.7017
-            R@1K: 0.8436
+          - nDCG@10: 0.7017
       - topic_key: dl20-passage
         eval_key: dl20-passage
         scores:
-          - MAP: 0.4596
-            nDCG@10: 0.6767
-            R@1K: 0.8468
+          - nDCG@10: 0.6767
   - name: cohere-embed-english-v3.0.fp32.cached_q
     display: "cohere-embed-english-v3.0 w/ HNSW fp32 (cached queries)"
     display_html: "cohere-embed-english-v3.0 w/ HNSW fp32 (cached queries)"
@@ -262,19 +207,14 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3647
-            R@1K: 0.9751
       - topic_key: dl19-passage.cohere-embed-english-v3.0
         eval_key: dl19-passage
         scores:
-          - MAP: 0.4883
-            nDCG@10: 0.6956
-            R@1K: 0.8612
+          - nDCG@10: 0.6956
       - topic_key: dl20-passage.cohere-embed-english-v3.0
         eval_key: dl20-passage
         scores:
-          - MAP: 0.5068
-            nDCG@10: 0.7245
-            R@1K: 0.8682
+          - nDCG@10: 0.7245
   - name: cohere-embed-english-v3.0.int8.cached_q
     display: "cohere-embed-english-v3.0 w/ HNSW int8 (cached queries)"
     display_html: "cohere-embed-english-v3.0 w/ HNSW int8 (cached queries)"
@@ -285,16 +225,11 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3656
-            R@1K: 0.9752
       - topic_key: dl19-passage.cohere-embed-english-v3.0
         eval_key: dl19-passage
         scores:
-          - MAP: 0.4888
-            nDCG@10: 0.6955
-            R@1K: 0.8643
+          - nDCG@10: 0.6955
       - topic_key: dl20-passage.cohere-embed-english-v3.0
         eval_key: dl20-passage
         scores:
-          - MAP: 0.5052
-            nDCG@10: 0.7262
-            R@1K: 0.8616
+          - nDCG@10: 0.7262

--- a/src/main/resources/reproduce/msmarco-v1-passage.yaml
+++ b/src/main/resources/reproduce/msmarco-v1-passage.yaml
@@ -9,14 +9,19 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.1840
+            R@1K: 0.8526
       - topic_key: dl19-passage
         eval_key: dl19-passage
         scores:
-          - nDCG@10: 0.5058
+          - MAP: 0.3013
+            nDCG@10: 0.5058
+            R@1K: 0.7501
       - topic_key: dl20-passage
         eval_key: dl20-passage
         scores:
-          - nDCG@10: 0.4796
+          - MAP: 0.2856
+            nDCG@10: 0.4796
+            R@1K: 0.7863
   - name: splade-pp-ed.cached_q
     display: "SPLADE++ EnsembleDistil (cached queries)"
     display_html: "SPLADE++ EnsembleDistil (cached queries)"
@@ -27,14 +32,19 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3830
+            R@1K: 0.9831
       - topic_key: dl19-passage.splade-pp-ed
         eval_key: dl19-passage
         scores:
-          - nDCG@10: 0.7317
+          - MAP: 0.5053
+            nDCG@10: 0.7317
+            R@1K: 0.8726
       - topic_key: dl20-passage.splade-pp-ed
         eval_key: dl20-passage
         scores:
-          - nDCG@10: 0.7198
+          - MAP: 0.5001
+            nDCG@10: 0.7198
+            R@1K: 0.8995
   - name: splade-pp-ed.onnx
     display: "SPLADE++ EnsembleDistil (ONNX)"
     display_html: "SPLADE++ EnsembleDistil (ONNX)"
@@ -45,14 +55,19 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3828
+            R@1K: 0.9831
       - topic_key: dl19-passage
         eval_key: dl19-passage
         scores:
-          - nDCG@10: 0.7308
+          - MAP: 0.5050
+            nDCG@10: 0.7308
+            R@1K: 0.8728
       - topic_key: dl20-passage
         eval_key: dl20-passage
         scores:
-          - nDCG@10: 0.7197
+          - MAP: 0.4999
+            nDCG@10: 0.7197
+            R@1K: 0.8998
   - name: cos-dpr-distil.fp32.cached_q
     display: "cosDPR-distil w/ HNSW fp32 (cached queries)"
     display_html: "cosDPR-distil w/ HNSW fp32 (cached queries)"
@@ -63,14 +78,19 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3887
+            R@1K: 0.9764
       - topic_key: dl19-passage.cos-dpr-distil
         eval_key: dl19-passage
         scores:
-          - nDCG@10: 0.7250
+          - MAP: 0.4660
+            nDCG@10: 0.7250
+            R@1K: 0.8222
       - topic_key: dl20-passage.cos-dpr-distil
         eval_key: dl20-passage
         scores:
-          - nDCG@10: 0.7025
+          - MAP: 0.4876
+            nDCG@10: 0.7025
+            R@1K: 0.8540
   - name: cos-dpr-distil.fp32.onnx
     display: "cosDPR-distil w/ HNSW fp32 (ONNX)"
     display_html: "cosDPR-distil w/ HNSW fp32 (ONNX)"
@@ -81,14 +101,19 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3887
+            R@1K: 0.9765
       - topic_key: dl19-passage
         eval_key: dl19-passage
         scores:
-          - nDCG@10: 0.7250
+          - MAP: 0.4660
+            nDCG@10: 0.7250
+            R@1K: 0.8222
       - topic_key: dl20-passage
         eval_key: dl20-passage
         scores:
-          - nDCG@10: 0.7025
+          - MAP: 0.4876
+            nDCG@10: 0.7025
+            R@1K: 0.8540
   - name: cos-dpr-distil.int8.cached_q
     display: "cosDPR-distil w/ HNSW int8 (cached queries)"
     display_html: "cosDPR-distil w/ HNSW int8 (cached queries)"
@@ -99,14 +124,19 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3897
+            R@1K: 0.9764
       - topic_key: dl19-passage.cos-dpr-distil
         eval_key: dl19-passage
         scores:
-          - nDCG@10: 0.7240
+          - MAP: 0.4662
+            nDCG@10: 0.7240
+            R@1K: 0.8219
       - topic_key: dl20-passage.cos-dpr-distil
         eval_key: dl20-passage
         scores:
-          - nDCG@10: 0.7004
+          - MAP: 0.4872
+            nDCG@10: 0.7004
+            R@1K: 0.8538
   - name: cos-dpr-distil.int8.onnx
     display: "cosDPR-distil w/ HNSW int8 (ONNX)"
     display_html: "cosDPR-distil w/ HNSW int8 (ONNX)"
@@ -117,14 +147,19 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3899
+            R@1K: 0.9764
       - topic_key: dl19-passage
         eval_key: dl19-passage
         scores:
-          - nDCG@10: 0.7247
+          - MAP: 0.4664
+            nDCG@10: 0.7247
+            R@1K: 0.8218
       - topic_key: dl20-passage
         eval_key: dl20-passage
         scores:
-          - nDCG@10: 0.6996
+          - MAP: 0.4871
+            nDCG@10: 0.6996
+            R@1K: 0.8538
   - name: bge-base-en-15.fp32.cached_q
     display: "bge-base-en-v1.5 w/ HNSW fp32 (cached queries)"
     display_html: "bge-base-en-v1.5 w/ HNSW fp32 (cached queries)"
@@ -135,14 +170,19 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3574
+            R@1K: 0.9788
       - topic_key: dl19-passage.bge-base-en-v1.5
         eval_key: dl19-passage
         scores:
-          - nDCG@10: 0.7065
+          - MAP: 0.4436
+            nDCG@10: 0.7065
+            R@1K: 0.8481
       - topic_key: dl20-passage.bge-base-en-v1.5
         eval_key: dl20-passage
         scores:
-          - nDCG@10: 0.6780
+          - MAP: 0.4648
+            nDCG@10: 0.6780
+            R@1K: 0.8483
   - name: bge-base-en-15.fp32.onnx
     display: "bge-base-en-v1.5 w/ HNSW fp32 (ONNX)"
     display_html: "bge-base-en-v1.5 w/ HNSW fp32 (ONNX)"
@@ -153,14 +193,19 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3575
+            R@1K: 0.9788
       - topic_key: dl19-passage
         eval_key: dl19-passage
         scores:
-          - nDCG@10: 0.7016
+          - MAP: 0.4486
+            nDCG@10: 0.7016
+            R@1K: 0.8441
       - topic_key: dl20-passage
         eval_key: dl20-passage
         scores:
-          - nDCG@10: 0.6768
+          - MAP: 0.4626
+            nDCG@10: 0.6768
+            R@1K: 0.8526
   - name: bge-base-en-15.int8.cached_q
     display: "bge-base-en-v1.5 w/ HNSW int8 (cached queries)"
     display_html: "bge-base-en-v1.5 w/ HNSW int8 (cached queries)"
@@ -171,14 +216,19 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3572
+            R@1K: 0.9774
       - topic_key: dl19-passage.bge-base-en-v1.5
         eval_key: dl19-passage
         scores:
-          - nDCG@10: 0.7016
+          - MAP: 0.4400
+            nDCG@10: 0.7016
+            R@1K: 0.8481
       - topic_key: dl20-passage.bge-base-en-v1.5
         eval_key: dl20-passage
         scores:
-          - nDCG@10: 0.6738
+          - MAP: 0.4623
+            nDCG@10: 0.6738
+            R@1K: 0.8420
   - name: bge-base-en-15.int8.onnx
     display: "bge-base-en-v1.5 w/ HNSW int8 (ONNX)"
     display_html: "bge-base-en-v1.5 w/ HNSW int8 (ONNX)"
@@ -189,14 +239,19 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3575
+            R@1K: 0.9772
       - topic_key: dl19-passage
         eval_key: dl19-passage
         scores:
-          - nDCG@10: 0.7017
+          - MAP: 0.4454
+            nDCG@10: 0.7017
+            R@1K: 0.8436
       - topic_key: dl20-passage
         eval_key: dl20-passage
         scores:
-          - nDCG@10: 0.6767
+          - MAP: 0.4596
+            nDCG@10: 0.6767
+            R@1K: 0.8468
   - name: cohere-embed-english-v3.0.fp32.cached_q
     display: "cohere-embed-english-v3.0 w/ HNSW fp32 (cached queries)"
     display_html: "cohere-embed-english-v3.0 w/ HNSW fp32 (cached queries)"
@@ -207,14 +262,19 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3647
+            R@1K: 0.9751
       - topic_key: dl19-passage.cohere-embed-english-v3.0
         eval_key: dl19-passage
         scores:
-          - nDCG@10: 0.6956
+          - MAP: 0.4883
+            nDCG@10: 0.6956
+            R@1K: 0.8612
       - topic_key: dl20-passage.cohere-embed-english-v3.0
         eval_key: dl20-passage
         scores:
-          - nDCG@10: 0.7245
+          - MAP: 0.5068
+            nDCG@10: 0.7245
+            R@1K: 0.8682
   - name: cohere-embed-english-v3.0.int8.cached_q
     display: "cohere-embed-english-v3.0 w/ HNSW int8 (cached queries)"
     display_html: "cohere-embed-english-v3.0 w/ HNSW int8 (cached queries)"
@@ -225,11 +285,16 @@ conditions:
         eval_key: msmarco-passage.dev-subset
         scores:
           - MRR@10: 0.3656
+            R@1K: 0.9752
       - topic_key: dl19-passage.cohere-embed-english-v3.0
         eval_key: dl19-passage
         scores:
-          - nDCG@10: 0.6955
+          - MAP: 0.4888
+            nDCG@10: 0.6955
+            R@1K: 0.8643
       - topic_key: dl20-passage.cohere-embed-english-v3.0
         eval_key: dl20-passage
         scores:
-          - nDCG@10: 0.7262
+          - MAP: 0.5052
+            nDCG@10: 0.7262
+            R@1K: 0.8616

--- a/src/main/resources/reproduce/msmarco-v2.1.yaml
+++ b/src/main/resources/reproduce/msmarco-v2.1.yaml
@@ -1,5 +1,5 @@
 conditions:
-  - name: bm25
+  - name: doc
     display: "BM25 doc (k1=0.9, b=0.4)"
     display_html: "BM25 doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)"
     display_row: ""
@@ -37,7 +37,7 @@ conditions:
             nDCG@10: 0.2914
             R@100: 0.2604
             R@1K: 0.5383
-  - name: bm25-segmented
+  - name: doc-segmented
     display: "BM25 segmented doc (k1=0.9, b=0.4)"
     display_html: "BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)"
     display_row: ""

--- a/src/test/java/io/anserini/doc/GenerateReproductionDocsTest.java
+++ b/src/test/java/io/anserini/doc/GenerateReproductionDocsTest.java
@@ -40,7 +40,7 @@ public class GenerateReproductionDocsTest {
   public final static String ROW_TEMPLATE_PATH = "src/main/resources/reproduce/msmarco_html_row_v1.template";
   public final static String COLLECTION = "msmarco-v1-passage";
   public final static String[] MODELS = {
-      "bm25-default",
+      "bm25",
       "splade-pp-ed.cached_q",
       "splade-pp-ed.onnx",
       "cos-dpr-distil.fp32.cached_q",


### PR DESCRIPTION
Aligned regression documentation output format with the repro scripts. The unified format is:
```
run.collection-name.condition-name.topic-name.txt
```
where `collection-name` in {"msmarco-v2.1-doc", "msmarco-v1-passage", "beir"}, `condition-name` is specified in the yaml files under `src/main/resources/reproduce`, and `topic-name` is specified by the corpus.

Additionally, the repro scripts now run the same amount of cases as in the documentation.