### PR TITLE
Add Reproduction Results for Anserini Repo Steps

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -482,3 +482,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@a68lin](https://github.com/a68lin) on 2024-04-11 (commit [`39cecf6`](https://github.com/castorini/anserini/commit/39cecf6c257bae85f4e9f6ab02e0be101338c3cc))
 + Results reproduced by [@DanielKohn1208](https://github.com/DanielKohn1208/) on 2024-04-21 (commit [`9863611d`](https://github.com/castorini/anserini/commit/9863611d307773c086e64496a2a94cf6599c28b0))
 + Results reproduced by [@emadahmed19](https://github.com/emadahmed19) on 2024-04-28 (commit [`a4064a6`](https://github.com/castorini/anserini/commit/a4064a6fcf6adc7a2cdb5f94e2959f6e3904d916))
++ Results reproduced by [@hrouzegar](https://github.com/hrouzegar) on 2024-04-29 (commit [`3229fcdd`](https://github.com/castorini/anserini/commit/3229fcdd44e77daec9ba44350ff4931af266fd84))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -379,3 +379,5 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@a68lin](https://github.com/a68lin) on 2024-04-11 (commit [`39cecf6`](https://github.com/castorini/anserini/commit/39cecf6c257bae85f4e9f6ab02e0be101338c3cc))
 + Results reproduced by [@DanielKohn1208](https://github.com/DanielKohn1208/) on 2024-04-21 (commit [`9863611d`](https://github.com/castorini/anserini/commit/9863611d307773c086e64496a2a94cf6599c28b0))
 + Results reproduced by [@emadahmed19](https://github.com/emadahmed19) on 2024-04-28 (commit [`a4064a6`](https://github.com/castorini/anserini/commit/a4064a6fcf6adc7a2cdb5f94e2959f6e3904d916))
++ Results reproduced by [@hrouzegar](https://github.com/hrouzegar) on 2024-04-30 (commit [`f6f0dd6`](https://github.com/castorini/anserini/commit/f6f0dd6dc4cdbc77b9b6fac10ed21dd6bed76d13))
+

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -380,4 +380,3 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@DanielKohn1208](https://github.com/DanielKohn1208/) on 2024-04-21 (commit [`9863611d`](https://github.com/castorini/anserini/commit/9863611d307773c086e64496a2a94cf6599c28b0))
 + Results reproduced by [@emadahmed19](https://github.com/emadahmed19) on 2024-04-28 (commit [`a4064a6`](https://github.com/castorini/anserini/commit/a4064a6fcf6adc7a2cdb5f94e2959f6e3904d916))
 + Results reproduced by [@hrouzegar](https://github.com/hrouzegar) on 2024-04-30 (commit [`f6f0dd6`](https://github.com/castorini/anserini/commit/f6f0dd6dc4cdbc77b9b6fac10ed21dd6bed76d13))
-


### PR DESCRIPTION
**Environment Details:**
-**Operating System:** Ubuntu 22.04.4 LTS
-**Java Version:** Upgraded to JDK 21 from JDK 11 to resolve compatibility issues that were initially causing build failures.

**Experience:**
The process followed the outlined steps without significant issues, except for an initial JDK version mismatch. Once the JDK was updated to version 21, all scripts executed flawlessly, and the expected results were successfully reproduced. The step-by-step guidance provided was clear and easy to follow.

**Suggestions for Improvement:**
Considering the JDK version mismatch issue I encountered, it could be beneficial to include a specific note about verifying JDK version requirements in the setup documentation, similar to the approach taken in the Pyserini documentation.