### PR TITLE
Added reproduction log entry by @MehrnnazSadeghieh

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -499,3 +499,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@Feng-12138](https://github.com/Feng-12138) on 2024-06-16 (commit [`ad97377`](https://github.com/castorini/anserini/commit/ad97377e463e70ee8b2f501ac7c41134af53e976))
 + Results reproduced by [@hosnahoseini](https://github.com/hosnahoseini) on 2024-06-18 (commit [`ad97377`](https://github.com/castorini/anserini/commit/ad97377e463e70ee8b2f501ac7c41134af53e976))
 + Results reproduced by [@FaizanFaisal25](https://github.com/FaizanFaisal25) on 2024-06-29 (commit [`e92370a`](https://github.com/FaizanFaisal25/anserini/commit/e92370a06eaa3bbc5bacdba65cc9c3f125590071))
+Results reproduced by [@MehrnazSadeghieh](https://github.com/MehrnazSadeghieh) on 2024-07-12 (commit [`6817e19`](https://github.com/MehrnazSadeghieh/anserini/commit/6817e191e5cbf57c30b06b5a64429d0e24b60b87))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -393,3 +393,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@Feng-12138](https://github.com/Feng-12138) on 2024-06-15 (commit [`ad97377`](https://github.com/castorini/anserini/commit/ad97377e463e70ee8b2f501ac7c41134af53e976))
 + Results reproduced by [@hosnahoseini](https://github.com/hosnahoseini) on 2024-06-15 (commit [`ad97377`](https://github.com/castorini/anserini/commit/ad97377e463e70ee8b2f501ac7c41134af53e976))
 + Results reproduced by [@FaizanFaisal25](https://github.com/FaizanFaisal25) on 2024-06-25 (commit [`e92370a`](https://github.com/FaizanFaisal25/anserini/commit/e92370a06eaa3bbc5bacdba65cc9c3f125590071))
+Results reproduced by [@MehrnazSadeghieh](https://github.com/MehrnazSadeghieh) on 2024-07-10 (commit [`3885b5c`](https://github.com/MehrnazSadeghieh/anserini/commit/3885b5c25178d2a88fc3b953d572b518ef0d1da6))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -393,4 +393,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@Feng-12138](https://github.com/Feng-12138) on 2024-06-15 (commit [`ad97377`](https://github.com/castorini/anserini/commit/ad97377e463e70ee8b2f501ac7c41134af53e976))
 + Results reproduced by [@hosnahoseini](https://github.com/hosnahoseini) on 2024-06-15 (commit [`ad97377`](https://github.com/castorini/anserini/commit/ad97377e463e70ee8b2f501ac7c41134af53e976))
 + Results reproduced by [@FaizanFaisal25](https://github.com/FaizanFaisal25) on 2024-06-25 (commit [`e92370a`](https://github.com/FaizanFaisal25/anserini/commit/e92370a06eaa3bbc5bacdba65cc9c3f125590071))
-Results reproduced by [@MehrnazSadeghieh](https://github.com/MehrnazSadeghieh) on 2024-07-10 (commit [`3885b5c`](https://github.com/MehrnazSadeghieh/anserini/commit/3885b5c25178d2a88fc3b953d572b518ef0d1da6))
+Results reproduced by [@MehrnazSadeghieh](https://github.com/MehrnazSadeghieh) on 2024-07-12 (commit [`6817e19`](https://github.com/MehrnazSadeghieh/anserini/commit/6817e191e5cbf57c30b06b5a64429d0e24b60b87))


### PR DESCRIPTION
I reproduced results on macOS using MacBook terminal. Everything worked successfully, except for using `curl` instead of `wget` for downloading the dataset.

Setup details:
- Operating System: macOS
- Environment: MacBook terminal
- Configuration: Since `wget` command did not work for me i Used `curl -o collections/msmarco-passage/collectionandqueries.tar.gz https://msmarco.z22.web.core.windows.net/msmarcoranking/collectionandqueries.tar.gz` instead of `wget`.

All steps completed without any issues.
