### PR TITLE
Get rid of extra options for HNSW indexes

### DIFF
--- a/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-arguana.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-arguana.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-arguana.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-arguana.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-arguana.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-arguana.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-bioasq.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-bioasq.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 500 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-bioasq.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-bioasq.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-bioasq.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 500 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-bioasq.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-climate-fever.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-climate-fever.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-climate-fever.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-climate-fever.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-climate-fever.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-climate-fever.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-fever.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-fever.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-fever.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-fever.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-fever.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-fever.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-fiqa.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-fiqa.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-fiqa.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-fiqa.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-fiqa.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-fiqa.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-hotpotqa.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-hotpotqa.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-hotpotqa.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-hotpotqa.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-hotpotqa.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-hotpotqa.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-nfcorpus.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-nfcorpus.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-nfcorpus.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-nfcorpus.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-nfcorpus.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-nfcorpus.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-nq.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-nq.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-nq.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-nq.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-nq.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-nq.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-quora.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-quora.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-quora.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-quora.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-quora.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-quora.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-robust04.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-robust04.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-robust04.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-robust04.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-robust04.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-robust04.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-scidocs.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-scidocs.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-scidocs.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-scidocs.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-scidocs.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-scidocs.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-scifact.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-scifact.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-scifact.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-scifact.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-scifact.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-scifact.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-signal1m.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-signal1m.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-signal1m.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-signal1m.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-signal1m.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-signal1m.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-trec-covid.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-trec-covid.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-trec-covid.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-trec-covid.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-trec-covid.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-trec-covid.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-trec-news.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-trec-news.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-trec-news.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-trec-news.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-trec-news.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-trec-news.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw-int8.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8 \
+  -threads 16 -M 16 -efC 100 -quantize.int8 \
   >& logs/log.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5 &
 ```
 

--- a/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw.cached.md
@@ -37,7 +37,7 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
   -input /path/to/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5 \
   -generator DenseVectorDocumentGenerator \
   -index indexes/lucene-hnsw.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/ \
-  -threads 16 -M 16 -efC 100 -memoryBuffer 65536 -noMerge \
+  -threads 16 -M 16 -efC 100 \
   >& logs/log.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5 &
 ```
 

--- a/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 500 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 500 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge -quantize.int8
+index_options: -M 16 -efC 100 -quantize.int8
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw.cached.yaml
@@ -7,7 +7,7 @@ index_type: hnsw
 collection_class: JsonDenseVectorCollection
 generator_class: DenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
   - metric: nDCG@10


### PR DESCRIPTION
Removed `-memoryBuffer 65536 -noMerge` options for HNSW regressions: revert to "default settings".