### PR TITLE
removed junit5 dependencies causing test error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -704,17 +704,5 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
-    </dependency> 
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.8.2</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Removed junit5 dependencies which caused the juni4 tests not recognized when building. 