### PR TITLE
Refactor tolerance settings for MS MARCO dense vector regressions

### DIFF
--- a/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -101,13 +101,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **BGE-base-en-v1.5**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.443     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.444     |
 | **nDCG@10**                                                                                                  | **BGE-base-en-v1.5**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.708     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.706     |
 | **R@100**                                                                                                    | **BGE-base-en-v1.5**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.614     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.617     |
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.843     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.847     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.bge-base-en-v1.5.hnsw-int8.cached.yaml).

--- a/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -109,8 +109,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.847     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.bge-base-en-v1.5.hnsw-int8.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -109,8 +109,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.847     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -103,11 +103,11 @@ With the above commands, you should be able to reproduce the following results:
 |:-------------------------------------------------------------------------------------------------------------|-----------|
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.444     |
 | **nDCG@10**                                                                                                  | **BGE-base-en-v1.5**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.702     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.706     |
 | **R@100**                                                                                                    | **BGE-base-en-v1.5**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.609     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.617     |
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.836     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.847     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx.yaml).

--- a/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw.cached.md
@@ -99,13 +99,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **BGE-base-en-v1.5**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.442     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.444     |
 | **nDCG@10**                                                                                                  | **BGE-base-en-v1.5**|
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.706     |
 | **R@100**                                                                                                    | **BGE-base-en-v1.5**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.616     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.617     |
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.842     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.847     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.bge-base-en-v1.5.hnsw.cached.yaml).

--- a/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw.cached.md
@@ -107,8 +107,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.847     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.bge-base-en-v1.5.hnsw.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw.onnx.md
@@ -107,8 +107,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.847     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.bge-base-en-v1.5.hnsw.onnx.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw.onnx.md
@@ -99,13 +99,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **BGE-base-en-v1.5**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.447     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.444     |
 | **nDCG@10**                                                                                                  | **BGE-base-en-v1.5**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.701     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.706     |
 | **R@100**                                                                                                    | **BGE-base-en-v1.5**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.607     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.617     |
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.837     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.847     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.bge-base-en-v1.5.hnsw.onnx.yaml).

--- a/docs/regressions/regressions-dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
@@ -94,13 +94,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cohere-embed-english-v3.0**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.487     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.488     |
 | **nDCG@10**                                                                                                  | **cohere-embed-english-v3.0**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.690     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.696     |
 | **R@100**                                                                                                    | **cohere-embed-english-v3.0**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.647     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.648     |
 | **R@1000**                                                                                                   | **cohere-embed-english-v3.0**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.850     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.863     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached.yaml).

--- a/docs/regressions/regressions-dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
@@ -102,8 +102,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cohere-embed-english-v3.0**|
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.863     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl19-passage.cohere-embed-english-v3.0.hnsw.cached.md
+++ b/docs/regressions/regressions-dl19-passage.cohere-embed-english-v3.0.hnsw.cached.md
@@ -94,13 +94,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cohere-embed-english-v3.0**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.486     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.488     |
 | **nDCG@10**                                                                                                  | **cohere-embed-english-v3.0**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.690     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.696     |
 | **R@100**                                                                                                    | **cohere-embed-english-v3.0**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.645     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.648     |
 | **R@1000**                                                                                                   | **cohere-embed-english-v3.0**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.851     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.863     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.cohere-embed-english-v3.0.hnsw.cached.yaml).

--- a/docs/regressions/regressions-dl19-passage.cohere-embed-english-v3.0.hnsw.cached.md
+++ b/docs/regressions/regressions-dl19-passage.cohere-embed-english-v3.0.hnsw.cached.md
@@ -102,8 +102,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cohere-embed-english-v3.0**|
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.863     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.cohere-embed-english-v3.0.hnsw.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw-int8.cached.md
@@ -109,8 +109,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cosDPR-distil**|
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.820     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.cos-dpr-distil.hnsw-int8.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw-int8.cached.md
@@ -101,13 +101,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cosDPR-distil**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.458     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.466     |
 | **nDCG@10**                                                                                                  | **cosDPR-distil**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.717     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.725     |
 | **R@100**                                                                                                    | **cosDPR-distil**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.605     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.617     |
 | **R@1000**                                                                                                   | **cosDPR-distil**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.805     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.820     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.cos-dpr-distil.hnsw-int8.cached.yaml).

--- a/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw-int8.onnx.md
@@ -111,8 +111,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cosDPR-distil**|
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.820     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.cos-dpr-distil.hnsw-int8.onnx.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw-int8.onnx.md
@@ -103,13 +103,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cosDPR-distil**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.458     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.466     |
 | **nDCG@10**                                                                                                  | **cosDPR-distil**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.717     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.725     |
 | **R@100**                                                                                                    | **cosDPR-distil**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.605     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.617     |
 | **R@1000**                                                                                                   | **cosDPR-distil**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.805     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.820     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.cos-dpr-distil.hnsw-int8.onnx.yaml).

--- a/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw.cached.md
+++ b/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw.cached.md
@@ -99,13 +99,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cosDPR-distil**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.458     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.466     |
 | **nDCG@10**                                                                                                  | **cosDPR-distil**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.717     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.725     |
 | **R@100**                                                                                                    | **cosDPR-distil**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.605     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.617     |
 | **R@1000**                                                                                                   | **cosDPR-distil**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.805     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.820     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.cos-dpr-distil.hnsw.cached.yaml).

--- a/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw.cached.md
+++ b/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw.cached.md
@@ -107,8 +107,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cosDPR-distil**|
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.820     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.cos-dpr-distil.hnsw.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw.onnx.md
+++ b/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw.onnx.md
@@ -101,13 +101,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cosDPR-distil**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.458     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.466     |
 | **nDCG@10**                                                                                                  | **cosDPR-distil**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.717     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.725     |
 | **R@100**                                                                                                    | **cosDPR-distil**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.605     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.617     |
 | **R@1000**                                                                                                   | **cosDPR-distil**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.805     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.820     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.cos-dpr-distil.hnsw.onnx.yaml).

--- a/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw.onnx.md
+++ b/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw.onnx.md
@@ -109,8 +109,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cosDPR-distil**|
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.820     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.cos-dpr-distil.hnsw.onnx.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl19-passage.openai-ada2.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl19-passage.openai-ada2.hnsw-int8.cached.md
@@ -109,8 +109,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **OpenAI-ada2**|
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.863     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.openai-ada2.hnsw-int8.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl19-passage.openai-ada2.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl19-passage.openai-ada2.hnsw-int8.cached.md
@@ -101,13 +101,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **OpenAI-ada2**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.478     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.479     |
 | **nDCG@10**                                                                                                  | **OpenAI-ada2**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.707     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.703     |
 | **R@100**                                                                                                    | **OpenAI-ada2**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.617     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.623     |
 | **R@1000**                                                                                                   | **OpenAI-ada2**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.853     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.863     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.openai-ada2.hnsw-int8.cached.yaml).

--- a/docs/regressions/regressions-dl19-passage.openai-ada2.hnsw.cached.md
+++ b/docs/regressions/regressions-dl19-passage.openai-ada2.hnsw.cached.md
@@ -101,11 +101,11 @@ With the above commands, you should be able to reproduce the following results:
 |:-------------------------------------------------------------------------------------------------------------|-----------|
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.479     |
 | **nDCG@10**                                                                                                  | **OpenAI-ada2**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.704     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.703     |
 | **R@100**                                                                                                    | **OpenAI-ada2**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.624     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.623     |
 | **R@1000**                                                                                                   | **OpenAI-ada2**|
-| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.857     |
+| [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.863     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.openai-ada2.hnsw.cached.yaml).

--- a/docs/regressions/regressions-dl19-passage.openai-ada2.hnsw.cached.md
+++ b/docs/regressions/regressions-dl19-passage.openai-ada2.hnsw.cached.md
@@ -107,8 +107,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **OpenAI-ada2**|
 | [DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.863     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl19-passage.openai-ada2.hnsw.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -109,8 +109,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.850     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.bge-base-en-v1.5.hnsw-int8.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -101,13 +101,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **BGE-base-en-v1.5**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.463     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.465     |
 | **nDCG@10**                                                                                                  | **BGE-base-en-v1.5**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.674     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.678     |
 | **R@100**                                                                                                    | **BGE-base-en-v1.5**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.712     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.717     |
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.840     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.850     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.bge-base-en-v1.5.hnsw-int8.cached.yaml).

--- a/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -101,13 +101,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **BGE-base-en-v1.5**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.462     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.465     |
 | **nDCG@10**                                                                                                  | **BGE-base-en-v1.5**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.677     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.678     |
 | **R@100**                                                                                                    | **BGE-base-en-v1.5**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.711     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.717     |
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.848     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.850     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx.yaml).

--- a/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -109,8 +109,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.850     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw.cached.md
@@ -107,8 +107,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.850     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.bge-base-en-v1.5.hnsw.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw.cached.md
@@ -99,13 +99,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **BGE-base-en-v1.5**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.464     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.465     |
 | **nDCG@10**                                                                                                  | **BGE-base-en-v1.5**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.677     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.678     |
 | **R@100**                                                                                                    | **BGE-base-en-v1.5**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.714     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.717     |
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.840     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.850     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.bge-base-en-v1.5.hnsw.cached.yaml).

--- a/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw.onnx.md
@@ -107,8 +107,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.850     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.bge-base-en-v1.5.hnsw.onnx.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw.onnx.md
@@ -99,13 +99,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **BGE-base-en-v1.5**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.462     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.465     |
 | **nDCG@10**                                                                                                  | **BGE-base-en-v1.5**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.677     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.678     |
 | **R@100**                                                                                                    | **BGE-base-en-v1.5**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.712     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.717     |
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.849     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.850     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.bge-base-en-v1.5.hnsw.onnx.yaml).

--- a/docs/regressions/regressions-dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
@@ -94,13 +94,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cohere-embed-english-v3.0**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.505     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.507     |
 | **nDCG@10**                                                                                                  | **cohere-embed-english-v3.0**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.722     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.725     |
 | **R@100**                                                                                                    | **cohere-embed-english-v3.0**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.720     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.728     |
 | **R@1000**                                                                                                   | **cohere-embed-english-v3.0**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.858     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.868     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached.yaml).

--- a/docs/regressions/regressions-dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
@@ -102,8 +102,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cohere-embed-english-v3.0**|
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.868     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl20-passage.cohere-embed-english-v3.0.hnsw.cached.md
+++ b/docs/regressions/regressions-dl20-passage.cohere-embed-english-v3.0.hnsw.cached.md
@@ -102,8 +102,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cohere-embed-english-v3.0**|
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.868     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.cohere-embed-english-v3.0.hnsw.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl20-passage.cohere-embed-english-v3.0.hnsw.cached.md
+++ b/docs/regressions/regressions-dl20-passage.cohere-embed-english-v3.0.hnsw.cached.md
@@ -94,13 +94,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cohere-embed-english-v3.0**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.505     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.507     |
 | **nDCG@10**                                                                                                  | **cohere-embed-english-v3.0**|
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.725     |
 | **R@100**                                                                                                    | **cohere-embed-english-v3.0**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.724     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.728     |
 | **R@1000**                                                                                                   | **cohere-embed-english-v3.0**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.864     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.868     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.cohere-embed-english-v3.0.hnsw.cached.yaml).

--- a/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw-int8.cached.md
@@ -101,13 +101,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cosDPR-distil**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.482     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.488     |
 | **nDCG@10**                                                                                                  | **cosDPR-distil**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.701     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.702     |
 | **R@100**                                                                                                    | **cosDPR-distil**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.712     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.720     |
 | **R@1000**                                                                                                   | **cosDPR-distil**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.843     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.853     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.cos-dpr-distil.hnsw-int8.cached.yaml).

--- a/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw-int8.cached.md
@@ -109,8 +109,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cosDPR-distil**|
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.853     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.cos-dpr-distil.hnsw-int8.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw-int8.onnx.md
@@ -111,8 +111,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cosDPR-distil**|
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.853     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.cos-dpr-distil.hnsw-int8.onnx.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw-int8.onnx.md
@@ -103,13 +103,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cosDPR-distil**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.482     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.488     |
 | **nDCG@10**                                                                                                  | **cosDPR-distil**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.701     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.702     |
 | **R@100**                                                                                                    | **cosDPR-distil**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.712     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.720     |
 | **R@1000**                                                                                                   | **cosDPR-distil**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.843     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.853     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.cos-dpr-distil.hnsw-int8.onnx.yaml).

--- a/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw.cached.md
+++ b/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw.cached.md
@@ -99,13 +99,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cosDPR-distil**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.482     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.488     |
 | **nDCG@10**                                                                                                  | **cosDPR-distil**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.701     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.702     |
 | **R@100**                                                                                                    | **cosDPR-distil**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.712     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.720     |
 | **R@1000**                                                                                                   | **cosDPR-distil**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.843     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.853     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.cos-dpr-distil.hnsw.cached.yaml).

--- a/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw.cached.md
+++ b/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw.cached.md
@@ -107,8 +107,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cosDPR-distil**|
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.853     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.cos-dpr-distil.hnsw.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw.onnx.md
+++ b/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw.onnx.md
@@ -101,13 +101,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cosDPR-distil**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.482     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.488     |
 | **nDCG@10**                                                                                                  | **cosDPR-distil**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.701     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.702     |
 | **R@100**                                                                                                    | **cosDPR-distil**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.712     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.720     |
 | **R@1000**                                                                                                   | **cosDPR-distil**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.843     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.853     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.cos-dpr-distil.hnsw.onnx.yaml).

--- a/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw.onnx.md
+++ b/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw.onnx.md
@@ -109,8 +109,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cosDPR-distil**|
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.853     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.cos-dpr-distil.hnsw.onnx.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl20-passage.openai-ada2.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl20-passage.openai-ada2.hnsw-int8.cached.md
@@ -103,11 +103,11 @@ With the above commands, you should be able to reproduce the following results:
 |:-------------------------------------------------------------------------------------------------------------|-----------|
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.477     |
 | **nDCG@10**                                                                                                  | **OpenAI-ada2**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.675     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.676     |
 | **R@100**                                                                                                    | **OpenAI-ada2**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.727     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.724     |
 | **R@1000**                                                                                                   | **OpenAI-ada2**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.866     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.871     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.openai-ada2.hnsw-int8.cached.yaml).

--- a/docs/regressions/regressions-dl20-passage.openai-ada2.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl20-passage.openai-ada2.hnsw-int8.cached.md
@@ -109,8 +109,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **OpenAI-ada2**|
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.871     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.openai-ada2.hnsw-int8.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-dl20-passage.openai-ada2.hnsw.cached.md
+++ b/docs/regressions/regressions-dl20-passage.openai-ada2.hnsw.cached.md
@@ -103,9 +103,9 @@ With the above commands, you should be able to reproduce the following results:
 | **nDCG@10**                                                                                                  | **OpenAI-ada2**|
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.676     |
 | **R@100**                                                                                                    | **OpenAI-ada2**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.723     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.724     |
 | **R@1000**                                                                                                   | **OpenAI-ada2**|
-| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.867     |
+| [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.871     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.openai-ada2.hnsw.cached.yaml).

--- a/docs/regressions/regressions-dl20-passage.openai-ada2.hnsw.cached.md
+++ b/docs/regressions/regressions-dl20-passage.openai-ada2.hnsw.cached.md
@@ -107,8 +107,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **OpenAI-ada2**|
 | [DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)                                                   | 0.871     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/dl20-passage.openai-ada2.hnsw.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -105,8 +105,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.981     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](../../docs/reproducibility.md)
 

--- a/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -97,13 +97,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **BGE-base-en-v1.5**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.362     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.364     |
 | **RR@10**                                                                                                    | **BGE-base-en-v1.5**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.356     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.358     |
 | **R@100**                                                                                                    | **BGE-base-en-v1.5**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.897     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.901     |
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.977     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.981     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.cached.yaml).

--- a/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -97,13 +97,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **BGE-base-en-v1.5**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.362     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.364     |
 | **RR@10**                                                                                                    | **BGE-base-en-v1.5**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.356     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.358     |
 | **R@100**                                                                                                    | **BGE-base-en-v1.5**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.897     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.901     |
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.977     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.981     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.yaml).

--- a/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -105,8 +105,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.981     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](../../docs/reproducibility.md)
 

--- a/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw.cached.md
@@ -103,8 +103,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.981     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.bge-base-en-v1.5.hnsw.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](../../docs/reproducibility.md)
 

--- a/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw.cached.md
@@ -95,13 +95,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **BGE-base-en-v1.5**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.363     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.364     |
 | **RR@10**                                                                                                    | **BGE-base-en-v1.5**|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.358     |
 | **R@100**                                                                                                    | **BGE-base-en-v1.5**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.897     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.901     |
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.977     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.981     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.bge-base-en-v1.5.hnsw.cached.yaml).

--- a/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.md
@@ -103,8 +103,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.981     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](../../docs/reproducibility.md)
 

--- a/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.md
@@ -95,13 +95,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **BGE-base-en-v1.5**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.363     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.364     |
 | **RR@10**                                                                                                    | **BGE-base-en-v1.5**|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.358     |
 | **R@100**                                                                                                    | **BGE-base-en-v1.5**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.897     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.901     |
 | **R@1000**                                                                                                   | **BGE-base-en-v1.5**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.977     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.981     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.yaml).

--- a/docs/regressions/regressions-msmarco-v1-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
@@ -103,8 +103,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cohere-embed-english-v3.0**|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.979     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.cohere-embed-english-v3.0.hnsw-int8.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](../../docs/reproducibility.md)
 

--- a/docs/regressions/regressions-msmarco-v1-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
@@ -95,13 +95,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **nDCG@10**                                                                                                  | **cohere-embed-english-v3.0**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.427     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.429     |
 | **AP@1000**                                                                                                  | **cohere-embed-english-v3.0**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.371     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.372     |
 | **RR@10**                                                                                                    | **cohere-embed-english-v3.0**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.365     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.366     |
 | **R@1000**                                                                                                   | **cohere-embed-english-v3.0**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.974     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.979     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.cohere-embed-english-v3.0.hnsw-int8.cached.yaml).

--- a/docs/regressions/regressions-msmarco-v1-passage.cohere-embed-english-v3.0.hnsw.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cohere-embed-english-v3.0.hnsw.cached.md
@@ -93,13 +93,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **nDCG@10**                                                                                                  | **cohere-embed-english-v3.0**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.428     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.429     |
 | **AP@1000**                                                                                                  | **cohere-embed-english-v3.0**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.371     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.372     |
 | **RR@10**                                                                                                    | **cohere-embed-english-v3.0**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.365     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.366     |
 | **R@1000**                                                                                                   | **cohere-embed-english-v3.0**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.974     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.979     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.cohere-embed-english-v3.0.hnsw.cached.yaml).

--- a/docs/regressions/regressions-msmarco-v1-passage.cohere-embed-english-v3.0.hnsw.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cohere-embed-english-v3.0.hnsw.cached.md
@@ -101,8 +101,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cohere-embed-english-v3.0**|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.979     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.cohere-embed-english-v3.0.hnsw.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](../../docs/reproducibility.md)
 

--- a/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw-int8.cached.md
@@ -97,13 +97,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cosDPR-distil**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.393     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.394     |
 | **RR@10**                                                                                                    | **cosDPR-distil**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.388     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.390     |
 | **R@100**                                                                                                    | **cosDPR-distil**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.903     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.908     |
 | **R@1000**                                                                                                   | **cosDPR-distil**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.974     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.980     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.cos-dpr-distil.hnsw-int8.cached.yaml).

--- a/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw-int8.cached.md
@@ -105,8 +105,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cosDPR-distil**|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.980     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.cos-dpr-distil.hnsw-int8.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](../../docs/reproducibility.md)
 

--- a/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.md
@@ -99,13 +99,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cosDPR-distil**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.393     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.394     |
 | **RR@10**                                                                                                    | **cosDPR-distil**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.388     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.390     |
 | **R@100**                                                                                                    | **cosDPR-distil**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.903     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.908     |
 | **R@1000**                                                                                                   | **cosDPR-distil**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.974     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.980     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.yaml).

--- a/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.md
@@ -107,8 +107,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cosDPR-distil**|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.980     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](../../docs/reproducibility.md)
 

--- a/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw.cached.md
@@ -95,13 +95,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cosDPR-distil**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.393     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.394     |
 | **RR@10**                                                                                                    | **cosDPR-distil**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.388     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.390     |
 | **R@100**                                                                                                    | **cosDPR-distil**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.903     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.908     |
 | **R@1000**                                                                                                   | **cosDPR-distil**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.974     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.980     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.cos-dpr-distil.hnsw.cached.yaml).

--- a/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw.cached.md
@@ -103,8 +103,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cosDPR-distil**|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.980     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.cos-dpr-distil.hnsw.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](../../docs/reproducibility.md)
 

--- a/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.md
@@ -105,8 +105,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **cosDPR-distil**|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.980     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](../../docs/reproducibility.md)
 

--- a/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.md
@@ -97,13 +97,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **cosDPR-distil**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.393     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.394     |
 | **RR@10**                                                                                                    | **cosDPR-distil**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.388     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.390     |
 | **R@100**                                                                                                    | **cosDPR-distil**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.903     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.908     |
 | **R@1000**                                                                                                   | **cosDPR-distil**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.974     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.980     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.yaml).

--- a/docs/regressions/regressions-msmarco-v1-passage.openai-ada2.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.openai-ada2.hnsw-int8.cached.md
@@ -97,13 +97,13 @@ With the above commands, you should be able to reproduce the following results:
 
 | **AP@1000**                                                                                                  | **OpenAI-ada2**|
 |:-------------------------------------------------------------------------------------------------------------|-----------|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.343     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.350     |
 | **RR@10**                                                                                                    | **OpenAI-ada2**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.336     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.343     |
 | **R@100**                                                                                                    | **OpenAI-ada2**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.894     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.900     |
 | **R@1000**                                                                                                   | **OpenAI-ada2**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.983     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.986     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.openai-ada2.hnsw-int8.cached.yaml).

--- a/docs/regressions/regressions-msmarco-v1-passage.openai-ada2.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.openai-ada2.hnsw-int8.cached.md
@@ -105,8 +105,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **OpenAI-ada2**|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.986     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.openai-ada2.hnsw-int8.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](../../docs/reproducibility.md)
 

--- a/docs/regressions/regressions-msmarco-v1-passage.openai-ada2.hnsw.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.openai-ada2.hnsw.cached.md
@@ -99,9 +99,9 @@ With the above commands, you should be able to reproduce the following results:
 | **RR@10**                                                                                                    | **OpenAI-ada2**|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.343     |
 | **R@100**                                                                                                    | **OpenAI-ada2**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.898     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.900     |
 | **R@1000**                                                                                                   | **OpenAI-ada2**|
-| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.985     |
+| [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.986     |
 
 Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
 Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.openai-ada2.hnsw.cached.yaml).

--- a/docs/regressions/regressions-msmarco-v1-passage.openai-ada2.hnsw.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.openai-ada2.hnsw.cached.md
@@ -103,8 +103,9 @@ With the above commands, you should be able to reproduce the following results:
 | **R@1000**                                                                                                   | **OpenAI-ada2**|
 | [MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)                                | 0.986     |
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](../../src/main/resources/regression/msmarco-v1-passage.openai-ada2.hnsw.cached.yaml).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](../../docs/reproducibility.md)
 

--- a/src/main/python/run_regression.py
+++ b/src/main/python/run_regression.py
@@ -263,6 +263,52 @@ hnsw_model_type_pattern = re.compile(r'(hnsw-int8-onnx|hnsw-int8-cached|hnsw-onn
 
 beir_dataset_pattern = re.compile(r'BEIR \(v1.0.0\): (.*)$')
 
+msmarco_v1_flat_int8_onnx = defaultdict(lambda: 0.002)
+msmarco_v1_flat_int8_cached = defaultdict(lambda: 0.002)
+msmarco_v1_flat_int8_cached['openai-ada2-flat-int8-cached'] = 0.008
+msmarco_v1_flat_onnx = defaultdict(lambda: 0.0001)
+msmarco_v1_flat_cached = defaultdict(lambda: 1e-9)
+
+msmarco_v1_flat_tolerance = {
+    'flat-int8-onnx': msmarco_v1_flat_int8_onnx,
+    'flat-int8-cached': msmarco_v1_flat_int8_cached,
+    'flat-onnx': msmarco_v1_flat_onnx,
+    'flat-cached': msmarco_v1_flat_cached,
+}
+
+dl19_flat_int8_onnx = defaultdict(lambda: 0.002)
+dl19_flat_int8_onnx['bge-flat-int8-onnx'] = 0.007
+dl19_flat_int8_onnx['cos-dpr-distil-flat-int8-onnx'] = 0.004
+dl19_flat_int8_cached = defaultdict(lambda: 0.002)
+dl19_flat_int8_cached['openai-ada2-flat-int8-cached'] = 0.008
+dl19_flat_onnx = defaultdict(lambda: 0.0001)
+dl19_flat_onnx['bge-flat-onnx'] = 0.008
+dl19_flat_cached = defaultdict(lambda: 1e-9)
+
+dl19_flat_tolerance = {
+    'flat-int8-onnx': dl19_flat_int8_onnx,
+    'flat-int8-cached': dl19_flat_int8_cached,
+    'flat-onnx': dl19_flat_onnx,
+    'flat-cached': dl19_flat_cached,
+}
+
+dl20_flat_int8_onnx = defaultdict(lambda: 0.002)
+dl20_flat_int8_onnx['bge-flat-int8-onnx'] = 0.004
+dl20_flat_int8_onnx['cos-dpr-distil-flat-int8-onnx'] = 0.004
+dl20_flat_int8_cached = defaultdict(lambda: 0.002)
+dl20_flat_int8_cached['bge-flat-int8-cached'] = 0.005
+dl20_flat_int8_cached['cos-dpr-distil-flat-int8-cached'] = 0.004
+dl20_flat_onnx = defaultdict(lambda: 0.0001)
+dl20_flat_onnx['bge-flat-onnx'] = 0.005
+dl20_flat_cached = defaultdict(lambda: 1e-9)
+
+dl20_flat_tolerance = {
+    'flat-int8-onnx': dl20_flat_int8_onnx,
+    'flat-int8-cached': dl20_flat_int8_cached,
+    'flat-onnx': dl20_flat_onnx,
+    'flat-cached': dl20_flat_cached,
+}
+
 
 def evaluate_and_verify(yaml_data, dry_run):
     fail_str = '\033[91m[FAIL]\033[0m '
@@ -295,73 +341,77 @@ def evaluate_and_verify(yaml_data, dry_run):
                 using_hnsw = True if 'type' in model and model['type'] == 'hnsw' else False
                 using_flat = True if 'type' in model and model['type'] == 'flat' else False
 
+                if using_flat:
+                    # Extract model
+                    match = flat_model_type_pattern.search(model['name'])
+                    model_type = match.group(1)
+
                 if using_flat and 'BEIR' in topic_set['name']:
                     # Extract BEIR dataset
                     match = beir_dataset_pattern.search(topic_set['name'])
                     beir_dataset = match.group(1)
 
-                    # Extract model
-                    match = flat_model_type_pattern.search(model['name'])
-                    model_type = match.group(1)
-
                     # Lookup tolerance
                     tolerance_ok = beir_flat_tolerance[model_type][beir_dataset]
                 elif using_flat and 'MS MARCO Passage' in topic_set['name']:
-                    if model['name'].endswith('-flat-int8-onnx'):
-                        tolerance_ok = 0.002
-                    elif model['name'].endswith('-flat-int8-cached'):
-                        if model['name'] == 'openai-ada2-flat-int8-cached':
-                            tolerance_ok = 0.008
-                        else:
-                            tolerance_ok = 0.002
-                    elif model['name'].endswith('-flat-onnx'):
-                        tolerance_ok = 0.0001
-                    else:
-                        tolerance_ok = 1e-9
+                    tolerance_ok = msmarco_v1_flat_tolerance[model_type][model['name']]
+#                     if model['name'].endswith('-flat-int8-onnx'):
+#                         tolerance_ok = 0.002
+#                     elif model['name'].endswith('-flat-int8-cached'):
+#                         if model['name'] == 'openai-ada2-flat-int8-cached':
+#                             tolerance_ok = 0.008
+#                         else:
+#                             tolerance_ok = 0.002
+#                     elif model['name'].endswith('-flat-onnx'):
+#                         tolerance_ok = 0.0001
+#                     else:
+#                         tolerance_ok = 1e-9
                 elif using_flat and 'DL19' in topic_set['name']:
-                    if model['name'].endswith('-flat-int8-onnx'):
-                        if model['name'] == 'bge-flat-int8-onnx':
-                            tolerance_ok = 0.007
-                        elif model['name'] == 'cos-dpr-distil-flat-int8-onnx':
-                            tolerance_ok = 0.004
-                        else:
-                            tolerance_ok = 0.002
-                    elif model['name'].endswith('-flat-int8-cached'):
-                        if model['name'] == 'openai-ada2-flat-int8-cached':
-                            tolerance_ok = 0.008
-                        else:
-                            tolerance_ok = 0.002
-                    elif model['name'].endswith('-flat-onnx'):
-                        if model['name'] == 'bge-flat-onnx':
-                            tolerance_ok = 0.008
-                        else:
-                            tolerance_ok = 0.0001
-                    else:
-                        tolerance_ok = 1e-9
+                    tolerance_ok = dl19_flat_tolerance[model_type][model['name']]
+#                     if model['name'].endswith('-flat-int8-onnx'):
+#                         if model['name'] == 'bge-flat-int8-onnx':
+#                             tolerance_ok = 0.007
+#                         elif model['name'] == 'cos-dpr-distil-flat-int8-onnx':
+#                             tolerance_ok = 0.004
+#                         else:
+#                             tolerance_ok = 0.002
+#                     elif model['name'].endswith('-flat-int8-cached'):
+#                         if model['name'] == 'openai-ada2-flat-int8-cached':
+#                             tolerance_ok = 0.008
+#                         else:
+#                             tolerance_ok = 0.002
+#                     elif model['name'].endswith('-flat-onnx'):
+#                         if model['name'] == 'bge-flat-onnx':
+#                             tolerance_ok = 0.008
+#                         else:
+#                             tolerance_ok = 0.0001
+#                     else:
+#                         tolerance_ok = 1e-9
                 elif using_flat and 'DL20' in topic_set['name']:
-                    if model['name'].endswith('-flat-int8-onnx'):
-                        if model['name'] == 'bge-flat-int8-onnx':
-                            tolerance_ok = 0.004
-                        elif model['name'] == 'cos-dpr-distil-flat-int8-onnx':
-                            tolerance_ok = 0.004
-                        else:
-                            tolerance_ok = 0.002
-                    elif model['name'].endswith('-flat-int8-cached'):
-                        if model['name'] == 'bge-flat-int8-cached':
-                            tolerance_ok = 0.005
-                        elif model['name'] == 'cos-dpr-distil-flat-int8-cached':
-                            tolerance_ok = 0.004
-                        else:
-                            tolerance_ok = 0.002
-                    elif model['name'].endswith('-flat-onnx'):
-                        if model['name'] == 'bge-flat-onnx':
-                            tolerance_ok = 0.005
-                        else:
-                            tolerance_ok = 0.0001
-                    else:
-                        tolerance_ok = 1e-9
-                else:
-                    tolerance_ok = 1e-9
+                    tolerance_ok = dl20_flat_tolerance[model_type][model['name']]
+#                     if model['name'].endswith('-flat-int8-onnx'):
+#                         if model['name'] == 'bge-flat-int8-onnx':
+#                             tolerance_ok = 0.004
+#                         elif model['name'] == 'cos-dpr-distil-flat-int8-onnx':
+#                             tolerance_ok = 0.004
+#                         else:
+#                             tolerance_ok = 0.002
+#                     elif model['name'].endswith('-flat-int8-cached'):
+#                         if model['name'] == 'bge-flat-int8-cached':
+#                             tolerance_ok = 0.005
+#                         elif model['name'] == 'cos-dpr-distil-flat-int8-cached':
+#                             tolerance_ok = 0.004
+#                         else:
+#                             tolerance_ok = 0.002
+#                     elif model['name'].endswith('-flat-onnx'):
+#                         if model['name'] == 'bge-flat-onnx':
+#                             tolerance_ok = 0.005
+#                         else:
+#                             tolerance_ok = 0.0001
+#                     else:
+#                         tolerance_ok = 1e-9
+#                 else:
+#                     tolerance_ok = 1e-9
 
                 if using_hnsw and 'BEIR' in topic_set['name']:
                     # Extract BEIR dataset

--- a/src/main/python/run_regression.py
+++ b/src/main/python/run_regression.py
@@ -322,12 +322,17 @@ msmarco_v1_hnsw_tolerance = {
 }
 
 dl19_hnsw_int8_onnx = defaultdict(lambda: 0.01)
+dl19_hnsw_int8_onnx['bge-hnsw-int8-onnx'] = 0.02
 dl19_hnsw_int8_onnx['cos-dpr-distil-hnsw-int8-onnx'] = 0.02
 dl19_hnsw_int8_cached = defaultdict(lambda: 0.01)
 dl19_hnsw_int8_cached['cohere-embed-english-v3.0-hnsw-int8-cached'] = 0.015
 dl19_hnsw_int8_cached['cos-dpr-distil-hnsw-int8-cached'] = 0.02
+dl19_hnsw_int8_cached['openai-ada2-hnsw-int8-cached'] = 0.015
 dl19_hnsw_onnx = defaultdict(lambda: 0.01)
+dl19_hnsw_onnx['bge-hnsw-onnx'] = 0.02
 dl19_hnsw_cached = defaultdict(lambda: 0.01)
+dl19_hnsw_cached['cohere-embed-english-v3.0-hnsw-cached'] = 0.02
+dl19_hnsw_cached['cos-dpr-distil-hnsw-cached'] = 0.015
 
 dl19_hnsw_tolerance = {
     'hnsw-int8-onnx': dl19_hnsw_int8_onnx,
@@ -341,7 +346,7 @@ dl20_hnsw_int8_cached = defaultdict(lambda: 0.01)
 dl20_hnsw_int8_cached['cohere-embed-english-v3.0-hnsw-int8-cached'] = 0.012
 dl20_hnsw_onnx = defaultdict(lambda: 0.01)
 dl20_hnsw_cached = defaultdict(lambda: 0.01)
-dl20_hnsw_cached['cohere-embed-english-v3.0-hnsw-cached'] = 0.015
+dl20_hnsw_cached['cohere-embed-english-v3.0-hnsw-cached'] = 0.025
 
 dl20_hnsw_tolerance = {
     'hnsw-int8-onnx': dl20_hnsw_int8_onnx,

--- a/src/main/python/run_regression.py
+++ b/src/main/python/run_regression.py
@@ -278,7 +278,6 @@ msmarco_v1_flat_tolerance = {
 
 dl19_flat_int8_onnx = defaultdict(lambda: 0.002)
 dl19_flat_int8_onnx['bge-flat-int8-onnx'] = 0.008
-#dl19_flat_int8_onnx['cos-dpr-distil-flat-int8-onnx'] = 0.004
 dl19_flat_int8_cached = defaultdict(lambda: 0.002)
 dl19_flat_int8_cached['bge-flat-int8-cached'] = 0.005
 dl19_flat_int8_cached['openai-ada2-flat-int8-cached'] = 0.008
@@ -295,7 +294,6 @@ dl19_flat_tolerance = {
 
 dl20_flat_int8_onnx = defaultdict(lambda: 0.002)
 dl20_flat_int8_onnx['bge-flat-int8-onnx'] = 0.004
-#dl20_flat_int8_onnx['cos-dpr-distil-flat-int8-onnx'] = 0.004
 dl20_flat_int8_cached = defaultdict(lambda: 0.002)
 dl20_flat_int8_cached['bge-flat-int8-cached'] = 0.005
 dl20_flat_int8_cached['cos-dpr-distil-flat-int8-cached'] = 0.004
@@ -324,7 +322,10 @@ msmarco_v1_hnsw_tolerance = {
 }
 
 dl19_hnsw_int8_onnx = defaultdict(lambda: 0.01)
+dl19_hnsw_int8_onnx['cos-dpr-distil-hnsw-int8-onnx'] = 0.02
 dl19_hnsw_int8_cached = defaultdict(lambda: 0.01)
+dl19_hnsw_int8_cached['cohere-embed-english-v3.0-hnsw-int8-cached'] = 0.015
+dl19_hnsw_int8_cached['cos-dpr-distil-hnsw-int8-cached'] = 0.02
 dl19_hnsw_onnx = defaultdict(lambda: 0.01)
 dl19_hnsw_cached = defaultdict(lambda: 0.01)
 
@@ -337,8 +338,10 @@ dl19_hnsw_tolerance = {
 
 dl20_hnsw_int8_onnx = defaultdict(lambda: 0.01)
 dl20_hnsw_int8_cached = defaultdict(lambda: 0.01)
+dl20_hnsw_int8_cached['cohere-embed-english-v3.0-hnsw-int8-cached'] = 0.012
 dl20_hnsw_onnx = defaultdict(lambda: 0.01)
 dl20_hnsw_cached = defaultdict(lambda: 0.01)
+dl20_hnsw_cached['cohere-embed-english-v3.0-hnsw-cached'] = 0.015
 
 dl20_hnsw_tolerance = {
     'hnsw-int8-onnx': dl20_hnsw_int8_onnx,

--- a/src/main/python/run_regression.py
+++ b/src/main/python/run_regression.py
@@ -277,9 +277,10 @@ msmarco_v1_flat_tolerance = {
 }
 
 dl19_flat_int8_onnx = defaultdict(lambda: 0.002)
-dl19_flat_int8_onnx['bge-flat-int8-onnx'] = 0.007
-dl19_flat_int8_onnx['cos-dpr-distil-flat-int8-onnx'] = 0.004
+dl19_flat_int8_onnx['bge-flat-int8-onnx'] = 0.008
+#dl19_flat_int8_onnx['cos-dpr-distil-flat-int8-onnx'] = 0.004
 dl19_flat_int8_cached = defaultdict(lambda: 0.002)
+dl19_flat_int8_cached['bge-flat-int8-cached'] = 0.005
 dl19_flat_int8_cached['openai-ada2-flat-int8-cached'] = 0.008
 dl19_flat_onnx = defaultdict(lambda: 0.0001)
 dl19_flat_onnx['bge-flat-onnx'] = 0.008
@@ -294,10 +295,11 @@ dl19_flat_tolerance = {
 
 dl20_flat_int8_onnx = defaultdict(lambda: 0.002)
 dl20_flat_int8_onnx['bge-flat-int8-onnx'] = 0.004
-dl20_flat_int8_onnx['cos-dpr-distil-flat-int8-onnx'] = 0.004
+#dl20_flat_int8_onnx['cos-dpr-distil-flat-int8-onnx'] = 0.004
 dl20_flat_int8_cached = defaultdict(lambda: 0.002)
 dl20_flat_int8_cached['bge-flat-int8-cached'] = 0.005
 dl20_flat_int8_cached['cos-dpr-distil-flat-int8-cached'] = 0.004
+dl20_flat_int8_cached['cohere-embed-english-v3.0-flat-int8-cached'] = 0.004
 dl20_flat_onnx = defaultdict(lambda: 0.0001)
 dl20_flat_onnx['bge-flat-onnx'] = 0.005
 dl20_flat_cached = defaultdict(lambda: 1e-9)
@@ -309,40 +311,40 @@ dl20_flat_tolerance = {
     'flat-cached': dl20_flat_cached,
 }
 
-msmarco_v1_hnsw_int8_onnx = defaultdict(lambda: 0.002)
-msmarco_v1_hnsw_int8_cached = defaultdict(lambda: 0.002)
-msmarco_v1_hnsw_onnx = defaultdict(lambda: 0.0001)
-msmarco_v1_hnsw_cached = defaultdict(lambda: 1e-9)
+msmarco_v1_hnsw_int8_onnx = defaultdict(lambda: 0.01)
+msmarco_v1_hnsw_int8_cached = defaultdict(lambda: 0.01)
+msmarco_v1_hnsw_onnx = defaultdict(lambda: 0.01)
+msmarco_v1_hnsw_cached = defaultdict(lambda: 0.01)
 
 msmarco_v1_hnsw_tolerance = {
-    'flat-int8-onnx': msmarco_v1_hnsw_int8_onnx,
-    'flat-int8-cached': msmarco_v1_hnsw_int8_cached,
-    'flat-onnx': msmarco_v1_hnsw_onnx,
-    'flat-cached': msmarco_v1_hnsw_cached,
+    'hnsw-int8-onnx': msmarco_v1_hnsw_int8_onnx,
+    'hnsw-int8-cached': msmarco_v1_hnsw_int8_cached,
+    'hnsw-onnx': msmarco_v1_hnsw_onnx,
+    'hnsw-cached': msmarco_v1_hnsw_cached,
 }
 
-dl19_hnsw_int8_onnx = defaultdict(lambda: 0.002)
-dl19_hnsw_int8_cached = defaultdict(lambda: 0.002)
-dl19_hnsw_onnx = defaultdict(lambda: 0.0001)
-dl19_hnsw_cached = defaultdict(lambda: 1e-9)
+dl19_hnsw_int8_onnx = defaultdict(lambda: 0.01)
+dl19_hnsw_int8_cached = defaultdict(lambda: 0.01)
+dl19_hnsw_onnx = defaultdict(lambda: 0.01)
+dl19_hnsw_cached = defaultdict(lambda: 0.01)
 
 dl19_hnsw_tolerance = {
-    'flat-int8-onnx': dl19_hnsw_int8_onnx,
-    'flat-int8-cached': dl19_hnsw_int8_cached,
-    'flat-onnx': dl19_hnsw_onnx,
-    'flat-cached': dl19_hnsw_cached,
+    'hnsw-int8-onnx': dl19_hnsw_int8_onnx,
+    'hnsw-int8-cached': dl19_hnsw_int8_cached,
+    'hnsw-onnx': dl19_hnsw_onnx,
+    'hnsw-cached': dl19_hnsw_cached,
 }
 
-dl20_hnsw_int8_onnx = defaultdict(lambda: 0.002)
-dl20_hnsw_int8_cached = defaultdict(lambda: 0.002)
-dl20_hnsw_onnx = defaultdict(lambda: 0.0001)
-dl20_hnsw_cached = defaultdict(lambda: 1e-9)
+dl20_hnsw_int8_onnx = defaultdict(lambda: 0.01)
+dl20_hnsw_int8_cached = defaultdict(lambda: 0.01)
+dl20_hnsw_onnx = defaultdict(lambda: 0.01)
+dl20_hnsw_cached = defaultdict(lambda: 0.01)
 
 dl20_hnsw_tolerance = {
-    'flat-int8-onnx': dl20_hnsw_int8_onnx,
-    'flat-int8-cached': dl20_hnsw_int8_cached,
-    'flat-onnx': dl20_hnsw_onnx,
-    'flat-cached': dl20_hnsw_cached,
+    'hnsw-int8-onnx': dl20_hnsw_int8_onnx,
+    'hnsw-int8-cached': dl20_hnsw_int8_cached,
+    'hnsw-onnx': dl20_hnsw_onnx,
+    'hnsw-cached': dl20_hnsw_cached,
 }
 
 def evaluate_and_verify(yaml_data, dry_run):

--- a/src/main/python/run_regression.py
+++ b/src/main/python/run_regression.py
@@ -312,7 +312,9 @@ dl20_flat_tolerance = {
 msmarco_v1_hnsw_int8_onnx = defaultdict(lambda: 0.01)
 msmarco_v1_hnsw_int8_cached = defaultdict(lambda: 0.01)
 msmarco_v1_hnsw_onnx = defaultdict(lambda: 0.01)
+msmarco_v1_hnsw_onnx['cos-dpr-distil-hnsw-onnx']  = 0.015
 msmarco_v1_hnsw_cached = defaultdict(lambda: 0.01)
+msmarco_v1_hnsw_cached['cos-dpr-distil-hnsw-cached'] = 0.015
 
 msmarco_v1_hnsw_tolerance = {
     'hnsw-int8-onnx': msmarco_v1_hnsw_int8_onnx,
@@ -323,12 +325,13 @@ msmarco_v1_hnsw_tolerance = {
 
 dl19_hnsw_int8_onnx = defaultdict(lambda: 0.01)
 dl19_hnsw_int8_onnx['bge-hnsw-int8-onnx'] = 0.02
-dl19_hnsw_int8_onnx['cos-dpr-distil-hnsw-int8-onnx'] = 0.02
+dl19_hnsw_int8_onnx['cos-dpr-distil-hnsw-int8-onnx'] = 0.025
 dl19_hnsw_int8_cached = defaultdict(lambda: 0.01)
+dl19_hnsw_int8_cached['bge-hnsw-int8-cached'] = 0.015
 dl19_hnsw_int8_cached['cohere-embed-english-v3.0-hnsw-int8-cached'] = 0.015
-dl19_hnsw_int8_cached['cos-dpr-distil-hnsw-int8-cached'] = 0.02
+dl19_hnsw_int8_cached['cos-dpr-distil-hnsw-int8-cached'] = 0.025
 dl19_hnsw_int8_cached['openai-ada2-hnsw-int8-cached'] = 0.015
-dl19_hnsw_onnx = defaultdict(lambda: 0.01)
+dl19_hnsw_onnx = defaultdict(lambda: 0.015)
 dl19_hnsw_onnx['bge-hnsw-onnx'] = 0.02
 dl19_hnsw_cached = defaultdict(lambda: 0.01)
 dl19_hnsw_cached['cohere-embed-english-v3.0-hnsw-cached'] = 0.02
@@ -343,10 +346,13 @@ dl19_hnsw_tolerance = {
 
 dl20_hnsw_int8_onnx = defaultdict(lambda: 0.01)
 dl20_hnsw_int8_cached = defaultdict(lambda: 0.01)
+dl20_hnsw_int8_cached['bge-hnsw-int8-cached'] = 0.015
 dl20_hnsw_int8_cached['cohere-embed-english-v3.0-hnsw-int8-cached'] = 0.012
-dl20_hnsw_onnx = defaultdict(lambda: 0.01)
+dl20_hnsw_onnx = defaultdict(lambda: 0.015)
 dl20_hnsw_cached = defaultdict(lambda: 0.01)
+dl20_hnsw_cached['bge-hnsw-cached'] = 0.015
 dl20_hnsw_cached['cohere-embed-english-v3.0-hnsw-cached'] = 0.025
+dl20_hnsw_cached['cos-dpr-distil-hnsw-cached'] = 0.015
 
 dl20_hnsw_tolerance = {
     'hnsw-int8-onnx': dl20_hnsw_int8_onnx,
@@ -354,6 +360,7 @@ dl20_hnsw_tolerance = {
     'hnsw-onnx': dl20_hnsw_onnx,
     'hnsw-cached': dl20_hnsw_cached,
 }
+
 
 def evaluate_and_verify(yaml_data, dry_run):
     fail_str = '\033[91m[FAIL]\033[0m '

--- a/src/main/python/run_regression.py
+++ b/src/main/python/run_regression.py
@@ -309,6 +309,41 @@ dl20_flat_tolerance = {
     'flat-cached': dl20_flat_cached,
 }
 
+msmarco_v1_hnsw_int8_onnx = defaultdict(lambda: 0.002)
+msmarco_v1_hnsw_int8_cached = defaultdict(lambda: 0.002)
+msmarco_v1_hnsw_onnx = defaultdict(lambda: 0.0001)
+msmarco_v1_hnsw_cached = defaultdict(lambda: 1e-9)
+
+msmarco_v1_hnsw_tolerance = {
+    'flat-int8-onnx': msmarco_v1_hnsw_int8_onnx,
+    'flat-int8-cached': msmarco_v1_hnsw_int8_cached,
+    'flat-onnx': msmarco_v1_hnsw_onnx,
+    'flat-cached': msmarco_v1_hnsw_cached,
+}
+
+dl19_hnsw_int8_onnx = defaultdict(lambda: 0.002)
+dl19_hnsw_int8_cached = defaultdict(lambda: 0.002)
+dl19_hnsw_onnx = defaultdict(lambda: 0.0001)
+dl19_hnsw_cached = defaultdict(lambda: 1e-9)
+
+dl19_hnsw_tolerance = {
+    'flat-int8-onnx': dl19_hnsw_int8_onnx,
+    'flat-int8-cached': dl19_hnsw_int8_cached,
+    'flat-onnx': dl19_hnsw_onnx,
+    'flat-cached': dl19_hnsw_cached,
+}
+
+dl20_hnsw_int8_onnx = defaultdict(lambda: 0.002)
+dl20_hnsw_int8_cached = defaultdict(lambda: 0.002)
+dl20_hnsw_onnx = defaultdict(lambda: 0.0001)
+dl20_hnsw_cached = defaultdict(lambda: 1e-9)
+
+dl20_hnsw_tolerance = {
+    'flat-int8-onnx': dl20_hnsw_int8_onnx,
+    'flat-int8-cached': dl20_hnsw_int8_cached,
+    'flat-onnx': dl20_hnsw_onnx,
+    'flat-cached': dl20_hnsw_cached,
+}
 
 def evaluate_and_verify(yaml_data, dry_run):
     fail_str = '\033[91m[FAIL]\033[0m '
@@ -346,84 +381,36 @@ def evaluate_and_verify(yaml_data, dry_run):
                     match = flat_model_type_pattern.search(model['name'])
                     model_type = match.group(1)
 
-                if using_flat and 'BEIR' in topic_set['name']:
-                    # Extract BEIR dataset
-                    match = beir_dataset_pattern.search(topic_set['name'])
-                    beir_dataset = match.group(1)
+                    if 'BEIR' in topic_set['name']:
+                        # Extract BEIR dataset
+                        match = beir_dataset_pattern.search(topic_set['name'])
+                        beir_dataset = match.group(1)
 
-                    # Lookup tolerance
-                    tolerance_ok = beir_flat_tolerance[model_type][beir_dataset]
-                elif using_flat and 'MS MARCO Passage' in topic_set['name']:
-                    tolerance_ok = msmarco_v1_flat_tolerance[model_type][model['name']]
-#                     if model['name'].endswith('-flat-int8-onnx'):
-#                         tolerance_ok = 0.002
-#                     elif model['name'].endswith('-flat-int8-cached'):
-#                         if model['name'] == 'openai-ada2-flat-int8-cached':
-#                             tolerance_ok = 0.008
-#                         else:
-#                             tolerance_ok = 0.002
-#                     elif model['name'].endswith('-flat-onnx'):
-#                         tolerance_ok = 0.0001
-#                     else:
-#                         tolerance_ok = 1e-9
-                elif using_flat and 'DL19' in topic_set['name']:
-                    tolerance_ok = dl19_flat_tolerance[model_type][model['name']]
-#                     if model['name'].endswith('-flat-int8-onnx'):
-#                         if model['name'] == 'bge-flat-int8-onnx':
-#                             tolerance_ok = 0.007
-#                         elif model['name'] == 'cos-dpr-distil-flat-int8-onnx':
-#                             tolerance_ok = 0.004
-#                         else:
-#                             tolerance_ok = 0.002
-#                     elif model['name'].endswith('-flat-int8-cached'):
-#                         if model['name'] == 'openai-ada2-flat-int8-cached':
-#                             tolerance_ok = 0.008
-#                         else:
-#                             tolerance_ok = 0.002
-#                     elif model['name'].endswith('-flat-onnx'):
-#                         if model['name'] == 'bge-flat-onnx':
-#                             tolerance_ok = 0.008
-#                         else:
-#                             tolerance_ok = 0.0001
-#                     else:
-#                         tolerance_ok = 1e-9
-                elif using_flat and 'DL20' in topic_set['name']:
-                    tolerance_ok = dl20_flat_tolerance[model_type][model['name']]
-#                     if model['name'].endswith('-flat-int8-onnx'):
-#                         if model['name'] == 'bge-flat-int8-onnx':
-#                             tolerance_ok = 0.004
-#                         elif model['name'] == 'cos-dpr-distil-flat-int8-onnx':
-#                             tolerance_ok = 0.004
-#                         else:
-#                             tolerance_ok = 0.002
-#                     elif model['name'].endswith('-flat-int8-cached'):
-#                         if model['name'] == 'bge-flat-int8-cached':
-#                             tolerance_ok = 0.005
-#                         elif model['name'] == 'cos-dpr-distil-flat-int8-cached':
-#                             tolerance_ok = 0.004
-#                         else:
-#                             tolerance_ok = 0.002
-#                     elif model['name'].endswith('-flat-onnx'):
-#                         if model['name'] == 'bge-flat-onnx':
-#                             tolerance_ok = 0.005
-#                         else:
-#                             tolerance_ok = 0.0001
-#                     else:
-#                         tolerance_ok = 1e-9
-#                 else:
-#                     tolerance_ok = 1e-9
+                        tolerance_ok = beir_flat_tolerance[model_type][beir_dataset]
+                    elif 'MS MARCO Passage' in topic_set['name']:
+                        tolerance_ok = msmarco_v1_flat_tolerance[model_type][model['name']]
+                    elif 'DL19' in topic_set['name']:
+                        tolerance_ok = dl19_flat_tolerance[model_type][model['name']]
+                    elif using_flat and 'DL20' in topic_set['name']:
+                        tolerance_ok = dl20_flat_tolerance[model_type][model['name']]
 
-                if using_hnsw and 'BEIR' in topic_set['name']:
-                    # Extract BEIR dataset
-                    match = beir_dataset_pattern.search(topic_set['name'])
-                    beir_dataset = match.group(1)
-
+                if using_hnsw:
                     # Extract model
                     match = hnsw_model_type_pattern.search(model['name'])
                     model_type = match.group(1)
 
-                    # Lookup tolerance
-                    tolerance_ok = beir_hnsw_tolerance[model_type][beir_dataset]
+                    if 'BEIR' in topic_set['name']:
+                        # Extract BEIR dataset
+                        match = beir_dataset_pattern.search(topic_set['name'])
+                        beir_dataset = match.group(1)
+
+                        tolerance_ok = beir_hnsw_tolerance[model_type][beir_dataset]
+                    elif 'MS MARCO Passage' in topic_set['name']:
+                        tolerance_ok = msmarco_v1_hnsw_tolerance[model_type][model['name']]
+                    elif 'DL19' in topic_set['name']:
+                        tolerance_ok = dl19_hnsw_tolerance[model_type][model['name']]
+                    elif 'DL20' in topic_set['name']:
+                        tolerance_ok = dl20_hnsw_tolerance[model_type][model['name']]
 
                 if using_flat or using_hnsw:
                     result_str = (f'expected: {expected:.4f} actual: {actual:.4f} '

--- a/src/main/resources/docgen/templates/dl19-passage.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/dl19-passage.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -87,8 +87,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -87,8 +87,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl19-passage.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/dl19-passage.bge-base-en-v1.5.hnsw.cached.template
@@ -85,8 +85,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl19-passage.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage.bge-base-en-v1.5.hnsw.onnx.template
@@ -85,8 +85,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached.template
@@ -80,8 +80,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl19-passage.cohere-embed-english-v3.0.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/dl19-passage.cohere-embed-english-v3.0.hnsw.cached.template
@@ -80,8 +80,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl19-passage.cos-dpr-distil.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/dl19-passage.cos-dpr-distil.hnsw-int8.cached.template
@@ -87,8 +87,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl19-passage.cos-dpr-distil.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage.cos-dpr-distil.hnsw-int8.onnx.template
@@ -89,8 +89,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl19-passage.cos-dpr-distil.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/dl19-passage.cos-dpr-distil.hnsw.cached.template
@@ -85,8 +85,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl19-passage.cos-dpr-distil.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage.cos-dpr-distil.hnsw.onnx.template
@@ -87,8 +87,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl19-passage.openai-ada2.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/dl19-passage.openai-ada2.hnsw-int8.cached.template
@@ -87,8 +87,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl19-passage.openai-ada2.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/dl19-passage.openai-ada2.hnsw.cached.template
@@ -85,8 +85,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl20-passage.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/dl20-passage.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -87,8 +87,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -87,8 +87,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl20-passage.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/dl20-passage.bge-base-en-v1.5.hnsw.cached.template
@@ -85,8 +85,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl20-passage.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage.bge-base-en-v1.5.hnsw.onnx.template
@@ -85,8 +85,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached.template
@@ -80,8 +80,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl20-passage.cohere-embed-english-v3.0.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/dl20-passage.cohere-embed-english-v3.0.hnsw.cached.template
@@ -80,8 +80,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl20-passage.cos-dpr-distil.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/dl20-passage.cos-dpr-distil.hnsw-int8.cached.template
@@ -87,8 +87,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl20-passage.cos-dpr-distil.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage.cos-dpr-distil.hnsw-int8.onnx.template
@@ -89,8 +89,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl20-passage.cos-dpr-distil.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/dl20-passage.cos-dpr-distil.hnsw.cached.template
@@ -85,8 +85,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl20-passage.cos-dpr-distil.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage.cos-dpr-distil.hnsw.onnx.template
@@ -87,8 +87,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl20-passage.openai-ada2.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/dl20-passage.openai-ada2.hnsw-int8.cached.template
@@ -87,8 +87,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/dl20-passage.openai-ada2.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/dl20-passage.openai-ada2.hnsw.cached.template
@@ -85,8 +85,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ❗ Retrieval metrics here are computed to depth 1000 hits per query (as opposed to 100 hits per query for document ranking).
 For computing nDCG, remember that we keep qrels of _all_ relevance grades, whereas for other metrics (e.g., AP), relevance grade 1 is considered not relevant (i.e., use the `-l 2` option in `trec_eval`).

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -83,8 +83,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](${root_path}/docs/reproducibility.md)
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -83,8 +83,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](${root_path}/docs/reproducibility.md)
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.bge-base-en-v1.5.hnsw.cached.template
@@ -81,8 +81,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](${root_path}/docs/reproducibility.md)
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.template
@@ -81,8 +81,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](${root_path}/docs/reproducibility.md)
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.cohere-embed-english-v3.0.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.cohere-embed-english-v3.0.hnsw-int8.cached.template
@@ -81,8 +81,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](${root_path}/docs/reproducibility.md)
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.cohere-embed-english-v3.0.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.cohere-embed-english-v3.0.hnsw.cached.template
@@ -79,8 +79,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](${root_path}/docs/reproducibility.md)
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.cos-dpr-distil.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.cos-dpr-distil.hnsw-int8.cached.template
@@ -83,8 +83,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](${root_path}/docs/reproducibility.md)
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.template
@@ -85,8 +85,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](${root_path}/docs/reproducibility.md)
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.cos-dpr-distil.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.cos-dpr-distil.hnsw.cached.template
@@ -81,8 +81,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](${root_path}/docs/reproducibility.md)
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.template
@@ -83,8 +83,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With ONNX query encoding on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](${root_path}/docs/reproducibility.md)
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.openai-ada2.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.openai-ada2.hnsw-int8.cached.template
@@ -83,8 +83,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that both HNSW indexing and quantization are non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](${root_path}/docs/reproducibility.md)
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.openai-ada2.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.openai-ada2.hnsw.cached.template
@@ -81,8 +81,9 @@ With the above commands, you should be able to reproduce the following results:
 
 ${effectiveness}
 
-Note that due to the non-deterministic nature of HNSW indexing, results may differ slightly between each experimental run.
-Nevertheless, scores are generally within 0.005 of the reference values recorded in [our YAML configuration file](${yaml}).
+The above figures are from running brute-force search with cached queries on non-quantized **flat** indexes.
+With cached queries on non-quantized HNSW indexes, observed results are likely to differ; scores may be lower by up to 0.01, sometimes more.
+Note that HNSW indexing is non-deterministic (i.e., results may differ slightly between trials).
 
 ## Reproduction Log[*](${root_path}/docs/reproducibility.md)
 

--- a/src/main/resources/regression/dl19-passage.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/dl19-passage.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.443
+        - 0.4435
       nDCG@10:
-        - 0.708
+        - 0.7065
       R@100:
-        - 0.614
+        - 0.6171
       R@1000:
-        - 0.843
+        - 0.8472

--- a/src/main/resources/regression/dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
     results:
       AP@1000:
-        - 0.444
+        - 0.4435
       nDCG@10:
-        - 0.702
+        - 0.7065
       R@100:
-        - 0.609
+        - 0.6171
       R@1000:
-        - 0.836
+        - 0.8472

--- a/src/main/resources/regression/dl19-passage.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/dl19-passage.bge-base-en-v1.5.hnsw.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.442
+        - 0.4435
       nDCG@10:
-        - 0.706
+        - 0.7065
       R@100:
-        - 0.616
+        - 0.6171
       R@1000:
-        - 0.842
+        - 0.8472

--- a/src/main/resources/regression/dl19-passage.bge-base-en-v1.5.hnsw.onnx.yaml
+++ b/src/main/resources/regression/dl19-passage.bge-base-en-v1.5.hnsw.onnx.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
     results:
       AP@1000:
-        - 0.447
+        - 0.4435
       nDCG@10:
-        - 0.701
+        - 0.7065
       R@100:
-        - 0.607
+        - 0.6171
       R@1000:
-        - 0.837
+        - 0.8472

--- a/src/main/resources/regression/dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.487
+        - 0.4884
       nDCG@10:
-        - 0.690
+        - 0.6956
       R@100:
-        - 0.647
+        - 0.6484
       R@1000:
-        - 0.850
+        - 0.8630

--- a/src/main/resources/regression/dl19-passage.cohere-embed-english-v3.0.hnsw.cached.yaml
+++ b/src/main/resources/regression/dl19-passage.cohere-embed-english-v3.0.hnsw.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.486
+        - 0.4884
       nDCG@10:
-        - 0.690
+        - 0.6956
       R@100:
-        - 0.645
+        - 0.6484
       R@1000:
-        - 0.851
+        - 0.8630

--- a/src/main/resources/regression/dl19-passage.cos-dpr-distil.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/dl19-passage.cos-dpr-distil.hnsw-int8.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.458
+        - 0.4656
       nDCG@10:
-        - 0.717
+        - 0.7250
       R@100:
-        - 0.605
+        - 0.6173
       R@1000:
-        - 0.805
+        - 0.8201

--- a/src/main/resources/regression/dl19-passage.cos-dpr-distil.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/dl19-passage.cos-dpr-distil.hnsw-int8.onnx.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder CosDprDistil
     results:
       AP@1000:
-        - 0.458
+        - 0.4656
       nDCG@10:
-        - 0.717
+        - 0.7250
       R@100:
-        - 0.605
+        - 0.6173
       R@1000:
-        - 0.805
+        - 0.8201

--- a/src/main/resources/regression/dl19-passage.cos-dpr-distil.hnsw.cached.yaml
+++ b/src/main/resources/regression/dl19-passage.cos-dpr-distil.hnsw.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.458
+        - 0.4656
       nDCG@10:
-        - 0.717
+        - 0.7250
       R@100:
-        - 0.605
+        - 0.6173
       R@1000:
-        - 0.805
+        - 0.8201

--- a/src/main/resources/regression/dl19-passage.cos-dpr-distil.hnsw.onnx.yaml
+++ b/src/main/resources/regression/dl19-passage.cos-dpr-distil.hnsw.onnx.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder CosDprDistil
     results:
       AP@1000:
-        - 0.458
+        - 0.4656
       nDCG@10:
-        - 0.717
+        - 0.7250
       R@100:
-        - 0.605
+        - 0.6173
       R@1000:
-        - 0.805
+        - 0.8201

--- a/src/main/resources/regression/dl19-passage.openai-ada2.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/dl19-passage.openai-ada2.hnsw-int8.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.478
+        - 0.4788
       nDCG@10:
-        - 0.707
+        - 0.7035
       R@100:
-        - 0.617
+        - 0.6235
       R@1000:
-        - 0.853
+        - 0.8629

--- a/src/main/resources/regression/dl19-passage.openai-ada2.hnsw.cached.yaml
+++ b/src/main/resources/regression/dl19-passage.openai-ada2.hnsw.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.479
+        - 0.4788
       nDCG@10:
-        - 0.704
+        - 0.7035
       R@100:
-        - 0.624
+        - 0.6235
       R@1000:
-        - 0.857
+        - 0.8629

--- a/src/main/resources/regression/dl20-passage.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/dl20-passage.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.463
+        - 0.4650
       nDCG@10:
-        - 0.674
+        - 0.6780
       R@100:
-        - 0.712
+        - 0.7169
       R@1000:
-        - 0.840
+        - 0.8503

--- a/src/main/resources/regression/dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
     results:
       AP@1000:
-        - 0.462
+        - 0.4650
       nDCG@10:
-        - 0.677
+        - 0.6780
       R@100:
-        - 0.711
+        - 0.7169
       R@1000:
-        - 0.848
+        - 0.8503

--- a/src/main/resources/regression/dl20-passage.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/dl20-passage.bge-base-en-v1.5.hnsw.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.464
+        - 0.4650
       nDCG@10:
-        - 0.677
+        - 0.6780
       R@100:
-        - 0.714
+        - 0.7169
       R@1000:
-        - 0.840
+        - 0.8503

--- a/src/main/resources/regression/dl20-passage.bge-base-en-v1.5.hnsw.onnx.yaml
+++ b/src/main/resources/regression/dl20-passage.bge-base-en-v1.5.hnsw.onnx.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
     results:
       AP@1000:
-        - 0.462
+        - 0.4650
       nDCG@10:
-        - 0.677
+        - 0.6780
       R@100:
-        - 0.712
+        - 0.7169
       R@1000:
-        - 0.849
+        - 0.8503

--- a/src/main/resources/regression/dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.505
+        - 0.5067
       nDCG@10:
-        - 0.722
+        - 0.7245
       R@100:
-        - 0.720
+        - 0.7279
       R@1000:
-        - 0.858
+        - 0.8682

--- a/src/main/resources/regression/dl20-passage.cohere-embed-english-v3.0.hnsw.cached.yaml
+++ b/src/main/resources/regression/dl20-passage.cohere-embed-english-v3.0.hnsw.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.505
+        - 0.5067
       nDCG@10:
-        - 0.725
+        - 0.7245
       R@100:
-        - 0.724
+        - 0.7279
       R@1000:
-        - 0.864
+        - 0.8682

--- a/src/main/resources/regression/dl20-passage.cos-dpr-distil.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/dl20-passage.cos-dpr-distil.hnsw-int8.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.482
+        - 0.4876
       nDCG@10:
-        - 0.701
+        - 0.7025
       R@100:
-        - 0.712
+        - 0.7204
       R@1000:
-        - 0.843
+        - 0.8533

--- a/src/main/resources/regression/dl20-passage.cos-dpr-distil.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/dl20-passage.cos-dpr-distil.hnsw-int8.onnx.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder CosDprDistil
     results:
       AP@1000:
-        - 0.482
+        - 0.4876
       nDCG@10:
-        - 0.701
+        - 0.7025
       R@100:
-        - 0.712
+        - 0.7204
       R@1000:
-        - 0.843
+        - 0.8533

--- a/src/main/resources/regression/dl20-passage.cos-dpr-distil.hnsw.cached.yaml
+++ b/src/main/resources/regression/dl20-passage.cos-dpr-distil.hnsw.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.482
+        - 0.4876
       nDCG@10:
-        - 0.701
+        - 0.7025
       R@100:
-        - 0.712
+        - 0.7204
       R@1000:
-        - 0.843
+        - 0.8533

--- a/src/main/resources/regression/dl20-passage.cos-dpr-distil.hnsw.onnx.yaml
+++ b/src/main/resources/regression/dl20-passage.cos-dpr-distil.hnsw.onnx.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder CosDprDistil
     results:
       AP@1000:
-        - 0.482
+        - 0.4876
       nDCG@10:
-        - 0.701
+        - 0.7025
       R@100:
-        - 0.712
+        - 0.7204
       R@1000:
-        - 0.843
+        - 0.8533

--- a/src/main/resources/regression/dl20-passage.openai-ada2.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/dl20-passage.openai-ada2.hnsw-int8.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.477
+        - 0.4771
       nDCG@10:
-        - 0.675
+        - 0.6759
       R@100:
-        - 0.727
+        - 0.7237
       R@1000:
-        - 0.866
+        - 0.8705

--- a/src/main/resources/regression/dl20-passage.openai-ada2.hnsw.cached.yaml
+++ b/src/main/resources/regression/dl20-passage.openai-ada2.hnsw.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.477
+        - 0.4771
       nDCG@10:
-        - 0.676
+        - 0.6759
       R@100:
-        - 0.723
+        - 0.7237
       R@1000:
-        - 0.867
+        - 0.8705

--- a/src/main/resources/regression/msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.362
+        - 0.3641
       RR@10:
-        - 0.356
+        - 0.3583
       R@100:
-        - 0.897
+        - 0.9006
       R@1000:
-        - 0.977
+        - 0.9811

--- a/src/main/resources/regression/msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
     results:
       AP@1000:
-        - 0.362
+        - 0.3641
       RR@10:
-        - 0.356
+        - 0.3583
       R@100:
-        - 0.897
+        - 0.9006
       R@1000:
-        - 0.977
+        - 0.9811

--- a/src/main/resources/regression/msmarco-v1-passage.bge-base-en-v1.5.hnsw.cached.yaml
+++ b/src/main/resources/regression/msmarco-v1-passage.bge-base-en-v1.5.hnsw.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.363
+        - 0.3641
       RR@10:
-        - 0.358
+        - 0.3583
       R@100:
-        - 0.897
+        - 0.9006
       R@1000:
-        - 0.977
+        - 0.9811

--- a/src/main/resources/regression/msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.yaml
+++ b/src/main/resources/regression/msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
     results:
       AP@1000:
-        - 0.363
+        - 0.3641
       RR@10:
-        - 0.358
+        - 0.3583
       R@100:
-        - 0.897
+        - 0.9006
       R@1000:
-        - 0.977
+        - 0.9811

--- a/src/main/resources/regression/msmarco-v1-passage.cohere-embed-english-v3.0.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/msmarco-v1-passage.cohere-embed-english-v3.0.hnsw-int8.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       nDCG@10:
-        - 0.427
+        - 0.4287
       AP@1000:
-        - 0.371
+        - 0.3716
       RR@10:
-        - 0.365
+        - 0.3658
       R@1000:
-        - 0.974
+        - 0.9786

--- a/src/main/resources/regression/msmarco-v1-passage.cohere-embed-english-v3.0.hnsw.cached.yaml
+++ b/src/main/resources/regression/msmarco-v1-passage.cohere-embed-english-v3.0.hnsw.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       nDCG@10:
-        - 0.428
+        - 0.4287
       AP@1000:
-        - 0.371
+        - 0.3716
       RR@10:
-        - 0.365
+        - 0.3658
       R@1000:
-        - 0.974
+        - 0.9786

--- a/src/main/resources/regression/msmarco-v1-passage.cos-dpr-distil.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/msmarco-v1-passage.cos-dpr-distil.hnsw-int8.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.393
+        - 0.3942
       RR@10:
-        - 0.388
+        - 0.3896
       R@100:
-        - 0.903
+        - 0.9075
       R@1000:
-        - 0.974
+        - 0.9796

--- a/src/main/resources/regression/msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder CosDprDistil
     results:
       AP@1000:
-        - 0.393
+        - 0.3942
       RR@10:
-        - 0.388
+        - 0.3896
       R@100:
-        - 0.903
+        - 0.9075
       R@1000:
-        - 0.974
+        - 0.9796

--- a/src/main/resources/regression/msmarco-v1-passage.cos-dpr-distil.hnsw.cached.yaml
+++ b/src/main/resources/regression/msmarco-v1-passage.cos-dpr-distil.hnsw.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.393
+        - 0.3942
       RR@10:
-        - 0.388
+        - 0.3896
       R@100:
-        - 0.903
+        - 0.9075
       R@1000:
-        - 0.974
+        - 0.9796

--- a/src/main/resources/regression/msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.yaml
+++ b/src/main/resources/regression/msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField title -threads 16 -hits 1000 -efSearch 1000 -encoder CosDprDistil
     results:
       AP@1000:
-        - 0.393
+        - 0.3942
       RR@10:
-        - 0.388
+        - 0.3896
       R@100:
-        - 0.903
+        - 0.9075
       R@1000:
-        - 0.974
+        - 0.9796

--- a/src/main/resources/regression/msmarco-v1-passage.openai-ada2.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/msmarco-v1-passage.openai-ada2.hnsw-int8.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.343
+        - 0.3505
       RR@10:
-        - 0.336
+        - 0.3434
       R@100:
-        - 0.894
+        - 0.8996
       R@1000:
-        - 0.983
+        - 0.9858

--- a/src/main/resources/regression/msmarco-v1-passage.openai-ada2.hnsw.cached.yaml
+++ b/src/main/resources/regression/msmarco-v1-passage.openai-ada2.hnsw.cached.yaml
@@ -56,10 +56,10 @@ models:
     params: -generator VectorQueryGenerator -topicField vector -threads 16 -hits 1000 -efSearch 1000
     results:
       AP@1000:
-        - 0.350
+        - 0.3505
       RR@10:
-        - 0.343
+        - 0.3434
       R@100:
-        - 0.898
+        - 0.8996
       R@1000:
-        - 0.985
+        - 0.9858


### PR DESCRIPTION
Continuation of #2538 

+ tweak docs for flat indexes.
+ refactor tolerance values for HNSW indexes, calibrate wrt flat index scores.