### PR TITLE
Fixes missing else to setSimilarity options

### DIFF
--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -182,7 +182,7 @@ public final class IndexCollection extends AbstractIndexer {
     if (args.bm25Accurate) {
       // Necessary during indexing as the norm used in BM25 is already determined at index time.
       config.setSimilarity(new AccurateBM25Similarity());
-    } if (args.impact ) {
+    } else if (args.impact ) {
       config.setSimilarity(new ImpactSimilarity());
     } else {
       config.setSimilarity(new BM25Similarity());


### PR DESCRIPTION
I noticed the setSimilarity options were set up as if they were a block of if else statements --- without the else if. If you tried to set BM25Accurate, it would be overridden by BM25.