### PR TITLE
Rename collection to index in route

### DIFF
--- a/src/main/frontend/pages/components/SearchBar.tsx
+++ b/src/main/frontend/pages/components/SearchBar.tsx
@@ -23,11 +23,11 @@ const SearchBar: React.FC = () => {
   const [query, setQuery] = useState<string>('');
   const [index, setIndex] = useState<string>('');
 
-  const fetchResults = async (query: string, collection: string) => {
+  const fetchResults = async (query: string, index: string) => {
     setLoading(true);
     try {
       let endpoint = '/api';
-      if (collection != '') endpoint += `/collection/${collection}`;
+      if (index != '') endpoint += `/index/${index}`;
       endpoint += `/search?query=${query}`;
       
       const response = await fetch(endpoint);

--- a/src/main/java/io/anserini/server/Controller.java
+++ b/src/main/java/io/anserini/server/Controller.java
@@ -30,19 +30,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(path = "/api")
 public class Controller {
 
-  private static final String DEFAULT_COLLECTION = "msmarco-v1-passage";
+  private static final String DEFAULT_INDEX = "msmarco-v1-passage";
 
-  @RequestMapping(method = RequestMethod.GET, path = {"/collection/{collection}/search", "/search"})
-  public Map<String, Object> search(@PathVariable(value = "collection", required = false) String collection,
+  @RequestMapping(method = RequestMethod.GET, path = {"/index/{index}/search", "/search"})
+  public Map<String, Object> search(@PathVariable(value = "index", required = false) String index,
       @RequestParam("query") String query,
       @RequestParam(value = "hits", defaultValue = "10") int hits,
       @RequestParam(value = "qid", defaultValue = "") String qid) {
 
-    if (collection == null) {
-      collection = DEFAULT_COLLECTION;
+    if (index == null) {
+      index = DEFAULT_INDEX;
     }
 
-    SearchService searchService = new SearchService(collection);
+    SearchService searchService = new SearchService(index);
     List<Map<String, Object>> candidates = searchService.search(query, hits);
 
     Map<String, Object> queryMap = new LinkedHashMap<>();


### PR DESCRIPTION
Renamed `/api/collection/` to `/api/index/`
following issue #2502