### PR TITLE
Tweak regression scores due to DJL upgrade

### DIFF
--- a/docs/regressions/regressions-dl19-doc-segmented.wp-ca.md
+++ b/docs/regressions/regressions-dl19-doc-segmented.wp-ca.md
@@ -76,13 +76,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@100**                                                                                                   | **BM25 (default)**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.2604    |
+| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.2606    |
 | **nDCG@10**                                                                                                  | **BM25 (default)**|
-| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.5396    |
+| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.5442    |
 | **R@100**                                                                                                    | **BM25 (default)**|
-| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.4040    |
+| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.4055    |
 | **R@1000**                                                                                                   | **BM25 (default)**|
-| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.6813    |
+| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.6835    |
 
 Explanation of settings:
 

--- a/docs/regressions/regressions-dl19-doc.wp-ca.md
+++ b/docs/regressions/regressions-dl19-doc.wp-ca.md
@@ -67,10 +67,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@100**                                                                                                   | **BM25 (default)**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.2476    |
+| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.2369    |
 | **nDCG@10**                                                                                                  | **BM25 (default)**|
-| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.5127    |
+| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.5299    |
 | **R@100**                                                                                                    | **BM25 (default)**|
-| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.3993    |
+| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.3643    |
 | **R@1000**                                                                                                   | **BM25 (default)**|
-| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.7073    |
+| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.6373    |

--- a/docs/regressions/regressions-dl19-doc.wp-hgf.md
+++ b/docs/regressions/regressions-dl19-doc.wp-hgf.md
@@ -68,10 +68,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@100**                                                                                                   | **BM25 (default)**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.1947    |
+| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.1940    |
 | **nDCG@10**                                                                                                  | **BM25 (default)**|
-| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.4672    |
+| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.4967    |
 | **R@100**                                                                                                    | **BM25 (default)**|
-| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.3400    |
+| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.3208    |
 | **R@1000**                                                                                                   | **BM25 (default)**|
-| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.6421    |
+| [DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)                                                       | 0.5319    |

--- a/docs/regressions/regressions-dl20-doc-segmented.wp-ca.md
+++ b/docs/regressions/regressions-dl20-doc-segmented.wp-ca.md
@@ -76,13 +76,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@100**                                                                                                   | **BM25 (default)**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.3568    |
+| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.3601    |
 | **nDCG@10**                                                                                                  | **BM25 (default)**|
-| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.5196    |
+| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.5253    |
 | **R@100**                                                                                                    | **BM25 (default)**|
 | [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.5912    |
 | **R@1000**                                                                                                   | **BM25 (default)**|
-| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.7856    |
+| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.7872    |
 
 Explanation of settings:
 

--- a/docs/regressions/regressions-dl20-doc.wp-ca.md
+++ b/docs/regressions/regressions-dl20-doc.wp-ca.md
@@ -67,10 +67,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@100**                                                                                                   | **BM25 (default)**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.3809    |
+| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.3529    |
 | **nDCG@10**                                                                                                  | **BM25 (default)**|
-| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.5422    |
+| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.5238    |
 | **R@100**                                                                                                    | **BM25 (default)**|
-| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.6074    |
+| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.5653    |
 | **R@1000**                                                                                                   | **BM25 (default)**|
-| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.8147    |
+| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.7800    |

--- a/docs/regressions/regressions-dl20-doc.wp-hgf.md
+++ b/docs/regressions/regressions-dl20-doc.wp-hgf.md
@@ -68,10 +68,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@100**                                                                                                   | **BM25 (default)**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.3258    |
+| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.3014    |
 | **nDCG@10**                                                                                                  | **BM25 (default)**|
-| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.5046    |
+| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.5011    |
 | **R@100**                                                                                                    | **BM25 (default)**|
-| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.5483    |
+| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.4899    |
 | **R@1000**                                                                                                   | **BM25 (default)**|
-| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.7436    |
+| [DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)                                                       | 0.6708    |

--- a/docs/regressions/regressions-miracl-v1.0-ar-aca.md
+++ b/docs/regressions/regressions-miracl-v1.0-ar-aca.md
@@ -56,6 +56,6 @@ With the above commands, you should be able to reproduce the following results:
 
 | **nDCG@10**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MIRACL (Arabic): dev](https://github.com/project-miracl/miracl)                                             | 0.4968    |
+| [MIRACL (Arabic): dev](https://github.com/project-miracl/miracl)                                             | 0.4962    |
 | **R@100**                                                                                                    | **BM25**  |
-| [MIRACL (Arabic): dev](https://github.com/project-miracl/miracl)                                             | 0.8980    |
+| [MIRACL (Arabic): dev](https://github.com/project-miracl/miracl)                                             | 0.8983    |

--- a/docs/regressions/regressions-miracl-v1.0-bn-aca.md
+++ b/docs/regressions/regressions-miracl-v1.0-bn-aca.md
@@ -56,6 +56,6 @@ With the above commands, you should be able to reproduce the following results:
 
 | **nDCG@10**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MIRACL (Bengali): dev](https://github.com/project-miracl/miracl)                                            | 0.5436    |
+| [MIRACL (Bengali): dev](https://github.com/project-miracl/miracl)                                            | 0.5431    |
 | **R@100**                                                                                                    | **BM25**  |
 | [MIRACL (Bengali): dev](https://github.com/project-miracl/miracl)                                            | 0.9387    |

--- a/docs/regressions/regressions-miracl-v1.0-fa-aca.md
+++ b/docs/regressions/regressions-miracl-v1.0-fa-aca.md
@@ -56,6 +56,6 @@ With the above commands, you should be able to reproduce the following results:
 
 | **nDCG@10**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MIRACL (Persian): dev](https://github.com/project-miracl/miracl)                                            | 0.3427    |
+| [MIRACL (Persian): dev](https://github.com/project-miracl/miracl)                                            | 0.3432    |
 | **R@100**                                                                                                    | **BM25**  |
-| [MIRACL (Persian): dev](https://github.com/project-miracl/miracl)                                            | 0.7600    |
+| [MIRACL (Persian): dev](https://github.com/project-miracl/miracl)                                            | 0.7589    |

--- a/docs/regressions/regressions-miracl-v1.0-fi-aca.md
+++ b/docs/regressions/regressions-miracl-v1.0-fi-aca.md
@@ -56,6 +56,6 @@ With the above commands, you should be able to reproduce the following results:
 
 | **nDCG@10**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MIRACL (Finnish): dev](https://github.com/project-miracl/miracl)                                            | 0.5674    |
+| [MIRACL (Finnish): dev](https://github.com/project-miracl/miracl)                                            | 0.5686    |
 | **R@100**                                                                                                    | **BM25**  |
 | [MIRACL (Finnish): dev](https://github.com/project-miracl/miracl)                                            | 0.8959    |

--- a/docs/regressions/regressions-miracl-v1.0-hi-aca.md
+++ b/docs/regressions/regressions-miracl-v1.0-hi-aca.md
@@ -56,6 +56,6 @@ With the above commands, you should be able to reproduce the following results:
 
 | **nDCG@10**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MIRACL (Hindi): dev](https://github.com/project-miracl/miracl)                                              | 0.4507    |
+| [MIRACL (Hindi): dev](https://github.com/project-miracl/miracl)                                              | 0.4515    |
 | **R@100**                                                                                                    | **BM25**  |
 | [MIRACL (Hindi): dev](https://github.com/project-miracl/miracl)                                              | 0.8655    |

--- a/docs/regressions/regressions-miracl-v1.0-id-aca.md
+++ b/docs/regressions/regressions-miracl-v1.0-id-aca.md
@@ -58,4 +58,4 @@ With the above commands, you should be able to reproduce the following results:
 |:-------------------------------------------------------------------------------------------------------------|-----------|
 | [MIRACL (Indonesian): dev](https://github.com/project-miracl/miracl)                                         | 0.4403    |
 | **R@100**                                                                                                    | **BM25**  |
-| [MIRACL (Indonesian): dev](https://github.com/project-miracl/miracl)                                         | 0.9007    |
+| [MIRACL (Indonesian): dev](https://github.com/project-miracl/miracl)                                         | 0.9005    |

--- a/docs/regressions/regressions-miracl-v1.0-ja-aca.md
+++ b/docs/regressions/regressions-miracl-v1.0-ja-aca.md
@@ -56,6 +56,6 @@ With the above commands, you should be able to reproduce the following results:
 
 | **nDCG@10**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MIRACL (Japanese): dev](https://github.com/project-miracl/miracl)                                           | 0.3974    |
+| [MIRACL (Japanese): dev](https://github.com/project-miracl/miracl)                                           | 0.3972    |
 | **R@100**                                                                                                    | **BM25**  |
-| [MIRACL (Japanese): dev](https://github.com/project-miracl/miracl)                                           | 0.8488    |
+| [MIRACL (Japanese): dev](https://github.com/project-miracl/miracl)                                           | 0.8479    |

--- a/docs/regressions/regressions-miracl-v1.0-ko-aca.md
+++ b/docs/regressions/regressions-miracl-v1.0-ko-aca.md
@@ -56,6 +56,6 @@ With the above commands, you should be able to reproduce the following results:
 
 | **nDCG@10**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MIRACL (Korean): dev](https://github.com/project-miracl/miracl)                                             | 0.4485    |
+| [MIRACL (Korean): dev](https://github.com/project-miracl/miracl)                                             | 0.4481    |
 | **R@100**                                                                                                    | **BM25**  |
-| [MIRACL (Korean): dev](https://github.com/project-miracl/miracl)                                             | 0.8218    |
+| [MIRACL (Korean): dev](https://github.com/project-miracl/miracl)                                             | 0.8234    |

--- a/docs/regressions/regressions-miracl-v1.0-ru-aca.md
+++ b/docs/regressions/regressions-miracl-v1.0-ru-aca.md
@@ -58,4 +58,4 @@ With the above commands, you should be able to reproduce the following results:
 |:-------------------------------------------------------------------------------------------------------------|-----------|
 | [MIRACL (Russian): dev](https://github.com/project-miracl/miracl)                                            | 0.3616    |
 | **R@100**                                                                                                    | **BM25**  |
-| [MIRACL (Russian): dev](https://github.com/project-miracl/miracl)                                            | 0.7579    |
+| [MIRACL (Russian): dev](https://github.com/project-miracl/miracl)                                            | 0.7578    |

--- a/docs/regressions/regressions-miracl-v1.0-sw-aca.md
+++ b/docs/regressions/regressions-miracl-v1.0-sw-aca.md
@@ -56,6 +56,6 @@ With the above commands, you should be able to reproduce the following results:
 
 | **nDCG@10**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MIRACL (Swahili): dev](https://github.com/project-miracl/miracl)                                            | 0.4146    |
+| [MIRACL (Swahili): dev](https://github.com/project-miracl/miracl)                                            | 0.4152    |
 | **R@100**                                                                                                    | **BM25**  |
-| [MIRACL (Swahili): dev](https://github.com/project-miracl/miracl)                                            | 0.8025    |
+| [MIRACL (Swahili): dev](https://github.com/project-miracl/miracl)                                            | 0.8021    |

--- a/docs/regressions/regressions-miracl-v1.0-te-aca.md
+++ b/docs/regressions/regressions-miracl-v1.0-te-aca.md
@@ -56,6 +56,6 @@ With the above commands, you should be able to reproduce the following results:
 
 | **nDCG@10**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MIRACL (Telugu): dev](https://github.com/project-miracl/miracl)                                             | 0.4885    |
+| [MIRACL (Telugu): dev](https://github.com/project-miracl/miracl)                                             | 0.4874    |
 | **R@100**                                                                                                    | **BM25**  |
-| [MIRACL (Telugu): dev](https://github.com/project-miracl/miracl)                                             | 0.8448    |
+| [MIRACL (Telugu): dev](https://github.com/project-miracl/miracl)                                             | 0.8436    |

--- a/docs/regressions/regressions-miracl-v1.0-th-aca.md
+++ b/docs/regressions/regressions-miracl-v1.0-th-aca.md
@@ -56,6 +56,6 @@ With the above commands, you should be able to reproduce the following results:
 
 | **nDCG@10**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MIRACL (Thai): dev](https://github.com/project-miracl/miracl)                                               | 0.5224    |
+| [MIRACL (Thai): dev](https://github.com/project-miracl/miracl)                                               | 0.5220    |
 | **R@100**                                                                                                    | **BM25**  |
 | [MIRACL (Thai): dev](https://github.com/project-miracl/miracl)                                               | 0.8875    |

--- a/docs/regressions/regressions-mrtydi-v1.1-ar-aca.md
+++ b/docs/regressions/regressions-mrtydi-v1.1-ar-aca.md
@@ -69,10 +69,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **MRR@100**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [Mr. TyDi (Arabic): train](https://github.com/castorini/mr.tydi)                                             | 0.3448    |
-| [Mr. TyDi (Arabic): dev](https://github.com/castorini/mr.tydi)                                               | 0.3530    |
-| [Mr. TyDi (Arabic): test](https://github.com/castorini/mr.tydi)                                              | 0.3821    |
+| [Mr. TyDi (Arabic): train](https://github.com/castorini/mr.tydi)                                             | 0.3449    |
+| [Mr. TyDi (Arabic): dev](https://github.com/castorini/mr.tydi)                                               | 0.3528    |
+| [Mr. TyDi (Arabic): test](https://github.com/castorini/mr.tydi)                                              | 0.3827    |
 | **R@100**                                                                                                    | **BM25**  |
-| [Mr. TyDi (Arabic): train](https://github.com/castorini/mr.tydi)                                             | 0.8026    |
-| [Mr. TyDi (Arabic): dev](https://github.com/castorini/mr.tydi)                                               | 0.8061    |
+| [Mr. TyDi (Arabic): train](https://github.com/castorini/mr.tydi)                                             | 0.8025    |
+| [Mr. TyDi (Arabic): dev](https://github.com/castorini/mr.tydi)                                               | 0.8067    |
 | [Mr. TyDi (Arabic): test](https://github.com/castorini/mr.tydi)                                              | 0.7986    |

--- a/docs/regressions/regressions-mrtydi-v1.1-bn-aca.md
+++ b/docs/regressions/regressions-mrtydi-v1.1-bn-aca.md
@@ -69,10 +69,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **MRR@100**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [Mr. TyDi (Bengali): train](https://github.com/castorini/mr.tydi)                                            | 0.3816    |
-| [Mr. TyDi (Bengali): dev](https://github.com/castorini/mr.tydi)                                              | 0.3632    |
-| [Mr. TyDi (Bengali): test](https://github.com/castorini/mr.tydi)                                             | 0.4396    |
+| [Mr. TyDi (Bengali): train](https://github.com/castorini/mr.tydi)                                            | 0.3833    |
+| [Mr. TyDi (Bengali): dev](https://github.com/castorini/mr.tydi)                                              | 0.3639    |
+| [Mr. TyDi (Bengali): test](https://github.com/castorini/mr.tydi)                                             | 0.4400    |
 | **R@100**                                                                                                    | **BM25**  |
-| [Mr. TyDi (Bengali): train](https://github.com/castorini/mr.tydi)                                            | 0.8716    |
-| [Mr. TyDi (Bengali): dev](https://github.com/castorini/mr.tydi)                                              | 0.8693    |
+| [Mr. TyDi (Bengali): train](https://github.com/castorini/mr.tydi)                                            | 0.8722    |
+| [Mr. TyDi (Bengali): dev](https://github.com/castorini/mr.tydi)                                              | 0.8716    |
 | [Mr. TyDi (Bengali): test](https://github.com/castorini/mr.tydi)                                             | 0.9234    |

--- a/docs/regressions/regressions-mrtydi-v1.1-en-aca.md
+++ b/docs/regressions/regressions-mrtydi-v1.1-en-aca.md
@@ -69,10 +69,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **MRR@100**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [Mr. TyDi (English): train](https://github.com/castorini/mr.tydi)                                            | 0.1624    |
+| [Mr. TyDi (English): train](https://github.com/castorini/mr.tydi)                                            | 0.1623    |
 | [Mr. TyDi (English): dev](https://github.com/castorini/mr.tydi)                                              | 0.1786    |
-| [Mr. TyDi (English): test](https://github.com/castorini/mr.tydi)                                             | 0.1482    |
+| [Mr. TyDi (English): test](https://github.com/castorini/mr.tydi)                                             | 0.1489    |
 | **R@100**                                                                                                    | **BM25**  |
-| [Mr. TyDi (English): train](https://github.com/castorini/mr.tydi)                                            | 0.5904    |
-| [Mr. TyDi (English): dev](https://github.com/castorini/mr.tydi)                                              | 0.6253    |
+| [Mr. TyDi (English): train](https://github.com/castorini/mr.tydi)                                            | 0.5901    |
+| [Mr. TyDi (English): dev](https://github.com/castorini/mr.tydi)                                              | 0.6264    |
 | [Mr. TyDi (English): test](https://github.com/castorini/mr.tydi)                                             | 0.5464    |

--- a/docs/regressions/regressions-mrtydi-v1.1-fi-aca.md
+++ b/docs/regressions/regressions-mrtydi-v1.1-fi-aca.md
@@ -69,10 +69,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **MRR@100**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [Mr. TyDi (Finnish): train](https://github.com/castorini/mr.tydi)                                            | 0.4176    |
-| [Mr. TyDi (Finnish): dev](https://github.com/castorini/mr.tydi)                                              | 0.4193    |
-| [Mr. TyDi (Finnish): test](https://github.com/castorini/mr.tydi)                                             | 0.2903    |
+| [Mr. TyDi (Finnish): train](https://github.com/castorini/mr.tydi)                                            | 0.4179    |
+| [Mr. TyDi (Finnish): dev](https://github.com/castorini/mr.tydi)                                              | 0.4186    |
+| [Mr. TyDi (Finnish): test](https://github.com/castorini/mr.tydi)                                             | 0.2898    |
 | **R@100**                                                                                                    | **BM25**  |
-| [Mr. TyDi (Finnish): train](https://github.com/castorini/mr.tydi)                                            | 0.8346    |
-| [Mr. TyDi (Finnish): dev](https://github.com/castorini/mr.tydi)                                              | 0.8458    |
+| [Mr. TyDi (Finnish): train](https://github.com/castorini/mr.tydi)                                            | 0.8351    |
+| [Mr. TyDi (Finnish): dev](https://github.com/castorini/mr.tydi)                                              | 0.8446    |
 | [Mr. TyDi (Finnish): test](https://github.com/castorini/mr.tydi)                                             | 0.7529    |

--- a/docs/regressions/regressions-mrtydi-v1.1-id-aca.md
+++ b/docs/regressions/regressions-mrtydi-v1.1-id-aca.md
@@ -69,10 +69,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **MRR@100**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [Mr. TyDi (Indonesian): train](https://github.com/castorini/mr.tydi)                                         | 0.2948    |
+| [Mr. TyDi (Indonesian): train](https://github.com/castorini/mr.tydi)                                         | 0.2947    |
 | [Mr. TyDi (Indonesian): dev](https://github.com/castorini/mr.tydi)                                           | 0.2868    |
-| [Mr. TyDi (Indonesian): test](https://github.com/castorini/mr.tydi)                                          | 0.3824    |
+| [Mr. TyDi (Indonesian): test](https://github.com/castorini/mr.tydi)                                          | 0.3821    |
 | **R@100**                                                                                                    | **BM25**  |
 | [Mr. TyDi (Indonesian): train](https://github.com/castorini/mr.tydi)                                         | 0.7962    |
 | [Mr. TyDi (Indonesian): dev](https://github.com/castorini/mr.tydi)                                           | 0.7990    |
-| [Mr. TyDi (Indonesian): test](https://github.com/castorini/mr.tydi)                                          | 0.8504    |
+| [Mr. TyDi (Indonesian): test](https://github.com/castorini/mr.tydi)                                          | 0.8492    |

--- a/docs/regressions/regressions-mrtydi-v1.1-ja-aca.md
+++ b/docs/regressions/regressions-mrtydi-v1.1-ja-aca.md
@@ -69,10 +69,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **MRR@100**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [Mr. TyDi (Japanese): train](https://github.com/castorini/mr.tydi)                                           | 0.2402    |
-| [Mr. TyDi (Japanese): dev](https://github.com/castorini/mr.tydi)                                             | 0.2477    |
-| [Mr. TyDi (Japanese): test](https://github.com/castorini/mr.tydi)                                            | 0.2316    |
+| [Mr. TyDi (Japanese): train](https://github.com/castorini/mr.tydi)                                           | 0.2401    |
+| [Mr. TyDi (Japanese): dev](https://github.com/castorini/mr.tydi)                                             | 0.2466    |
+| [Mr. TyDi (Japanese): test](https://github.com/castorini/mr.tydi)                                            | 0.2294    |
 | **R@100**                                                                                                    | **BM25**  |
-| [Mr. TyDi (Japanese): train](https://github.com/castorini/mr.tydi)                                           | 0.7571    |
-| [Mr. TyDi (Japanese): dev](https://github.com/castorini/mr.tydi)                                             | 0.7694    |
-| [Mr. TyDi (Japanese): test](https://github.com/castorini/mr.tydi)                                            | 0.7007    |
+| [Mr. TyDi (Japanese): train](https://github.com/castorini/mr.tydi)                                           | 0.7563    |
+| [Mr. TyDi (Japanese): dev](https://github.com/castorini/mr.tydi)                                             | 0.7662    |
+| [Mr. TyDi (Japanese): test](https://github.com/castorini/mr.tydi)                                            | 0.7021    |

--- a/docs/regressions/regressions-mrtydi-v1.1-ko-aca.md
+++ b/docs/regressions/regressions-mrtydi-v1.1-ko-aca.md
@@ -69,10 +69,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **MRR@100**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [Mr. TyDi (Korean): train](https://github.com/castorini/mr.tydi)                                             | 0.2694    |
-| [Mr. TyDi (Korean): dev](https://github.com/castorini/mr.tydi)                                               | 0.3100    |
-| [Mr. TyDi (Korean): test](https://github.com/castorini/mr.tydi)                                              | 0.2907    |
+| [Mr. TyDi (Korean): train](https://github.com/castorini/mr.tydi)                                             | 0.2684    |
+| [Mr. TyDi (Korean): dev](https://github.com/castorini/mr.tydi)                                               | 0.3120    |
+| [Mr. TyDi (Korean): test](https://github.com/castorini/mr.tydi)                                              | 0.2909    |
 | **R@100**                                                                                                    | **BM25**  |
 | [Mr. TyDi (Korean): train](https://github.com/castorini/mr.tydi)                                             | 0.6483    |
 | [Mr. TyDi (Korean): dev](https://github.com/castorini/mr.tydi)                                               | 0.6898    |
-| [Mr. TyDi (Korean): test](https://github.com/castorini/mr.tydi)                                              | 0.6433    |
+| [Mr. TyDi (Korean): test](https://github.com/castorini/mr.tydi)                                              | 0.6409    |

--- a/docs/regressions/regressions-mrtydi-v1.1-ru-aca.md
+++ b/docs/regressions/regressions-mrtydi-v1.1-ru-aca.md
@@ -69,9 +69,9 @@ With the above commands, you should be able to reproduce the following results:
 
 | **MRR@100**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [Mr. TyDi (Russian): train](https://github.com/castorini/mr.tydi)                                            | 0.2509    |
-| [Mr. TyDi (Russian): dev](https://github.com/castorini/mr.tydi)                                              | 0.2421    |
-| [Mr. TyDi (Russian): test](https://github.com/castorini/mr.tydi)                                             | 0.3720    |
+| [Mr. TyDi (Russian): train](https://github.com/castorini/mr.tydi)                                            | 0.2510    |
+| [Mr. TyDi (Russian): dev](https://github.com/castorini/mr.tydi)                                              | 0.2423    |
+| [Mr. TyDi (Russian): test](https://github.com/castorini/mr.tydi)                                             | 0.3718    |
 | **R@100**                                                                                                    | **BM25**  |
 | [Mr. TyDi (Russian): train](https://github.com/castorini/mr.tydi)                                            | 0.6614    |
 | [Mr. TyDi (Russian): dev](https://github.com/castorini/mr.tydi)                                              | 0.6676    |

--- a/docs/regressions/regressions-mrtydi-v1.1-sw-aca.md
+++ b/docs/regressions/regressions-mrtydi-v1.1-sw-aca.md
@@ -69,10 +69,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **MRR@100**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [Mr. TyDi (Swahili): train](https://github.com/castorini/mr.tydi)                                            | 0.2997    |
-| [Mr. TyDi (Swahili): dev](https://github.com/castorini/mr.tydi)                                              | 0.2928    |
-| [Mr. TyDi (Swahili): test](https://github.com/castorini/mr.tydi)                                             | 0.4257    |
+| [Mr. TyDi (Swahili): train](https://github.com/castorini/mr.tydi)                                            | 0.3000    |
+| [Mr. TyDi (Swahili): dev](https://github.com/castorini/mr.tydi)                                              | 0.2922    |
+| [Mr. TyDi (Swahili): test](https://github.com/castorini/mr.tydi)                                             | 0.4251    |
 | **R@100**                                                                                                    | **BM25**  |
-| [Mr. TyDi (Swahili): train](https://github.com/castorini/mr.tydi)                                            | 0.7020    |
+| [Mr. TyDi (Swahili): train](https://github.com/castorini/mr.tydi)                                            | 0.7023    |
 | [Mr. TyDi (Swahili): dev](https://github.com/castorini/mr.tydi)                                              | 0.6984    |
-| [Mr. TyDi (Swahili): test](https://github.com/castorini/mr.tydi)                                             | 0.8396    |
+| [Mr. TyDi (Swahili): test](https://github.com/castorini/mr.tydi)                                             | 0.8410    |

--- a/docs/regressions/regressions-mrtydi-v1.1-te-aca.md
+++ b/docs/regressions/regressions-mrtydi-v1.1-te-aca.md
@@ -69,10 +69,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **MRR@100**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [Mr. TyDi (Telugu): train](https://github.com/castorini/mr.tydi)                                             | 0.4063    |
-| [Mr. TyDi (Telugu): dev](https://github.com/castorini/mr.tydi)                                               | 0.4131    |
-| [Mr. TyDi (Telugu): test](https://github.com/castorini/mr.tydi)                                              | 0.5096    |
+| [Mr. TyDi (Telugu): train](https://github.com/castorini/mr.tydi)                                             | 0.4051    |
+| [Mr. TyDi (Telugu): dev](https://github.com/castorini/mr.tydi)                                               | 0.4127    |
+| [Mr. TyDi (Telugu): test](https://github.com/castorini/mr.tydi)                                              | 0.5083    |
 | **R@100**                                                                                                    | **BM25**  |
-| [Mr. TyDi (Telugu): train](https://github.com/castorini/mr.tydi)                                             | 0.8379    |
-| [Mr. TyDi (Telugu): dev](https://github.com/castorini/mr.tydi)                                               | 0.8332    |
+| [Mr. TyDi (Telugu): train](https://github.com/castorini/mr.tydi)                                             | 0.8371    |
+| [Mr. TyDi (Telugu): dev](https://github.com/castorini/mr.tydi)                                               | 0.8321    |
 | [Mr. TyDi (Telugu): test](https://github.com/castorini/mr.tydi)                                              | 0.9110    |

--- a/docs/regressions/regressions-mrtydi-v1.1-th-aca.md
+++ b/docs/regressions/regressions-mrtydi-v1.1-th-aca.md
@@ -69,9 +69,9 @@ With the above commands, you should be able to reproduce the following results:
 
 | **MRR@100**                                                                                                  | **BM25**  |
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [Mr. TyDi (Thai): train](https://github.com/castorini/mr.tydi)                                               | 0.3780    |
-| [Mr. TyDi (Thai): dev](https://github.com/castorini/mr.tydi)                                                 | 0.4034    |
-| [Mr. TyDi (Thai): test](https://github.com/castorini/mr.tydi)                                                | 0.4468    |
+| [Mr. TyDi (Thai): train](https://github.com/castorini/mr.tydi)                                               | 0.3781    |
+| [Mr. TyDi (Thai): dev](https://github.com/castorini/mr.tydi)                                                 | 0.4029    |
+| [Mr. TyDi (Thai): test](https://github.com/castorini/mr.tydi)                                                | 0.4473    |
 | **R@100**                                                                                                    | **BM25**  |
 | [Mr. TyDi (Thai): train](https://github.com/castorini/mr.tydi)                                               | 0.8690    |
 | [Mr. TyDi (Thai): dev](https://github.com/castorini/mr.tydi)                                                 | 0.8751    |

--- a/docs/regressions/regressions-msmarco-v1-doc-segmented.wp-ca.md
+++ b/docs/regressions/regressions-msmarco-v1-doc-segmented.wp-ca.md
@@ -75,13 +75,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **BM25 (default)**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2787    |
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2791    |
 | **RR@100**                                                                                                   | **BM25 (default)**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2781    |
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2785    |
 | **R@100**                                                                                                    | **BM25 (default)**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.7990    |
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.8009    |
 | **R@1000**                                                                                                   | **BM25 (default)**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9286    |
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9299    |
 
 Explanation of settings:
 

--- a/docs/regressions/regressions-msmarco-v1-doc.wp-ca.md
+++ b/docs/regressions/regressions-msmarco-v1-doc.wp-ca.md
@@ -64,10 +64,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **BM25 (default)**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2410    |
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2787    |
 | **RR@100**                                                                                                   | **BM25 (default)**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2403    |
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2781    |
 | **R@100**                                                                                                    | **BM25 (default)**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.7441    |
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.7959    |
 | **R@1000**                                                                                                   | **BM25 (default)**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9004    |
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9336    |

--- a/docs/regressions/regressions-msmarco-v1-doc.wp-hgf.md
+++ b/docs/regressions/regressions-msmarco-v1-doc.wp-hgf.md
@@ -65,10 +65,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **BM25 (default)**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2234    |
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2657    |
 | **RR@100**                                                                                                   | **BM25 (default)**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2227    |
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.2651    |
 | **R@100**                                                                                                    | **BM25 (default)**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.7031    |
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.7624    |
 | **R@1000**                                                                                                   | **BM25 (default)**|
-| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.8743    |
+| [MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)                                   | 0.9056    |

--- a/src/main/java/io/anserini/analysis/CompositeAnalyzer.java
+++ b/src/main/java/io/anserini/analysis/CompositeAnalyzer.java
@@ -45,6 +45,22 @@ public class CompositeAnalyzer extends Analyzer {
   private static HuggingFaceTokenizer makeTokenizer(String tokenizerNameOrPath) throws IOException {
     Map<String, String> options = new ConcurrentHashMap<>();
     options.put("addSpecialTokens", "false");
+    // Note upgrading from djl v0.21.0 to v0.28.0 (June 2024)
+    //
+    // In theory, since we're just tokenizing, we shouldn't be constrained by the modelMaxLength.
+    // Previously, at v0.21.0, we were able to tokenize arbitrarily long sequences.
+    // However, the implementation seems to have changed.
+    //
+    // As of the v0.28.0 upgrade, if we put a large value, we get the warning:
+    // "maxLength is greater then (sic) modelMaxLength, change to: 512"
+    //
+    // On the other hand, if we don't set this value, we get the warning:
+    // "maxLength is not explicitly specified, use modelMaxLength: 512".
+    //
+    // In other words, the implementation forces truncation, even for our IR application, i.e., it
+    // forces FirstP retrieval.
+    options.put("maxLength", "512");
+
     Path path = Paths.get(tokenizerNameOrPath);
     
     if (Files.exists(path) == true) {

--- a/src/main/java/io/anserini/analysis/HuggingFaceTokenizerAnalyzer.java
+++ b/src/main/java/io/anserini/analysis/HuggingFaceTokenizerAnalyzer.java
@@ -40,6 +40,21 @@ public class HuggingFaceTokenizerAnalyzer extends Analyzer {
   public HuggingFaceTokenizerAnalyzer(String huggingFaceModelId) throws IOException {
     Map<String, String> options = new ConcurrentHashMap<>();
     options.put("addSpecialTokens", "false");
+    // Note upgrading from djl v0.21.0 to v0.28.0 (June 2024)
+    //
+    // In theory, since we're just tokenizing, we shouldn't be constrained by the modelMaxLength.
+    // Previously, at v0.21.0, we were able to tokenize arbitrarily long sequences.
+    // However, the implementation seems to have changed.
+    //
+    // As of the v0.28.0 upgrade, if we put a large value, we get the warning:
+    // "maxLength is greater then (sic) modelMaxLength, change to: 512"
+    //
+    // On the other hand, if we don't set this value, we get the warning:
+    // "maxLength is not explicitly specified, use modelMaxLength: 512".
+    //
+    // In other words, the implementation forces truncation, even for our IR application, i.e., it
+    // forces FirstP retrieval.
+    options.put("maxLength", "512");
     Path path = Paths.get(huggingFaceModelId);
     
     if(Files.exists(path) == true){

--- a/src/main/python/regressions-batch03.txt
+++ b/src/main/python/regressions-batch03.txt
@@ -51,43 +51,43 @@ python src/main/python/run_regression.py --verify --search --regression dl23-doc
 python src/main/python/run_regression.py --verify --search --regression rag24-doc-segmented-raggy-dev > logs/log.rag24-doc-segmented-raggy-dev.txt 2>&1
 
 # Flat indexes for MS MARCO v1
-python src/main/python/run_regression.py --search --regression msmarco-v1-passage.bge-base-en-v1.5.flat.onnx > logs/log.msmarco-v1-passage.bge-base-en-v1.5.flat.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression msmarco-v1-passage.cos-dpr-distil.flat.onnx > logs/log.msmarco-v1-passage.cos-dpr-distil.flat.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.bge-base-en-v1.5.flat.onnx > logs/log.msmarco-v1-passage.bge-base-en-v1.5.flat.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.cos-dpr-distil.flat.onnx > logs/log.msmarco-v1-passage.cos-dpr-distil.flat.onnx.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression msmarco-v1-passage.bge-base-en-v1.5.flat-int8.onnx > logs/log.msmarco-v1-passage.bge-base-en-v1.5.flat-int8.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression msmarco-v1-passage.cos-dpr-distil.flat-int8.onnx > logs/log.msmarco-v1-passage.cos-dpr-distil.flat-int8.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.bge-base-en-v1.5.flat-int8.onnx > logs/log.msmarco-v1-passage.bge-base-en-v1.5.flat-int8.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.cos-dpr-distil.flat-int8.onnx > logs/log.msmarco-v1-passage.cos-dpr-distil.flat-int8.onnx.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl19-passage.bge-base-en-v1.5.flat.cached > logs/log.dl19-passage.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.cohere-embed-english-v3.0.flat.cached > logs/log.dl19-passage.cohere-embed-english-v3.0.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.cos-dpr-distil.flat.cached > logs/log.dl19-passage.cos-dpr-distil.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.openai-ada2.flat.cached > logs/log.dl19-passage.openai-ada2.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.bge-base-en-v1.5.flat.cached > logs/log.dl19-passage.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.cohere-embed-english-v3.0.flat.cached > logs/log.dl19-passage.cohere-embed-english-v3.0.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.cos-dpr-distil.flat.cached > logs/log.dl19-passage.cos-dpr-distil.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.openai-ada2.flat.cached > logs/log.dl19-passage.openai-ada2.flat.cached.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl19-passage.bge-base-en-v1.5.flat-int8.cached > logs/log.dl19-passage.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.cohere-embed-english-v3.0.flat-int8.cached > logs/log.dl19-passage.cohere-embed-english-v3.0.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.cos-dpr-distil.flat-int8.cached > logs/log.dl19-passage.cos-dpr-distil.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.openai-ada2.flat-int8.cached > logs/log.dl19-passage.openai-ada2.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.bge-base-en-v1.5.flat-int8.cached > logs/log.dl19-passage.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.cohere-embed-english-v3.0.flat-int8.cached > logs/log.dl19-passage.cohere-embed-english-v3.0.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.cos-dpr-distil.flat-int8.cached > logs/log.dl19-passage.cos-dpr-distil.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.openai-ada2.flat-int8.cached > logs/log.dl19-passage.openai-ada2.flat-int8.cached.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl19-passage.bge-base-en-v1.5.flat.onnx > logs/log.dl19-passage.bge-base-en-v1.5.flat.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.cos-dpr-distil.flat.onnx > logs/log.dl19-passage.cos-dpr-distil.flat.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.bge-base-en-v1.5.flat.onnx > logs/log.dl19-passage.bge-base-en-v1.5.flat.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.cos-dpr-distil.flat.onnx > logs/log.dl19-passage.cos-dpr-distil.flat.onnx.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl19-passage.bge-base-en-v1.5.flat-int8.onnx > logs/log.dl19-passage.bge-base-en-v1.5.flat-int8.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.cos-dpr-distil.flat-int8.onnx > logs/log.dl19-passage.cos-dpr-distil.flat-int8.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.bge-base-en-v1.5.flat-int8.onnx > logs/log.dl19-passage.bge-base-en-v1.5.flat-int8.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.cos-dpr-distil.flat-int8.onnx > logs/log.dl19-passage.cos-dpr-distil.flat-int8.onnx.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl20-passage.bge-base-en-v1.5.flat.cached > logs/log.dl20-passage.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.cohere-embed-english-v3.0.flat.cached > logs/log.dl20-passage.cohere-embed-english-v3.0.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.cos-dpr-distil.flat.cached > logs/log.dl20-passage.cos-dpr-distil.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.openai-ada2.flat.cached > logs/log.dl20-passage.openai-ada2.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.bge-base-en-v1.5.flat.cached > logs/log.dl20-passage.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.cohere-embed-english-v3.0.flat.cached > logs/log.dl20-passage.cohere-embed-english-v3.0.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.cos-dpr-distil.flat.cached > logs/log.dl20-passage.cos-dpr-distil.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.openai-ada2.flat.cached > logs/log.dl20-passage.openai-ada2.flat.cached.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl20-passage.bge-base-en-v1.5.flat-int8.cached > logs/log.dl20-passage.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.cohere-embed-english-v3.0.flat-int8.cached > logs/log.dl20-passage.cohere-embed-english-v3.0.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.cos-dpr-distil.flat-int8.cached > logs/log.dl20-passage.cos-dpr-distil.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.openai-ada2.flat-int8.cached > logs/log.dl20-passage.openai-ada2.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.bge-base-en-v1.5.flat-int8.cached > logs/log.dl20-passage.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.cohere-embed-english-v3.0.flat-int8.cached > logs/log.dl20-passage.cohere-embed-english-v3.0.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.cos-dpr-distil.flat-int8.cached > logs/log.dl20-passage.cos-dpr-distil.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.openai-ada2.flat-int8.cached > logs/log.dl20-passage.openai-ada2.flat-int8.cached.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl20-passage.bge-base-en-v1.5.flat.onnx > logs/log.dl20-passage.bge-base-en-v1.5.flat.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.cos-dpr-distil.flat.onnx > logs/log.dl20-passage.cos-dpr-distil.flat.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.bge-base-en-v1.5.flat.onnx > logs/log.dl20-passage.bge-base-en-v1.5.flat.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.cos-dpr-distil.flat.onnx > logs/log.dl20-passage.cos-dpr-distil.flat.onnx.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl20-passage.bge-base-en-v1.5.flat-int8.onnx > logs/log.dl20-passage.bge-base-en-v1.5.flat-int8.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.cos-dpr-distil.flat-int8.onnx > logs/log.dl20-passage.cos-dpr-distil.flat-int8.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.bge-base-en-v1.5.flat-int8.onnx > logs/log.dl20-passage.bge-base-en-v1.5.flat-int8.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.cos-dpr-distil.flat-int8.onnx > logs/log.dl20-passage.cos-dpr-distil.flat-int8.onnx.txt 2>&1
 
 # MS MARCO V1 doc
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-doc > logs/log.msmarco-v1-doc.txt 2>&1
@@ -128,171 +128,171 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v2-doc-segmented.unicoil-0shot-v2.cached > logs/log.msmarco-v2-doc-segmented.unicoil-0shot-v2.cached.txt 2>&1
 
 # MS MARCO V1 passage search-only
-python src/main/python/run_regression.py --search --regression msmarco-v1-passage.cos-dpr-distil.hnsw.onnx > logs/log.msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx > logs/log.msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx > logs/log.msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx > logs/log.msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression msmarco-v1-passage.splade-pp-ed.onnx > logs/log.msmarco-v1-passage.splade-pp-ed.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression msmarco-v1-passage.splade-pp-sd.onnx > logs/log.msmarco-v1-passage.splade-pp-sd.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.cos-dpr-distil.hnsw.onnx > logs/log.msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx > logs/log.msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx > logs/log.msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx > logs/log.msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.splade-pp-ed.onnx > logs/log.msmarco-v1-passage.splade-pp-ed.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.splade-pp-sd.onnx > logs/log.msmarco-v1-passage.splade-pp-sd.onnx.txt 2>&1
 
 # MS MARCO V2 passage search-only
 python src/main/python/run_regression.py --verify --search --regression msmarco-v2-passage.splade-pp-ed.onnx > logs/log.msmarco-v2-passage.splade-pp-ed.onnx.txt 2>&1
 python src/main/python/run_regression.py --verify --search --regression msmarco-v2-passage.splade-pp-sd.onnx > logs/log.msmarco-v2-passage.splade-pp-sd.onnx.txt 2>&1
 
 # DL19
-python src/main/python/run_regression.py --search --regression dl19-passage > logs/log.dl19-passage.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.bm25-b8 > logs/log.dl19-passage.bm25-b8.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.wp-ca > logs/log.dl19-passage.wp-ca.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.wp-tok > logs/log.dl19-passage.wp-tok.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.wp-hgf > logs/log.dl19-passage.wp-hgf.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.docTTTTTquery > logs/log.dl19-passage.docTTTTTquery.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.splade-pp-ed.onnx > logs/log.dl19-passage.splade-pp-ed.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.splade-pp-sd.onnx > logs/log.dl19-passage.splade-pp-sd.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage > logs/log.dl19-passage.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.bm25-b8 > logs/log.dl19-passage.bm25-b8.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.wp-ca > logs/log.dl19-passage.wp-ca.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.wp-tok > logs/log.dl19-passage.wp-tok.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.wp-hgf > logs/log.dl19-passage.wp-hgf.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.docTTTTTquery > logs/log.dl19-passage.docTTTTTquery.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.splade-pp-ed.onnx > logs/log.dl19-passage.splade-pp-ed.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.splade-pp-sd.onnx > logs/log.dl19-passage.splade-pp-sd.onnx.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl19-passage.bge-base-en-v1.5.hnsw.cached > logs/log.dl19-passage.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.bge-base-en-v1.5.hnsw-int8.cached > logs/log.dl19-passage.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.cos-dpr-distil.hnsw.cached > logs/log.dl19-passage.cos-dpr-distil.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.cos-dpr-distil.hnsw-int8.cached > logs/log.dl19-passage.cos-dpr-distil.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.cos-dpr-distil.fw > logs/log.dl19-passage.cos-dpr-distil.fw.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.cos-dpr-distil.lexlsh > logs/log.dl19-passage.cos-dpr-distil.lexlsh.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.openai-ada2.hnsw.cached > logs/log.dl19-passage.openai-ada2.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.openai-ada2.hnsw-int8.cached > logs/log.dl19-passage.openai-ada2.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.cohere-embed-english-v3.0.hnsw.cached > logs/log.dl19-passage.cohere-embed-english-v3.0.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached > logs/log.dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.bge-base-en-v1.5.hnsw.cached > logs/log.dl19-passage.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.bge-base-en-v1.5.hnsw-int8.cached > logs/log.dl19-passage.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.cos-dpr-distil.hnsw.cached > logs/log.dl19-passage.cos-dpr-distil.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.cos-dpr-distil.hnsw-int8.cached > logs/log.dl19-passage.cos-dpr-distil.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.cos-dpr-distil.fw > logs/log.dl19-passage.cos-dpr-distil.fw.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.cos-dpr-distil.lexlsh > logs/log.dl19-passage.cos-dpr-distil.lexlsh.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.openai-ada2.hnsw.cached > logs/log.dl19-passage.openai-ada2.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.openai-ada2.hnsw-int8.cached > logs/log.dl19-passage.openai-ada2.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.cohere-embed-english-v3.0.hnsw.cached > logs/log.dl19-passage.cohere-embed-english-v3.0.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached > logs/log.dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl19-passage.unicoil.cached > logs/log.dl19-passage.unicoil.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.unicoil-noexp.cached > logs/log.dl19-passage.unicoil-noexp.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.splade-pp-ed.cached > logs/log.dl19-passage.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.splade-pp-sd.cached > logs/log.dl19-passage.splade-pp-sd.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.unicoil.cached > logs/log.dl19-passage.unicoil.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.unicoil-noexp.cached > logs/log.dl19-passage.unicoil-noexp.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.splade-pp-ed.cached > logs/log.dl19-passage.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.splade-pp-sd.cached > logs/log.dl19-passage.splade-pp-sd.cached.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl19-passage.cos-dpr-distil.hnsw.onnx > logs/log.dl19-passage.cos-dpr-distil.hnsw.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.cos-dpr-distil.hnsw-int8.onnx > logs/log.dl19-passage.cos-dpr-distil.hnsw-int8.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.cos-dpr-distil.hnsw.onnx > logs/log.dl19-passage.cos-dpr-distil.hnsw.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.cos-dpr-distil.hnsw-int8.onnx > logs/log.dl19-passage.cos-dpr-distil.hnsw-int8.onnx.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl19-passage.bge-base-en-v1.5.hnsw.onnx > logs/log.dl19-passage.bge-base-en-v1.5.hnsw.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx > logs/log.dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.bge-base-en-v1.5.hnsw.onnx > logs/log.dl19-passage.bge-base-en-v1.5.hnsw.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx > logs/log.dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl19-doc > logs/log.dl19-doc.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-doc.wp-ca > logs/log.dl19-doc.wp-ca.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-doc.wp-tok > logs/log.dl19-doc.wp-tok.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-doc.wp-hgf > logs/log.dl19-doc.wp-hgf.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-doc.docTTTTTquery > logs/log.dl19-doc.docTTTTTquery.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-doc > logs/log.dl19-doc.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-doc.wp-ca > logs/log.dl19-doc.wp-ca.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-doc.wp-tok > logs/log.dl19-doc.wp-tok.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-doc.wp-hgf > logs/log.dl19-doc.wp-hgf.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-doc.docTTTTTquery > logs/log.dl19-doc.docTTTTTquery.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl19-doc-segmented > logs/log.dl19-doc-segmented.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-doc-segmented.wp-ca > logs/log.dl19-doc-segmented.wp-ca.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-doc-segmented.wp-tok > logs/log.dl19-doc-segmented.wp-tok.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-doc-segmented.docTTTTTquery > logs/log.dl19-doc-segmented.docTTTTTquery.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-doc-segmented.unicoil.cached > logs/log.dl19-doc-segmented.unicoil.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl19-doc-segmented.unicoil-noexp.cached > logs/log.dl19-doc-segmented.unicoil-noexp.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-doc-segmented > logs/log.dl19-doc-segmented.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-doc-segmented.wp-ca > logs/log.dl19-doc-segmented.wp-ca.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-doc-segmented.wp-tok > logs/log.dl19-doc-segmented.wp-tok.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-doc-segmented.docTTTTTquery > logs/log.dl19-doc-segmented.docTTTTTquery.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-doc-segmented.unicoil.cached > logs/log.dl19-doc-segmented.unicoil.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl19-doc-segmented.unicoil-noexp.cached > logs/log.dl19-doc-segmented.unicoil-noexp.cached.txt 2>&1
 
 # DL20
-python src/main/python/run_regression.py --search --regression dl20-passage > logs/log.dl20-passage.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.bm25-b8 > logs/log.dl20-passage.bm25-b8.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.wp-ca > logs/log.dl20-passage.wp-ca.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.wp-tok > logs/log.dl20-passage.wp-tok.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.wp-hgf > logs/log.dl20-passage.wp-hgf.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.docTTTTTquery > logs/log.dl20-passage.docTTTTTquery.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.splade-pp-ed.onnx > logs/log.dl20-passage.splade-pp-ed.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.splade-pp-sd.onnx > logs/log.dl20-passage.splade-pp-sd.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage > logs/log.dl20-passage.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.bm25-b8 > logs/log.dl20-passage.bm25-b8.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.wp-ca > logs/log.dl20-passage.wp-ca.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.wp-tok > logs/log.dl20-passage.wp-tok.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.wp-hgf > logs/log.dl20-passage.wp-hgf.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.docTTTTTquery > logs/log.dl20-passage.docTTTTTquery.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.splade-pp-ed.onnx > logs/log.dl20-passage.splade-pp-ed.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.splade-pp-sd.onnx > logs/log.dl20-passage.splade-pp-sd.onnx.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl20-passage.bge-base-en-v1.5.hnsw.cached > logs/log.dl20-passage.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.bge-base-en-v1.5.hnsw-int8.cached > logs/log.dl20-passage.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.cos-dpr-distil.hnsw.cached > logs/log.dl20-passage.cos-dpr-distil.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.cos-dpr-distil.hnsw-int8.cached > logs/log.dl20-passage.cos-dpr-distil.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.cos-dpr-distil.fw > logs/log.dl20-passage.cos-dpr-distil.fw.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.cos-dpr-distil.lexlsh > logs/log.dl20-passage.cos-dpr-distil.lexlsh.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.openai-ada2.hnsw.cached > logs/log.dl20-passage.openai-ada2.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.openai-ada2.hnsw-int8.cached > logs/log.dl20-passage.openai-ada2.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.cohere-embed-english-v3.0.hnsw.cached > logs/log.dl20-passage.cohere-embed-english-v3.0.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached > logs/log.dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.bge-base-en-v1.5.hnsw.cached > logs/log.dl20-passage.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.bge-base-en-v1.5.hnsw-int8.cached > logs/log.dl20-passage.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.cos-dpr-distil.hnsw.cached > logs/log.dl20-passage.cos-dpr-distil.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.cos-dpr-distil.hnsw-int8.cached > logs/log.dl20-passage.cos-dpr-distil.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.cos-dpr-distil.fw > logs/log.dl20-passage.cos-dpr-distil.fw.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.cos-dpr-distil.lexlsh > logs/log.dl20-passage.cos-dpr-distil.lexlsh.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.openai-ada2.hnsw.cached > logs/log.dl20-passage.openai-ada2.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.openai-ada2.hnsw-int8.cached > logs/log.dl20-passage.openai-ada2.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.cohere-embed-english-v3.0.hnsw.cached > logs/log.dl20-passage.cohere-embed-english-v3.0.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached > logs/log.dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl20-passage.unicoil.cached > logs/log.dl20-passage.unicoil.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.unicoil-noexp.cached > logs/log.dl20-passage.unicoil-noexp.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.splade-pp-ed.cached > logs/log.dl20-passage.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.splade-pp-sd.cached > logs/log.dl20-passage.splade-pp-sd.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.unicoil.cached > logs/log.dl20-passage.unicoil.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.unicoil-noexp.cached > logs/log.dl20-passage.unicoil-noexp.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.splade-pp-ed.cached > logs/log.dl20-passage.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.splade-pp-sd.cached > logs/log.dl20-passage.splade-pp-sd.cached.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl20-passage.cos-dpr-distil.hnsw.onnx > logs/log.dl20-passage.cos-dpr-distil.hnsw.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.cos-dpr-distil.hnsw-int8.onnx > logs/log.dl20-passage.cos-dpr-distil.hnsw-int8.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.cos-dpr-distil.hnsw.onnx > logs/log.dl20-passage.cos-dpr-distil.hnsw.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.cos-dpr-distil.hnsw-int8.onnx > logs/log.dl20-passage.cos-dpr-distil.hnsw-int8.onnx.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl20-passage.bge-base-en-v1.5.hnsw.onnx > logs/log.dl20-passage.bge-base-en-v1.5.hnsw.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx > logs/log.dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.bge-base-en-v1.5.hnsw.onnx > logs/log.dl20-passage.bge-base-en-v1.5.hnsw.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx > logs/log.dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl20-doc > logs/log.dl20-doc.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-doc.wp-ca > logs/log.dl20-doc.wp-ca.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-doc.wp-tok > logs/log.dl20-doc.wp-tok.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-doc.wp-hgf > logs/log.dl20-doc.wp-hgf.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-doc.docTTTTTquery > logs/log.dl20-doc.docTTTTTquery.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-doc > logs/log.dl20-doc.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-doc.wp-ca > logs/log.dl20-doc.wp-ca.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-doc.wp-tok > logs/log.dl20-doc.wp-tok.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-doc.wp-hgf > logs/log.dl20-doc.wp-hgf.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-doc.docTTTTTquery > logs/log.dl20-doc.docTTTTTquery.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl20-doc-segmented > logs/log.dl20-doc-segmented.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-doc-segmented.wp-ca > logs/log.dl20-doc-segmented.wp-ca.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-doc-segmented.wp-tok > logs/log.dl20-doc-segmented.wp-tok.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-doc-segmented.docTTTTTquery > logs/log.dl20-doc-segmented.docTTTTTquery.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-doc-segmented.unicoil.cached > logs/log.dl20-doc-segmented.unicoil.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl20-doc-segmented.unicoil-noexp.cached > logs/log.dl20-doc-segmented.unicoil-noexp.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-doc-segmented > logs/log.dl20-doc-segmented.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-doc-segmented.wp-ca > logs/log.dl20-doc-segmented.wp-ca.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-doc-segmented.wp-tok > logs/log.dl20-doc-segmented.wp-tok.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-doc-segmented.docTTTTTquery > logs/log.dl20-doc-segmented.docTTTTTquery.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-doc-segmented.unicoil.cached > logs/log.dl20-doc-segmented.unicoil.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl20-doc-segmented.unicoil-noexp.cached > logs/log.dl20-doc-segmented.unicoil-noexp.cached.txt 2>&1
 
 # DL21
-python src/main/python/run_regression.py --search --regression dl21-passage > logs/log.dl21-passage.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl21-passage.d2q-t5 > logs/log.dl21-passage.d2q-t5.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-passage > logs/log.dl21-passage.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-passage.d2q-t5 > logs/log.dl21-passage.d2q-t5.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl21-passage-augmented > logs/log.dl21-passage-augmented.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl21-passage-augmented.d2q-t5 > logs/log.dl21-passage-augmented-d2q-t5.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-passage-augmented > logs/log.dl21-passage-augmented.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-passage-augmented.d2q-t5 > logs/log.dl21-passage-augmented-d2q-t5.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl21-passage.unicoil-noexp-0shot.cached > logs/log.dl21-passage.unicoil-noexp-0shot.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl21-passage.unicoil-0shot.cached > logs/log.dl21-passage.unicoil-0shot.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl21-passage.splade-pp-ed.cached > logs/log.dl21-passage.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl21-passage.splade-pp-ed.onnx > logs/log.dl21-passage.splade-pp-ed.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl21-passage.splade-pp-sd.cached > logs/log.dl21-passage.splade-pp-sd.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl21-passage.splade-pp-sd.onnx > logs/log.dl21-passage.splade-pp-sd.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-passage.unicoil-noexp-0shot.cached > logs/log.dl21-passage.unicoil-noexp-0shot.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-passage.unicoil-0shot.cached > logs/log.dl21-passage.unicoil-0shot.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-passage.splade-pp-ed.cached > logs/log.dl21-passage.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-passage.splade-pp-ed.onnx > logs/log.dl21-passage.splade-pp-ed.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-passage.splade-pp-sd.cached > logs/log.dl21-passage.splade-pp-sd.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-passage.splade-pp-sd.onnx > logs/log.dl21-passage.splade-pp-sd.onnx.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl21-doc > logs/log.dl21-doc.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl21-doc.d2q-t5 > logs/log.dl21-doc.d2q-t5.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-doc > logs/log.dl21-doc.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-doc.d2q-t5 > logs/log.dl21-doc.d2q-t5.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl21-doc-segmented > logs/log.dl21-doc-segmented.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl21-doc-segmented.d2q-t5 > logs/log.dl21-doc-segmented.d2q-t5.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl21-doc-segmented.unicoil-noexp-0shot.cached > logs/log.dl21-doc-segmented.unicoil-noexp-0shot.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl21-doc-segmented.unicoil-noexp-0shot-v2.cached > logs/log.dl21-doc-segmented.unicoil-noexp-0shot-v2.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl21-doc-segmented.unicoil-0shot.cached > logs/log.dl21-doc-segmented.unicoil-0shot.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl21-doc-segmented.unicoil-0shot-v2.cached > logs/log.dl21-doc-segmented.unicoil-0shot-v2.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-doc-segmented > logs/log.dl21-doc-segmented.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-doc-segmented.d2q-t5 > logs/log.dl21-doc-segmented.d2q-t5.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-doc-segmented.unicoil-noexp-0shot.cached > logs/log.dl21-doc-segmented.unicoil-noexp-0shot.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-doc-segmented.unicoil-noexp-0shot-v2.cached > logs/log.dl21-doc-segmented.unicoil-noexp-0shot-v2.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-doc-segmented.unicoil-0shot.cached > logs/log.dl21-doc-segmented.unicoil-0shot.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl21-doc-segmented.unicoil-0shot-v2.cached > logs/log.dl21-doc-segmented.unicoil-0shot-v2.cached.txt 2>&1
 
 # DL22
-python src/main/python/run_regression.py --search --regression dl22-passage > logs/log.dl22-passage.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl22-passage.d2q-t5 > logs/log.dl22-passage.d2q-t5.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl22-passage > logs/log.dl22-passage.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl22-passage.d2q-t5 > logs/log.dl22-passage.d2q-t5.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl22-passage-augmented > logs/log.dl22-passage-augmented.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl22-passage-augmented.d2q-t5 > logs/log.dl22-passage-augmented.d2q-t5.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl22-passage-augmented > logs/log.dl22-passage-augmented.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl22-passage-augmented.d2q-t5 > logs/log.dl22-passage-augmented.d2q-t5.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl22-passage.unicoil-noexp-0shot.cached > logs/log.dl22-passage.unicoil-noexp-0shot.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl22-passage.unicoil-0shot.cached > logs/log.dl22-passage.unicoil-0shot.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl22-passage.splade-pp-ed.cached > logs/log.dl22-passage.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl22-passage.splade-pp-ed.onnx > logs/log.dl22-passage.splade-pp-ed.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl22-passage.splade-pp-sd.cached > logs/log.dl22-passage.splade-pp-sd.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl22-passage.splade-pp-sd.onnx > logs/log.dl22-passage.splade-pp-sd.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl22-passage.unicoil-noexp-0shot.cached > logs/log.dl22-passage.unicoil-noexp-0shot.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl22-passage.unicoil-0shot.cached > logs/log.dl22-passage.unicoil-0shot.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl22-passage.splade-pp-ed.cached > logs/log.dl22-passage.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl22-passage.splade-pp-ed.onnx > logs/log.dl22-passage.splade-pp-ed.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl22-passage.splade-pp-sd.cached > logs/log.dl22-passage.splade-pp-sd.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl22-passage.splade-pp-sd.onnx > logs/log.dl22-passage.splade-pp-sd.onnx.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl22-doc > logs/log.dl22-doc.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl22-doc.d2q-t5 > logs/log.dl22-doc.d2q-t5.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl22-doc > logs/log.dl22-doc.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl22-doc.d2q-t5 > logs/log.dl22-doc.d2q-t5.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl22-doc-segmented > logs/log.dl22-doc-segmented.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl22-doc-segmented.d2q-t5 > logs/log.dl22-doc-segmented.d2q-t5.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl22-doc-segmented.unicoil-noexp-0shot-v2.cached > logs/log.dl22-doc-segmented.unicoil-noexp-0shot-v2.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl22-doc-segmented.unicoil-0shot-v2.cached > logs/log.dl22-doc-segmented.unicoil-0shot-v2.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl22-doc-segmented > logs/log.dl22-doc-segmented.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl22-doc-segmented.d2q-t5 > logs/log.dl22-doc-segmented.d2q-t5.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl22-doc-segmented.unicoil-noexp-0shot-v2.cached > logs/log.dl22-doc-segmented.unicoil-noexp-0shot-v2.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl22-doc-segmented.unicoil-0shot-v2.cached > logs/log.dl22-doc-segmented.unicoil-0shot-v2.cached.txt 2>&1
 
 # DL23
-python src/main/python/run_regression.py --search --regression dl23-passage > logs/log.dl23-passage.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl23-passage.d2q-t5 > logs/log.dl23-passage.d2q-t5.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl23-passage > logs/log.dl23-passage.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl23-passage.d2q-t5 > logs/log.dl23-passage.d2q-t5.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl23-passage-augmented > logs/log.dl23-passage-augmented.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl23-passage-augmented.d2q-t5 > logs/log.dl23-passage-augmented.d2q-t5.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl23-passage-augmented > logs/log.dl23-passage-augmented.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl23-passage-augmented.d2q-t5 > logs/log.dl23-passage-augmented.d2q-t5.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl23-passage.unicoil-noexp-0shot.cached > logs/log.dl23-passage.unicoil-noexp-0shot.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl23-passage.unicoil-0shot.cached > logs/log.dl23-passage.unicoil-0shot.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl23-passage.splade-pp-ed.cached > logs/log.dl23-passage.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl23-passage.splade-pp-ed.onnx > logs/log.dl23-passage.splade-pp-ed.onnx.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl23-passage.splade-pp-sd.cached > logs/log.dl23-passage.splade-pp-sd.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl23-passage.splade-pp-sd.onnx > logs/log.dl23-passage.splade-pp-sd.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl23-passage.unicoil-noexp-0shot.cached > logs/log.dl23-passage.unicoil-noexp-0shot.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl23-passage.unicoil-0shot.cached > logs/log.dl23-passage.unicoil-0shot.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl23-passage.splade-pp-ed.cached > logs/log.dl23-passage.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl23-passage.splade-pp-ed.onnx > logs/log.dl23-passage.splade-pp-ed.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl23-passage.splade-pp-sd.cached > logs/log.dl23-passage.splade-pp-sd.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl23-passage.splade-pp-sd.onnx > logs/log.dl23-passage.splade-pp-sd.onnx.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl23-doc > logs/log.dl23-doc.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl23-doc.d2q-t5 > logs/log.dl23-doc.d2q-t5.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl23-doc > logs/log.dl23-doc.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl23-doc.d2q-t5 > logs/log.dl23-doc.d2q-t5.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression dl23-doc-segmented > logs/log.dl23-doc-segmented.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl23-doc-segmented.d2q-t5 > logs/log.dl23-doc-segmented.d2q-t5.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl23-doc-segmented.unicoil-noexp-0shot-v2.cached > logs/log.dl23-doc-segmented.unicoil-noexp-0shot-v2.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression dl23-doc-segmented.unicoil-0shot-v2.cached > logs/log.dl23-doc-segmented.unicoil-0shot-v2.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl23-doc-segmented > logs/log.dl23-doc-segmented.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl23-doc-segmented.d2q-t5 > logs/log.dl23-doc-segmented.d2q-t5.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl23-doc-segmented.unicoil-noexp-0shot-v2.cached > logs/log.dl23-doc-segmented.unicoil-noexp-0shot-v2.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression dl23-doc-segmented.unicoil-0shot-v2.cached > logs/log.dl23-doc-segmented.unicoil-0shot-v2.cached.txt 2>&1

--- a/src/main/python/regressions-batch04.txt
+++ b/src/main/python/regressions-batch04.txt
@@ -118,65 +118,65 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.onnx > logs/log.beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.onnx.txt 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.onnx > logs/log.beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.onnx.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-arguana.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-arguana.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-bioasq.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-bioasq.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-climate-fever.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-climate-fever.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-fever.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-fever.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-fiqa.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-fiqa.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-hotpotqa.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-hotpotqa.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-nfcorpus.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-nfcorpus.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-nq.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-nq.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-quora.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-quora.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-robust04.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-robust04.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-scidocs.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-scidocs.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-scifact.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-scifact.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-signal1m.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-signal1m.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-trec-news.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-trec-news.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-arguana.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-arguana.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-bioasq.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-bioasq.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-climate-fever.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-climate-fever.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-fever.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-fever.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-fiqa.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-fiqa.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-hotpotqa.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-hotpotqa.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-nfcorpus.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-nfcorpus.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-nq.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-nq.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-quora.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-quora.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-robust04.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-robust04.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-scidocs.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-scidocs.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-scifact.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-scifact.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-signal1m.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-signal1m.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-trec-news.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-trec-news.bge-base-en-v1.5.flat.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.flat.cached > logs/log.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.flat.cached.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-arguana.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-arguana.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-bioasq.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-bioasq.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-climate-fever.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-climate-fever.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-fever.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-fever.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-fiqa.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-fiqa.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-hotpotqa.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-hotpotqa.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-nfcorpus.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-nfcorpus.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-nq.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-nq.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-quora.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-quora.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-robust04.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-robust04.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-scidocs.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-scidocs.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-scifact.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-scifact.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-signal1m.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-signal1m.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-trec-news.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-trec-news.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-arguana.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-arguana.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-bioasq.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-bioasq.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-climate-fever.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-climate-fever.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-fever.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-fever.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-fiqa.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-fiqa.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-hotpotqa.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-hotpotqa.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-nfcorpus.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-nfcorpus.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-nq.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-nq.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-quora.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-quora.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-robust04.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-robust04.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-scidocs.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-scidocs.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-scifact.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-scifact.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-signal1m.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-signal1m.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-trec-news.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-trec-news.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.flat-int8.cached > logs/log.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
 
 python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-trec-covid.splade-pp-ed.onnx > logs/log.beir-v1.0.0-trec-covid.splade-pp-ed.onnx.txt 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-bioasq.splade-pp-ed.onnx > logs/log.beir-v1.0.0-bioasq.splade-pp-ed.onnx.txt 2>&1
@@ -328,95 +328,95 @@ python src/main/python/run_regression.py --index --verify --search --regression 
 python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-climate-fever.multifield > logs/log.beir-v1.0.0-climate-fever.multifield.txt 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-scifact.multifield > logs/log.beir-v1.0.0-scifact.multifield.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-trec-covid.splade-pp-ed.cached > logs/log.beir-v1.0.0-trec-covid.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-bioasq.splade-pp-ed.cached > logs/log.beir-v1.0.0-bioasq.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-nfcorpus.splade-pp-ed.cached > logs/log.beir-v1.0.0-nfcorpus.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-nq.splade-pp-ed.cached > logs/log.beir-v1.0.0-nq.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-hotpotqa.splade-pp-ed.cached > logs/log.beir-v1.0.0-hotpotqa.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-fiqa.splade-pp-ed.cached > logs/log.beir-v1.0.0-fiqa.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-signal1m.splade-pp-ed.cached > logs/log.beir-v1.0.0-signal1m.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-trec-news.splade-pp-ed.cached > logs/log.beir-v1.0.0-trec-news.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-robust04.splade-pp-ed.cached > logs/log.beir-v1.0.0-robust04.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-arguana.splade-pp-ed.cached > logs/log.beir-v1.0.0-arguana.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-webis-touche2020.splade-pp-ed.cached > logs/log.beir-v1.0.0-webis-touche2020.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-android.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-android.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-english.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-english.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-gaming.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-gaming.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-gis.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-gis.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-mathematica.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-mathematica.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-physics.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-physics.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-programmers.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-programmers.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-stats.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-stats.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-tex.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-tex.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-unix.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-unix.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-webmasters.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-webmasters.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-wordpress.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-wordpress.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-quora.splade-pp-ed.cached > logs/log.beir-v1.0.0-quora.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-dbpedia-entity.splade-pp-ed.cached > logs/log.beir-v1.0.0-dbpedia-entity.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-scidocs.splade-pp-ed.cached > logs/log.beir-v1.0.0-scidocs.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-fever.splade-pp-ed.cached > logs/log.beir-v1.0.0-fever.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-climate-fever.splade-pp-ed.cached > logs/log.beir-v1.0.0-climate-fever.splade-pp-ed.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-scifact.splade-pp-ed.cached > logs/log.beir-v1.0.0-scifact.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-trec-covid.splade-pp-ed.cached > logs/log.beir-v1.0.0-trec-covid.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-bioasq.splade-pp-ed.cached > logs/log.beir-v1.0.0-bioasq.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-nfcorpus.splade-pp-ed.cached > logs/log.beir-v1.0.0-nfcorpus.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-nq.splade-pp-ed.cached > logs/log.beir-v1.0.0-nq.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-hotpotqa.splade-pp-ed.cached > logs/log.beir-v1.0.0-hotpotqa.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-fiqa.splade-pp-ed.cached > logs/log.beir-v1.0.0-fiqa.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-signal1m.splade-pp-ed.cached > logs/log.beir-v1.0.0-signal1m.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-trec-news.splade-pp-ed.cached > logs/log.beir-v1.0.0-trec-news.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-robust04.splade-pp-ed.cached > logs/log.beir-v1.0.0-robust04.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-arguana.splade-pp-ed.cached > logs/log.beir-v1.0.0-arguana.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-webis-touche2020.splade-pp-ed.cached > logs/log.beir-v1.0.0-webis-touche2020.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-android.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-android.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-english.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-english.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-gaming.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-gaming.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-gis.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-gis.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-mathematica.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-mathematica.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-physics.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-physics.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-programmers.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-programmers.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-stats.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-stats.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-tex.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-tex.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-unix.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-unix.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-webmasters.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-webmasters.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-wordpress.splade-pp-ed.cached > logs/log.beir-v1.0.0-cqadupstack-wordpress.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-quora.splade-pp-ed.cached > logs/log.beir-v1.0.0-quora.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-dbpedia-entity.splade-pp-ed.cached > logs/log.beir-v1.0.0-dbpedia-entity.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-scidocs.splade-pp-ed.cached > logs/log.beir-v1.0.0-scidocs.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-fever.splade-pp-ed.cached > logs/log.beir-v1.0.0-fever.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-climate-fever.splade-pp-ed.cached > logs/log.beir-v1.0.0-climate-fever.splade-pp-ed.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-scifact.splade-pp-ed.cached > logs/log.beir-v1.0.0-scifact.splade-pp-ed.cached.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-nq.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-nq.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-quora.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-quora.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-fever.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-fever.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-nq.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-nq.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-quora.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-quora.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-fever.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-fever.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw.cached > logs/log.beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw.cached.txt 2>&1
 
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-nq.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-nq.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-quora.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-quora.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-fever.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-fever.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --search --regression beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-nq.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-nq.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-quora.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-quora.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-fever.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-fever.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.cached > logs/log.beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
 
 # MIRACL
 python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ar > logs/log.miracl-v1.0-ar.txt 2>&1

--- a/src/main/resources/regression/dl19-doc-segmented.wp-ca.yaml
+++ b/src/main/resources/regression/dl19-doc-segmented.wp-ca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -analyzeWithHuggingFac
 index_stats:
   documents: 20545677
   documents (non-empty): 20545677
-  total terms: 9539433626
+  total terms: 9237138939
 
 metrics:
   - metric: AP@100
@@ -55,10 +55,10 @@ models:
     params: -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -analyzeWithHuggingFaceTokenizer bert-base-uncased -useCompositeAnalyzer
     results:
       AP@100:
-        - 0.2604
+        - 0.2606
       nDCG@10:
-        - 0.5396
+        - 0.5442
       R@100:
-        - 0.4040
+        - 0.4055
       R@1000:
-        - 0.6813
+        - 0.6835

--- a/src/main/resources/regression/dl19-doc.wp-ca.yaml
+++ b/src/main/resources/regression/dl19-doc.wp-ca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -analyzeWithHuggingFac
 index_stats:
   documents: 3213835
   documents (non-empty): 3213835
-  total terms: 8068479907
+  total terms: 4174492077
 
 metrics:
   - metric: AP@100
@@ -55,10 +55,10 @@ models:
     params: -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased -useCompositeAnalyzer
     results:
       AP@100:
-        - 0.2476
+        - 0.2369
       nDCG@10:
-        - 0.5127
+        - 0.5299
       R@100:
-        - 0.3993
+        - 0.3643
       R@1000:
-        - 0.7073
+        - 0.6373

--- a/src/main/resources/regression/dl19-doc.wp-hgf.yaml
+++ b/src/main/resources/regression/dl19-doc.wp-hgf.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -analyzeWithHuggingFac
 index_stats:
   documents: 3213835
   documents (non-empty): 3213835
-  total terms: 5326253111
+  total terms: 1432265281
 
 metrics:
   - metric: AP@100
@@ -55,10 +55,10 @@ models:
     params: -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased
     results:
       AP@100:
-        - 0.1947
+        - 0.1940
       nDCG@10:
-        - 0.4672
+        - 0.4967
       R@100:
-        - 0.3400
+        - 0.3208
       R@1000:
-        - 0.6421
+        - 0.5319

--- a/src/main/resources/regression/dl19-passage.wp-ca.yaml
+++ b/src/main/resources/regression/dl19-passage.wp-ca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -analyzeWithHuggingFac
 index_stats:
   documents: 8841823
   documents (non-empty): 8841823
-  total terms: 1015216415
+  total terms: 1015215709
 
 metrics:
   - metric: AP@1000

--- a/src/main/resources/regression/dl19-passage.wp-hgf.yaml
+++ b/src/main/resources/regression/dl19-passage.wp-hgf.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -analyzeWithHuggingFac
 index_stats:
   documents: 8841823
   documents (non-empty): 8841823
-  total terms: 662900376
+  total terms: 662899670
 
 metrics:
   - metric: AP@1000

--- a/src/main/resources/regression/dl20-doc-segmented.wp-ca.yaml
+++ b/src/main/resources/regression/dl20-doc-segmented.wp-ca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -analyzeWithHuggingFac
 index_stats:
   documents: 20545677
   documents (non-empty): 20545677
-  total terms: 9539433626
+  total terms: 9237138939
 
 metrics:
   - metric: AP@100
@@ -55,10 +55,10 @@ models:
     params: -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -analyzeWithHuggingFaceTokenizer bert-base-uncased -useCompositeAnalyzer
     results:
       AP@100:
-        - 0.3568
+        - 0.3601
       nDCG@10:
-        - 0.5196
+        - 0.5253
       R@100:
         - 0.5912
       R@1000:
-        - 0.7856
+        - 0.7872

--- a/src/main/resources/regression/dl20-doc.wp-ca.yaml
+++ b/src/main/resources/regression/dl20-doc.wp-ca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -analyzeWithHuggingFac
 index_stats:
   documents: 3213835
   documents (non-empty): 3213835
-  total terms: 8068479907
+  total terms: 4174492077
 
 metrics:
   - metric: AP@100
@@ -55,10 +55,10 @@ models:
     params: -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased -useCompositeAnalyzer
     results:
       AP@100:
-        - 0.3809
+        - 0.3529
       nDCG@10:
-        - 0.5422
+        - 0.5238
       R@100:
-        - 0.6074
+        - 0.5653
       R@1000:
-        - 0.8147
+        - 0.7800

--- a/src/main/resources/regression/dl20-doc.wp-hgf.yaml
+++ b/src/main/resources/regression/dl20-doc.wp-hgf.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -analyzeWithHuggingFac
 index_stats:
   documents: 3213835
   documents (non-empty): 3213835
-  total terms: 5326253111
+  total terms: 1432265281
 
 metrics:
   - metric: AP@100
@@ -55,10 +55,10 @@ models:
     params: -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased
     results:
       AP@100:
-        - 0.3258
+        - 0.3014
       nDCG@10:
-        - 0.5046
+        - 0.5011
       R@100:
-        - 0.5483
+        - 0.4899
       R@1000:
-        - 0.7436
+        - 0.6708

--- a/src/main/resources/regression/dl20-passage.wp-ca.yaml
+++ b/src/main/resources/regression/dl20-passage.wp-ca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -analyzeWithHuggingFac
 index_stats:
   documents: 8841823
   documents (non-empty): 8841823
-  total terms: 1015216415
+  total terms: 1015215709
 
 metrics:
   - metric: AP@1000

--- a/src/main/resources/regression/dl20-passage.wp-hgf.yaml
+++ b/src/main/resources/regression/dl20-passage.wp-hgf.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -analyzeWithHuggingFac
 index_stats:
   documents: 8841823
   documents (non-empty): 8841823
-  total terms: 662900376
+  total terms: 662899670
 
 metrics:
   - metric: AP@1000

--- a/src/main/resources/regression/miracl-v1.0-ar-aca.yaml
+++ b/src/main/resources/regression/miracl-v1.0-ar-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language ar -useAutoC
 index_stats:
   documents: 2061414
   documents (non-empty): 2061414
-  total terms: 260815270
+  total terms: 257930934
 
 metrics:
   - metric: nDCG@10
@@ -41,6 +41,6 @@ models:
     params: -bm25 -hits 100 -language ar -useAutoCompositeAnalyzer
     results:
       nDCG@10:
-        - 0.4968
+        - 0.4962
       R@100:
-        - 0.8980
+        - 0.8983

--- a/src/main/resources/regression/miracl-v1.0-bn-aca.yaml
+++ b/src/main/resources/regression/miracl-v1.0-bn-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language bn -useAutoC
 index_stats:
   documents: 297265
   documents (non-empty): 297265
-  total terms: 50406186
+  total terms: 49822054
 
 metrics:
   - metric: nDCG@10
@@ -41,6 +41,6 @@ models:
     params: -bm25 -hits 100 -language bn -useAutoCompositeAnalyzer
     results:
       nDCG@10:
-        - 0.5436
+        - 0.5431
       R@100:
         - 0.9387

--- a/src/main/resources/regression/miracl-v1.0-en-aca.yaml
+++ b/src/main/resources/regression/miracl-v1.0-en-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language en -useAutoC
 index_stats:
   documents: 32893221
   documents (non-empty): 32893221
-  total terms: 4444236121
+  total terms: 4434741473
 
 metrics:
   - metric: nDCG@10

--- a/src/main/resources/regression/miracl-v1.0-fa-aca.yaml
+++ b/src/main/resources/regression/miracl-v1.0-fa-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language fa -useAutoC
 index_stats:
   documents: 2207172
   documents (non-empty): 2207172
-  total terms: 217253645
+  total terms: 216128675
 
 metrics:
   - metric: nDCG@10
@@ -41,6 +41,6 @@ models:
     params: -bm25 -hits 100 -language fa -useAutoCompositeAnalyzer
     results:
       nDCG@10:
-        - 0.3427
+        - 0.3432
       R@100:
-        - 0.7600
+        - 0.7589

--- a/src/main/resources/regression/miracl-v1.0-fi-aca.yaml
+++ b/src/main/resources/regression/miracl-v1.0-fi-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language fi -useAutoC
 index_stats:
   documents: 1883509
   documents (non-empty): 1883509
-  total terms: 333931821
+  total terms: 332197112
 
 metrics:
   - metric: nDCG@10
@@ -41,6 +41,6 @@ models:
     params: -bm25 -hits 100 -language fi -useAutoCompositeAnalyzer
     results:
       nDCG@10:
-        - 0.5674
+        - 0.5686
       R@100:
         - 0.8959

--- a/src/main/resources/regression/miracl-v1.0-hi-aca.yaml
+++ b/src/main/resources/regression/miracl-v1.0-hi-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language hi -useAutoC
 index_stats:
   documents: 506264
   documents (non-empty): 506264
-  total terms: 70906980
+  total terms: 70120584
 
 metrics:
   - metric: nDCG@10
@@ -41,6 +41,6 @@ models:
     params: -bm25 -hits 100 -language hi -useAutoCompositeAnalyzer
     results:
       nDCG@10:
-        - 0.4507
+        - 0.4515
       R@100:
         - 0.8655

--- a/src/main/resources/regression/miracl-v1.0-id-aca.yaml
+++ b/src/main/resources/regression/miracl-v1.0-id-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language id -useAutoC
 index_stats:
   documents: 1446315
   documents (non-empty): 1446315
-  total terms: 153874678
+  total terms: 153500215
 
 metrics:
   - metric: nDCG@10
@@ -43,4 +43,4 @@ models:
       nDCG@10:
         - 0.4403
       R@100:
-        - 0.9007
+        - 0.9005

--- a/src/main/resources/regression/miracl-v1.0-ja-aca.yaml
+++ b/src/main/resources/regression/miracl-v1.0-ja-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language ja -useAutoC
 index_stats:
   documents: 6953614
   documents (non-empty): 6953614
-  total terms: 1035434979
+  total terms: 1030346439
 
 metrics:
   - metric: nDCG@10
@@ -41,6 +41,6 @@ models:
     params: -bm25 -hits 100 -language ja -useAutoCompositeAnalyzer
     results:
       nDCG@10:
-        - 0.3974
+        - 0.3972
       R@100:
-        - 0.8488
+        - 0.8479

--- a/src/main/resources/regression/miracl-v1.0-ko-aca.yaml
+++ b/src/main/resources/regression/miracl-v1.0-ko-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language ko -useAutoC
 index_stats:
   documents: 1486752
   documents (non-empty): 1486752
-  total terms: 247477047
+  total terms: 246580791
 
 metrics:
   - metric: nDCG@10
@@ -41,6 +41,6 @@ models:
     params: -bm25 -hits 100 -language ko -useAutoCompositeAnalyzer
     results:
       nDCG@10:
-        - 0.4485
+        - 0.4481
       R@100:
-        - 0.8218
+        - 0.8234

--- a/src/main/resources/regression/miracl-v1.0-ru-aca.yaml
+++ b/src/main/resources/regression/miracl-v1.0-ru-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language ru -useAutoC
 index_stats:
   documents: 9543918
   documents (non-empty): 9543918
-  total terms: 1091588157
+  total terms: 1088054115
 
 metrics:
   - metric: nDCG@10
@@ -43,4 +43,4 @@ models:
       nDCG@10:
         - 0.3616
       R@100:
-        - 0.7579
+        - 0.7578

--- a/src/main/resources/regression/miracl-v1.0-sw-aca.yaml
+++ b/src/main/resources/regression/miracl-v1.0-sw-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language sw -useAutoC
 index_stats:
   documents: 131924
   documents (non-empty): 131924
-  total terms: 7898934
+  total terms: 7844636
 
 metrics:
   - metric: nDCG@10
@@ -41,6 +41,6 @@ models:
     params: -bm25 -hits 100 -language sw -useAutoCompositeAnalyzer
     results:
       nDCG@10:
-        - 0.4146
+        - 0.4152
       R@100:
-        - 0.8025
+        - 0.8021

--- a/src/main/resources/regression/miracl-v1.0-te-aca.yaml
+++ b/src/main/resources/regression/miracl-v1.0-te-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language te -useAutoC
 index_stats:
   documents: 518079
   documents (non-empty): 518079
-  total terms: 64747475
+  total terms: 63774262
 
 metrics:
   - metric: nDCG@10
@@ -41,6 +41,6 @@ models:
     params: -bm25 -hits 100 -language te -useAutoCompositeAnalyzer
     results:
       nDCG@10:
-        - 0.4885
+        - 0.4874
       R@100:
-        - 0.8448
+        - 0.8436

--- a/src/main/resources/regression/miracl-v1.0-th-aca.yaml
+++ b/src/main/resources/regression/miracl-v1.0-th-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language th -useAutoC
 index_stats:
   documents: 542166
   documents (non-empty): 542166
-  total terms: 77097598
+  total terms: 76764090
 
 metrics:
   - metric: nDCG@10
@@ -41,6 +41,6 @@ models:
     params: -bm25 -hits 100 -language th -useAutoCompositeAnalyzer
     results:
       nDCG@10:
-        - 0.5224
+        - 0.5220
       R@100:
         - 0.8875

--- a/src/main/resources/regression/mrtydi-v1.1-ar-aca.yaml
+++ b/src/main/resources/regression/mrtydi-v1.1-ar-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language ar -useAutoC
 index_stats:
   documents: 2106586
   documents (non-empty): 2106586
-  total terms: 268259096
+  total terms: 264860235
 
 metrics:
   - metric: MRR@100
@@ -49,10 +49,10 @@ models:
     params: -bm25 -hits 100 -language ar -useAutoCompositeAnalyzer
     results:
       MRR@100:
-        - 0.3448
-        - 0.3530
-        - 0.3821
+        - 0.3449
+        - 0.3528
+        - 0.3827
       R@100:
-        - 0.8026
-        - 0.8061
+        - 0.8025
+        - 0.8067
         - 0.7986

--- a/src/main/resources/regression/mrtydi-v1.1-bn-aca.yaml
+++ b/src/main/resources/regression/mrtydi-v1.1-bn-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language bn -useAutoC
 index_stats:
   documents: 304059
   documents (non-empty): 304059
-  total terms: 51509766
+  total terms: 50841132
 
 metrics:
   - metric: MRR@100
@@ -49,10 +49,10 @@ models:
     params: -bm25 -hits 100 -language bn -useAutoCompositeAnalyzer
     results:
       MRR@100:
-        - 0.3816
-        - 0.3632
-        - 0.4396
+        - 0.3833
+        - 0.3639
+        - 0.4400
       R@100:
+        - 0.8722
         - 0.8716
-        - 0.8693
         - 0.9234

--- a/src/main/resources/regression/mrtydi-v1.1-en-aca.yaml
+++ b/src/main/resources/regression/mrtydi-v1.1-en-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language en -useAutoC
 index_stats:
   documents: 32907100
   documents (non-empty): 32907100
-  total terms: 4450505310
+  total terms: 4440593740
 
 metrics:
   - metric: MRR@100
@@ -49,10 +49,10 @@ models:
     params: -bm25 -hits 100 -language en -useAutoCompositeAnalyzer
     results:
       MRR@100:
-        - 0.1624
+        - 0.1623
         - 0.1786
-        - 0.1482
+        - 0.1489
       R@100:
-        - 0.5904
-        - 0.6253
+        - 0.5901
+        - 0.6264
         - 0.5464

--- a/src/main/resources/regression/mrtydi-v1.1-fi-aca.yaml
+++ b/src/main/resources/regression/mrtydi-v1.1-fi-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language fi -useAutoC
 index_stats:
   documents: 1908757
   documents (non-empty): 1908757
-  total terms: 339631623
+  total terms: 337146120
 
 metrics:
   - metric: MRR@100
@@ -49,10 +49,10 @@ models:
     params: -bm25 -hits 100 -language fi -useAutoCompositeAnalyzer
     results:
       MRR@100:
-        - 0.4176
-        - 0.4193
-        - 0.2903
+        - 0.4179
+        - 0.4186
+        - 0.2898
       R@100:
-        - 0.8346
-        - 0.8458
+        - 0.8351
+        - 0.8446
         - 0.7529

--- a/src/main/resources/regression/mrtydi-v1.1-id-aca.yaml
+++ b/src/main/resources/regression/mrtydi-v1.1-id-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language id -useAutoC
 index_stats:
   documents: 1469399
   documents (non-empty): 1469399
-  total terms: 156984597
+  total terms: 156423022
 
 metrics:
   - metric: MRR@100
@@ -49,10 +49,10 @@ models:
     params: -bm25 -hits 100 -language id -useAutoCompositeAnalyzer
     results:
       MRR@100:
-        - 0.2948
+        - 0.2947
         - 0.2868
-        - 0.3824
+        - 0.3821
       R@100:
         - 0.7962
         - 0.7990
-        - 0.8504
+        - 0.8492

--- a/src/main/resources/regression/mrtydi-v1.1-ja-aca.yaml
+++ b/src/main/resources/regression/mrtydi-v1.1-ja-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language ja -useAutoC
 index_stats:
   documents: 7000027
   documents (non-empty): 7000027
-  total terms: 1049585663
+  total terms: 1042136443
 
 metrics:
   - metric: MRR@100
@@ -49,10 +49,10 @@ models:
     params: -bm25 -hits 100 -language ja -useAutoCompositeAnalyzer
     results:
       MRR@100:
-        - 0.2402
-        - 0.2477
-        - 0.2316
+        - 0.2401
+        - 0.2466
+        - 0.2294
       R@100:
-        - 0.7571
-        - 0.7694
-        - 0.7007
+        - 0.7563
+        - 0.7662
+        - 0.7021

--- a/src/main/resources/regression/mrtydi-v1.1-ko-aca.yaml
+++ b/src/main/resources/regression/mrtydi-v1.1-ko-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language ko -useAutoC
 index_stats:
   documents: 1496126
   documents (non-empty): 1496126
-  total terms: 249266634
+  total terms: 248277762
 
 metrics:
   - metric: MRR@100
@@ -49,10 +49,10 @@ models:
     params: -bm25 -hits 100 -language ko -useAutoCompositeAnalyzer
     results:
       MRR@100:
-        - 0.2694
-        - 0.3100
-        - 0.2907
+        - 0.2684
+        - 0.3120
+        - 0.2909
       R@100:
         - 0.6483
         - 0.6898
-        - 0.6433
+        - 0.6409

--- a/src/main/resources/regression/mrtydi-v1.1-ru-aca.yaml
+++ b/src/main/resources/regression/mrtydi-v1.1-ru-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language ru -useAutoC
 index_stats:
   documents: 9597504
   documents (non-empty): 9597504
-  total terms: 1102772471
+  total terms: 1098205798
 
 metrics:
   - metric: MRR@100
@@ -49,9 +49,9 @@ models:
     params: -bm25 -hits 100 -language ru -useAutoCompositeAnalyzer
     results:
       MRR@100:
-        - 0.2509
-        - 0.2421
-        - 0.3720
+        - 0.2510
+        - 0.2423
+        - 0.3718
       R@100:
         - 0.6614
         - 0.6676

--- a/src/main/resources/regression/mrtydi-v1.1-sw-aca.yaml
+++ b/src/main/resources/regression/mrtydi-v1.1-sw-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language sw -useAutoC
 index_stats:
   documents: 136689
   documents (non-empty): 136689
-  total terms: 8332906
+  total terms: 8226054
 
 metrics:
   - metric: MRR@100
@@ -49,10 +49,10 @@ models:
     params: -bm25 -hits 100 -language sw -useAutoCompositeAnalyzer
     results:
       MRR@100:
-        - 0.2997
-        - 0.2928
-        - 0.4257
+        - 0.3000
+        - 0.2922
+        - 0.4251
       R@100:
-        - 0.7020
+        - 0.7023
         - 0.6984
-        - 0.8396
+        - 0.8410

--- a/src/main/resources/regression/mrtydi-v1.1-te-aca.yaml
+++ b/src/main/resources/regression/mrtydi-v1.1-te-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language te -useAutoC
 index_stats:
   documents: 548224
   documents (non-empty): 548224
-  total terms: 66656576
+  total terms: 65741581
 
 metrics:
   - metric: MRR@100
@@ -49,10 +49,10 @@ models:
     params: -bm25 -hits 100 -language te -useAutoCompositeAnalyzer
     results:
       MRR@100:
-        - 0.4063
-        - 0.4131
-        - 0.5096
+        - 0.4051
+        - 0.4127
+        - 0.5083
       R@100:
-        - 0.8379
-        - 0.8332
+        - 0.8371
+        - 0.8321
         - 0.9110

--- a/src/main/resources/regression/mrtydi-v1.1-th-aca.yaml
+++ b/src/main/resources/regression/mrtydi-v1.1-th-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language th -useAutoC
 index_stats:
   documents: 568855
   documents (non-empty): 568855
-  total terms: 81518928
+  total terms: 80953465
 
 metrics:
   - metric: MRR@100
@@ -49,9 +49,9 @@ models:
     params: -bm25 -hits 100 -language th -useAutoCompositeAnalyzer
     results:
       MRR@100:
-        - 0.3780
-        - 0.4034
-        - 0.4468
+        - 0.3781
+        - 0.4029
+        - 0.4473
       R@100:
         - 0.8690
         - 0.8751

--- a/src/main/resources/regression/msmarco-v1-doc-segmented.wp-ca.yaml
+++ b/src/main/resources/regression/msmarco-v1-doc-segmented.wp-ca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -analyzeWithHuggingFac
 index_stats:
   documents: 20545677
   documents (non-empty): 20545677
-  total terms: 9539433626
+  total terms: 9237138939
 
 metrics:
   - metric: AP@1000
@@ -55,10 +55,10 @@ models:
     params: -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -analyzeWithHuggingFaceTokenizer bert-base-uncased -useCompositeAnalyzer
     results:
       AP@1000:
-        - 0.2787
+        - 0.2791
       RR@100:
-        - 0.2781
+        - 0.2785
       R@100:
-        - 0.7990
+        - 0.8009
       R@1000:
-        - 0.9286
+        - 0.9299

--- a/src/main/resources/regression/msmarco-v1-doc.wp-ca.yaml
+++ b/src/main/resources/regression/msmarco-v1-doc.wp-ca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -analyzeWithHuggingFac
 index_stats:
   documents: 3213835
   documents (non-empty): 3213835
-  total terms: 8068479907
+  total terms: 4174492077
 
 metrics:
   - metric: AP@1000
@@ -55,10 +55,10 @@ models:
     params: -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased -useCompositeAnalyzer
     results:
       AP@1000:
-        - 0.2410
+        - 0.2787
       RR@100:
-        - 0.2403
+        - 0.2781
       R@100:
-        - 0.7441
+        - 0.7959
       R@1000:
-        - 0.9004
+        - 0.9336

--- a/src/main/resources/regression/msmarco-v1-doc.wp-hgf.yaml
+++ b/src/main/resources/regression/msmarco-v1-doc.wp-hgf.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -analyzeWithHuggingFac
 index_stats:
   documents: 3213835
   documents (non-empty): 3213835
-  total terms: 5326253111
+  total terms: 1432265281
 
 metrics:
   - metric: AP@1000
@@ -55,10 +55,10 @@ models:
     params: -bm25 -analyzeWithHuggingFaceTokenizer bert-base-uncased
     results:
       AP@1000:
-        - 0.2234
+        - 0.2657
       RR@100:
-        - 0.2227
+        - 0.2651
       R@100:
-        - 0.7031
+        - 0.7624
       R@1000:
-        - 0.8743
+        - 0.9056

--- a/src/main/resources/regression/msmarco-v1-passage.wp-ca.yaml
+++ b/src/main/resources/regression/msmarco-v1-passage.wp-ca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -analyzeWithHuggingFac
 index_stats:
   documents: 8841823
   documents (non-empty): 8841823
-  total terms: 1015216415
+  total terms: 1015215709
 
 metrics:
   - metric: AP@1000

--- a/src/main/resources/regression/msmarco-v1-passage.wp-hgf.yaml
+++ b/src/main/resources/regression/msmarco-v1-passage.wp-hgf.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -analyzeWithHuggingFac
 index_stats:
   documents: 8841823
   documents (non-empty): 8841823
-  total terms: 662900376
+  total terms: 662899670
 
 metrics:
   - metric: AP@1000


### PR DESCRIPTION
Recent upgrade to DJL v0.28.0 #2529 caused a bunch of score differences related to underlying use of hgf tokenizers.

Documented in code, but extracting here for visibility:

```
    // Note upgrading from djl v0.21.0 to v0.28.0 (June 2024)
    //
    // In theory, since we're just tokenizing, we shouldn't be constrained by the modelMaxLength.
    // Previously, at v0.21.0, we were able to tokenize arbitrarily long sequences.
    // However, the implementation seems to have changed.
    //
    // As of the v0.28.0 upgrade, if we put a large value, we get the warning:
    // "maxLength is greater then (sic) modelMaxLength, change to: 512"
    //
    // On the other hand, if we don't set this value, we get the warning:
    // "maxLength is not explicitly specified, use modelMaxLength: 512".
    //
    // In other words, the implementation forces truncation, even for our IR application, i.e., it
    // forces FirstP retrieval.
```