### PR TITLE
Initial implementation of flat vector search

### DIFF
--- a/docs/regressions/regressions-beir-v1.0.0-arguana-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-arguana-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-arguana-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-arguana-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-arguana-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-arguana-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-arguana-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-arguana-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-arguana-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-arguana-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-arguana-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-arguana-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-bioasq-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-bioasq-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-bioasq-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 500 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-bioasq-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-bioasq-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-bioasq-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 500 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-bioasq-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-bioasq-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-bioasq-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 500 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-bioasq-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-bioasq-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-bioasq-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 500 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-climate-fever-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-climate-fever-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-climate-fever-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-climate-fever-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-fever-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fever-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-fever-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-fever-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fever-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-fever-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-fever-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fever-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-fever-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-fever-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fever-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-fever-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-fiqa-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fiqa-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-fiqa-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-fiqa-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fiqa-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-fiqa-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-fiqa-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fiqa-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-fiqa-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-fiqa-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fiqa-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-fiqa-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-hotpotqa-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-hotpotqa-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-hotpotqa-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-hotpotqa-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-hotpotqa-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-hotpotqa-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-hotpotqa-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-hotpotqa-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-hotpotqa-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-hotpotqa-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-hotpotqa-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-hotpotqa-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-nfcorpus-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nfcorpus-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-nfcorpus-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-nfcorpus-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nfcorpus-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-nfcorpus-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-nfcorpus-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nfcorpus-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-nfcorpus-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-nfcorpus-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nfcorpus-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-nfcorpus-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-nq-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nq-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-nq-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-nq-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nq-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-nq-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-nq-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nq-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-nq-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-nq-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nq-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-nq-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-quora-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-quora-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-quora-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-quora-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-quora-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-quora-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-quora-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-quora-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-quora-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-quora-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-quora-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-quora-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-robust04-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-robust04-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-robust04-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-robust04-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-robust04-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-robust04-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-robust04-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-robust04-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-robust04-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-robust04-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-robust04-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-robust04-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-scidocs-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scidocs-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-scidocs-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-scidocs-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scidocs-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-scidocs-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-scidocs-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scidocs-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-scidocs-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-scidocs-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scidocs-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-scidocs-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-scifact-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-scifact-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-scifact-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-scifact-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-signal1m-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-signal1m-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-signal1m-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-signal1m-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-signal1m-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-signal1m-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-signal1m-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-signal1m-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-signal1m-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-signal1m-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-signal1m-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-signal1m-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-trec-covid-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-covid-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-trec-covid-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-trec-covid-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-covid-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-trec-covid-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-trec-covid-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-covid-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-trec-covid-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-trec-covid-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-covid-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-trec-covid-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-trec-news-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-news-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-trec-news-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-trec-news-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-news-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-trec-news-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-trec-news-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-news-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-trec-news-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-trec-news-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-news-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-trec-news-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-hnsw-int8-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-hnsw-int8-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-hnsw-int8.md
+++ b/docs/regressions/regressions-beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-hnsw-int8.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-int8/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-hnsw-onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-hnsw-onnx.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-webis-touche2020-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/docs/regressions/regressions-beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-hnsw.md
+++ b/docs/regressions/regressions-beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-hnsw.md
@@ -35,7 +35,7 @@ Sample indexing command, building HNSW indexes:
 bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -collection JsonDenseVectorCollection \
   -input /path/to/beir-v1.0.0-bge-base-en-v1.5 \
-  -generator HnswDenseVectorDocumentGenerator \
+  -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-webis-touche2020-bge-base-en-v1.5/ \
   -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
   >& logs/log.beir-v1.0.0-bge-base-en-v1.5 &

--- a/src/main/java/io/anserini/index/AbstractIndexer.java
+++ b/src/main/java/io/anserini/index/AbstractIndexer.java
@@ -175,6 +175,7 @@ public abstract class AbstractIndexer implements Runnable {
         LOG.debug(inputFile.getParent().getFileName().toString() + File.separator +
             inputFile.getFileName().toString() + ": " + cnt + " docs added.");
       } catch (Exception e) {
+        e.printStackTrace();
         LOG.error(Thread.currentThread().getName() + ": Unexpected Exception:", e.getMessage());
       }
     }

--- a/src/main/java/io/anserini/index/IndexFlatDenseVectors.java
+++ b/src/main/java/io/anserini/index/IndexFlatDenseVectors.java
@@ -1,0 +1,137 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.index;
+
+import io.anserini.collection.SourceDocument;
+import io.anserini.index.codecs.AnseriniFlatVectorFormat;
+import io.anserini.index.generator.LuceneDocumentGenerator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99Codec;
+import org.apache.lucene.index.ConcurrentMergeScheduler;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.ParserProperties;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class IndexFlatDenseVectors extends AbstractIndexer {
+  private static final Logger LOG = LogManager.getLogger(IndexFlatDenseVectors.class);
+
+  public static final class Args extends AbstractIndexer.Args {
+    @Option(name = "-generator", metaVar = "[class]", usage = "Document generator class in io.anserini.index.generator.")
+    public String generatorClass = "HnswDenseVectorDocumentGenerator";
+
+    @Option(name = "-M", metaVar = "[num]", usage = "HNSW parameters M")
+    public int M = 16;
+
+    @Option(name = "-efC", metaVar = "[num]", usage = "HNSW parameters ef Construction")
+    public int efC = 100;
+
+    @Option(name = "-quantize.int8", usage = "Quantize vectors into int8.")
+    public boolean quantizeInt8 = false;
+
+    @Option(name = "-storeVectors", usage = "Boolean switch to store raw raw vectors.")
+    public boolean storeVectors = false;
+  }
+
+  @SuppressWarnings("unchecked")
+  public IndexFlatDenseVectors(Args args) {
+    super(args);
+
+    try {
+      super.generatorClass = (Class<LuceneDocumentGenerator<? extends SourceDocument>>)
+          Class.forName("io.anserini.index.generator." + args.generatorClass);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(String.format("Unable to load generator class \"%s\".", args.generatorClass));
+    }
+
+    try {
+      final Directory dir = FSDirectory.open(Paths.get(args.index));
+      final IndexWriterConfig config;
+
+      if (args.quantizeInt8) {
+        config = new IndexWriterConfig().setCodec(
+            new Lucene99Codec() {
+              @Override
+              public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+                return new AnseriniFlatVectorFormat();
+              }
+            });
+      } else {
+        config = new IndexWriterConfig().setCodec(
+            new Lucene99Codec() {
+              @Override
+              public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+                return new AnseriniFlatVectorFormat();
+              }
+            });
+      }
+
+      config.setOpenMode(IndexWriterConfig.OpenMode.CREATE);
+      config.setRAMBufferSizeMB(args.memoryBuffer);
+      config.setUseCompoundFile(false);
+      config.setMergeScheduler(new ConcurrentMergeScheduler());
+
+      this.writer = new IndexWriter(dir, config);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(String.format("Unable to create IndexWriter: %s.", e.getMessage()));
+    }
+
+    LOG.info("FlatDenseVector settings:");
+    LOG.info(" + Generator: " + args.generatorClass);
+    LOG.info(" + Store document vectors? " + args.storeVectors);
+    LOG.info(" + Int8 quantization? " + args.quantizeInt8);
+  }
+
+  public static void main(String[] args) throws Exception {
+    Args indexArgs = new Args();
+    CmdLineParser parser = new CmdLineParser(indexArgs, ParserProperties.defaults().withUsageWidth(120));
+
+    try {
+      parser.parseArgument(args);
+    } catch (CmdLineException e) {
+      if (indexArgs.options) {
+        System.err.printf("Options for %s:\n\n", IndexFlatDenseVectors.class.getSimpleName());
+        parser.printUsage(System.err);
+
+        List<String> required = new ArrayList<>();
+        parser.getOptions().forEach((option) -> {
+          if (option.option.required()) {
+            required.add(option.option.toString());
+          }
+        });
+
+        System.err.printf("\nRequired options are %s\n", required);
+      } else {
+        System.err.printf("Error: %s. For help, use \"-options\" to print out information about options.\n", e.getMessage());
+      }
+
+      return;
+    }
+
+    new IndexFlatDenseVectors(indexArgs).run();
+  }
+}

--- a/src/main/java/io/anserini/index/IndexFlatDenseVectors.java
+++ b/src/main/java/io/anserini/index/IndexFlatDenseVectors.java
@@ -19,14 +19,12 @@ package io.anserini.index;
 import io.anserini.collection.SourceDocument;
 import io.anserini.index.codecs.AnseriniFlatVectorFormat;
 import io.anserini.index.generator.LuceneDocumentGenerator;
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.codecs.lucene99.Lucene99Codec;
-import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
 import org.apache.lucene.index.ConcurrentMergeScheduler;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -74,7 +72,7 @@ public final class IndexFlatDenseVectors extends AbstractIndexer {
       final IndexWriterConfig config;
 
       if (args.quantizeInt8) {
-        throw new NotImplementedException("Quantization not currently implemented.");
+        throw new UnsupportedOperationException("Quantization not currently implemented.");
       } else {
         config = new IndexWriterConfig().setCodec(
             new Lucene99Codec() {
@@ -92,7 +90,7 @@ public final class IndexFlatDenseVectors extends AbstractIndexer {
 
       this.writer = new IndexWriter(dir, config);
     } catch (Exception e) {
-      throw new IllegalArgumentException(String.format("Unable to create IndexWriter: %s.", e.getMessage()));
+      throw new IllegalArgumentException(String.format("Unable to create IndexWriter: %s", e.getMessage()));
     }
 
     LOG.info("FlatDenseVector settings:");

--- a/src/main/java/io/anserini/index/IndexHnswDenseVectors.java
+++ b/src/main/java/io/anserini/index/IndexHnswDenseVectors.java
@@ -50,7 +50,7 @@ public final class IndexHnswDenseVectors extends AbstractIndexer {
 
   public static final class Args extends AbstractIndexer.Args {
     @Option(name = "-generator", metaVar = "[class]", usage = "Document generator class in io.anserini.index.generator.")
-    public String generatorClass = "HnswDenseVectorDocumentGenerator";
+    public String generatorClass = "DenseVectorDocumentGenerator";
 
     @Option(name = "-M", metaVar = "[num]", usage = "HNSW parameters M")
     public int M = 16;

--- a/src/main/java/io/anserini/index/codecs/AnseriniFlatVectorFormat.java
+++ b/src/main/java/io/anserini/index/codecs/AnseriniFlatVectorFormat.java
@@ -1,0 +1,160 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.index.codecs;
+
+import org.apache.lucene.codecs.FlatVectorsFormat;
+import org.apache.lucene.codecs.FlatVectorsReader;
+import org.apache.lucene.codecs.FlatVectorsWriter;
+import org.apache.lucene.codecs.KnnFieldVectorsWriter;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.Sorter;
+import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.hnsw.OrdinalTranslatedKnnCollector;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+
+import java.io.IOException;
+
+public class AnseriniFlatVectorFormat extends KnnVectorsFormat {
+
+  static final String NAME = "AnseriniFlatVectorFormat";
+
+  private final FlatVectorsFormat format = new Lucene99FlatVectorsFormat();
+
+  /**
+   * Sole constructor
+   */
+  public AnseriniFlatVectorFormat() {
+    super(NAME);
+  }
+
+  @Override
+  public KnnVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+    return new AnseriniFlatVectorWriter(format.fieldsWriter(state));
+  }
+
+  @Override
+  public KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException {
+    return new AnseriniFlatVectorReader(format.fieldsReader(state));
+  }
+
+  public static class AnseriniFlatVectorWriter extends KnnVectorsWriter {
+
+    private final FlatVectorsWriter writer;
+
+    public AnseriniFlatVectorWriter(FlatVectorsWriter writer) {
+      super();
+      this.writer = writer;
+    }
+
+    @Override
+    public KnnFieldVectorsWriter<?> addField(FieldInfo fieldInfo) throws IOException {
+      return writer.addField(fieldInfo, null);
+    }
+
+    @Override
+    public void flush(int maxDoc, Sorter.DocMap sortMap) throws IOException {
+      writer.flush(maxDoc, sortMap);
+    }
+
+    @Override
+    public void finish() throws IOException {
+      writer.finish();
+    }
+
+    @Override
+    public void close() throws IOException {
+      writer.close();
+    }
+
+    @Override
+    public long ramBytesUsed() {
+      return writer.ramBytesUsed();
+    }
+
+    @Override
+    public void mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
+      writer.mergeOneField(fieldInfo, mergeState);
+    }
+  }
+
+  public static class AnseriniFlatVectorReader extends KnnVectorsReader {
+
+    private final FlatVectorsReader reader;
+
+    public AnseriniFlatVectorReader(FlatVectorsReader reader) {
+      super();
+      this.reader = reader;
+    }
+
+    @Override
+    public void checkIntegrity() throws IOException {
+      reader.checkIntegrity();
+    }
+
+    @Override
+    public FloatVectorValues getFloatVectorValues(String field) throws IOException {
+      return reader.getFloatVectorValues(field);
+    }
+
+    @Override
+    public ByteVectorValues getByteVectorValues(String field) throws IOException {
+      return reader.getByteVectorValues(field);
+    }
+
+    @Override
+    public void search(String field, float[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
+      collectAllMatchingDocs(knnCollector, acceptDocs, reader.getRandomVectorScorer(field, target));
+    }
+
+    private void collectAllMatchingDocs(KnnCollector knnCollector, Bits acceptDocs, RandomVectorScorer scorer) throws IOException {
+      OrdinalTranslatedKnnCollector collector = new OrdinalTranslatedKnnCollector(knnCollector, scorer::ordToDoc);
+      Bits acceptedOrds = scorer.getAcceptOrds(acceptDocs);
+      for (int i = 0; i < scorer.maxOrd(); i++) {
+        if (acceptedOrds == null || acceptedOrds.get(i)) {
+          collector.collect(i, scorer.score(i));
+          collector.incVisitedCount(1);
+        }
+      }
+      assert collector.earlyTerminated() == false;
+    }
+
+    @Override
+    public void search(String field, byte[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
+      collectAllMatchingDocs(knnCollector, acceptDocs, reader.getRandomVectorScorer(field, target));
+    }
+
+    @Override
+    public void close() throws IOException {
+      reader.close();
+    }
+
+    @Override
+    public long ramBytesUsed() {
+      return reader.ramBytesUsed();
+    }
+  }
+}

--- a/src/main/java/io/anserini/index/generator/DenseVectorDocumentGenerator.java
+++ b/src/main/java/io/anserini/index/generator/DenseVectorDocumentGenerator.java
@@ -18,16 +18,13 @@ package io.anserini.index.generator;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.anserini.collection.SourceDocument;
 import io.anserini.index.Constants;
-import io.anserini.index.IndexHnswDenseVectors;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnFloatVectorField;
-import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.util.BytesRef;
@@ -39,8 +36,8 @@ import java.util.ArrayList;
  *
  * @param <T> type of the source document
  */
-public class HnswDenseVectorDocumentGenerator<T extends SourceDocument> implements LuceneDocumentGenerator<T> {
-  public HnswDenseVectorDocumentGenerator() {
+public class DenseVectorDocumentGenerator<T extends SourceDocument> implements LuceneDocumentGenerator<T> {
+  public DenseVectorDocumentGenerator() {
   }
 
   private float[] convertJsonArray(String vectorString) throws JsonProcessingException {

--- a/src/main/java/io/anserini/search/FlatDenseSearcher.java
+++ b/src/main/java/io/anserini/search/FlatDenseSearcher.java
@@ -1,0 +1,212 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.search;
+
+import ai.onnxruntime.OrtException;
+import io.anserini.encoder.dense.DenseEncoder;
+import io.anserini.index.Constants;
+import io.anserini.search.query.VectorQueryGenerator;
+import io.anserini.util.PrebuiltIndexHandler;
+
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.FSDirectory;
+import org.kohsuke.args4j.Option;
+
+import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class FlatDenseSearcher<K extends Comparable<K>> extends BaseSearcher<K> implements Closeable {
+  // These are the default tie-breaking rules for documents that end up with the same score with respect to a query.
+  // For most collections, docids are strings, and we break ties by lexicographic sort order.
+  public static final Sort BREAK_SCORE_TIES_BY_DOCID =
+      new Sort(SortField.FIELD_SCORE, new SortField(Constants.ID, SortField.Type.STRING_VAL));
+
+  private static final Logger LOG = LogManager.getLogger(FlatDenseSearcher.class);
+
+  /**
+   * This class holds arguments for configuring the flat searcher for dense vectors. Note that, explicitly, there are
+   * no arguments that define queries and outputs, since this class is meant to be called interactively.
+   */
+  public static class Args extends BaseSearchArgs {
+    @Option(name = "-generator", metaVar = "[class]", usage = "QueryGenerator to use.")
+    public String queryGenerator = "VectorQueryGenerator";
+
+    @Option(name ="-encoder", metaVar = "[encoder]", usage = "Dense encoder to use.")
+    public String encoder = null;
+  }
+
+  private final IndexReader reader;
+  private final VectorQueryGenerator generator;
+  private final DenseEncoder encoder;
+  // Dummy, but needed for KnnFloatVectorQuery
+  private final int DUMMY_EF_SEARCH = 1000;
+
+  public FlatDenseSearcher(Args args) {
+    super(args);
+
+    // We might not be able to successfully create a reader for a variety of reasons, anything from path doesn't exist
+    // to corrupt index. Gather all possible exceptions together as an unchecked exception to make initialization and
+    // error reporting clearer.
+    Path indexPath = Path.of(args.index);
+    PrebuiltIndexHandler indexHandler = new PrebuiltIndexHandler(args.index);
+    if (!Files.exists(indexPath)) {
+      // it doesn't exist locally, we try to download it from remote
+      try {
+        indexHandler.initialize();
+        indexHandler.download();
+        indexPath = Path.of(indexHandler.decompressIndex());
+      } catch (IOException e) {
+        throw new RuntimeException("MD5 checksum does not match!");
+      } catch (Exception e) {
+        throw new IllegalArgumentException(String.format("\"%s\" does not appear to be a valid index.", args.index));
+      }
+    } else {
+      // if it exists locally, we use it
+      indexPath = Paths.get(args.index);
+    }
+
+    try {
+      this.reader = DirectoryReader.open(FSDirectory.open(indexPath));
+    } catch (IOException e) {
+      throw new IllegalArgumentException(String.format("\"%s\" does not appear to be a valid index.", args.index));
+    }
+
+    setIndexSearcher(new IndexSearcher(this.reader));
+
+    try {
+      this.generator = (VectorQueryGenerator) Class
+          .forName(String.format("io.anserini.search.query.%s", args.queryGenerator))
+          .getConstructor().newInstance();
+    } catch (Exception e) {
+      throw new IllegalArgumentException(String.format("Unable to load QueryGenerator \"%s\".", args.queryGenerator));
+    }
+
+    if (args.encoder != null) {
+      try {
+        encoder = (DenseEncoder) Class
+            .forName(String.format("io.anserini.encoder.dense.%sEncoder", args.encoder))
+            .getConstructor().newInstance();
+      } catch (Exception e) {
+        throw new IllegalArgumentException(String.format("Unable to load Encoder \"%s\".", args.encoder));
+      }
+    } else {
+      encoder = null;
+    }
+  }
+
+  public SortedMap<K, ScoredDoc[]> batch_search(List<K> qids, List<String> queries, int hits) {
+    final SortedMap<K, ScoredDoc[]> results = new ConcurrentSkipListMap<>();
+    final ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(args.threads);
+    final AtomicInteger cnt = new AtomicInteger();
+
+    final long start = System.nanoTime();
+    assert qids.size() == queries.size();
+    for (int i=0; i<qids.size(); i++) {
+      K qid = qids.get(i);
+      String queryString = queries.get(i);
+
+      // This is the per-query execution, in parallel.
+      executor.execute(() -> {
+        try {
+          results.put(qid, search(qid, queryString, hits));
+        } catch (IOException e) {
+          throw new CompletionException(e);
+        }
+
+        int n = cnt.incrementAndGet();
+        if (n % 100 == 0) {
+          LOG.info(String.format("%d queries processed", n));
+        }
+      });
+    }
+
+    executor.shutdown();
+
+    try {
+      // Wait for existing tasks to terminate.
+      while (!executor.awaitTermination(1, TimeUnit.MINUTES));
+    } catch (InterruptedException ie) {
+      // (Re-)Cancel if current thread also interrupted.
+      executor.shutdownNow();
+      // Preserve interrupt status.
+      Thread.currentThread().interrupt();
+    }
+    final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+
+    LOG.info(queries.size() + " queries processed in " +
+        DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss") +
+        String.format(" = ~%.2f q/s", queries.size() / (durationMillis / 1000.0)));
+
+    return results;
+  }
+
+  public ScoredDoc[] search(float[] queryFloat, int hits) throws IOException {
+    return search(null, queryFloat, hits);
+  }
+
+  public ScoredDoc[] search(@Nullable K qid, float[] queryFloat, int hits) throws IOException {
+    KnnFloatVectorQuery query = new KnnFloatVectorQuery(Constants.VECTOR, queryFloat, DUMMY_EF_SEARCH);
+    TopDocs topDocs = getIndexSearcher().search(query, hits, BREAK_SCORE_TIES_BY_DOCID, true);
+
+    return super.processLuceneTopDocs(qid, topDocs);
+  }
+
+  public ScoredDoc[] search(String queryString, int hits) throws IOException {
+    return search(null, queryString, hits);
+  }
+
+  public ScoredDoc[] search(@Nullable K qid, String queryString, int hits) throws IOException {
+    if (encoder != null) {
+      try {
+        return search(qid, encoder.encode(queryString), hits);
+      } catch (OrtException e) {
+        throw new RuntimeException("Error encoding query.");
+      }
+    }
+
+    KnnFloatVectorQuery query = generator.buildQuery(Constants.VECTOR, queryString, DUMMY_EF_SEARCH);
+    TopDocs topDocs = getIndexSearcher().search(query, hits, BREAK_SCORE_TIES_BY_DOCID, true);
+
+    return super.processLuceneTopDocs(qid, topDocs);
+  }
+
+  @Override
+  public void close() throws IOException {
+    reader.close();
+  }
+}

--- a/src/main/java/io/anserini/search/SearchFlatDenseVectors.java
+++ b/src/main/java/io/anserini/search/SearchFlatDenseVectors.java
@@ -1,0 +1,194 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.search;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.anserini.search.topicreader.TopicReader;
+import io.anserini.search.topicreader.Topics;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.ParserProperties;
+import org.kohsuke.args4j.spi.StringArrayOptionHandler;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Main entry point for flat search.
+ */
+public final class SearchFlatDenseVectors<K extends Comparable<K>> implements Runnable, Closeable {
+  private static final Logger LOG = LogManager.getLogger(SearchFlatDenseVectors.class);
+
+  public static class Args extends FlatDenseSearcher.Args {
+    @Option(name = "-topics", metaVar = "[file]", handler = StringArrayOptionHandler.class, required = true, usage = "topics file")
+    public String[] topics;
+
+    @Option(name = "-output", metaVar = "[file]", required = true, usage = "output file")
+    public String output;
+
+    @Option(name = "-topicReader", usage = "TopicReader to use.")
+    public String topicReader = "JsonIntVector";
+
+    @Option(name = "-topicField", usage = "Topic field that should be used as the query.")
+    public String topicField = "vector";
+
+    @Option(name = "-hits", metaVar = "[number]", usage = "max number of hits to return")
+    public int hits = 1000;
+
+    @Option(name = "-runtag", metaVar = "[tag]", usage = "runtag")
+    public String runtag = "Anserini";
+
+    @Option(name = "-format", metaVar = "[output format]", usage = "Output format, default \"trec\", alternative \"msmarco\".")
+    public String format = "trec";
+
+    @Option(name = "-options", usage = "Print information about options.")
+    public Boolean options = false;
+  }
+
+  private final Args args;
+  private final FlatDenseSearcher<K> searcher;
+  private final List<K> qids= new ArrayList<>();
+  private final List<String> queries = new ArrayList<>();
+
+  public SearchFlatDenseVectors(Args args) throws IOException {
+    this.args = args;
+    this.searcher = new FlatDenseSearcher<>(args);
+
+    LOG.info(String.format("============ Initializing %s ============", this.getClass().getSimpleName()));
+    LOG.info("Index: " + args.index);
+    LOG.info("Topics: " + Arrays.toString(args.topics));
+    LOG.info("Query generator: " + args.queryGenerator);
+    LOG.info("Encoder: " + args.encoder);
+    LOG.info("Threads: " + args.threads);
+
+    // We might not be able to successfully read topics for a variety of reasons. Gather all possible
+    // exceptions together as an unchecked exception to make initialization and error reporting clearer.
+    SortedMap<K, Map<String, String>> topics = new TreeMap<>();
+    for (String topicsFile : args.topics) {
+      Path topicsFilePath = Paths.get(topicsFile);
+      if (!Files.exists(topicsFilePath) || !Files.isRegularFile(topicsFilePath) || !Files.isReadable(topicsFilePath)) {
+        Topics ref = Topics.getByName(topicsFile);
+        if (ref==null) {
+          throw new IllegalArgumentException(String.format("\"%s\" does not refer to valid topics.", topicsFilePath));
+        } else {
+          topics.putAll(TopicReader.getTopics(ref));
+        }
+      } else {
+        try {
+          @SuppressWarnings("unchecked")
+          TopicReader<K> tr = (TopicReader<K>) Class
+              .forName(String.format("io.anserini.search.topicreader.%sTopicReader", args.topicReader))
+              .getConstructor(Path.class).newInstance(topicsFilePath);
+
+          topics.putAll(tr.read());
+        } catch (Exception e) {
+          throw new IllegalArgumentException(String.format("Unable to load topic reader \"%s\".", args.topicReader));
+        }
+      }
+    }
+
+    // Now iterate through all the topics to pick out the right field with proper exception handling.
+    try {
+      topics.forEach((qid, topic) -> {
+        String query;
+        if ( args.encoder != null ) {
+          query = topic.get("title");
+        } else {
+          query = topic.get(args.topicField);
+        }
+        assert query != null;
+        qids.add(qid);
+        queries.add(query);
+      });
+    } catch (AssertionError|Exception e) {
+      throw new IllegalArgumentException(String.format("Unable to read topic field \"%s\".", args.topicField));
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    searcher.close();
+  }
+
+  @Override
+  public void run() {
+    LOG.info("============ Launching Search Threads ============");
+    SortedMap<K, ScoredDoc[]> results = searcher.batch_search(qids, queries, args.hits);
+
+    try(RunOutputWriter<K> out = new RunOutputWriter<>(args.output, args.format, args.runtag, null)) {
+      // zip query to results
+      results.forEach((qid, hits) -> {
+        try {
+          out.writeTopic(qid, queries.get(qids.indexOf(qid)), results.get(qid));
+        } catch (JsonProcessingException e) {
+          // Handle the exception or rethrow as unchecked
+          throw new RuntimeException(e);
+        }
+      });
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    Args searchArgs = new Args();
+    CmdLineParser parser = new CmdLineParser(searchArgs, ParserProperties.defaults().withUsageWidth(120));
+
+    try {
+      parser.parseArgument(args);
+    } catch (CmdLineException e) {
+      if (searchArgs.options) {
+        System.err.printf("Options for %s:\n\n", SearchFlatDenseVectors.class.getSimpleName());
+        parser.printUsage(System.err);
+
+        List<String> required = new ArrayList<>();
+        parser.getOptions().forEach((option) -> {
+          if (option.option.required()) {
+            required.add(option.option.toString());
+          }
+        });
+
+        System.err.printf("\nRequired options are %s\n", required);
+      } else {
+        System.err.printf("Error: %s. For help, use \"-options\" to print out information about options.\n", e.getMessage());
+      }
+
+      return;
+    }
+
+    // We're at top-level already inside a main; makes no sense to propagate exceptions further, so reformat the
+    // exception messages and display on console.
+    try(SearchFlatDenseVectors<?> searcher = new SearchFlatDenseVectors<>(searchArgs)) {
+      searcher.run();
+    } catch (RuntimeException e) {
+      System.err.printf("Error: %s\n", e.getMessage());
+    }
+  }
+}

--- a/src/main/python/run_regression.py
+++ b/src/main/python/run_regression.py
@@ -209,8 +209,10 @@ def evaluate_and_verify(yaml_data, dry_run):
                 actual = round(float(eval_out), metric['metric_precision'])
 
                 using_hnsw = True \
-                    if 'VectorQueryGenerator' in model['params'] or \
+                    if ('VectorQueryGenerator' in model['params'] and '-efSearch' in model['params']) or \
                        ('-encoder' in model['params'] and ('SpladePlusPlusEnsembleDistil' not in model['params'] and 'SpladePlusPlusSelfDistil' not in model['params'])) else False
+                # The first part of the clause is janky; VectorQueryGenerator tells us we're doing dense,
+                # except with flat, we *don't* use -efSearch
 
                 # For HNSW, we only print to third digit
                 if using_hnsw:

--- a/src/main/python/run_regression.py
+++ b/src/main/python/run_regression.py
@@ -55,13 +55,15 @@ CORPUS_ROOTS = [
 ]
 
 INDEX_COMMAND = 'bin/run.sh io.anserini.index.IndexCollection'
-INDEX_HNSW_COMMAND = 'bin/run.sh io.anserini.index.IndexHnswDenseVectors'
+INDEX_FLAT_DENSE_COMMAND = 'bin/run.sh io.anserini.index.IndexFlatDenseVectors'
+INDEX_HNSW_DENSE_COMMAND = 'bin/run.sh io.anserini.index.IndexHnswDenseVectors'
 INDEX_INVERTED_DENSE_COMMAND = 'bin/run.sh io.anserini.index.IndexInvertedDenseVectors'
 
 INDEX_STATS_COMMAND = 'bin/run.sh io.anserini.index.IndexReaderUtils'
 
 SEARCH_COMMAND = 'bin/run.sh io.anserini.search.SearchCollection'
-SEARCH_HNSW_COMMAND = 'bin/run.sh io.anserini.search.SearchHnswDenseVectors'
+SEARCH_FLAT_DENSE_COMMAND = 'bin/run.sh io.anserini.search.SearchFlatDenseVectors'
+SEARCH_HNSW_DENSE_COMMAND = 'bin/run.sh io.anserini.search.SearchHnswDenseVectors'
 SEARCH_INVERTED_DENSE_COMMAND = 'bin/run.sh io.anserini.search.SearchInvertedDenseVectors'
 
 
@@ -121,7 +123,9 @@ def construct_indexing_command(yaml_data, args):
     if yaml_data.get('index_type') == 'inverted-dense':
         root_cmd = INDEX_INVERTED_DENSE_COMMAND
     elif yaml_data.get('index_type') == 'hnsw':
-        root_cmd = INDEX_HNSW_COMMAND
+        root_cmd = INDEX_HNSW_DENSE_COMMAND
+    elif yaml_data.get('index_type') == 'flat':
+        root_cmd = INDEX_FLAT_DENSE_COMMAND
     else:
         root_cmd = INDEX_COMMAND
 
@@ -148,7 +152,7 @@ def construct_runfile_path(index, id, model_name):
 def construct_search_commands(yaml_data):
     ranking_commands = [
         [
-            SEARCH_INVERTED_DENSE_COMMAND if model.get('type') == 'inverted-dense' else SEARCH_HNSW_COMMAND if model.get('type') == 'hnsw' else SEARCH_COMMAND,
+            SEARCH_INVERTED_DENSE_COMMAND if model.get('type') == 'inverted-dense' else SEARCH_HNSW_DENSE_COMMAND if model.get('type') == 'hnsw' else SEARCH_FLAT_DENSE_COMMAND if model.get('type') == 'flat' else SEARCH_COMMAND,
             '-index', construct_index_path(yaml_data),
             '-topics', os.path.join('tools/topics-and-qrels', topic_set['path']),
             '-topicReader', topic_set['topic_reader'] if 'topic_reader' in topic_set and topic_set['topic_reader'] else yaml_data['topic_reader'],
@@ -382,6 +386,8 @@ if __name__ == '__main__':
         logger.info('='*10 + ' Verifying Index ' + '='*10)
         if yaml_data.get('index_type') == 'hnsw':
             logger.info('Skipping verification step for HNSW dense indexes.')
+        elif yaml_data.get('index_type') == 'flat':
+            logger.info('Skipping verification step for flat dense indexes.')
         else:
             verification_command_args = [INDEX_STATS_COMMAND, '-index', construct_index_path(yaml_data), '-stats']
             if yaml_data.get('index_type') == 'inverted-dense':

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
@@ -1,0 +1,1 @@
+io.anserini.index.codecs.AnseriniFlatVectorFormat

--- a/src/main/resources/regression/beir-v1.0.0-arguana-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana
 index_path: indexes/lucene-hnsw.beir-v1.0.0-arguana-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-arguana-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana
 index_path: indexes/lucene-hnsw.beir-v1.0.0-arguana-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-arguana-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana
 index_path: indexes/lucene-hnsw.beir-v1.0.0-arguana-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-arguana-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana
 index_path: indexes/lucene-hnsw.beir-v1.0.0-arguana-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana
+
+index_path: indexes/lucene-flat.beir-v1.0.0-arguana.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): ArguAna"
+    id: test
+    path: topics.beir-v1.0.0-arguana.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-arguana.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.636
+      R@100:
+        - 0.992
+      R@1000:
+        - 0.996

--- a/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.636
+        - 0.6361
       R@100:
-        - 0.992
+        - 0.9915
       R@1000:
-        - 0.996
+        - 0.9964

--- a/src/main/resources/regression/beir-v1.0.0-bioasq-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq
 index_path: indexes/lucene-hnsw.beir-v1.0.0-bioasq-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 500 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-bioasq-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq
 index_path: indexes/lucene-hnsw.beir-v1.0.0-bioasq-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 500 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-bioasq-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq
 index_path: indexes/lucene-hnsw.beir-v1.0.0-bioasq-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 500 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-bioasq-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq
 index_path: indexes/lucene-hnsw.beir-v1.0.0-bioasq-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 500 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.410
+        - 0.4149
       R@100:
-        - 0.622
+        - 0.6317
       R@1000:
-        - 0.794
+        - 0.8059

--- a/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq
+
+index_path: indexes/lucene-flat.beir-v1.0.0-bioasq.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): BioASQ"
+    id: test
+    path: topics.beir-v1.0.0-bioasq.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-bioasq.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.410
+      R@100:
+        - 0.622
+      R@1000:
+        - 0.794

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever
 index_path: indexes/lucene-hnsw.beir-v1.0.0-climate-fever-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever
 index_path: indexes/lucene-hnsw.beir-v1.0.0-climate-fever-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever
 index_path: indexes/lucene-hnsw.beir-v1.0.0-climate-fever-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever
 index_path: indexes/lucene-hnsw.beir-v1.0.0-climate-fever-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever
+
+index_path: indexes/lucene-flat.beir-v1.0.0-climate-fever.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): Climate-FEVER"
+    id: test
+    path: topics.beir-v1.0.0-climate-fever.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-climate-fever.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.312
+      R@100:
+        - 0.636
+      R@1000:
+        - 0.829

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.312
+        - 0.3119
       R@100:
-        - 0.636
+        - 0.6362
       R@1000:
-        - 0.829
+        - 0.8307

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-android-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.507
+        - 0.5075
       R@100:
-        - 0.845
+        - 0.8454
       R@1000:
-        - 0.962
+        - 0.9611

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android
+
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-android"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-android.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-android.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.507
+      R@100:
+        - 0.845
+      R@1000:
+        - 0.962

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-english-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.485
+        - 0.4857
       R@100:
-        - 0.757
+        - 0.7587
       R@1000:
-        - 0.882
+        - 0.8839

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english
+
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-english"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-english.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-english.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.485
+      R@100:
+        - 0.757
+      R@1000:
+        - 0.882

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gaming-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.595
+        - 0.5965
       R@100:
-        - 0.901
+        - 0.9036
       R@1000:
-        - 0.970
+        - 0.9719

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming
+
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-gaming"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gaming.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gaming.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.595
+      R@100:
+        - 0.901
+      R@1000:
+        - 0.970

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gis-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.412
+        - 0.4127
       R@100:
-        - 0.767
+        - 0.7682
       R@1000:
-        - 0.911
+        - 0.9117

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis
+
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-gis"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gis.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gis.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.412
+      R@100:
+        - 0.767
+      R@1000:
+        - 0.911

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-mathematica-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.316
+        - 0.3163
       R@100:
-        - 0.692
+        - 0.6922
       R@1000:
-        - 0.881
+        - 0.8810

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica
+
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-mathematica"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-mathematica.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.316
+      R@100:
+        - 0.692
+      R@1000:
+        - 0.881

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-physics-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.472
+        - 0.4722
       R@100:
-        - 0.808
+        - 0.8081
       R@1000:
-        - 0.941
+        - 0.9406

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics
+
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-physics"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-physics.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-physics.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.472
+      R@100:
+        - 0.808
+      R@1000:
+        - 0.941

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-programmers-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.424
+        - 0.4242
       R@100:
-        - 0.786
+        - 0.7856
       R@1000:
-        - 0.935
+        - 0.9348

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers
+
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-programmers"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-programmers.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-programmers.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.424
+      R@100:
+        - 0.786
+      R@1000:
+        - 0.935

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-stats-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.373
+        - 0.3732
       R@100:
-        - 0.673
+        - 0.6727
       R@1000:
-        - 0.849
+        - 0.8445

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats
+
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-stats"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-stats.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-stats.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.373
+      R@100:
+        - 0.673
+      R@1000:
+        - 0.849

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-tex-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.311
+        - 0.3115
       R@100:
-        - 0.647
+        - 0.6486
       R@1000:
-        - 0.852
+        - 0.8537

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex
+
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-tex"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-tex.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-tex.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.311
+      R@100:
+        - 0.647
+      R@1000:
+        - 0.852

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-unix-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.422
+        - 0.4219
       R@100:
-        - 0.780
+        - 0.7797
       R@1000:
-        - 0.925
+        - 0.9237

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix
+
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-unix"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-unix.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-unix.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.422
+      R@100:
+        - 0.780
+      R@1000:
+        - 0.925

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-webmasters-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.406
+        - 0.4065
       R@100:
-        - 0.777
+        - 0.7774
       R@1000:
-        - 0.937
+        - 0.9380

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters
+
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-webmasters"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-webmasters.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.406
+      R@100:
+        - 0.777
+      R@1000:
+        - 0.937

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress
 index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-wordpress-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress
+
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-wordpress"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-wordpress.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.355
+      R@100:
+        - 0.705
+      R@1000:
+        - 0.886

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.355
+        - 0.3547
       R@100:
-        - 0.705
+        - 0.7065
       R@1000:
-        - 0.886
+        - 0.8861

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity
 index_path: indexes/lucene-hnsw.beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity
 index_path: indexes/lucene-hnsw.beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity
 index_path: indexes/lucene-hnsw.beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity
 index_path: indexes/lucene-hnsw.beir-v1.0.0-dbpedia-entity-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.407
+        - 0.4074
       R@100:
-        - 0.528
+        - 0.5303
       R@1000:
-        - 0.778
+        - 0.7833

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity
+
+index_path: indexes/lucene-flat.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): DBPedia"
+    id: test
+    path: topics.beir-v1.0.0-dbpedia-entity.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-dbpedia-entity.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.407
+      R@100:
+        - 0.528
+      R@1000:
+        - 0.778

--- a/src/main/resources/regression/beir-v1.0.0-fever-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever
 index_path: indexes/lucene-hnsw.beir-v1.0.0-fever-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-fever-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever
 index_path: indexes/lucene-hnsw.beir-v1.0.0-fever-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-fever-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever
 index_path: indexes/lucene-hnsw.beir-v1.0.0-fever-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-fever-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever
 index_path: indexes/lucene-hnsw.beir-v1.0.0-fever-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever
+
+index_path: indexes/lucene-flat.beir-v1.0.0-fever.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): FEVER"
+    id: test
+    path: topics.beir-v1.0.0-fever.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-fever.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.861
+      R@100:
+        - 0.967
+      R@1000:
+        - 0.980

--- a/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.861
+        - 0.8630
       R@100:
-        - 0.967
+        - 0.9719
       R@1000:
-        - 0.980
+        - 0.9855

--- a/src/main/resources/regression/beir-v1.0.0-fiqa-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa
 index_path: indexes/lucene-hnsw.beir-v1.0.0-fiqa-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-fiqa-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa
 index_path: indexes/lucene-hnsw.beir-v1.0.0-fiqa-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-fiqa-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa
 index_path: indexes/lucene-hnsw.beir-v1.0.0-fiqa-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-fiqa-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa
 index_path: indexes/lucene-hnsw.beir-v1.0.0-fiqa-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.405
+        - 0.4065
       R@100:
-        - 0.739
+        - 0.7415
       R@1000:
-        - 0.902
+        - 0.9083

--- a/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa
+
+index_path: indexes/lucene-flat.beir-v1.0.0-fiqa.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): FiQA-2018"
+    id: test
+    path: topics.beir-v1.0.0-fiqa.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-fiqa.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.405
+      R@100:
+        - 0.739
+      R@1000:
+        - 0.902

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa
 index_path: indexes/lucene-hnsw.beir-v1.0.0-hotpotqa-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa
 index_path: indexes/lucene-hnsw.beir-v1.0.0-hotpotqa-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa
 index_path: indexes/lucene-hnsw.beir-v1.0.0-hotpotqa-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa
 index_path: indexes/lucene-hnsw.beir-v1.0.0-hotpotqa-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.722
+        - 0.7259
       R@100:
-        - 0.866
+        - 0.8727
       R@1000:
-        - 0.936
+        - 0.9424

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa
+
+index_path: indexes/lucene-flat.beir-v1.0.0-hotpotqa.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): HotpotQA"
+    id: test
+    path: topics.beir-v1.0.0-hotpotqa.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-hotpotqa.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.722
+      R@100:
+        - 0.866
+      R@1000:
+        - 0.936

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus
 index_path: indexes/lucene-hnsw.beir-v1.0.0-nfcorpus-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus
 index_path: indexes/lucene-hnsw.beir-v1.0.0-nfcorpus-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus
 index_path: indexes/lucene-hnsw.beir-v1.0.0-nfcorpus-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus
 index_path: indexes/lucene-hnsw.beir-v1.0.0-nfcorpus-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus
+
+index_path: indexes/lucene-flat.beir-v1.0.0-nfcorpus.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): NFCorpus"
+    id: test
+    path: topics.beir-v1.0.0-nfcorpus.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-nfcorpus.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.374
+      R@100:
+        - 0.337
+      R@1000:
+        - 0.661

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.374
+        - 0.3735
       R@100:
-        - 0.337
+        - 0.3368
       R@1000:
-        - 0.661
+        - 0.6622

--- a/src/main/resources/regression/beir-v1.0.0-nq-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq
 index_path: indexes/lucene-hnsw.beir-v1.0.0-nq-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-nq-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq
 index_path: indexes/lucene-hnsw.beir-v1.0.0-nq-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-nq-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq
 index_path: indexes/lucene-hnsw.beir-v1.0.0-nq-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-nq-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq
 index_path: indexes/lucene-hnsw.beir-v1.0.0-nq-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq
+
+index_path: indexes/lucene-flat.beir-v1.0.0-nq.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): NQ"
+    id: test
+    path: topics.beir-v1.0.0-nq.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-nq.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.541
+      R@100:
+        - 0.940
+      R@1000:
+        - 0.984

--- a/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.541
+        - 0.5413
       R@100:
-        - 0.940
+        - 0.9415
       R@1000:
-        - 0.984
+        - 0.9859

--- a/src/main/resources/regression/beir-v1.0.0-quora-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora
 index_path: indexes/lucene-hnsw.beir-v1.0.0-quora-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-quora-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora
 index_path: indexes/lucene-hnsw.beir-v1.0.0-quora-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-quora-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora
 index_path: indexes/lucene-hnsw.beir-v1.0.0-quora-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-quora-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora
 index_path: indexes/lucene-hnsw.beir-v1.0.0-quora-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora
+
+index_path: indexes/lucene-flat.beir-v1.0.0-quora.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): Quora"
+    id: test
+    path: topics.beir-v1.0.0-quora.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-quora.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.889
+      R@100:
+        - 0.997
+      R@1000:
+        - 1.000

--- a/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.889
+        - 0.8890
       R@100:
-        - 0.997
+        - 0.9967
       R@1000:
-        - 1.000
+        - 0.9998

--- a/src/main/resources/regression/beir-v1.0.0-robust04-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04
 index_path: indexes/lucene-hnsw.beir-v1.0.0-robust04-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-robust04-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04
 index_path: indexes/lucene-hnsw.beir-v1.0.0-robust04-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-robust04-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04
 index_path: indexes/lucene-hnsw.beir-v1.0.0-robust04-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-robust04-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04
 index_path: indexes/lucene-hnsw.beir-v1.0.0-robust04-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.447
+        - 0.4465
       R@100:
-        - 0.350
+        - 0.3507
       R@1000:
-        - 0.596
+        - 0.5981

--- a/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04
+
+index_path: indexes/lucene-flat.beir-v1.0.0-robust04.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): Robust04"
+    id: test
+    path: topics.beir-v1.0.0-robust04.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-robust04.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.447
+      R@100:
+        - 0.350
+      R@1000:
+        - 0.596

--- a/src/main/resources/regression/beir-v1.0.0-scidocs-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs
 index_path: indexes/lucene-hnsw.beir-v1.0.0-scidocs-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-scidocs-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs
 index_path: indexes/lucene-hnsw.beir-v1.0.0-scidocs-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-scidocs-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs
 index_path: indexes/lucene-hnsw.beir-v1.0.0-scidocs-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-scidocs-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs
 index_path: indexes/lucene-hnsw.beir-v1.0.0-scidocs-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs
+
+index_path: indexes/lucene-flat.beir-v1.0.0-scidocs.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): SCIDOCS"
+    id: test
+    path: topics.beir-v1.0.0-scidocs.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-scidocs.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.217
+      R@100:
+        - 0.496
+      R@1000:
+        - 0.783

--- a/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.217
+        - 0.2170
       R@100:
-        - 0.496
+        - 0.4959
       R@1000:
-        - 0.783
+        - 0.7824

--- a/src/main/resources/regression/beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact
 index_path: indexes/lucene-hnsw.beir-v1.0.0-scifact-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact
 index_path: indexes/lucene-hnsw.beir-v1.0.0-scifact-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact
 index_path: indexes/lucene-hnsw.beir-v1.0.0-scifact-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact
 index_path: indexes/lucene-hnsw.beir-v1.0.0-scifact-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact
+
+index_path: indexes/lucene-flat.beir-v1.0.0-scifact.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): SciFact"
+    id: test
+    path: topics.beir-v1.0.0-scifact.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-scifact.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.741
+      R@100:
+        - 0.967
+      R@1000:
+        - 0.997

--- a/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.741
+        - 0.7408
       R@100:
-        - 0.967
+        - 0.9667
       R@1000:
-        - 0.997
+        - 0.9967

--- a/src/main/resources/regression/beir-v1.0.0-signal1m-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m
 index_path: indexes/lucene-hnsw.beir-v1.0.0-signal1m-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-signal1m-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m
 index_path: indexes/lucene-hnsw.beir-v1.0.0-signal1m-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-signal1m-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m
 index_path: indexes/lucene-hnsw.beir-v1.0.0-signal1m-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-signal1m-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m
 index_path: indexes/lucene-hnsw.beir-v1.0.0-signal1m-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m
+
+index_path: indexes/lucene-flat.beir-v1.0.0-signal1m.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): Signal-1M"
+    id: test
+    path: topics.beir-v1.0.0-signal1m.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-signal1m.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.282
+      R@100:
+        - 0.298
+      R@1000:
+        - 0.500

--- a/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.282
+        - 0.2886
       R@100:
-        - 0.298
+        - 0.3112
       R@1000:
-        - 0.500
+        - 0.5331

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid
 index_path: indexes/lucene-hnsw.beir-v1.0.0-trec-covid-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid
 index_path: indexes/lucene-hnsw.beir-v1.0.0-trec-covid-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid
 index_path: indexes/lucene-hnsw.beir-v1.0.0-trec-covid-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid
 index_path: indexes/lucene-hnsw.beir-v1.0.0-trec-covid-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid
+
+index_path: indexes/lucene-flat.beir-v1.0.0-trec-covid.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): TREC-COVID"
+    id: test
+    path: topics.beir-v1.0.0-trec-covid.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-trec-covid.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.781
+      R@100:
+        - 0.141
+      R@1000:
+        - 0.477

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.781
+        - 0.7814
       R@100:
-        - 0.141
+        - 0.1406
       R@1000:
-        - 0.477
+        - 0.4768

--- a/src/main/resources/regression/beir-v1.0.0-trec-news-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news
 index_path: indexes/lucene-hnsw.beir-v1.0.0-trec-news-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-trec-news-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news
 index_path: indexes/lucene-hnsw.beir-v1.0.0-trec-news-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-trec-news-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news
 index_path: indexes/lucene-hnsw.beir-v1.0.0-trec-news-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-trec-news-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news
 index_path: indexes/lucene-hnsw.beir-v1.0.0-trec-news-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news
+
+index_path: indexes/lucene-flat.beir-v1.0.0-trec-news.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): TREC-NEWS"
+    id: test
+    path: topics.beir-v1.0.0-trec-news.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-trec-news.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.441
+      R@100:
+        - 0.488
+      R@1000:
+        - 0.770

--- a/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.441
+        - 0.4425
       R@100:
-        - 0.488
+        - 0.4992
       R@1000:
-        - 0.770
+        - 0.7875

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-hnsw-int8-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-hnsw-int8-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020
 index_path: indexes/lucene-hnsw.beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-hnsw-int8.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-hnsw-int8.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020
 index_path: indexes/lucene-hnsw.beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-int8/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
 

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-hnsw-onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-hnsw-onnx.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020
 index_path: indexes/lucene-hnsw.beir-v1.0.0-webis-touche2020-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-hnsw.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020-bge-base-en-v1.5-hnsw.yaml
@@ -5,7 +5,7 @@ corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020
 index_path: indexes/lucene-hnsw.beir-v1.0.0-webis-touche2020-bge-base-en-v1.5/
 index_type: hnsw
 collection_class: JsonDenseVectorCollection
-generator_class: HnswDenseVectorDocumentGenerator
+generator_class: DenseVectorDocumentGenerator
 index_threads: 16
 index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
 

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.flat.yaml
@@ -1,0 +1,53 @@
+---
+corpus: beir-v1.0.0.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020
+
+index_path: indexes/lucene-flat.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/
+index_type: flat
+collection_class: JsonDenseVectorCollection
+generator_class: DenseVectorDocumentGenerator
+index_threads: 16
+index_options: ""
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): Webis-Touche2020"
+    id: test
+    path: topics.beir-v1.0.0-webis-touche2020.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-webis-touche2020.test.txt
+
+models:
+  - name: bge-flat
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
+    results:
+      nDCG@10:
+        - 0.257
+      R@100:
+        - 0.486
+      R@1000:
+        - 0.831

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.flat.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.flat.yaml
@@ -46,8 +46,8 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads 16 -hits 1000
     results:
       nDCG@10:
-        - 0.257
+        - 0.2570
       R@100:
-        - 0.486
+        - 0.4857
       R@1000:
-        - 0.831
+        - 0.8298

--- a/src/test/java/io/anserini/index/IndexFlatDenseVectorsTest.java
+++ b/src/test/java/io/anserini/index/IndexFlatDenseVectorsTest.java
@@ -1,0 +1,171 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.index;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.lucene.index.IndexReader;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link IndexFlatDenseVectors}
+ */
+public class IndexFlatDenseVectorsTest {
+  private final ByteArrayOutputStream err = new ByteArrayOutputStream();
+  private PrintStream save;
+
+  private void redirectStderr() {
+    save = System.err;
+    err.reset();
+    System.setErr(new PrintStream(err));
+  }
+
+  private void restoreStderr() {
+    System.setErr(save);
+  }
+
+  @BeforeClass
+  public static void setupClass() {
+    Configurator.setLevel(AbstractIndexer.class.getName(), Level.ERROR);
+    Configurator.setLevel(IndexFlatDenseVectors.class.getName(), Level.ERROR);
+  }
+
+  @Test
+  public void testEmptyInvocation() throws Exception {
+    redirectStderr();
+    String[] indexArgs = new String[] {};
+
+    IndexFlatDenseVectors.main(indexArgs);
+    assertTrue(err.toString().contains("Error"));
+    assertTrue(err.toString().contains("is required"));
+
+    restoreStderr();
+  }
+
+  @Test
+  public void testAskForHelp() throws Exception {
+    redirectStderr();
+
+    IndexFlatDenseVectors.main(new String[] {"-options"});
+    assertTrue(err.toString().contains("Options for"));
+
+    restoreStderr();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidCollection() throws Exception {
+    String[] indexArgs = new String[] {
+        "-collection", "FakeJsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
+        "-index", "target/idx-sample-hnsw" + System.currentTimeMillis(),
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCollectionPath() throws Exception {
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/openai_ada2/json_vector_fake_path",
+        "-index", "target/idx-sample-hnsw" + System.currentTimeMillis(),
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidGenerator() throws Exception {
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
+        "-index", "target/idx-sample-hnsw" + System.currentTimeMillis(),
+        "-generator", "FakeDenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+  }
+
+  @Test
+  public void testDefaultGenerator() throws Exception {
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
+        "-index", "target/idx-sample-hnsw" + System.currentTimeMillis(),
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+    // If this succeeded, then the default -generator of DenseVectorDocumentGenerator must have worked.
+  }
+
+  @Test
+  public void test1() throws Exception {
+    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    IndexReader reader = IndexReaderUtils.getReader(indexPath);
+    assertNotNull(reader);
+
+    Map<String, Object> results = IndexReaderUtils.getIndexStats(reader, Constants.VECTOR);
+    assertNotNull(results);
+    assertEquals(100, results.get("documents"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testQuantizedInt8() throws Exception {
+    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1", "-quantize.int8"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    IndexReader reader = IndexReaderUtils.getReader(indexPath);
+    assertNotNull(reader);
+
+    Map<String, Object> results = IndexReaderUtils.getIndexStats(reader, Constants.VECTOR);
+    assertNotNull(results);
+    assertEquals(100, results.get("documents"));
+  }
+}

--- a/src/test/java/io/anserini/index/IndexHnswDenseVectorsTest.java
+++ b/src/test/java/io/anserini/index/IndexHnswDenseVectorsTest.java
@@ -109,7 +109,7 @@ public class IndexHnswDenseVectorsTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
         "-index", "target/idx-sample-hnsw" + System.currentTimeMillis(),
-        "-generator", "FakeHnswDenseVectorDocumentGenerator",
+        "-generator", "FakeDenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };
@@ -128,7 +128,7 @@ public class IndexHnswDenseVectorsTest {
     };
 
     IndexHnswDenseVectors.main(indexArgs);
-    // If this succeeded, then the default -generator of HnswDenseVectorDocumentGenerator must have worked.
+    // If this succeeded, then the default -generator of DenseVectorDocumentGenerator must have worked.
   }
 
   @Test
@@ -138,7 +138,7 @@ public class IndexHnswDenseVectorsTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };
@@ -160,7 +160,7 @@ public class IndexHnswDenseVectorsTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100", "-quantize.int8"
     };

--- a/src/test/java/io/anserini/search/FlatDenseSearcherTest.java
+++ b/src/test/java/io/anserini/search/FlatDenseSearcherTest.java
@@ -1,0 +1,440 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.search;
+
+import io.anserini.index.IndexFlatDenseVectors;
+import io.anserini.search.topicreader.JsonIntVectorTopicReader;
+import io.anserini.search.topicreader.TopicReader;
+import io.anserini.search.topicreader.TsvIntTopicReader;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class FlatDenseSearcherTest {
+  @BeforeClass
+  public static void setupClass() {
+    Configurator.setLevel(IndexFlatDenseVectors.class.getName(), Level.ERROR);
+    Configurator.setLevel(FlatDenseSearcher.class.getName(), Level.ERROR);
+  }
+
+  @Test
+  public void testAda2() throws Exception {
+    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    FlatDenseSearcher.Args args = new FlatDenseSearcher.Args();
+    args.index = indexPath;
+
+    TopicReader<Integer> topicReader = new JsonIntVectorTopicReader(
+        Path.of("src/test/resources/sample_topics/sample-topics.msmarco-passage-dev-openai-ada2.jsonl"));
+
+    SortedMap<Integer, Map<String, String>> topics = topicReader.read();
+    Iterator<Integer> iterator = topics.keySet().iterator();
+
+    try(FlatDenseSearcher<Integer> searcher = new FlatDenseSearcher<>(args)) {
+      int qid = iterator.next();
+      ScoredDoc[] results;
+
+      assertEquals(160885, qid);
+      results = searcher.search(qid, topics.get(qid).get("vector"), 5);
+      assertEquals(5, results.length);
+      assertEquals("45", results[0].docid);
+      assertEquals("44", results[1].docid);
+      assertEquals("40", results[2].docid);
+      assertEquals("48", results[3].docid);
+      assertEquals("41", results[4].docid);
+
+      assertEquals(0.863064f, results[0].score, 10e-6);
+      assertEquals(0.861596f, results[1].score, 10e-6);
+      assertEquals(0.858651f, results[2].score, 10e-6);
+      assertEquals(0.858514f, results[3].score, 10e-6);
+      assertEquals(0.856264f, results[4].score, 10e-6);
+
+      // Now test without qid
+      results = searcher.search(topics.get(qid).get("vector"), 5);
+      assertEquals(5, results.length);
+      assertEquals("45", results[0].docid);
+      assertEquals("44", results[1].docid);
+      assertEquals("40", results[2].docid);
+      assertEquals("48", results[3].docid);
+      assertEquals("41", results[4].docid);
+
+      assertEquals(0.863064f, results[0].score, 10e-6);
+      assertEquals(0.861596f, results[1].score, 10e-6);
+      assertEquals(0.858651f, results[2].score, 10e-6);
+      assertEquals(0.858514f, results[3].score, 10e-6);
+      assertEquals(0.856264f, results[4].score, 10e-6);
+
+      qid = iterator.next();
+      assertEquals(867490, qid);
+      results = searcher.search(qid, topics.get(qid).get("vector"), 5);
+      assertEquals(5, results.length);
+      assertEquals("10", results[0].docid);
+      assertEquals("45", results[1].docid);
+      assertEquals("44", results[2].docid);
+      assertEquals("95", results[3].docid);
+      assertEquals("97", results[4].docid);
+
+      assertEquals(0.850332f, results[0].score, 10e-6);
+      assertEquals(0.846281f, results[1].score, 10e-6);
+      assertEquals(0.845236f, results[2].score, 10e-6);
+      assertEquals(0.845013f, results[3].score, 10e-6);
+      assertEquals(0.844905f, results[4].score, 10e-6);
+
+      // Now test without qid
+      results = searcher.search(topics.get(qid).get("vector"), 5);
+      assertEquals(5, results.length);
+      assertEquals("10", results[0].docid);
+      assertEquals("45", results[1].docid);
+      assertEquals("44", results[2].docid);
+      assertEquals("95", results[3].docid);
+      assertEquals("97", results[4].docid);
+
+      assertEquals(0.850332f, results[0].score, 10e-6);
+      assertEquals(0.846281f, results[1].score, 10e-6);
+      assertEquals(0.845236f, results[2].score, 10e-6);
+      assertEquals(0.845013f, results[3].score, 10e-6);
+      assertEquals(0.844905f, results[4].score, 10e-6);
+    }
+  }
+
+  @Test
+  public void testAda2Batch() throws Exception {
+    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    FlatDenseSearcher.Args args = new FlatDenseSearcher.Args();
+    args.index = indexPath;
+
+    TopicReader<Integer> topicReader = new JsonIntVectorTopicReader(
+        Path.of("src/test/resources/sample_topics/sample-topics.msmarco-passage-dev-openai-ada2.jsonl"));
+
+    SortedMap<Integer, Map<String, String>> topics = topicReader.read();
+
+    List<Integer> qids= new ArrayList<>();
+    List<String> queries = new ArrayList<>();
+
+    topics.forEach((qid, topic) -> {
+      String query = topic.get("vector");
+      assert query != null;
+      qids.add(qid);
+      queries.add(query);
+    });
+
+    try(FlatDenseSearcher<Integer> searcher = new FlatDenseSearcher<>(args)) {
+      SortedMap<Integer, ScoredDoc[]> allResults = searcher.batch_search(qids, queries, 5);
+
+      ScoredDoc[] results = allResults.get(160885);
+      assertEquals(5, results.length);
+      assertEquals("45", results[0].docid);
+      assertEquals("44", results[1].docid);
+      assertEquals("40", results[2].docid);
+      assertEquals("48", results[3].docid);
+      assertEquals("41", results[4].docid);
+
+      assertEquals(0.863064f, results[0].score, 10e-6);
+      assertEquals(0.861596f, results[1].score, 10e-6);
+      assertEquals(0.858651f, results[2].score, 10e-6);
+      assertEquals(0.858514f, results[3].score, 10e-6);
+      assertEquals(0.856264f, results[4].score, 10e-6);
+
+      results = allResults.get(867490);
+      assertEquals(5, results.length);
+      assertEquals("10", results[0].docid);
+      assertEquals("45", results[1].docid);
+      assertEquals("44", results[2].docid);
+      assertEquals("95", results[3].docid);
+      assertEquals("97", results[4].docid);
+
+      assertEquals(0.850332f, results[0].score, 10e-6);
+      assertEquals(0.846281f, results[1].score, 10e-6);
+      assertEquals(0.845236f, results[2].score, 10e-6);
+      assertEquals(0.845013f, results[3].score, 10e-6);
+      assertEquals(0.844905f, results[4].score, 10e-6);
+    }
+  }
+
+  @Test
+  public void testCosDpr() throws Exception {
+    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/cos-dpr-distil/json_vector/",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    FlatDenseSearcher.Args args = new FlatDenseSearcher.Args();
+    args.index = indexPath;
+
+    TopicReader<Integer> topicReader = new JsonIntVectorTopicReader(
+        Path.of("src/test/resources/sample_topics/sample-topics.msmarco-passage-dev-cos-dpr-distil.jsonl"));
+
+    SortedMap<Integer, Map<String, String>> topics = topicReader.read();
+    Iterator<Integer> iterator = topics.keySet().iterator();
+
+    try(FlatDenseSearcher<Integer> searcher = new FlatDenseSearcher<>(args)) {
+      int qid = iterator.next();
+      ScoredDoc[] results;
+
+      assertEquals(2, qid);
+      results = searcher.search(qid, topics.get(qid).get("vector"), 5);
+      assertEquals(5, results.length);
+      assertEquals("208", results[0].docid);
+      assertEquals("224", results[1].docid);
+      assertEquals("384", results[2].docid);
+      assertEquals("136", results[3].docid);
+      assertEquals("720", results[4].docid);
+
+      assertEquals(0.578725f, results[0].score, 10e-6);
+      assertEquals(0.578704f, results[1].score, 10e-6);
+      assertEquals(0.573909f, results[2].score, 10e-6);
+      assertEquals(0.573040f, results[3].score, 10e-6);
+      assertEquals(0.571078f, results[4].score, 10e-6);
+
+      // Now test without qid
+      results = searcher.search(topics.get(qid).get("vector"), 5);
+      assertEquals(5, results.length);
+      assertEquals("208", results[0].docid);
+      assertEquals("224", results[1].docid);
+      assertEquals("384", results[2].docid);
+      assertEquals("136", results[3].docid);
+      assertEquals("720", results[4].docid);
+
+      assertEquals(0.578725f, results[0].score, 10e-6);
+      assertEquals(0.578704f, results[1].score, 10e-6);
+      assertEquals(0.573909f, results[2].score, 10e-6);
+      assertEquals(0.573040f, results[3].score, 10e-6);
+      assertEquals(0.571078f, results[4].score, 10e-6);
+
+      qid = iterator.next();
+      assertEquals(1048585, qid);
+      results = searcher.search(qid, topics.get(qid).get("vector"), 5);
+      assertEquals(5, results.length);
+      assertEquals("624", results[0].docid);
+      assertEquals("120", results[1].docid);
+      assertEquals("320", results[2].docid);
+      assertEquals("232", results[3].docid);
+      assertEquals("328", results[4].docid);
+
+      assertEquals(0.568415f, results[0].score, 10e-6);
+      assertEquals(0.563448f, results[1].score, 10e-6);
+      assertEquals(0.558943f, results[2].score, 10e-6);
+      assertEquals(0.550981f, results[3].score, 10e-6);
+      assertEquals(0.550971f, results[4].score, 10e-6);
+
+      // Now test without qid
+      results = searcher.search(topics.get(qid).get("vector"), 5);
+      assertEquals(5, results.length);
+      assertEquals("624", results[0].docid);
+      assertEquals("120", results[1].docid);
+      assertEquals("320", results[2].docid);
+      assertEquals("232", results[3].docid);
+      assertEquals("328", results[4].docid);
+
+      assertEquals(0.568415f, results[0].score, 10e-6);
+      assertEquals(0.563448f, results[1].score, 10e-6);
+      assertEquals(0.558943f, results[2].score, 10e-6);
+      assertEquals(0.550981f, results[3].score, 10e-6);
+      assertEquals(0.550971f, results[4].score, 10e-6);
+    }
+  }
+
+  @Test
+  public void testCosDprWithOnnx() throws Exception {
+    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/cos-dpr-distil/json_vector/",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    FlatDenseSearcher.Args args = new FlatDenseSearcher.Args();
+    args.index = indexPath;
+    args.encoder = "CosDprDistil";
+
+    TopicReader<Integer> topicReader = new TsvIntTopicReader(
+        Path.of("src/test/resources/sample_topics/sample-topics.msmarco-passage-dev-cos-dpr-distil.tsv"));
+
+    SortedMap<Integer, Map<String, String>> topics = topicReader.read();
+    Iterator<Integer> iterator = topics.keySet().iterator();
+
+    try(FlatDenseSearcher<Integer> searcher = new FlatDenseSearcher<>(args)) {
+      int qid = iterator.next();
+      ScoredDoc[] results;
+
+      assertEquals(2, qid);
+      results = searcher.search(qid, topics.get(qid).get("title"), 5);
+      assertEquals(5, results.length);
+      assertEquals("208", results[0].docid);
+      assertEquals("224", results[1].docid);
+      assertEquals("384", results[2].docid);
+      assertEquals("136", results[3].docid);
+      assertEquals("720", results[4].docid);
+
+      assertEquals(0.578723f, results[0].score, 10e-4);
+      assertEquals(0.578716f, results[1].score, 10e-4);
+      assertEquals(0.573913f, results[2].score, 10e-4);
+      assertEquals(0.573051f, results[3].score, 10e-4);
+      assertEquals(0.571061f, results[4].score, 10e-4);
+
+      // Now test without qid
+      results = searcher.search(topics.get(qid).get("title"), 5);
+      assertEquals(5, results.length);
+      assertEquals("208", results[0].docid);
+      assertEquals("224", results[1].docid);
+      assertEquals("384", results[2].docid);
+      assertEquals("136", results[3].docid);
+      assertEquals("720", results[4].docid);
+
+      assertEquals(0.578723f, results[0].score, 10e-4);
+      assertEquals(0.578716f, results[1].score, 10e-4);
+      assertEquals(0.573913f, results[2].score, 10e-4);
+      assertEquals(0.573051f, results[3].score, 10e-4);
+      assertEquals(0.571061f, results[4].score, 10e-4);
+
+      qid = iterator.next();
+      assertEquals(1048585, qid);
+      results = searcher.search(qid, topics.get(qid).get("title"), 5);
+      assertEquals(5, results.length);
+      assertEquals("624", results[0].docid);
+      assertEquals("120", results[1].docid);
+      assertEquals("320", results[2].docid);
+      assertEquals("328", results[3].docid);
+      assertEquals("232", results[4].docid);
+
+      assertEquals(0.568417f, results[0].score, 10e-4);
+      assertEquals(0.563483f, results[1].score, 10e-4);
+      assertEquals(0.558932f, results[2].score, 10e-4);
+      assertEquals(0.550985f, results[3].score, 10e-4);
+      assertEquals(0.550977f, results[4].score, 10e-4);
+
+      // Now test without qid
+      results = searcher.search(topics.get(qid).get("title"), 5);
+      assertEquals(5, results.length);
+      assertEquals("624", results[0].docid);
+      assertEquals("120", results[1].docid);
+      assertEquals("320", results[2].docid);
+      assertEquals("328", results[3].docid);
+      assertEquals("232", results[4].docid);
+
+      assertEquals(0.568417f, results[0].score, 10e-4);
+      assertEquals(0.563483f, results[1].score, 10e-4);
+      assertEquals(0.558932f, results[2].score, 10e-4);
+      assertEquals(0.550985f, results[3].score, 10e-4);
+      assertEquals(0.550977f, results[4].score, 10e-4);
+    }
+  }
+
+  @Test
+  public void testCosDprBatchWithOnnx() throws Exception {
+    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/cos-dpr-distil/json_vector/",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    FlatDenseSearcher.Args args = new FlatDenseSearcher.Args();
+    args.index = indexPath;
+    args.encoder = "CosDprDistil";
+
+    TopicReader<Integer> topicReader = new TsvIntTopicReader(
+        Path.of("src/test/resources/sample_topics/sample-topics.msmarco-passage-dev-cos-dpr-distil.tsv"));
+
+    SortedMap<Integer, Map<String, String>> topics = topicReader.read();
+
+    List<Integer> qids= new ArrayList<>();
+    List<String> queries = new ArrayList<>();
+
+    topics.forEach((qid, topic) -> {
+      String query = topic.get("title");
+      assert query != null;
+      qids.add(qid);
+      queries.add(query);
+    });
+
+    try(FlatDenseSearcher<Integer> searcher = new FlatDenseSearcher<>(args)) {
+      SortedMap<Integer, ScoredDoc[]> allResults = searcher.batch_search(qids, queries, 5);
+
+      ScoredDoc[] results = allResults.get(2);
+      assertEquals(5, results.length);
+      assertEquals("208", results[0].docid);
+      assertEquals("224", results[1].docid);
+      assertEquals("384", results[2].docid);
+      assertEquals("136", results[3].docid);
+      assertEquals("720", results[4].docid);
+
+      assertEquals(0.578723f, results[0].score, 10e-4);
+      assertEquals(0.578716f, results[1].score, 10e-4);
+      assertEquals(0.573913f, results[2].score, 10e-4);
+      assertEquals(0.573051f, results[3].score, 10e-4);
+      assertEquals(0.571061f, results[4].score, 10e-4);
+
+      results = allResults.get(1048585);
+      assertEquals(5, results.length);
+      assertEquals("624", results[0].docid);
+      assertEquals("120", results[1].docid);
+      assertEquals("320", results[2].docid);
+      assertEquals("328", results[3].docid);
+      assertEquals("232", results[4].docid);
+
+      assertEquals(0.568417f, results[0].score, 10e-4);
+      assertEquals(0.563483f, results[1].score, 10e-4);
+      assertEquals(0.558932f, results[2].score, 10e-4);
+      assertEquals(0.550985f, results[3].score, 10e-4);
+      assertEquals(0.550977f, results[4].score, 10e-4);
+    }
+  }
+}

--- a/src/test/java/io/anserini/search/HnswDenseSearcherTest.java
+++ b/src/test/java/io/anserini/search/HnswDenseSearcherTest.java
@@ -48,7 +48,7 @@ public class HnswDenseSearcherTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };
@@ -138,7 +138,7 @@ public class HnswDenseSearcherTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };
@@ -203,7 +203,7 @@ public class HnswDenseSearcherTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cos-dpr-distil/json_vector/",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };
@@ -293,7 +293,7 @@ public class HnswDenseSearcherTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cos-dpr-distil/json_vector/",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };
@@ -384,7 +384,7 @@ public class HnswDenseSearcherTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cos-dpr-distil/json_vector/",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };

--- a/src/test/java/io/anserini/search/InvertedDenseSearcherTest.java
+++ b/src/test/java/io/anserini/search/InvertedDenseSearcherTest.java
@@ -24,7 +24,6 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;

--- a/src/test/java/io/anserini/search/SearchFlatDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchFlatDenseVectorsTest.java
@@ -1,0 +1,518 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.search;
+
+import io.anserini.TestUtils;
+import io.anserini.index.AbstractIndexer;
+import io.anserini.index.IndexFlatDenseVectors;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link SearchFlatDenseVectors}
+ */
+public class SearchFlatDenseVectorsTest {
+  private final ByteArrayOutputStream err = new ByteArrayOutputStream();
+  private PrintStream save;
+
+  private void redirectStderr() {
+    save = System.err;
+    err.reset();
+    System.setErr(new PrintStream(err));
+  }
+
+  private void restoreStderr() {
+    System.setErr(save);
+  }
+
+  @BeforeClass
+  public static void setupClass() {
+    Configurator.setLevel(AbstractIndexer.class.getName(), Level.ERROR);
+    Configurator.setLevel(IndexFlatDenseVectors.class.getName(), Level.ERROR);
+    Configurator.setLevel(SearchFlatDenseVectors.class.getName(), Level.ERROR);
+    Configurator.setLevel(FlatDenseSearcher.class.getName(), Level.ERROR);
+  }
+
+  @Test
+  public void testEmptyInvocation() throws Exception {
+    redirectStderr();
+
+    SearchFlatDenseVectors.main(new String[] {});
+    assertTrue(err.toString().contains("Error"));
+    assertTrue(err.toString().contains("is required"));
+
+    restoreStderr();
+  }
+
+  @Test
+  public void testAskForHelp() throws Exception {
+    redirectStderr();
+
+    SearchFlatDenseVectors.main(new String[] {"-options"});
+    assertTrue(err.toString().contains("Options for"));
+
+    restoreStderr();
+  }
+
+  @Test
+  public void testInvalidIndex1() throws Exception {
+    redirectStderr();
+
+    // Fake path that doesn't exist.
+    String[] searchArgs = new String[] {
+        "-index", "/fake/path",
+        "-topics", "src/test/resources/sample_topics/sample-topics.msmarco-passage-dev-openai-ada2.jsonl",
+        "-output", "target/run-" + System.currentTimeMillis(),
+        "-generator", "VectorQueryGenerator",
+        "-topicReader", "JsonIntVector",
+        "-topicField", "vector",
+        "-hits", "5"};
+    SearchFlatDenseVectors.main(searchArgs);
+
+    assertEquals("Error: \"/fake/path\" does not appear to be a valid index.\n", err.toString());
+    restoreStderr();
+  }
+
+  @Test
+  public void testInvalidIndex2() throws Exception {
+    redirectStderr();
+
+    // Path that does exist, but isn't an index.
+    String[] searchArgs = new String[] {
+        "-index", "/fake/path",
+        "-topics", "src/test/resources/sample_topics/sample-topics.msmarco-passage-dev-openai-ada2.jsonl",
+        "-output", "target/run-" + System.currentTimeMillis(),
+        "-generator", "VectorQueryGenerator",
+        "-topicReader", "JsonIntVector",
+        "-topicField", "vector",
+        "-hits", "5"};
+    SearchFlatDenseVectors.main(searchArgs);
+
+    assertEquals("Error: \"/fake/path\" does not appear to be a valid index.\n", err.toString());
+    restoreStderr();
+  }
+
+  @Test
+  public void searchInvalidTopics() throws Exception {
+    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    String runfile = "target/run-" + System.currentTimeMillis();
+    String[] searchArgs = new String[] {
+        "-index", indexPath,
+        "-topics", "fake/topics/here",
+        "-output", runfile,
+        "-generator", "VectorQueryGenerator",
+        "-topicReader", "JsonIntVector",
+        "-topicField", "vector",
+        "-hits", "5"};
+
+    redirectStderr();
+    SearchFlatDenseVectors.main(searchArgs);
+
+    assertEquals("Error: \"fake/topics/here\" does not refer to valid topics.\n", err.toString());
+    restoreStderr();
+  }
+
+  @Test
+  public void searchInvalidReader() throws Exception {
+    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    String runfile = "target/run-" + System.currentTimeMillis();
+    String[] searchArgs = new String[] {
+        "-index", indexPath,
+        "-topics", "src/test/resources/sample_topics/sample-topics.msmarco-passage-dev-openai-ada2.jsonl",
+        "-output", runfile,
+        "-generator", "VectorQueryGenerator",
+        "-topicReader", "FakeJsonIntVector",
+        "-topicField", "vector",
+        "-hits", "5"};
+
+    redirectStderr();
+    SearchFlatDenseVectors.main(searchArgs);
+
+    assertEquals("Error: Unable to load topic reader \"FakeJsonIntVector\".\n", err.toString());
+    restoreStderr();
+  }
+
+  @Test
+  public void searchInvalidTopicField() throws Exception {
+    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    String runfile = "target/run-" + System.currentTimeMillis();
+    String[] searchArgs = new String[] {
+        "-index", indexPath,
+        "-topics", "src/test/resources/sample_topics/sample-topics.msmarco-passage-dev-openai-ada2.jsonl",
+        "-output", runfile,
+        "-generator", "VectorQueryGenerator",
+        "-topicReader", "JsonIntVector",
+        "-topicField", "fake_field",
+        "-hits", "5"};
+
+    redirectStderr();
+    SearchFlatDenseVectors.main(searchArgs);
+
+    assertEquals("Error: Unable to read topic field \"fake_field\".\n", err.toString());
+    restoreStderr();
+  }
+
+  @Test
+  public void searchInvalidGenerator() throws Exception {
+    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    String runfile = "target/run-" + System.currentTimeMillis();
+    String[] searchArgs = new String[] {
+        "-index", indexPath,
+        "-topics", "src/test/resources/sample_topics/sample-topics.msmarco-passage-dev-openai-ada2.jsonl",
+        "-output", runfile,
+        "-generator", "FakeVectorQueryGenerator",
+        "-topicReader", "JsonIntVector",
+        "-topicField", "vector",
+        "-hits", "5"};
+
+    redirectStderr();
+    SearchFlatDenseVectors.main(searchArgs);
+
+    assertEquals("Error: Unable to load QueryGenerator \"FakeVectorQueryGenerator\".\n", err.toString());
+    restoreStderr();
+  }
+
+  @Test
+  public void searchInvalidEncoder() throws Exception {
+    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    String runfile = "target/run-" + System.currentTimeMillis();
+    String[] searchArgs = new String[] {
+        "-index", indexPath,
+        "-topics", "src/test/resources/sample_topics/sample-topics.msmarco-passage-dev-openai-ada2.jsonl",
+        "-output", runfile,
+        "-generator", "VectorQueryGenerator",
+        "-encoder", "FakeEncoder",
+        "-topicReader", "JsonIntVector",
+        "-topicField", "vector",
+        "-hits", "5"};
+
+    redirectStderr();
+    SearchFlatDenseVectors.main(searchArgs);
+
+    assertEquals("Error: Unable to load Encoder \"FakeEncoder\".\n", err.toString());
+    restoreStderr();
+  }
+
+  @Test
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void testBasicAda2() throws Exception {
+    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    String runfile = "target/run-" + System.currentTimeMillis();
+    String[] searchArgs = new String[] {
+        "-index", indexPath,
+        "-topics", "src/test/resources/sample_topics/sample-topics.msmarco-passage-dev-openai-ada2.jsonl",
+        "-output", runfile,
+        "-generator", "VectorQueryGenerator",
+        "-topicReader", "JsonIntVector",
+        "-topicField", "vector",
+        "-hits", "5"};
+    SearchFlatDenseVectors.main(searchArgs);
+
+    TestUtils.checkRunFileApproximate(runfile, new String[] {
+        "160885 Q0 45 1 0.863064 Anserini",
+        "160885 Q0 44 2 0.861596 Anserini",
+        "160885 Q0 40 3 0.858651 Anserini",
+        "160885 Q0 48 4 0.858514 Anserini",
+        "160885 Q0 41 5 0.856265 Anserini",
+        "867490 Q0 10 1 0.850331 Anserini",
+        "867490 Q0 45 2 0.846281 Anserini",
+        "867490 Q0 44 3 0.845236 Anserini",
+        "867490 Q0 95 4 0.845013 Anserini",
+        "867490 Q0 97 5 0.844905 Anserini"
+    });
+
+    new File(runfile).delete();
+  }
+
+  @Test
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void testBasicCosDpr() throws Exception {
+    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/cos-dpr-distil/json_vector/",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    String runfile = "target/run-" + System.currentTimeMillis();
+    String[] searchArgs = new String[] {
+        "-index", indexPath,
+        "-topics", "src/test/resources/sample_topics/sample-topics.msmarco-passage-dev-cos-dpr-distil.jsonl",
+        "-output", runfile,
+        "-generator", "VectorQueryGenerator",
+        "-topicReader", "JsonIntVector",
+        "-topicField", "vector",
+        "-hits", "5"};
+    SearchFlatDenseVectors.main(searchArgs);
+
+    TestUtils.checkRunFileApproximate(runfile, new String[] {
+        "2 Q0 208 1 0.578725 Anserini",
+        "2 Q0 224 2 0.578704 Anserini",
+        "2 Q0 384 3 0.573909 Anserini",
+        "2 Q0 136 4 0.573040 Anserini",
+        "2 Q0 720 5 0.571078 Anserini",
+        "1048585 Q0 624 1 0.568415 Anserini",
+        "1048585 Q0 120 2 0.563448 Anserini",
+        "1048585 Q0 320 3 0.558943 Anserini",
+        "1048585 Q0 232 4 0.550981 Anserini",
+        "1048585 Q0 328 5 0.550971 Anserini"
+    });
+
+    new File(runfile).delete();
+  }
+
+  @Test
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void testBasicCosDprSpecifyTopicsAsSymbol() throws Exception {
+    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/cos-dpr-distil/json_vector/",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    String runfile = "target/run-" + System.currentTimeMillis();
+    String[] searchArgs = new String[] {
+        "-index", indexPath,
+        "-topics", "TREC2019_DL_PASSAGE_COS_DPR_DISTIL",
+        "-output", runfile,
+        "-hits", "5"};
+    SearchFlatDenseVectors.main(searchArgs);
+
+    // Not checking content, just checking if the topics were loaded successfully.
+    File f = new File(runfile);
+    assertTrue(f.exists());
+    f.delete();
+
+    runfile = "target/run-" + System.currentTimeMillis();
+    searchArgs = new String[] {
+        "-index", indexPath,
+        "-topics", "TREC2019_DL_PASSAGE",
+        "-encoder", "CosDprDistil",
+        "-output", runfile,
+        "-hits", "5"};
+    SearchFlatDenseVectors.main(searchArgs);
+
+    // Not checking content, just checking if the topics were loaded successfully.
+    f = new File(runfile);
+    assertTrue(f.exists());
+    f.delete();
+  }
+
+  @Test
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void testBasicWithOnnx() throws Exception {
+    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/cos-dpr-distil/json_vector/",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    String runfile = "target/run-" + System.currentTimeMillis();
+    String[] searchArgs = new String[] {
+        "-index", indexPath,
+        "-topics", "src/test/resources/sample_topics/sample-topics.msmarco-passage-dev-cos-dpr-distil.tsv",
+        "-output", runfile,
+        "-generator", "VectorQueryGenerator",
+        "-encoder", "CosDprDistil",
+        "-topicReader", "TsvInt",
+        "-topicField", "title",
+        "-hits", "5"};
+    SearchFlatDenseVectors.main(searchArgs);
+
+    // Note output is slightly different from pre-encoded query vectors.
+    TestUtils.checkRunFileApproximate(runfile, new String[] {
+        "2 Q0 208 1 0.578723 Anserini",
+        "2 Q0 224 2 0.578716 Anserini",
+        "2 Q0 384 3 0.573913 Anserini",
+        "2 Q0 136 4 0.573051 Anserini",
+        "2 Q0 720 5 0.571061 Anserini",
+        "1048585 Q0 624 1 0.568417 Anserini",
+        "1048585 Q0 120 2 0.563483 Anserini",
+        "1048585 Q0 320 3 0.558932 Anserini",
+        "1048585 Q0 328 4 0.550985 Anserini",
+        "1048585 Q0 232 5 0.550977 Anserini"
+    });
+
+    new File(runfile).delete();
+  }
+
+  @Test
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void testRemoveQuery() throws Exception {
+    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/openai_ada2/json_vector/",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    String runfile = "target/run-" + System.currentTimeMillis();
+    String[] searchArgs = new String[] {
+        "-index", indexPath,
+        "-topics", "src/test/resources/sample_topics/sample-topics.msmarco-passage-dev-openai-ada2a.jsonl",
+        "-output", runfile,
+        "-generator", "VectorQueryGenerator",
+        "-topicReader", "JsonStringVector",
+        "-topicField", "vector",
+        "-hits", "5",
+        "-removeQuery"};
+    SearchFlatDenseVectors.main(searchArgs);
+
+    TestUtils.checkRunFileApproximate(runfile, new String[] {
+        "10 Q0 45 1 0.846281 Anserini",
+        "10 Q0 44 2 0.845236 Anserini",
+        "10 Q0 95 3 0.845013 Anserini",
+        "10 Q0 97 4 0.844905 Anserini",
+        "45 Q0 44 1 0.861596 Anserini",
+        "45 Q0 40 2 0.858651 Anserini",
+        "45 Q0 48 3 0.858514 Anserini",
+        "45 Q0 41 4 0.856264 Anserini",
+    });
+
+    new File(runfile).delete();
+  }
+
+  @Test
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  public void testPassage() throws Exception {
+    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String[] indexArgs = new String[] {
+        "-collection", "JsonDenseVectorCollection",
+        "-input", "src/test/resources/sample_docs/openai_ada2/json_vector2",
+        "-index", indexPath,
+        "-generator", "DenseVectorDocumentGenerator",
+        "-threads", "1"
+    };
+
+    IndexFlatDenseVectors.main(indexArgs);
+
+    String runfile = "target/run-" + System.currentTimeMillis();
+    String[] searchArgs = new String[] {
+        "-index", indexPath,
+        "-topics", "src/test/resources/sample_topics/sample-topics.msmarco-passage-dev-openai-ada2.jsonl",
+        "-output", runfile,
+        "-generator", "VectorQueryGenerator",
+        "-topicReader", "JsonIntVector",
+        "-topicField", "vector",
+        "-selectMaxPassage",
+        "-selectMaxPassage.hits", "5",
+        "-hits", "10"};
+    SearchFlatDenseVectors.main(searchArgs);
+
+    TestUtils.checkRunFileApproximate(runfile, new String[] {
+        "160885 Q0 44 1 0.863064 Anserini",
+        "160885 Q0 40 2 0.858651 Anserini",
+        "160885 Q0 48 3 0.858514 Anserini",
+        "160885 Q0 a 4 0.856264 Anserini",
+        "160885 Q0 46 5 0.849332 Anserini",
+        "867490 Q0 10 1 0.850332 Anserini",
+        "867490 Q0 44 2 0.846281 Anserini",
+        "867490 Q0 b 3 0.845013 Anserini",
+        "867490 Q0 40 4 0.837815 Anserini",
+        "867490 Q0 46 5 0.837050 Anserini"
+    });
+
+    new File(runfile).delete();
+  }
+}

--- a/src/test/java/io/anserini/search/SearchHnswDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchHnswDenseVectorsTest.java
@@ -124,7 +124,7 @@ public class SearchHnswDenseVectorsTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };
@@ -156,7 +156,7 @@ public class SearchHnswDenseVectorsTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };
@@ -188,7 +188,7 @@ public class SearchHnswDenseVectorsTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };
@@ -220,7 +220,7 @@ public class SearchHnswDenseVectorsTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };
@@ -252,7 +252,7 @@ public class SearchHnswDenseVectorsTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };
@@ -286,7 +286,7 @@ public class SearchHnswDenseVectorsTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };
@@ -329,7 +329,7 @@ public class SearchHnswDenseVectorsTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cos-dpr-distil/json_vector/",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };
@@ -372,7 +372,7 @@ public class SearchHnswDenseVectorsTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cos-dpr-distil/json_vector/",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };
@@ -417,7 +417,7 @@ public class SearchHnswDenseVectorsTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cos-dpr-distil/json_vector/",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };
@@ -462,7 +462,7 @@ public class SearchHnswDenseVectorsTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };
@@ -504,7 +504,7 @@ public class SearchHnswDenseVectorsTest {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector2",
         "-index", indexPath,
-        "-generator", "HnswDenseVectorDocumentGenerator",
+        "-generator", "DenseVectorDocumentGenerator",
         "-threads", "1",
         "-M", "16", "-efC", "100"
     };


### PR DESCRIPTION
+ 1st installment - initial implementation checked with BEIR BGE (cached queries).
+ no quantized yet.
+ no ONNX yet.

The following works:

```
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-arguana.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-arguana.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-bioasq.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-bioasq.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-climate-fever.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-climate-fever.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-fever.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-fever.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-fiqa.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-fiqa.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-hotpotqa.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-hotpotqa.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-nfcorpus.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-nfcorpus.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-nq.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-nq.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-quora.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-quora.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-robust04.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-robust04.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-scidocs.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-scidocs.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-scifact.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-scifact.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-signal1m.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-signal1m.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-trec-news.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-trec-news.bge-base-en-v1.5.flat
python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.flat >& logs/log.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.flat
```