### PR TITLE
Added to Reproduction Logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -488,3 +488,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@baixabhi](https://github.com/baixabhi) on 2024-05-09 (commit [`8e188670`](https://github.com/castorini/anserini/commit/8e188670e038c79782302ee3596828ea688250e0))
 + Results reproduced by [@Yuv-sue1005](https://github.com/Yuv-sue1005/) on 2024-05-10 (commit ['3abc2a0'](https://github.com/castorini/anserini/commit/3abc2a0f0dbcb26630825577b39219f0c2754534/))
 + Results reproduced by [@hrouzegar](https://github.com/hrouzegar) on 2024-05-11 (commit [`3229fcdd`](https://github.com/castorini/anserini/commit/3229fcdd44e77daec9ba44350ff4931af266fd84))
++ Results reproduced by [@RohanNankani](https://github.com/RohanNankani) on 2024-05-17 (commit [`a6ea614`](https://github.com/castorini/anserini/commit/a6ea6147fa68bca2a8f869479dee28d620d93dbd))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -385,3 +385,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@KenWuqianhao](https://github.com/KenWuqianghao) on 2024-05-08 (commit [`0558bf4`](https://github.com/castorini/anserini/commit/0558bf416ea3f955af683f23c75a5170539076e6))
 + Results reproduced by [@Yuv-sue1005](https://github.com/Yuv-sue1005) on 2024-05-10 (commit [`0558bf4`](https://github.com/castorini/anserini/commit/0558bf416ea3f955af683f23c75a5170539076e6))
 + Results reproduced by [@hrouzegar](https://github.com/hrouzegar) on 2024-05-11 (commit [`f6f0dd6`](https://github.com/castorini/anserini/commit/f6f0dd6dc4cdbc77b9b6fac10ed21dd6bed76d13))
++ Results reproduced by [@RohanNankani](https://github.com/RohanNankani) on 2024-05-17 (commit [`a6ea614`](https://github.com/castorini/anserini/commit/a6ea6147fa68bca2a8f869479dee28d620d93dbd))


### PR DESCRIPTION
Setup:

I did this on Google Collab with the following specifications:
OpenJDK 21.0.2
Python 3.10.12

On Google Colab, the intial version was JDK 11 and so I had to upgrade that after which the everything ran smoothly. One problem with doing this on Google Colab was that sometimes the session had to be restarted at which point I lost all the work I had done. To fix this, I had to create a back up on my Google Drive.