### PR TITLE
Fix default params in webapp

### DIFF
--- a/src/main/java/io/anserini/server/SearchService.java
+++ b/src/main/java/io/anserini/server/SearchService.java
@@ -31,8 +31,8 @@ import java.util.stream.Collectors;
 public class SearchService {
 
   final private String indexDir;
-  final private float k1 = 0.82f;
-  final private float b = 0.68f;
+  final private float k1 = 0.9f;
+  final private float b = 0.4f;
 
   public SearchService(String prebuiltIndex) {
     PrebuiltIndexHandler handler = new PrebuiltIndexHandler(prebuiltIndex);

--- a/src/test/java/io/anserini/server/ControllerTest.java
+++ b/src/test/java/io/anserini/server/ControllerTest.java
@@ -32,7 +32,7 @@ public class ControllerTest {
     List<QueryResult> results = controller.search(null, "Albert Einstein");
 
     assertEquals(results.size(), 10);
-    assertEquals(results.get(0).getDocid(), "3075155");
+    assertEquals(results.get(0).getDocid(), "3553430");
   }
 
   @Test


### PR DESCRIPTION
Fixed the params `k1` and `b` to match the fatjar regressions https://github.com/castorini/anserini/blob/master/docs/fatjar-regressions/fatjar-regressions-v0.36.1-SNAPSHOT.md