### PR TITLE
Align all parquet BEIR yaml configs with jsonl versions

### DIFF
--- a/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-arguana.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-arguana.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): ArguAna"
+    id: test
+    path: topics.beir-v1.0.0-arguana.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-arguana.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.6361
+      R@100:
+        - 0.9915
+      R@1000:
+        - 0.9964
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-arguana.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-arguana.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-arguana.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-arguana.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): ArguAna"
+    id: test
+    path: topics.beir-v1.0.0-arguana.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-arguana.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.6361
+      R@100:
+        - 0.9915
+      R@1000:
+        - 0.9964
+    tolerance:
+      nDCG@10:
+        - 0.02
+      R@100:
+        - 0.03
+      R@1000:
+        - 0.004

--- a/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-arguana.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-arguana.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-arguana.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): ArguAna"
-  id: test
-  path: topics.beir-v1.0.0-arguana.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  - name: "BEIR (v1.0.0): ArguAna"
+    id: test
+    path: topics.beir-v1.0.0-arguana.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-arguana.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.6361
-    R@100:
-    - 0.9915
-    R@1000:
-    - 0.9964
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.6361
+      R@100:
+        - 0.9915
+      R@1000:
+        - 0.9964

--- a/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-arguana.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana.parquet
 
-index_path: indexes/parquet/arguana
+index_path: indexes/lucene-flat.beir-v1.0.0-arguana.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): ArguAna"
-  id: test
-  path: topics.beir-v1.0.0-arguana.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  - name: "BEIR (v1.0.0): ArguAna"
+    id: test
+    path: topics.beir-v1.0.0-arguana.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-arguana.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.6361
-    R@100:
-    - 0.9915
-    R@1000:
-    - 0.9964
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.6361
+      R@100:
+        - 0.9915
+      R@1000:
+        - 0.9964
+    tolerance:
+      nDCG@10:
+        - 0.02
+      R@100:
+        - 0.02
+      R@1000:
+        - 0.004

--- a/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-arguana.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-arguana.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): ArguAna"
+    id: test
+    path: topics.beir-v1.0.0-arguana.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-arguana.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.6361
+      R@100:
+        - 0.9915
+      R@1000:
+        - 0.9964
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-arguana.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-arguana.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): ArguAna"
+    id: test
+    path: topics.beir-v1.0.0-arguana.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-arguana.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.6361
+      R@100:
+        - 0.9915
+      R@1000:
+        - 0.9964
+    tolerance:
+      nDCG@10:
+        - 0.02
+      R@100:
+        - 0.025
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-arguana.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana.parquet
 
-index_path: indexes/parquet/arguana
+index_path: indexes/lucene-hnsw.beir-v1.0.0-arguana.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): ArguAna"
-  id: test
-  path: topics.beir-v1.0.0-arguana.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  - name: "BEIR (v1.0.0): ArguAna"
+    id: test
+    path: topics.beir-v1.0.0-arguana.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-arguana.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.6361
-    R@100:
-    - 0.9915
-    R@1000:
-    - 0.9964
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.6361
+      R@100:
+        - 0.9915
+      R@1000:
+        - 0.9964
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-arguana.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/arguana.parquet
 
-index_path: indexes/parquet/arguana
+index_path: indexes/lucene-hnsw.beir-v1.0.0-arguana.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): ArguAna"
-  id: test
-  path: topics.beir-v1.0.0-arguana.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-arguana.test.txt
+  - name: "BEIR (v1.0.0): ArguAna"
+    id: test
+    path: topics.beir-v1.0.0-arguana.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-arguana.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.6361
-    R@100:
-    - 0.9915
-    R@1000:
-    - 0.9964
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.6361
+      R@100:
+        - 0.9915
+      R@1000:
+        - 0.9964
+    tolerance:
+      nDCG@10:
+        - 0.02
+      R@100:
+        - 0.02
+      R@1000:
+        - 0.004

--- a/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-bioasq.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-bioasq.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): BioASQ"
+    id: test
+    path: topics.beir-v1.0.0-bioasq.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-bioasq.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4149
+      R@100:
+        - 0.6317
+      R@1000:
+        - 0.8059
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.004
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-bioasq.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-bioasq.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-bioasq.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-bioasq.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): BioASQ"
+    id: test
+    path: topics.beir-v1.0.0-bioasq.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-bioasq.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4149
+      R@100:
+        - 0.6317
+      R@1000:
+        - 0.8059
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-bioasq.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-bioasq.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-bioasq.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): BioASQ"
-  id: test
-  path: topics.beir-v1.0.0-bioasq.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-bioasq.test.txt
+  - name: "BEIR (v1.0.0): BioASQ"
+    id: test
+    path: topics.beir-v1.0.0-bioasq.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-bioasq.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.4149
-    R@100:
-    - 0.6317
-    R@1000:
-    - 0.8059
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4149
+      R@100:
+        - 0.6317
+      R@1000:
+        - 0.8059

--- a/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-bioasq.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq.parquet
 
-index_path: indexes/parquet/bioasq
+index_path: indexes/lucene-flat.beir-v1.0.0-bioasq.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): BioASQ"
-  id: test
-  path: topics.beir-v1.0.0-bioasq.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-bioasq.test.txt
+  - name: "BEIR (v1.0.0): BioASQ"
+    id: test
+    path: topics.beir-v1.0.0-bioasq.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-bioasq.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4149
-    R@100:
-    - 0.6317
-    R@1000:
-    - 0.8059
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4149
+      R@100:
+        - 0.6317
+      R@1000:
+        - 0.8059
+    tolerance:
+      nDCG@10:
+        - 0.0002
+      R@100:
+        - 0.0002
+      R@1000:
+        - 0.0004

--- a/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-bioasq.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-bioasq.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): BioASQ"
+    id: test
+    path: topics.beir-v1.0.0-bioasq.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-bioasq.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 2000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4149
+      R@100:
+        - 0.6317
+      R@1000:
+        - 0.8059
+    tolerance:
+      nDCG@10:
+        - 0.03
+      R@100:
+        - 0.035
+      R@1000:
+        - 0.06

--- a/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-bioasq.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-bioasq.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 500 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): BioASQ"
+    id: test
+    path: topics.beir-v1.0.0-bioasq.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-bioasq.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 2000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4149
+      R@100:
+        - 0.6317
+      R@1000:
+        - 0.8059
+    tolerance:
+      nDCG@10:
+        - 0.03
+      R@100:
+        - 0.035
+      R@1000:
+        - 0.06

--- a/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-bioasq.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq.parquet
 
-index_path: indexes/parquet/bioasq
+index_path: indexes/lucene-hnsw.beir-v1.0.0-bioasq.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): BioASQ"
-  id: test
-  path: topics.beir-v1.0.0-bioasq.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-bioasq.test.txt
+  - name: "BEIR (v1.0.0): BioASQ"
+    id: test
+    path: topics.beir-v1.0.0-bioasq.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-bioasq.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 5000
-  results:
-    nDCG@10:
-    - 0.4149
-    R@100:
-    - 0.6317
-    R@1000:
-    - 0.8059
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 2000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4149
+      R@100:
+        - 0.6317
+      R@1000:
+        - 0.8059
+    tolerance:
+      nDCG@10:
+        - 0.02
+      R@100:
+        - 0.03
+      R@1000:
+        - 0.04

--- a/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-bioasq.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/bioasq.parquet
 
-index_path: indexes/parquet/bioasq
+index_path: indexes/lucene-hnsw.beir-v1.0.0-bioasq.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 500 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): BioASQ"
-  id: test
-  path: topics.beir-v1.0.0-bioasq.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-bioasq.test.txt
+  - name: "BEIR (v1.0.0): BioASQ"
+    id: test
+    path: topics.beir-v1.0.0-bioasq.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-bioasq.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 5000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4149
-    R@100:
-    - 0.6317
-    R@1000:
-    - 0.8059
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 2000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4149
+      R@100:
+        - 0.6317
+      R@1000:
+        - 0.8059
+    tolerance:
+      nDCG@10:
+        - 0.02
+      R@100:
+        - 0.03
+      R@1000:
+        - 0.04

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-climate-fever.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-climate-fever.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-climate-fever.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-climate-fever.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): Climate-FEVER"
+    id: test
+    path: topics.beir-v1.0.0-climate-fever.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-climate-fever.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3119
+      R@100:
+        - 0.6362
+      R@1000:
+        - 0.8307
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.004
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-climate-fever.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-climate-fever.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-climate-fever.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-climate-fever.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): Climate-FEVER"
+    id: test
+    path: topics.beir-v1.0.0-climate-fever.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-climate-fever.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3119
+      R@100:
+        - 0.6362
+      R@1000:
+        - 0.8307
+    tolerance:
+      nDCG@10:
+        - 0.005
+      R@100:
+        - 0.004
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-climate-fever.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): Climate-FEVER"
-  id: test
-  path: topics.beir-v1.0.0-climate-fever.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-climate-fever.test.txt
+  - name: "BEIR (v1.0.0): Climate-FEVER"
+    id: test
+    path: topics.beir-v1.0.0-climate-fever.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-climate-fever.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.3119
-    R@100:
-    - 0.6362
-    R@1000:
-    - 0.8307
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3119
+      R@100:
+        - 0.6362
+      R@1000:
+        - 0.8307

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-climate-fever.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever.parquet
 
-index_path: indexes/parquet/climate-fever
+index_path: indexes/lucene-flat.beir-v1.0.0-climate-fever.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): Climate-FEVER"
-  id: test
-  path: topics.beir-v1.0.0-climate-fever.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-climate-fever.test.txt
+  - name: "BEIR (v1.0.0): Climate-FEVER"
+    id: test
+    path: topics.beir-v1.0.0-climate-fever.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-climate-fever.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.3119
-    R@100:
-    - 0.6362
-    R@1000:
-    - 0.8307
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3119
+      R@100:
+        - 0.6362
+      R@1000:
+        - 0.8307
+    tolerance:
+      nDCG@10:
+        - 0.0003
+      R@100:
+        - 0.0009
+      R@1000:
+        - 0.0002

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-climate-fever.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-climate-fever.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): Climate-FEVER"
+    id: test
+    path: topics.beir-v1.0.0-climate-fever.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-climate-fever.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3119
+      R@100:
+        - 0.6362
+      R@1000:
+        - 0.8307
+    tolerance:
+      nDCG@10:
+        - 0.005
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-climate-fever.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-climate-fever.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): Climate-FEVER"
+    id: test
+    path: topics.beir-v1.0.0-climate-fever.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-climate-fever.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3119
+      R@100:
+        - 0.6362
+      R@1000:
+        - 0.8307
+    tolerance:
+      nDCG@10:
+        - 0.006
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-climate-fever.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever.parquet
 
-index_path: indexes/parquet/climate-fever
+index_path: indexes/lucene-hnsw.beir-v1.0.0-climate-fever.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): Climate-FEVER"
-  id: test
-  path: topics.beir-v1.0.0-climate-fever.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-climate-fever.test.txt
+  - name: "BEIR (v1.0.0): Climate-FEVER"
+    id: test
+    path: topics.beir-v1.0.0-climate-fever.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-climate-fever.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.3119
-    R@100:
-    - 0.6362
-    R@1000:
-    - 0.8307
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3119
+      R@100:
+        - 0.6362
+      R@1000:
+        - 0.8307
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-climate-fever.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/climate-fever.parquet
 
-index_path: indexes/parquet/climate-fever
+index_path: indexes/lucene-hnsw.beir-v1.0.0-climate-fever.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): Climate-FEVER"
-  id: test
-  path: topics.beir-v1.0.0-climate-fever.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-climate-fever.test.txt
+  - name: "BEIR (v1.0.0): Climate-FEVER"
+    id: test
+    path: topics.beir-v1.0.0-climate-fever.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-climate-fever.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.3119
-    R@100:
-    - 0.6362
-    R@1000:
-    - 0.8307
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3119
+      R@100:
+        - 0.6362
+      R@1000:
+        - 0.8307
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-android"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-android.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-android.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5075
+      R@100:
+        - 0.8454
+      R@1000:
+        - 0.9611
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-android"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-android.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-android.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5075
+      R@100:
+        - 0.8454
+      R@1000:
+        - 0.9611
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-android"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-android.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-android.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-android"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-android.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-android.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.5075
-    R@100:
-    - 0.8454
-    R@1000:
-    - 0.9611
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5075
+      R@100:
+        - 0.8454
+      R@1000:
+        - 0.9611

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android.parquet
 
-index_path: indexes/parquet/cqadupstack-android
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-android"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-android.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-android.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-android"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-android.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-android.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.5075
-    R@100:
-    - 0.8454
-    R@1000:
-    - 0.9611
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5075
+      R@100:
+        - 0.8454
+      R@1000:
+        - 0.9611
+    tolerance:
+      nDCG@10:
+        - 0.0002
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-android"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-android.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-android.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5075
+      R@100:
+        - 0.8454
+      R@1000:
+        - 0.9611
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-android"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-android.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-android.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5075
+      R@100:
+        - 0.8454
+      R@1000:
+        - 0.9611
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android.parquet
 
-index_path: indexes/parquet/cqadupstack-android
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-android"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-android.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-android.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-android"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-android.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-android.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.5075
-    R@100:
-    - 0.8454
-    R@1000:
-    - 0.9611
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5075
+      R@100:
+        - 0.8454
+      R@1000:
+        - 0.9611
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-android.parquet
 
-index_path: indexes/parquet/cqadupstack-android
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-android"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-android.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-android.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-android"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-android.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-android.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.5075
-    R@100:
-    - 0.8454
-    R@1000:
-    - 0.9611
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5075
+      R@100:
+        - 0.8454
+      R@1000:
+        - 0.9611
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-english"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-english.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-english.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4857
+      R@100:
+        - 0.7587
+      R@1000:
+        - 0.8839
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-english"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-english.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-english.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4857
+      R@100:
+        - 0.7587
+      R@1000:
+        - 0.8839
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-english"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-english.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-english.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-english"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-english.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-english.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.4857
-    R@100:
-    - 0.7587
-    R@1000:
-    - 0.8839
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4857
+      R@100:
+        - 0.7587
+      R@1000:
+        - 0.8839

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english.parquet
 
-index_path: indexes/parquet/cqadupstack-english
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-english"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-english.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-english.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-english"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-english.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-english.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4857
-    R@100:
-    - 0.7587
-    R@1000:
-    - 0.8839
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4857
+      R@100:
+        - 0.7587
+      R@1000:
+        - 0.8839
+    tolerance:
+      nDCG@10:
+        - 0.0001
+      R@100:
+        - 0.0002
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-english"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-english.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-english.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4857
+      R@100:
+        - 0.7587
+      R@1000:
+        - 0.8839
+    tolerance:
+      nDCG@10:
+        - 0.003
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-english"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-english.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-english.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4857
+      R@100:
+        - 0.7587
+      R@1000:
+        - 0.8839
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english.parquet
 
-index_path: indexes/parquet/cqadupstack-english
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-english"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-english.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-english.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-english"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-english.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-english.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.4857
-    R@100:
-    - 0.7587
-    R@1000:
-    - 0.8839
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4857
+      R@100:
+        - 0.7587
+      R@1000:
+        - 0.8839
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-english.parquet
 
-index_path: indexes/parquet/cqadupstack-english
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-english"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-english.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-english.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-english"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-english.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-english.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4857
-    R@100:
-    - 0.7587
-    R@1000:
-    - 0.8839
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4857
+      R@100:
+        - 0.7587
+      R@1000:
+        - 0.8839
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-gaming"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gaming.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gaming.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5965
+      R@100:
+        - 0.9036
+      R@1000:
+        - 0.9719
+    tolerance:
+      nDCG@10:
+        - 0.003
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-gaming"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gaming.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gaming.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5965
+      R@100:
+        - 0.9036
+      R@1000:
+        - 0.9719
+    tolerance:
+      nDCG@10:
+        - 0.003
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-gaming"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-gaming.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-gaming.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-gaming"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gaming.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gaming.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.5965
-    R@100:
-    - 0.9036
-    R@1000:
-    - 0.9719
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5965
+      R@100:
+        - 0.9036
+      R@1000:
+        - 0.9719

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming.parquet
 
-index_path: indexes/parquet/cqadupstack-gaming
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-gaming"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-gaming.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-gaming.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-gaming"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gaming.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gaming.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.5965
-    R@100:
-    - 0.9036
-    R@1000:
-    - 0.9719
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5965
+      R@100:
+        - 0.9036
+      R@1000:
+        - 0.9719
+    tolerance:
+      nDCG@10:
+        - 0.0003
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-gaming"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gaming.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gaming.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5965
+      R@100:
+        - 0.9036
+      R@1000:
+        - 0.9719
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-gaming"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gaming.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gaming.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5965
+      R@100:
+        - 0.9036
+      R@1000:
+        - 0.9719
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming.parquet
 
-index_path: indexes/parquet/cqadupstack-gaming
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-gaming"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-gaming.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-gaming.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-gaming"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gaming.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gaming.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.5965
-    R@100:
-    - 0.9036
-    R@1000:
-    - 0.9719
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5965
+      R@100:
+        - 0.9036
+      R@1000:
+        - 0.9719
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gaming.parquet
 
-index_path: indexes/parquet/cqadupstack-gaming
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-gaming"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-gaming.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-gaming.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-gaming"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gaming.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gaming.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.5965
-    R@100:
-    - 0.9036
-    R@1000:
-    - 0.9719
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5965
+      R@100:
+        - 0.9036
+      R@1000:
+        - 0.9719
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-gis"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gis.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gis.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4127
+      R@100:
+        - 0.7682
+      R@1000:
+        - 0.9117
+    tolerance:
+      nDCG@10:
+        - 0.003
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-gis"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gis.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gis.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4127
+      R@100:
+        - 0.7682
+      R@1000:
+        - 0.9117
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-gis"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-gis.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-gis.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-gis"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gis.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gis.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.4127
-    R@100:
-    - 0.7682
-    R@1000:
-    - 0.9117
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4127
+      R@100:
+        - 0.7682
+      R@1000:
+        - 0.9117

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis.parquet
 
-index_path: indexes/parquet/cqadupstack-gis
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-gis"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-gis.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-gis.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-gis"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gis.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gis.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4127
-    R@100:
-    - 0.7682
-    R@1000:
-    - 0.9117
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4127
+      R@100:
+        - 0.7682
+      R@1000:
+        - 0.9117
+    tolerance:
+      nDCG@10:
+        - 0.0005
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-gis"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gis.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gis.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4127
+      R@100:
+        - 0.7682
+      R@1000:
+        - 0.9117
+    tolerance:
+      nDCG@10:
+        - 0.003
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.004

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-gis"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gis.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gis.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4127
+      R@100:
+        - 0.7682
+      R@1000:
+        - 0.9117
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.004

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis.parquet
 
-index_path: indexes/parquet/cqadupstack-gis
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-gis"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-gis.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-gis.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-gis"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gis.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gis.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.4127
-    R@100:
-    - 0.7682
-    R@1000:
-    - 0.9117
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4127
+      R@100:
+        - 0.7682
+      R@1000:
+        - 0.9117
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-gis.parquet
 
-index_path: indexes/parquet/cqadupstack-gis
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-gis"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-gis.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-gis.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-gis"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-gis.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-gis.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4127
-    R@100:
-    - 0.7682
-    R@1000:
-    - 0.9117
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4127
+      R@100:
+        - 0.7682
+      R@1000:
+        - 0.9117
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-mathematica"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-mathematica.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3163
+      R@100:
+        - 0.6922
+      R@1000:
+        - 0.8810
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-mathematica"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-mathematica.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3163
+      R@100:
+        - 0.6922
+      R@1000:
+        - 0.8810
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-mathematica"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-mathematica.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-mathematica"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-mathematica.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.3163
-    R@100:
-    - 0.6922
-    R@1000:
-    - 0.8810
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3163
+      R@100:
+        - 0.6922
+      R@1000:
+        - 0.8810

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica.parquet
 
-index_path: indexes/parquet/cqadupstack-mathematica
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-mathematica"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-mathematica.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-mathematica"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-mathematica.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.3163
-    R@100:
-    - 0.6922
-    R@1000:
-    - 0.8810
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3163
+      R@100:
+        - 0.6922
+      R@1000:
+        - 0.8810
+    tolerance:
+      nDCG@10:
+        - 0.0001
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-mathematica"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-mathematica.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3163
+      R@100:
+        - 0.6922
+      R@1000:
+        - 0.8810
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-mathematica"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-mathematica.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3163
+      R@100:
+        - 0.6922
+      R@1000:
+        - 0.8810
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica.parquet
 
-index_path: indexes/parquet/cqadupstack-mathematica
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-mathematica"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-mathematica.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-mathematica"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-mathematica.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.3163
-    R@100:
-    - 0.6922
-    R@1000:
-    - 0.8810
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3163
+      R@100:
+        - 0.6922
+      R@1000:
+        - 0.8810
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-mathematica.parquet
 
-index_path: indexes/parquet/cqadupstack-mathematica
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-mathematica"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-mathematica.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-mathematica"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-mathematica.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.3163
-    R@100:
-    - 0.6922
-    R@1000:
-    - 0.8810
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3163
+      R@100:
+        - 0.6922
+      R@1000:
+        - 0.8810
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-physics"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-physics.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-physics.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4722
+      R@100:
+        - 0.8081
+      R@1000:
+        - 0.9406
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-physics"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-physics.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-physics.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4722
+      R@100:
+        - 0.8081
+      R@1000:
+        - 0.9406
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-physics"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-physics.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-physics.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-physics"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-physics.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-physics.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.4722
-    R@100:
-    - 0.8081
-    R@1000:
-    - 0.9406
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4722
+      R@100:
+        - 0.8081
+      R@1000:
+        - 0.9406

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics.parquet
 
-index_path: indexes/parquet/cqadupstack-physics
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-physics"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-physics.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-physics.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-physics"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-physics.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-physics.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4722
-    R@100:
-    - 0.8081
-    R@1000:
-    - 0.9406
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4722
+      R@100:
+        - 0.8081
+      R@1000:
+        - 0.9406
+    tolerance:
+      nDCG@10:
+        - 0.0003
+      R@100:
+        - 0.0004
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-physics"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-physics.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-physics.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4722
+      R@100:
+        - 0.8081
+      R@1000:
+        - 0.9406
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-physics"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-physics.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-physics.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4722
+      R@100:
+        - 0.8081
+      R@1000:
+        - 0.9406
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics.parquet
 
-index_path: indexes/parquet/cqadupstack-physics
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-physics"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-physics.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-physics.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-physics"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-physics.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-physics.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.4722
-    R@100:
-    - 0.8081
-    R@1000:
-    - 0.9406
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4722
+      R@100:
+        - 0.8081
+      R@1000:
+        - 0.9406
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-physics.parquet
 
-index_path: indexes/parquet/cqadupstack-physics
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-physics"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-physics.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-physics.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-physics"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-physics.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-physics.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4722
-    R@100:
-    - 0.8081
-    R@1000:
-    - 0.9406
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4722
+      R@100:
+        - 0.8081
+      R@1000:
+        - 0.9406
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-programmers"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-programmers.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-programmers.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4242
+      R@100:
+        - 0.7856
+      R@1000:
+        - 0.9348
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-programmers"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-programmers.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-programmers.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4242
+      R@100:
+        - 0.7856
+      R@1000:
+        - 0.9348
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-programmers"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-programmers.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-programmers.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-programmers"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-programmers.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-programmers.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.4242
-    R@100:
-    - 0.7856
-    R@1000:
-    - 0.9348
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4242
+      R@100:
+        - 0.7856
+      R@1000:
+        - 0.9348

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers.parquet
 
-index_path: indexes/parquet/cqadupstack-programmers
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-programmers"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-programmers.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-programmers.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-programmers"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-programmers.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-programmers.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4242
-    R@100:
-    - 0.7856
-    R@1000:
-    - 0.9348
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4242
+      R@100:
+        - 0.7856
+      R@1000:
+        - 0.9348
+    tolerance:
+      nDCG@10:
+        - 0.0005
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0006

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-programmers"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-programmers.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-programmers.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4242
+      R@100:
+        - 0.7856
+      R@1000:
+        - 0.9348
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-programmers"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-programmers.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-programmers.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4242
+      R@100:
+        - 0.7856
+      R@1000:
+        - 0.9348
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers.parquet
 
-index_path: indexes/parquet/cqadupstack-programmers
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-programmers"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-programmers.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-programmers.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-programmers"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-programmers.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-programmers.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.4242
-    R@100:
-    - 0.7856
-    R@1000:
-    - 0.9348
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4242
+      R@100:
+        - 0.7856
+      R@1000:
+        - 0.9348
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-programmers.parquet
 
-index_path: indexes/parquet/cqadupstack-programmers
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-programmers"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-programmers.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-programmers.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-programmers"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-programmers.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-programmers.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4242
-    R@100:
-    - 0.7856
-    R@1000:
-    - 0.9348
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4242
+      R@100:
+        - 0.7856
+      R@1000:
+        - 0.9348
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-stats"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-stats.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-stats.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3732
+      R@100:
+        - 0.6727
+      R@1000:
+        - 0.8445
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-stats"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-stats.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-stats.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3732
+      R@100:
+        - 0.6727
+      R@1000:
+        - 0.8445
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.005

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-stats"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-stats.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-stats.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-stats"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-stats.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-stats.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.3732
-    R@100:
-    - 0.6727
-    R@1000:
-    - 0.8445
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3732
+      R@100:
+        - 0.6727
+      R@1000:
+        - 0.8445

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats.parquet
 
-index_path: indexes/parquet/cqadupstack-stats
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-stats"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-stats.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-stats.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-stats"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-stats.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-stats.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.3732
-    R@100:
-    - 0.6727
-    R@1000:
-    - 0.8445
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3732
+      R@100:
+        - 0.6727
+      R@1000:
+        - 0.8445
+    tolerance:
+      nDCG@10:
+        - 0.0005
+      R@100:
+        - 0.0009
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-stats"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-stats.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-stats.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3732
+      R@100:
+        - 0.6727
+      R@1000:
+        - 0.8445
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.008

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-stats"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-stats.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-stats.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3732
+      R@100:
+        - 0.6727
+      R@1000:
+        - 0.8445
+    tolerance:
+      nDCG@10:
+        - 0.005
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.01

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats.parquet
 
-index_path: indexes/parquet/cqadupstack-stats
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-stats"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-stats.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-stats.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-stats"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-stats.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-stats.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.3732
-    R@100:
-    - 0.6727
-    R@1000:
-    - 0.8445
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3732
+      R@100:
+        - 0.6727
+      R@1000:
+        - 0.8445
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.005

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-stats.parquet
 
-index_path: indexes/parquet/cqadupstack-stats
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-stats"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-stats.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-stats.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-stats"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-stats.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-stats.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.3732
-    R@100:
-    - 0.6727
-    R@1000:
-    - 0.8445
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3732
+      R@100:
+        - 0.6727
+      R@1000:
+        - 0.8445
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.005

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-tex"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-tex.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-tex.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3115
+      R@100:
+        - 0.6486
+      R@1000:
+        - 0.8537
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-tex"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-tex.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-tex.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3115
+      R@100:
+        - 0.6486
+      R@1000:
+        - 0.8537
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-tex"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-tex.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-tex.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-tex"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-tex.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-tex.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.3115
-    R@100:
-    - 0.6486
-    R@1000:
-    - 0.8537
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3115
+      R@100:
+        - 0.6486
+      R@1000:
+        - 0.8537

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex.parquet
 
-index_path: indexes/parquet/cqadupstack-tex
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-tex"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-tex.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-tex.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-tex"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-tex.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-tex.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.3115
-    R@100:
-    - 0.6486
-    R@1000:
-    - 0.8537
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3115
+      R@100:
+        - 0.6486
+      R@1000:
+        - 0.8537
+    tolerance:
+      nDCG@10:
+        - 0.0001
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-tex"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-tex.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-tex.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3115
+      R@100:
+        - 0.6486
+      R@1000:
+        - 0.8537
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-tex"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-tex.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-tex.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3115
+      R@100:
+        - 0.6486
+      R@1000:
+        - 0.8537
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex.parquet
 
-index_path: indexes/parquet/cqadupstack-tex
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-tex"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-tex.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-tex.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-tex"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-tex.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-tex.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.3115
-    R@100:
-    - 0.6486
-    R@1000:
-    - 0.8537
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3115
+      R@100:
+        - 0.6486
+      R@1000:
+        - 0.8537
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-tex.parquet
 
-index_path: indexes/parquet/cqadupstack-tex
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-tex"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-tex.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-tex.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-tex"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-tex.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-tex.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.3115
-    R@100:
-    - 0.6486
-    R@1000:
-    - 0.8537
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3115
+      R@100:
+        - 0.6486
+      R@1000:
+        - 0.8537
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-unix"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-unix.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-unix.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4219
+      R@100:
+        - 0.7797
+      R@1000:
+        - 0.9237
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-unix"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-unix.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-unix.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4219
+      R@100:
+        - 0.7797
+      R@1000:
+        - 0.9237
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-unix"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-unix.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-unix.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-unix"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-unix.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-unix.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.4219
-    R@100:
-    - 0.7797
-    R@1000:
-    - 0.9237
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4219
+      R@100:
+        - 0.7797
+      R@1000:
+        - 0.9237

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix.parquet
 
-index_path: indexes/parquet/cqadupstack-unix
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-unix"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-unix.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-unix.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-unix"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-unix.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-unix.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4219
-    R@100:
-    - 0.7797
-    R@1000:
-    - 0.9237
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4219
+      R@100:
+        - 0.7797
+      R@1000:
+        - 0.9237
+    tolerance:
+      nDCG@10:
+        - 0.0001
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0003

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-unix"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-unix.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-unix.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4219
+      R@100:
+        - 0.7797
+      R@1000:
+        - 0.9237
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-unix"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-unix.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-unix.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4219
+      R@100:
+        - 0.7797
+      R@1000:
+        - 0.9237
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.004
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix.parquet
 
-index_path: indexes/parquet/cqadupstack-unix
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-unix"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-unix.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-unix.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-unix"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-unix.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-unix.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.4219
-    R@100:
-    - 0.7797
-    R@1000:
-    - 0.9237
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4219
+      R@100:
+        - 0.7797
+      R@1000:
+        - 0.9237
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-unix.parquet
 
-index_path: indexes/parquet/cqadupstack-unix
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-unix"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-unix.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-unix.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-unix"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-unix.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-unix.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4219
-    R@100:
-    - 0.7797
-    R@1000:
-    - 0.9237
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4219
+      R@100:
+        - 0.7797
+      R@1000:
+        - 0.9237
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-webmasters"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-webmasters.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4065
+      R@100:
+        - 0.7774
+      R@1000:
+        - 0.9380
+    tolerance:
+      nDCG@10:
+        - 0.005
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-webmasters"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-webmasters.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4065
+      R@100:
+        - 0.7774
+      R@1000:
+        - 0.9380
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-webmasters"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-webmasters.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-webmasters"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-webmasters.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.4065
-    R@100:
-    - 0.7774
-    R@1000:
-    - 0.9380
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4065
+      R@100:
+        - 0.7774
+      R@1000:
+        - 0.9380

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters.parquet
 
-index_path: indexes/parquet/cqadupstack-webmasters
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-webmasters"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-webmasters.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-webmasters"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-webmasters.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4065
-    R@100:
-    - 0.7774
-    R@1000:
-    - 0.9380
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4065
+      R@100:
+        - 0.7774
+      R@1000:
+        - 0.9380
+    tolerance:
+      nDCG@10:
+        - 0.0001
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-webmasters"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-webmasters.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4065
+      R@100:
+        - 0.7774
+      R@1000:
+        - 0.9380
+    tolerance:
+      nDCG@10:
+        - 0.005
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-webmasters"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-webmasters.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4065
+      R@100:
+        - 0.7774
+      R@1000:
+        - 0.9380
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.004
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters.parquet
 
-index_path: indexes/parquet/cqadupstack-webmasters
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-webmasters"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-webmasters.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-webmasters"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-webmasters.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.4065
-    R@100:
-    - 0.7774
-    R@1000:
-    - 0.9380
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4065
+      R@100:
+        - 0.7774
+      R@1000:
+        - 0.9380
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-webmasters.parquet
 
-index_path: indexes/parquet/cqadupstack-webmasters
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-webmasters"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-webmasters.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-webmasters"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-webmasters.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4065
-    R@100:
-    - 0.7774
-    R@1000:
-    - 0.9380
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4065
+      R@100:
+        - 0.7774
+      R@1000:
+        - 0.9380
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-wordpress"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-wordpress.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3547
+      R@100:
+        - 0.7065
+      R@1000:
+        - 0.8861
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-wordpress"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-wordpress.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3547
+      R@100:
+        - 0.7065
+      R@1000:
+        - 0.8861
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-wordpress"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-wordpress.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-wordpress"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-wordpress.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.3547
-    R@100:
-    - 0.7065
-    R@1000:
-    - 0.8861
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3547
+      R@100:
+        - 0.7065
+      R@1000:
+        - 0.8861

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress.parquet
 
-index_path: indexes/parquet/cqadupstack-wordpress
+index_path: indexes/lucene-flat.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-wordpress"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-wordpress.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-wordpress"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-wordpress.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.3547
-    R@100:
-    - 0.7065
-    R@1000:
-    - 0.8861
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3547
+      R@100:
+        - 0.7065
+      R@1000:
+        - 0.8861
+    tolerance:
+      nDCG@10:
+        - 0.0001
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-wordpress"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-wordpress.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3547
+      R@100:
+        - 0.7065
+      R@1000:
+        - 0.8861
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): CQADupStack-wordpress"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-wordpress.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3547
+      R@100:
+        - 0.7065
+      R@1000:
+        - 0.8861
+    tolerance:
+      nDCG@10:
+        - 0.006
+      R@100:
+        - 0.004
+      R@1000:
+        - 0.004

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress.parquet
 
-index_path: indexes/parquet/cqadupstack-wordpress
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-wordpress"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-wordpress.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-wordpress"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-wordpress.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.3547
-    R@100:
-    - 0.7065
-    R@1000:
-    - 0.8861
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3547
+      R@100:
+        - 0.7065
+      R@1000:
+        - 0.8861
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/cqadupstack-wordpress.parquet
 
-index_path: indexes/parquet/cqadupstack-wordpress
+index_path: indexes/lucene-hnsw.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): CQADupStack-wordpress"
-  id: test
-  path: topics.beir-v1.0.0-cqadupstack-wordpress.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt
+  - name: "BEIR (v1.0.0): CQADupStack-wordpress"
+    id: test
+    path: topics.beir-v1.0.0-cqadupstack-wordpress.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.3547
-    R@100:
-    - 0.7065
-    R@1000:
-    - 0.8861
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3547
+      R@100:
+        - 0.7065
+      R@1000:
+        - 0.8861
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.004
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): DBPedia"
+    id: test
+    path: topics.beir-v1.0.0-dbpedia-entity.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-dbpedia-entity.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4074
+      R@100:
+        - 0.5303
+      R@1000:
+        - 0.7833
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.004
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): DBPedia"
+    id: test
+    path: topics.beir-v1.0.0-dbpedia-entity.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-dbpedia-entity.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4074
+      R@100:
+        - 0.5303
+      R@1000:
+        - 0.7833
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.004
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): DBPedia"
-  id: test
-  path: topics.beir-v1.0.0-dbpedia-entity.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-dbpedia-entity.test.txt
+  - name: "BEIR (v1.0.0): DBPedia"
+    id: test
+    path: topics.beir-v1.0.0-dbpedia-entity.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-dbpedia-entity.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.4074
-    R@100:
-    - 0.5303
-    R@1000:
-    - 0.7833
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4074
+      R@100:
+        - 0.5303
+      R@1000:
+        - 0.7833

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity.parquet
 
-index_path: indexes/parquet/dbpedia-entity
+index_path: indexes/lucene-flat.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): DBPedia"
-  id: test
-  path: topics.beir-v1.0.0-dbpedia-entity.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-dbpedia-entity.test.txt
+  - name: "BEIR (v1.0.0): DBPedia"
+    id: test
+    path: topics.beir-v1.0.0-dbpedia-entity.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-dbpedia-entity.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4074
-    R@100:
-    - 0.5303
-    R@1000:
-    - 0.7833
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4074
+      R@100:
+        - 0.5303
+      R@1000:
+        - 0.7833
+    tolerance:
+      nDCG@10:
+        - 0.0002
+      R@100:
+        - 0.0006
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): DBPedia"
+    id: test
+    path: topics.beir-v1.0.0-dbpedia-entity.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-dbpedia-entity.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4074
+      R@100:
+        - 0.5303
+      R@1000:
+        - 0.7833
+    tolerance:
+      nDCG@10:
+        - 0.003
+      R@100:
+        - 0.01
+      R@1000:
+        - 0.02

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): DBPedia"
+    id: test
+    path: topics.beir-v1.0.0-dbpedia-entity.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-dbpedia-entity.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4074
+      R@100:
+        - 0.5303
+      R@1000:
+        - 0.7833
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.01
+      R@1000:
+        - 0.02

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity.parquet
 
-index_path: indexes/parquet/dbpedia-entity
+index_path: indexes/lucene-hnsw.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): DBPedia"
-  id: test
-  path: topics.beir-v1.0.0-dbpedia-entity.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-dbpedia-entity.test.txt
+  - name: "BEIR (v1.0.0): DBPedia"
+    id: test
+    path: topics.beir-v1.0.0-dbpedia-entity.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-dbpedia-entity.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.4074
-    R@100:
-    - 0.5303
-    R@1000:
-    - 0.7833
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4074
+      R@100:
+        - 0.5303
+      R@1000:
+        - 0.7833
+    tolerance:
+      nDCG@10:
+        - 0.005
+      R@100:
+        - 0.008
+      R@1000:
+        - 0.02

--- a/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/dbpedia-entity.parquet
 
-index_path: indexes/parquet/dbpedia-entity
+index_path: indexes/lucene-hnsw.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): DBPedia"
-  id: test
-  path: topics.beir-v1.0.0-dbpedia-entity.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-dbpedia-entity.test.txt
+  - name: "BEIR (v1.0.0): DBPedia"
+    id: test
+    path: topics.beir-v1.0.0-dbpedia-entity.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-dbpedia-entity.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4074
-    R@100:
-    - 0.5303
-    R@1000:
-    - 0.7833
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4074
+      R@100:
+        - 0.5303
+      R@1000:
+        - 0.7833
+    tolerance:
+      nDCG@10:
+        - 0.005
+      R@100:
+        - 0.008
+      R@1000:
+        - 0.02

--- a/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-fever.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-fever.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): FEVER"
+    id: test
+    path: topics.beir-v1.0.0-fever.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-fever.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.8630
+      R@100:
+        - 0.9719
+      R@1000:
+        - 0.9855
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-fever.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-fever.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-fever.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-fever.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): FEVER"
+    id: test
+    path: topics.beir-v1.0.0-fever.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-fever.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.8630
+      R@100:
+        - 0.9719
+      R@1000:
+        - 0.9855
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-fever.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-fever.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-fever.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): FEVER"
-  id: test
-  path: topics.beir-v1.0.0-fever.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-fever.test.txt
+  - name: "BEIR (v1.0.0): FEVER"
+    id: test
+    path: topics.beir-v1.0.0-fever.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-fever.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.8630
-    R@100:
-    - 0.9719
-    R@1000:
-    - 0.9855
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.8630
+      R@100:
+        - 0.9719
+      R@1000:
+        - 0.9855

--- a/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-fever.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever.parquet
 
-index_path: indexes/parquet/fever
+index_path: indexes/lucene-flat.beir-v1.0.0-fever.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): FEVER"
-  id: test
-  path: topics.beir-v1.0.0-fever.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-fever.test.txt
+  - name: "BEIR (v1.0.0): FEVER"
+    id: test
+    path: topics.beir-v1.0.0-fever.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-fever.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.8630
-    R@100:
-    - 0.9719
-    R@1000:
-    - 0.9855
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.8630
+      R@100:
+        - 0.9719
+      R@1000:
+        - 0.9855
+    tolerance:
+      nDCG@10:
+        - 0.0002
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-fever.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-fever.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): FEVER"
+    id: test
+    path: topics.beir-v1.0.0-fever.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-fever.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.8630
+      R@100:
+        - 0.9719
+      R@1000:
+        - 0.9855
+    tolerance:
+      nDCG@10:
+        - 0.015
+      R@100:
+        - 0.02
+      R@1000:
+        - 0.02

--- a/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-fever.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-fever.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): FEVER"
+    id: test
+    path: topics.beir-v1.0.0-fever.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-fever.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.8630
+      R@100:
+        - 0.9719
+      R@1000:
+        - 0.9855
+    tolerance:
+      nDCG@10:
+        - 0.02
+      R@100:
+        - 0.02
+      R@1000:
+        - 0.02

--- a/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-fever.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever.parquet
 
-index_path: indexes/parquet/fever
+index_path: indexes/lucene-hnsw.beir-v1.0.0-fever.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): FEVER"
-  id: test
-  path: topics.beir-v1.0.0-fever.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-fever.test.txt
+  - name: "BEIR (v1.0.0): FEVER"
+    id: test
+    path: topics.beir-v1.0.0-fever.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-fever.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.8630
-    R@100:
-    - 0.9719
-    R@1000:
-    - 0.9855
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.8630
+      R@100:
+        - 0.9719
+      R@1000:
+        - 0.9855
+    tolerance:
+      nDCG@10:
+        - 0.008
+      R@100:
+        - 0.015
+      R@1000:
+        - 0.015

--- a/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-fever.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fever.parquet
 
-index_path: indexes/parquet/fever
+index_path: indexes/lucene-hnsw.beir-v1.0.0-fever.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): FEVER"
-  id: test
-  path: topics.beir-v1.0.0-fever.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-fever.test.txt
+  - name: "BEIR (v1.0.0): FEVER"
+    id: test
+    path: topics.beir-v1.0.0-fever.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-fever.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.8630
-    R@100:
-    - 0.9719
-    R@1000:
-    - 0.9855
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.8630
+      R@100:
+        - 0.9719
+      R@1000:
+        - 0.9855
+    tolerance:
+      nDCG@10:
+        - 0.008
+      R@100:
+        - 0.015
+      R@1000:
+        - 0.015

--- a/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-fiqa.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-fiqa.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): FiQA-2018"
+    id: test
+    path: topics.beir-v1.0.0-fiqa.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-fiqa.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4065
+      R@100:
+        - 0.7415
+      R@1000:
+        - 0.9083
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-fiqa.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-fiqa.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-fiqa.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-fiqa.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-fiqa.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-fiqa.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): FiQA-2018"
+    id: test
+    path: topics.beir-v1.0.0-fiqa.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-fiqa.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4065
+      R@100:
+        - 0.7415
+      R@1000:
+        - 0.9083
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-fiqa.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): FiQA-2018"
-  id: test
-  path: topics.beir-v1.0.0-fiqa.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-fiqa.test.txt
+  - name: "BEIR (v1.0.0): FiQA-2018"
+    id: test
+    path: topics.beir-v1.0.0-fiqa.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-fiqa.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.4065
-    R@100:
-    - 0.7415
-    R@1000:
-    - 0.9083
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4065
+      R@100:
+        - 0.7415
+      R@1000:
+        - 0.9083

--- a/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-fiqa.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa.parquet
 
-index_path: indexes/parquet/fiqa
+index_path: indexes/lucene-flat.beir-v1.0.0-fiqa.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): FiQA-2018"
-  id: test
-  path: topics.beir-v1.0.0-fiqa.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-fiqa.test.txt
+  - name: "BEIR (v1.0.0): FiQA-2018"
+    id: test
+    path: topics.beir-v1.0.0-fiqa.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-fiqa.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4065
-    R@100:
-    - 0.7415
-    R@1000:
-    - 0.9083
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4065
+      R@100:
+        - 0.7415
+      R@1000:
+        - 0.9083
+    tolerance:
+      nDCG@10:
+        - 0.0001
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-fiqa.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-fiqa.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): FiQA-2018"
+    id: test
+    path: topics.beir-v1.0.0-fiqa.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-fiqa.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4065
+      R@100:
+        - 0.7415
+      R@1000:
+        - 0.9083
+    tolerance:
+      nDCG@10:
+        - 0.006
+      R@100:
+        - 0.005
+      R@1000:
+        - 0.007

--- a/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-fiqa.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-fiqa.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): FiQA-2018"
+    id: test
+    path: topics.beir-v1.0.0-fiqa.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-fiqa.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4065
+      R@100:
+        - 0.7415
+      R@1000:
+        - 0.9083
+    tolerance:
+      nDCG@10:
+        - 0.006
+      R@100:
+        - 0.005
+      R@1000:
+        - 0.007

--- a/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-fiqa.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa.parquet
 
-index_path: indexes/parquet/fiqa
+index_path: indexes/lucene-hnsw.beir-v1.0.0-fiqa.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): FiQA-2018"
-  id: test
-  path: topics.beir-v1.0.0-fiqa.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-fiqa.test.txt
+  - name: "BEIR (v1.0.0): FiQA-2018"
+    id: test
+    path: topics.beir-v1.0.0-fiqa.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-fiqa.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.4065
-    R@100:
-    - 0.7415
-    R@1000:
-    - 0.9083
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4065
+      R@100:
+        - 0.7415
+      R@1000:
+        - 0.9083
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.004
+      R@1000:
+        - 0.007

--- a/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-fiqa.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/fiqa.parquet
 
-index_path: indexes/parquet/fiqa
+index_path: indexes/lucene-hnsw.beir-v1.0.0-fiqa.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): FiQA-2018"
-  id: test
-  path: topics.beir-v1.0.0-fiqa.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-fiqa.test.txt
+  - name: "BEIR (v1.0.0): FiQA-2018"
+    id: test
+    path: topics.beir-v1.0.0-fiqa.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-fiqa.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4065
-    R@100:
-    - 0.7415
-    R@1000:
-    - 0.9083
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4065
+      R@100:
+        - 0.7415
+      R@1000:
+        - 0.9083
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.004
+      R@1000:
+        - 0.007

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-hotpotqa.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-hotpotqa.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-hotpotqa.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-hotpotqa.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): HotpotQA"
+    id: test
+    path: topics.beir-v1.0.0-hotpotqa.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-hotpotqa.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7259
+      R@100:
+        - 0.8727
+      R@1000:
+        - 0.9424
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-hotpotqa.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-hotpotqa.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-hotpotqa.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-hotpotqa.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): HotpotQA"
+    id: test
+    path: topics.beir-v1.0.0-hotpotqa.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-hotpotqa.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7259
+      R@100:
+        - 0.8727
+      R@1000:
+        - 0.9424
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-hotpotqa.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): HotpotQA"
-  id: test
-  path: topics.beir-v1.0.0-hotpotqa.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-hotpotqa.test.txt
+  - name: "BEIR (v1.0.0): HotpotQA"
+    id: test
+    path: topics.beir-v1.0.0-hotpotqa.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-hotpotqa.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.7259
-    R@100:
-    - 0.8727
-    R@1000:
-    - 0.9424
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7259
+      R@100:
+        - 0.8727
+      R@1000:
+        - 0.9424

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-hotpotqa.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa.parquet
 
-index_path: indexes/parquet/hotpotqa
+index_path: indexes/lucene-flat.beir-v1.0.0-hotpotqa.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): HotpotQA"
-  id: test
-  path: topics.beir-v1.0.0-hotpotqa.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-hotpotqa.test.txt
+  - name: "BEIR (v1.0.0): HotpotQA"
+    id: test
+    path: topics.beir-v1.0.0-hotpotqa.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-hotpotqa.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.7259
-    R@100:
-    - 0.8727
-    R@1000:
-    - 0.9424
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7259
+      R@100:
+        - 0.8727
+      R@1000:
+        - 0.9424
+    tolerance:
+      nDCG@10:
+        - 0.0001
+      R@100:
+        - 0.0002
+      R@1000:
+        - 0.0002

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-hotpotqa.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-hotpotqa.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): HotpotQA"
+    id: test
+    path: topics.beir-v1.0.0-hotpotqa.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-hotpotqa.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7259
+      R@100:
+        - 0.8727
+      R@1000:
+        - 0.9424
+    tolerance:
+      nDCG@10:
+        - 0.02
+      R@100:
+        - 0.03
+      R@1000:
+        - 0.03

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-hotpotqa.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-hotpotqa.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): HotpotQA"
+    id: test
+    path: topics.beir-v1.0.0-hotpotqa.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-hotpotqa.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7259
+      R@100:
+        - 0.8727
+      R@1000:
+        - 0.9424
+    tolerance:
+      nDCG@10:
+        - 0.02
+      R@100:
+        - 0.025
+      R@1000:
+        - 0.03

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-hotpotqa.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa.parquet
 
-index_path: indexes/parquet/hotpotqa
+index_path: indexes/lucene-hnsw.beir-v1.0.0-hotpotqa.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): HotpotQA"
-  id: test
-  path: topics.beir-v1.0.0-hotpotqa.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-hotpotqa.test.txt
+  - name: "BEIR (v1.0.0): HotpotQA"
+    id: test
+    path: topics.beir-v1.0.0-hotpotqa.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-hotpotqa.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.7259
-    R@100:
-    - 0.8727
-    R@1000:
-    - 0.9424
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7259
+      R@100:
+        - 0.8727
+      R@1000:
+        - 0.9424
+    tolerance:
+      nDCG@10:
+        - 0.02
+      R@100:
+        - 0.02
+      R@1000:
+        - 0.02

--- a/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-hotpotqa.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/hotpotqa.parquet
 
-index_path: indexes/parquet/hotpotqa
+index_path: indexes/lucene-hnsw.beir-v1.0.0-hotpotqa.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): HotpotQA"
-  id: test
-  path: topics.beir-v1.0.0-hotpotqa.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-hotpotqa.test.txt
+  - name: "BEIR (v1.0.0): HotpotQA"
+    id: test
+    path: topics.beir-v1.0.0-hotpotqa.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-hotpotqa.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.7259
-    R@100:
-    - 0.8727
-    R@1000:
-    - 0.9424
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7259
+      R@100:
+        - 0.8727
+      R@1000:
+        - 0.9424
+    tolerance:
+      nDCG@10:
+        - 0.02
+      R@100:
+        - 0.02
+      R@1000:
+        - 0.02

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-nfcorpus.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-nfcorpus.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-nfcorpus.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-nfcorpus.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): NFCorpus"
+    id: test
+    path: topics.beir-v1.0.0-nfcorpus.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-nfcorpus.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3735
+      R@100:
+        - 0.3368
+      R@1000:
+        - 0.6622
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.006

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-nfcorpus.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-nfcorpus.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-nfcorpus.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-nfcorpus.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): NFCorpus"
+    id: test
+    path: topics.beir-v1.0.0-nfcorpus.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-nfcorpus.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3735
+      R@100:
+        - 0.3368
+      R@1000:
+        - 0.6622
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.007

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-nfcorpus.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): NFCorpus"
-  id: test
-  path: topics.beir-v1.0.0-nfcorpus.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-nfcorpus.test.txt
+  - name: "BEIR (v1.0.0): NFCorpus"
+    id: test
+    path: topics.beir-v1.0.0-nfcorpus.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-nfcorpus.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.3735
-    R@100:
-    - 0.3368
-    R@1000:
-    - 0.6622
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3735
+      R@100:
+        - 0.3368
+      R@1000:
+        - 0.6622

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-nfcorpus.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus.parquet
 
-index_path: indexes/parquet/nfcorpus
+index_path: indexes/lucene-flat.beir-v1.0.0-nfcorpus.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): NFCorpus"
-  id: test
-  path: topics.beir-v1.0.0-nfcorpus.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-nfcorpus.test.txt
+  - name: "BEIR (v1.0.0): NFCorpus"
+    id: test
+    path: topics.beir-v1.0.0-nfcorpus.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-nfcorpus.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.3735
-    R@100:
-    - 0.3368
-    R@1000:
-    - 0.6622
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3735
+      R@100:
+        - 0.3368
+      R@1000:
+        - 0.6622
+    tolerance:
+      nDCG@10:
+        - 0.0001
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-nfcorpus.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-nfcorpus.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): NFCorpus"
+    id: test
+    path: topics.beir-v1.0.0-nfcorpus.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-nfcorpus.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3735
+      R@100:
+        - 0.3368
+      R@1000:
+        - 0.6622
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.005

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-nfcorpus.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-nfcorpus.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): NFCorpus"
+    id: test
+    path: topics.beir-v1.0.0-nfcorpus.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-nfcorpus.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3735
+      R@100:
+        - 0.3368
+      R@1000:
+        - 0.6622
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.006

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-nfcorpus.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus.parquet
 
-index_path: indexes/parquet/nfcorpus
+index_path: indexes/lucene-hnsw.beir-v1.0.0-nfcorpus.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): NFCorpus"
-  id: test
-  path: topics.beir-v1.0.0-nfcorpus.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-nfcorpus.test.txt
+  - name: "BEIR (v1.0.0): NFCorpus"
+    id: test
+    path: topics.beir-v1.0.0-nfcorpus.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-nfcorpus.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.3735
-    R@100:
-    - 0.3368
-    R@1000:
-    - 0.6622
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3735
+      R@100:
+        - 0.3368
+      R@1000:
+        - 0.6622
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-nfcorpus.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nfcorpus.parquet
 
-index_path: indexes/parquet/nfcorpus
+index_path: indexes/lucene-hnsw.beir-v1.0.0-nfcorpus.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): NFCorpus"
-  id: test
-  path: topics.beir-v1.0.0-nfcorpus.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-nfcorpus.test.txt
+  - name: "BEIR (v1.0.0): NFCorpus"
+    id: test
+    path: topics.beir-v1.0.0-nfcorpus.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-nfcorpus.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.3735
-    R@100:
-    - 0.3368
-    R@1000:
-    - 0.6622
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.3735
+      R@100:
+        - 0.3368
+      R@1000:
+        - 0.6622
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-nq.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-nq.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-nq.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-nq.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): NQ"
+    id: test
+    path: topics.beir-v1.0.0-nq.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-nq.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5413
+      R@100:
+        - 0.9415
+      R@1000:
+        - 0.9859
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-nq.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-nq.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): NQ"
+    id: test
+    path: topics.beir-v1.0.0-nq.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-nq.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5413
+      R@100:
+        - 0.9415
+      R@1000:
+        - 0.9859
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-nq.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-nq.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-nq.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): NQ"
-  id: test
-  path: topics.beir-v1.0.0-nq.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-nq.test.txt
+  - name: "BEIR (v1.0.0): NQ"
+    id: test
+    path: topics.beir-v1.0.0-nq.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-nq.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.5413
-    R@100:
-    - 0.9415
-    R@1000:
-    - 0.9859
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5413
+      R@100:
+        - 0.9415
+      R@1000:
+        - 0.9859

--- a/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-nq.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq.parquet
 
-index_path: indexes/parquet/nq
+index_path: indexes/lucene-flat.beir-v1.0.0-nq.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): NQ"
-  id: test
-  path: topics.beir-v1.0.0-nq.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-nq.test.txt
+  - name: "BEIR (v1.0.0): NQ"
+    id: test
+    path: topics.beir-v1.0.0-nq.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-nq.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.5413
-    R@100:
-    - 0.9415
-    R@1000:
-    - 0.9859
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5413
+      R@100:
+        - 0.9415
+      R@1000:
+        - 0.9859
+    tolerance:
+      nDCG@10:
+        - 0.0001
+      R@100:
+        - 0.0002
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-nq.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-nq.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): NQ"
+    id: test
+    path: topics.beir-v1.0.0-nq.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-nq.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5413
+      R@100:
+        - 0.9415
+      R@1000:
+        - 0.9859
+    tolerance:
+      nDCG@10:
+        - 0.005
+      R@100:
+        - 0.009
+      R@1000:
+        - 0.009

--- a/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-nq.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-nq.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): NQ"
+    id: test
+    path: topics.beir-v1.0.0-nq.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-nq.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5413
+      R@100:
+        - 0.9415
+      R@1000:
+        - 0.9859
+    tolerance:
+      nDCG@10:
+        - 0.005
+      R@100:
+        - 0.009
+      R@1000:
+        - 0.009

--- a/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-nq.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq.parquet
 
-index_path: indexes/parquet/nq
+index_path: indexes/lucene-hnsw.beir-v1.0.0-nq.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): NQ"
-  id: test
-  path: topics.beir-v1.0.0-nq.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-nq.test.txt
+  - name: "BEIR (v1.0.0): NQ"
+    id: test
+    path: topics.beir-v1.0.0-nq.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-nq.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.5413
-    R@100:
-    - 0.9415
-    R@1000:
-    - 0.9859
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5413
+      R@100:
+        - 0.9415
+      R@1000:
+        - 0.9859
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.008
+      R@1000:
+        - 0.009

--- a/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-nq.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/nq.parquet
 
-index_path: indexes/parquet/nq
+index_path: indexes/lucene-hnsw.beir-v1.0.0-nq.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): NQ"
-  id: test
-  path: topics.beir-v1.0.0-nq.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-nq.test.txt
+  - name: "BEIR (v1.0.0): NQ"
+    id: test
+    path: topics.beir-v1.0.0-nq.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-nq.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.5413
-    R@100:
-    - 0.9415
-    R@1000:
-    - 0.9859
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.5413
+      R@100:
+        - 0.9415
+      R@1000:
+        - 0.9859
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.007
+      R@1000:
+        - 0.009

--- a/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-quora.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-quora.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-quora.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-quora.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): Quora"
+    id: test
+    path: topics.beir-v1.0.0-quora.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-quora.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.8890
+      R@100:
+        - 0.9967
+      R@1000:
+        - 0.9998
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-quora.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-quora.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-quora.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-quora.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): Quora"
+    id: test
+    path: topics.beir-v1.0.0-quora.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-quora.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.8890
+      R@100:
+        - 0.9967
+      R@1000:
+        - 0.9998
+    tolerance:
+      nDCG@10:
+        - 0.003
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-quora.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): Quora"
-  id: test
-  path: topics.beir-v1.0.0-quora.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-quora.test.txt
+  - name: "BEIR (v1.0.0): Quora"
+    id: test
+    path: topics.beir-v1.0.0-quora.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-quora.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.8890
-    R@100:
-    - 0.9967
-    R@1000:
-    - 0.9998
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.8890
+      R@100:
+        - 0.9967
+      R@1000:
+        - 0.9998

--- a/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-quora.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora.parquet
 
-index_path: indexes/parquet/quora
+index_path: indexes/lucene-flat.beir-v1.0.0-quora.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): Quora"
-  id: test
-  path: topics.beir-v1.0.0-quora.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-quora.test.txt
+  - name: "BEIR (v1.0.0): Quora"
+    id: test
+    path: topics.beir-v1.0.0-quora.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-quora.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.8890
-    R@100:
-    - 0.9967
-    R@1000:
-    - 0.9998
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.8890
+      R@100:
+        - 0.9967
+      R@1000:
+        - 0.9998
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-quora.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-quora.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): Quora"
+    id: test
+    path: topics.beir-v1.0.0-quora.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-quora.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.8890
+      R@100:
+        - 0.9967
+      R@1000:
+        - 0.9998
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-quora.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-quora.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): Quora"
+    id: test
+    path: topics.beir-v1.0.0-quora.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-quora.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.8890
+      R@100:
+        - 0.9967
+      R@1000:
+        - 0.9998
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-quora.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora.parquet
 
-index_path: indexes/parquet/quora
+index_path: indexes/lucene-hnsw.beir-v1.0.0-quora.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): Quora"
-  id: test
-  path: topics.beir-v1.0.0-quora.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-quora.test.txt
+  - name: "BEIR (v1.0.0): Quora"
+    id: test
+    path: topics.beir-v1.0.0-quora.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-quora.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.8890
-    R@100:
-    - 0.9967
-    R@1000:
-    - 0.9998
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.8890
+      R@100:
+        - 0.9967
+      R@1000:
+        - 0.9998
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-quora.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/quora.parquet
 
-index_path: indexes/parquet/quora
+index_path: indexes/lucene-hnsw.beir-v1.0.0-quora.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): Quora"
-  id: test
-  path: topics.beir-v1.0.0-quora.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-quora.test.txt
+  - name: "BEIR (v1.0.0): Quora"
+    id: test
+    path: topics.beir-v1.0.0-quora.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-quora.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.8890
-    R@100:
-    - 0.9967
-    R@1000:
-    - 0.9998
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.8890
+      R@100:
+        - 0.9967
+      R@1000:
+        - 0.9998
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-robust04.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-robust04.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): Robust04"
+    id: test
+    path: topics.beir-v1.0.0-robust04.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-robust04.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4465
+      R@100:
+        - 0.3507
+      R@1000:
+        - 0.5981
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.004
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-robust04.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-robust04.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-robust04.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-robust04.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): Robust04"
+    id: test
+    path: topics.beir-v1.0.0-robust04.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-robust04.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4465
+      R@100:
+        - 0.3507
+      R@1000:
+        - 0.5981
+    tolerance:
+      nDCG@10:
+        - 0.005
+      R@100:
+        - 0.005
+      R@1000:
+        - 0.004

--- a/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-robust04.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-robust04.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-robust04.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): Robust04"
-  id: test
-  path: topics.beir-v1.0.0-robust04.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-robust04.test.txt
+  - name: "BEIR (v1.0.0): Robust04"
+    id: test
+    path: topics.beir-v1.0.0-robust04.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-robust04.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.4465
-    R@100:
-    - 0.3507
-    R@1000:
-    - 0.5981
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4465
+      R@100:
+        - 0.3507
+      R@1000:
+        - 0.5981

--- a/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-robust04.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04.parquet
 
-index_path: indexes/parquet/robust04
+index_path: indexes/lucene-flat.beir-v1.0.0-robust04.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): Robust04"
-  id: test
-  path: topics.beir-v1.0.0-robust04.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-robust04.test.txt
+  - name: "BEIR (v1.0.0): Robust04"
+    id: test
+    path: topics.beir-v1.0.0-robust04.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-robust04.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4465
-    R@100:
-    - 0.3507
-    R@1000:
-    - 0.5981
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4465
+      R@100:
+        - 0.3507
+      R@1000:
+        - 0.5981
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-robust04.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-robust04.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): Robust04"
+    id: test
+    path: topics.beir-v1.0.0-robust04.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-robust04.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4465
+      R@100:
+        - 0.3507
+      R@1000:
+        - 0.5981
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.005
+      R@1000:
+        - 0.005

--- a/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-robust04.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-robust04.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): Robust04"
+    id: test
+    path: topics.beir-v1.0.0-robust04.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-robust04.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4465
+      R@100:
+        - 0.3507
+      R@1000:
+        - 0.5981
+    tolerance:
+      nDCG@10:
+        - 0.005
+      R@100:
+        - 0.006
+      R@1000:
+        - 0.007

--- a/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-robust04.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04.parquet
 
-index_path: indexes/parquet/robust04
+index_path: indexes/lucene-hnsw.beir-v1.0.0-robust04.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): Robust04"
-  id: test
-  path: topics.beir-v1.0.0-robust04.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-robust04.test.txt
+  - name: "BEIR (v1.0.0): Robust04"
+    id: test
+    path: topics.beir-v1.0.0-robust04.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-robust04.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.4465
-    R@100:
-    - 0.3507
-    R@1000:
-    - 0.5981
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4465
+      R@100:
+        - 0.3507
+      R@1000:
+        - 0.5981
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.004

--- a/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-robust04.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/robust04.parquet
 
-index_path: indexes/parquet/robust04
+index_path: indexes/lucene-hnsw.beir-v1.0.0-robust04.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): Robust04"
-  id: test
-  path: topics.beir-v1.0.0-robust04.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-robust04.test.txt
+  - name: "BEIR (v1.0.0): Robust04"
+    id: test
+    path: topics.beir-v1.0.0-robust04.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-robust04.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4465
-    R@100:
-    - 0.3507
-    R@1000:
-    - 0.5981
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4465
+      R@100:
+        - 0.3507
+      R@1000:
+        - 0.5981
+    tolerance:
+      nDCG@10:
+        - 0.004
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.006

--- a/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-scidocs.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-scidocs.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-scidocs.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-scidocs.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): SCIDOCS"
+    id: test
+    path: topics.beir-v1.0.0-scidocs.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-scidocs.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2170
+      R@100:
+        - 0.4959
+      R@1000:
+        - 0.7824
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-scidocs.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-scidocs.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-scidocs.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-scidocs.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): SCIDOCS"
+    id: test
+    path: topics.beir-v1.0.0-scidocs.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-scidocs.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2170
+      R@100:
+        - 0.4959
+      R@1000:
+        - 0.7824
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-scidocs.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): SCIDOCS"
-  id: test
-  path: topics.beir-v1.0.0-scidocs.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-scidocs.test.txt
+  - name: "BEIR (v1.0.0): SCIDOCS"
+    id: test
+    path: topics.beir-v1.0.0-scidocs.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-scidocs.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.2170
-    R@100:
-    - 0.4959
-    R@1000:
-    - 0.7824
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2170
+      R@100:
+        - 0.4959
+      R@1000:
+        - 0.7824

--- a/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-scidocs.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs.parquet
 
-index_path: indexes/parquet/scidocs
+index_path: indexes/lucene-flat.beir-v1.0.0-scidocs.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): SCIDOCS"
-  id: test
-  path: topics.beir-v1.0.0-scidocs.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-scidocs.test.txt
+  - name: "BEIR (v1.0.0): SCIDOCS"
+    id: test
+    path: topics.beir-v1.0.0-scidocs.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-scidocs.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.2170
-    R@100:
-    - 0.4959
-    R@1000:
-    - 0.7824
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2170
+      R@100:
+        - 0.4959
+      R@1000:
+        - 0.7824
+    tolerance:
+      nDCG@10:
+        - 0.0001
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-scidocs.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-scidocs.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): SCIDOCS"
+    id: test
+    path: topics.beir-v1.0.0-scidocs.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-scidocs.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2170
+      R@100:
+        - 0.4959
+      R@1000:
+        - 0.7824
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-scidocs.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-scidocs.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): SCIDOCS"
+    id: test
+    path: topics.beir-v1.0.0-scidocs.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-scidocs.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2170
+      R@100:
+        - 0.4959
+      R@1000:
+        - 0.7824
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-scidocs.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs.parquet
 
-index_path: indexes/parquet/scidocs
+index_path: indexes/lucene-hnsw.beir-v1.0.0-scidocs.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): SCIDOCS"
-  id: test
-  path: topics.beir-v1.0.0-scidocs.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-scidocs.test.txt
+  - name: "BEIR (v1.0.0): SCIDOCS"
+    id: test
+    path: topics.beir-v1.0.0-scidocs.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-scidocs.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.2170
-    R@100:
-    - 0.4959
-    R@1000:
-    - 0.7824
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2170
+      R@100:
+        - 0.4959
+      R@1000:
+        - 0.7824
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-scidocs.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scidocs.parquet
 
-index_path: indexes/parquet/scidocs
+index_path: indexes/lucene-hnsw.beir-v1.0.0-scidocs.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): SCIDOCS"
-  id: test
-  path: topics.beir-v1.0.0-scidocs.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-scidocs.test.txt
+  - name: "BEIR (v1.0.0): SCIDOCS"
+    id: test
+    path: topics.beir-v1.0.0-scidocs.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-scidocs.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.2170
-    R@100:
-    - 0.4959
-    R@1000:
-    - 0.7824
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2170
+      R@100:
+        - 0.4959
+      R@1000:
+        - 0.7824
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-scifact.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-scifact.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): SciFact"
+    id: test
+    path: topics.beir-v1.0.0-scifact.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-scifact.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7408
+      R@100:
+        - 0.9667
+      R@1000:
+        - 0.9967
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-scifact.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-scifact.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-scifact.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-scifact.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): SciFact"
+    id: test
+    path: topics.beir-v1.0.0-scifact.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-scifact.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7408
+      R@100:
+        - 0.9667
+      R@1000:
+        - 0.9967
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-scifact.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-scifact.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-scifact.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): SciFact"
-  id: test
-  path: topics.beir-v1.0.0-scifact.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-scifact.test.txt
+  - name: "BEIR (v1.0.0): SciFact"
+    id: test
+    path: topics.beir-v1.0.0-scifact.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-scifact.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -removeQuery
-    -threads 16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.7408
-    R@100:
-    - 0.9667
-    R@1000:
-    - 0.9967
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7408
+      R@100:
+        - 0.9667
+      R@1000:
+        - 0.9967

--- a/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-scifact.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact.parquet
 
-index_path: indexes/parquet/scifact
+index_path: indexes/lucene-flat.beir-v1.0.0-scifact.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): SciFact"
-  id: test
-  path: topics.beir-v1.0.0-scifact.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-scifact.test.txt
+  - name: "BEIR (v1.0.0): SciFact"
+    id: test
+    path: topics.beir-v1.0.0-scifact.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-scifact.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -removeQuery
-    -threads 16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.7408
-    R@100:
-    - 0.9667
-    R@1000:
-    - 0.9967
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7408
+      R@100:
+        - 0.9667
+      R@1000:
+        - 0.9967
+    tolerance:
+      nDCG@10:
+        - 0.0001
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-scifact.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-scifact.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): SciFact"
+    id: test
+    path: topics.beir-v1.0.0-scifact.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-scifact.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7408
+      R@100:
+        - 0.9667
+      R@1000:
+        - 0.9967
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-scifact.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-scifact.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): SciFact"
+    id: test
+    path: topics.beir-v1.0.0-scifact.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-scifact.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7408
+      R@100:
+        - 0.9667
+      R@1000:
+        - 0.9967
+    tolerance:
+      nDCG@10:
+        - 0.002
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-scifact.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact.parquet
 
-index_path: indexes/parquet/scifact
+index_path: indexes/lucene-hnsw.beir-v1.0.0-scifact.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): SciFact"
-  id: test
-  path: topics.beir-v1.0.0-scifact.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-scifact.test.txt
+  - name: "BEIR (v1.0.0): SciFact"
+    id: test
+    path: topics.beir-v1.0.0-scifact.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-scifact.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -removeQuery
-    -threads 16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.7408
-    R@100:
-    - 0.9667
-    R@1000:
-    - 0.9967
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7408
+      R@100:
+        - 0.9667
+      R@1000:
+        - 0.9967
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-scifact.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/scifact.parquet
 
-index_path: indexes/parquet/scifact
+index_path: indexes/lucene-hnsw.beir-v1.0.0-scifact.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): SciFact"
-  id: test
-  path: topics.beir-v1.0.0-scifact.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-scifact.test.txt
+  - name: "BEIR (v1.0.0): SciFact"
+    id: test
+    path: topics.beir-v1.0.0-scifact.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-scifact.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -removeQuery
-    -threads 16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.7408
-    R@100:
-    - 0.9667
-    R@1000:
-    - 0.9967
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7408
+      R@100:
+        - 0.9667
+      R@1000:
+        - 0.9967
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-signal1m.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-signal1m.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-signal1m.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-signal1m.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): Signal-1M"
+    id: test
+    path: topics.beir-v1.0.0-signal1m.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-signal1m.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2886
+      R@100:
+        - 0.3112
+      R@1000:
+        - 0.5331
+    tolerance:
+      nDCG@10:
+        - 0.007
+      R@100:
+        - 0.004
+      R@1000:
+        - 0.005

--- a/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-signal1m.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-signal1m.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): Signal-1M"
+    id: test
+    path: topics.beir-v1.0.0-signal1m.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-signal1m.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2886
+      R@100:
+        - 0.3112
+      R@1000:
+        - 0.5331
+    tolerance:
+      nDCG@10:
+        - 0.008
+      R@100:
+        - 0.004
+      R@1000:
+        - 0.005

--- a/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-signal1m.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-signal1m.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-signal1m.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): Signal-1M"
-  id: test
-  path: topics.beir-v1.0.0-signal1m.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-signal1m.test.txt
+  - name: "BEIR (v1.0.0): Signal-1M"
+    id: test
+    path: topics.beir-v1.0.0-signal1m.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-signal1m.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.2886
-    R@100:
-    - 0.3112
-    R@1000:
-    - 0.5331
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2886
+      R@100:
+        - 0.3112
+      R@1000:
+        - 0.5331

--- a/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-signal1m.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m.parquet
 
-index_path: indexes/parquet/signal1m
+index_path: indexes/lucene-flat.beir-v1.0.0-signal1m.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): Signal-1M"
-  id: test
-  path: topics.beir-v1.0.0-signal1m.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-signal1m.test.txt
+  - name: "BEIR (v1.0.0): Signal-1M"
+    id: test
+    path: topics.beir-v1.0.0-signal1m.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-signal1m.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.2886
-    R@100:
-    - 0.3112
-    R@1000:
-    - 0.5331
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2886
+      R@100:
+        - 0.3112
+      R@1000:
+        - 0.5331
+    tolerance:
+      nDCG@10:
+        - 0.0001
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-signal1m.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-signal1m.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): Signal-1M"
+    id: test
+    path: topics.beir-v1.0.0-signal1m.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-signal1m.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2886
+      R@100:
+        - 0.3112
+      R@1000:
+        - 0.5331
+    tolerance:
+      nDCG@10:
+        - 0.025
+      R@100:
+        - 0.03
+      R@1000:
+        - 0.05

--- a/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-signal1m.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-signal1m.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): Signal-1M"
+    id: test
+    path: topics.beir-v1.0.0-signal1m.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-signal1m.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2886
+      R@100:
+        - 0.3112
+      R@1000:
+        - 0.5331
+    tolerance:
+      nDCG@10:
+        - 0.02
+      R@100:
+        - 0.025
+      R@1000:
+        - 0.05

--- a/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-signal1m.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m.parquet
 
-index_path: indexes/parquet/signal1m
+index_path: indexes/lucene-hnsw.beir-v1.0.0-signal1m.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): Signal-1M"
-  id: test
-  path: topics.beir-v1.0.0-signal1m.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-signal1m.test.txt
+  - name: "BEIR (v1.0.0): Signal-1M"
+    id: test
+    path: topics.beir-v1.0.0-signal1m.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-signal1m.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.2886
-    R@100:
-    - 0.3112
-    R@1000:
-    - 0.5331
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2886
+      R@100:
+        - 0.3112
+      R@1000:
+        - 0.5331
+    tolerance:
+      nDCG@10:
+        - 0.015
+      R@100:
+        - 0.03
+      R@1000:
+        - 0.05

--- a/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-signal1m.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/signal1m.parquet
 
-index_path: indexes/parquet/signal1m
+index_path: indexes/lucene-hnsw.beir-v1.0.0-signal1m.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): Signal-1M"
-  id: test
-  path: topics.beir-v1.0.0-signal1m.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-signal1m.test.txt
+  - name: "BEIR (v1.0.0): Signal-1M"
+    id: test
+    path: topics.beir-v1.0.0-signal1m.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-signal1m.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.2886
-    R@100:
-    - 0.3112
-    R@1000:
-    - 0.5331
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2886
+      R@100:
+        - 0.3112
+      R@1000:
+        - 0.5331
+    tolerance:
+      nDCG@10:
+        - 0.015
+      R@100:
+        - 0.03
+      R@1000:
+        - 0.045

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-trec-covid.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-trec-covid.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-trec-covid.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-trec-covid.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): TREC-COVID"
+    id: test
+    path: topics.beir-v1.0.0-trec-covid.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-trec-covid.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7814
+      R@100:
+        - 0.1406
+      R@1000:
+        - 0.4768
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-trec-covid.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-trec-covid.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): TREC-COVID"
+    id: test
+    path: topics.beir-v1.0.0-trec-covid.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-trec-covid.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7814
+      R@100:
+        - 0.1406
+      R@1000:
+        - 0.4768
+    tolerance:
+      nDCG@10:
+        - 0.003
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-trec-covid.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-trec-covid.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-trec-covid.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): TREC-COVID"
-  id: test
-  path: topics.beir-v1.0.0-trec-covid.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-trec-covid.test.txt
+  - name: "BEIR (v1.0.0): TREC-COVID"
+    id: test
+    path: topics.beir-v1.0.0-trec-covid.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-trec-covid.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.7814
-    R@100:
-    - 0.1406
-    R@1000:
-    - 0.4768
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7814
+      R@100:
+        - 0.1406
+      R@1000:
+        - 0.4768

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-trec-covid.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid.parquet
 
-index_path: indexes/parquet/trec-covid
+index_path: indexes/lucene-flat.beir-v1.0.0-trec-covid.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): TREC-COVID"
-  id: test
-  path: topics.beir-v1.0.0-trec-covid.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-trec-covid.test.txt
+  - name: "BEIR (v1.0.0): TREC-COVID"
+    id: test
+    path: topics.beir-v1.0.0-trec-covid.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-trec-covid.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.7814
-    R@100:
-    - 0.1406
-    R@1000:
-    - 0.4768
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7814
+      R@100:
+        - 0.1406
+      R@1000:
+        - 0.4768
+    tolerance:
+      nDCG@10:
+        - 0.0001
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0004

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-trec-covid.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-trec-covid.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): TREC-COVID"
+    id: test
+    path: topics.beir-v1.0.0-trec-covid.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-trec-covid.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7814
+      R@100:
+        - 0.1406
+      R@1000:
+        - 0.4768
+    tolerance:
+      nDCG@10:
+        - 0.006
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-trec-covid.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-trec-covid.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): TREC-COVID"
+    id: test
+    path: topics.beir-v1.0.0-trec-covid.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-trec-covid.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7814
+      R@100:
+        - 0.1406
+      R@1000:
+        - 0.4768
+    tolerance:
+      nDCG@10:
+        - 0.006
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.002

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-trec-covid.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid.parquet
 
-index_path: indexes/parquet/trec-covid
+index_path: indexes/lucene-hnsw.beir-v1.0.0-trec-covid.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): TREC-COVID"
-  id: test
-  path: topics.beir-v1.0.0-trec-covid.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-trec-covid.test.txt
+  - name: "BEIR (v1.0.0): TREC-COVID"
+    id: test
+    path: topics.beir-v1.0.0-trec-covid.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-trec-covid.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.7814
-    R@100:
-    - 0.1406
-    R@1000:
-    - 0.4768
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7814
+      R@100:
+        - 0.1406
+      R@1000:
+        - 0.4768
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-trec-covid.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-covid.parquet
 
-index_path: indexes/parquet/trec-covid
+index_path: indexes/lucene-hnsw.beir-v1.0.0-trec-covid.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): TREC-COVID"
-  id: test
-  path: topics.beir-v1.0.0-trec-covid.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-trec-covid.test.txt
+  - name: "BEIR (v1.0.0): TREC-COVID"
+    id: test
+    path: topics.beir-v1.0.0-trec-covid.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-trec-covid.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.7814
-    R@100:
-    - 0.1406
-    R@1000:
-    - 0.4768
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.7814
+      R@100:
+        - 0.1406
+      R@1000:
+        - 0.4768
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-trec-news.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-trec-news.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-trec-news.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-trec-news.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): TREC-NEWS"
+    id: test
+    path: topics.beir-v1.0.0-trec-news.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-trec-news.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4425
+      R@100:
+        - 0.4992
+      R@1000:
+        - 0.7875
+    tolerance:
+      nDCG@10:
+        - 0.015
+      R@100:
+        - 0.007
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-trec-news.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-trec-news.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): TREC-NEWS"
+    id: test
+    path: topics.beir-v1.0.0-trec-news.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-trec-news.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4425
+      R@100:
+        - 0.4992
+      R@1000:
+        - 0.7875
+    tolerance:
+      nDCG@10:
+        - 0.01
+      R@100:
+        - 0.005
+      R@1000:
+        - 0.003

--- a/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-trec-news.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-trec-news.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-trec-news.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): TREC-NEWS"
-  id: test
-  path: topics.beir-v1.0.0-trec-news.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-trec-news.test.txt
+  - name: "BEIR (v1.0.0): TREC-NEWS"
+    id: test
+    path: topics.beir-v1.0.0-trec-news.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-trec-news.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.4425
-    R@100:
-    - 0.4992
-    R@1000:
-    - 0.7875
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4425
+      R@100:
+        - 0.4992
+      R@1000:
+        - 0.7875

--- a/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-trec-news.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news.parquet
 
-index_path: indexes/parquet/trec-news
+index_path: indexes/lucene-flat.beir-v1.0.0-trec-news.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): TREC-NEWS"
-  id: test
-  path: topics.beir-v1.0.0-trec-news.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-trec-news.test.txt
+  - name: "BEIR (v1.0.0): TREC-NEWS"
+    id: test
+    path: topics.beir-v1.0.0-trec-news.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-trec-news.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4425
-    R@100:
-    - 0.4992
-    R@1000:
-    - 0.7875
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4425
+      R@100:
+        - 0.4992
+      R@1000:
+        - 0.7875
+    tolerance:
+      nDCG@10:
+        - 0.0002
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-trec-news.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-trec-news.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): TREC-NEWS"
+    id: test
+    path: topics.beir-v1.0.0-trec-news.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-trec-news.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4425
+      R@100:
+        - 0.4992
+      R@1000:
+        - 0.7875
+    tolerance:
+      nDCG@10:
+        - 0.015
+      R@100:
+        - 0.015
+      R@1000:
+        - 0.03

--- a/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-trec-news.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-trec-news.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): TREC-NEWS"
+    id: test
+    path: topics.beir-v1.0.0-trec-news.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-trec-news.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4425
+      R@100:
+        - 0.4992
+      R@1000:
+        - 0.7875
+    tolerance:
+      nDCG@10:
+        - 0.015
+      R@100:
+        - 0.015
+      R@1000:
+        - 0.03

--- a/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-trec-news.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news.parquet
 
-index_path: indexes/parquet/trec-news
+index_path: indexes/lucene-hnsw.beir-v1.0.0-trec-news.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): TREC-NEWS"
-  id: test
-  path: topics.beir-v1.0.0-trec-news.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-trec-news.test.txt
+  - name: "BEIR (v1.0.0): TREC-NEWS"
+    id: test
+    path: topics.beir-v1.0.0-trec-news.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-trec-news.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.4425
-    R@100:
-    - 0.4992
-    R@1000:
-    - 0.7875
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4425
+      R@100:
+        - 0.4992
+      R@1000:
+        - 0.7875
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.01
+      R@1000:
+        - 0.02

--- a/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-trec-news.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/trec-news.parquet
 
-index_path: indexes/parquet/trec-news
+index_path: indexes/lucene-hnsw.beir-v1.0.0-trec-news.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): TREC-NEWS"
-  id: test
-  path: topics.beir-v1.0.0-trec-news.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-trec-news.test.txt
+  - name: "BEIR (v1.0.0): TREC-NEWS"
+    id: test
+    path: topics.beir-v1.0.0-trec-news.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-trec-news.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.4425
-    R@100:
-    - 0.4992
-    R@1000:
-    - 0.7875
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.4425
+      R@100:
+        - 0.4992
+      R@1000:
+        - 0.7875
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.009
+      R@1000:
+        - 0.02

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-webis-touche2020.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): Webis-Touche2020"
+    id: test
+    path: topics.beir-v1.0.0-webis-touche2020.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-webis-touche2020.test.txt
+
+models:
+  - name: bge-flat-int8-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2570
+      R@100:
+        - 0.4857
+      R@1000:
+        - 0.8298
+    tolerance:
+      nDCG@10:
+        - 0.008
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.005

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.flat-int8.cached.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-webis-touche2020.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,6 +1,6 @@
 ---
 corpus: beir-v1.0.0-webis-touche2020.bge-base-en-v1.5
-corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020.parquet
 
 index_path: indexes/lucene-flat-int8.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/
 index_type: flat

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.flat-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-webis-touche2020.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020
+
+index_path: indexes/lucene-flat-int8.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/
+index_type: flat
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): Webis-Touche2020"
+    id: test
+    path: topics.beir-v1.0.0-webis-touche2020.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-webis-touche2020.test.txt
+
+models:
+  - name: bge-flat-int8-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2570
+      R@100:
+        - 0.4857
+      R@1000:
+        - 0.8298
+    tolerance:
+      nDCG@10:
+        - 0.008
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.005

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.flat.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.flat.cached.yaml
@@ -1,3 +1,4 @@
+---
 corpus: beir-v1.0.0-webis-touche2020.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020.parquet
 
@@ -9,45 +10,44 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): Webis-Touche2020"
-  id: test
-  path: topics.beir-v1.0.0-webis-touche2020.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-webis-touche2020.test.txt
+  - name: "BEIR (v1.0.0): Webis-Touche2020"
+    id: test
+    path: topics.beir-v1.0.0-webis-touche2020.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-webis-touche2020.test.txt
 
 models:
-- name: bge-flat-cached
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000
-  results:
-    nDCG@10:
-    - 0.2570
-    R@100:
-    - 0.4857
-    R@1000:
-    - 0.8298
+  - name: bge-flat-cached
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2570
+      R@100:
+        - 0.4857
+      R@1000:
+        - 0.8298

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.flat.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.flat.onnx.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-webis-touche2020.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020.parquet
 
-index_path: indexes/parquet/webis-touche2020
+index_path: indexes/lucene-flat.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/
 index_type: flat
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: ""
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): Webis-Touche2020"
-  id: test
-  path: topics.beir-v1.0.0-webis-touche2020.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-webis-touche2020.test.txt
+  - name: "BEIR (v1.0.0): Webis-Touche2020"
+    id: test
+    path: topics.beir-v1.0.0-webis-touche2020.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-webis-touche2020.test.txt
 
 models:
-- name: bge-flat-onnx
-  display: BGE-base-en-v1.5
-  type: flat
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.2570
-    R@100:
-    - 0.4857
-    R@1000:
-    - 0.8298
+  - name: bge-flat-onnx
+    display: BGE-base-en-v1.5
+    type: flat
+    params: -encoder BgeBaseEn15 -hits 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2570
+      R@100:
+        - 0.4857
+      R@1000:
+        - 0.8298
+    tolerance:
+      nDCG@10:
+        - 0.0001
+      R@100:
+        - 0.0001
+      R@1000:
+        - 0.0001

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw-int8.cached.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-webis-touche2020.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonStringVector
+topics:
+  - name: "BEIR (v1.0.0): Webis-Touche2020"
+    id: test
+    path: topics.beir-v1.0.0-webis-touche2020.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-webis-touche2020.test.txt
+
+models:
+  - name: bge-hnsw-int8-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2570
+      R@100:
+        - 0.4857
+      R@1000:
+        - 0.8298
+    tolerance:
+      nDCG@10:
+        - 0.008
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.005

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw-int8.onnx.yaml
@@ -1,0 +1,60 @@
+---
+corpus: beir-v1.0.0-webis-touche2020.bge-base-en-v1.5
+corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020.parquet
+
+index_path: indexes/lucene-hnsw-int8.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/
+index_type: hnsw
+collection_class: ParquetDenseVectorCollection
+generator_class: ParquetDenseVectorDocumentGenerator
+index_threads: 16
+index_options: -M 16 -efC 100 -quantize.int8
+
+metrics:
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvString
+topics:
+  - name: "BEIR (v1.0.0): Webis-Touche2020"
+    id: test
+    path: topics.beir-v1.0.0-webis-touche2020.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-webis-touche2020.test.txt
+
+models:
+  - name: bge-hnsw-int8-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2570
+      R@100:
+        - 0.4857
+      R@1000:
+        - 0.8298
+    tolerance:
+      nDCG@10:
+        - 0.008
+      R@100:
+        - 0.003
+      R@1000:
+        - 0.006

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw.cached.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw.cached.yaml
@@ -1,7 +1,8 @@
+---
 corpus: beir-v1.0.0-webis-touche2020.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020.parquet
 
-index_path: indexes/parquet/webis-touche2020
+index_path: indexes/lucene-hnsw.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
@@ -9,45 +10,51 @@ index_threads: 16
 index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: JsonStringVector
 topics:
-- name: "BEIR (v1.0.0): Webis-Touche2020"
-  id: test
-  path: topics.beir-v1.0.0-webis-touche2020.test.bge-base-en-v1.5.jsonl.gz
-  qrel: qrels.beir-v1.0.0-webis-touche2020.test.txt
+  - name: "BEIR (v1.0.0): Webis-Touche2020"
+    id: test
+    path: topics.beir-v1.0.0-webis-touche2020.test.bge-base-en-v1.5.jsonl.gz
+    qrel: qrels.beir-v1.0.0-webis-touche2020.test.txt
 
 models:
-- name: bge-hnsw-cached
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField vector -removeQuery -threads
-    16 -hits 1000 -efSearch 1000
-  results:
-    nDCG@10:
-    - 0.2570
-    R@100:
-    - 0.4857
-    R@1000:
-    - 0.8298
+  - name: bge-hnsw-cached
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2570
+      R@100:
+        - 0.4857
+      R@1000:
+        - 0.8298
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.001
+      R@1000:
+        - 0.001

--- a/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
+++ b/src/main/resources/regression/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw.onnx.yaml
@@ -1,53 +1,60 @@
+---
 corpus: beir-v1.0.0-webis-touche2020.bge-base-en-v1.5
 corpus_path: collections/beir-v1.0.0/bge-base-en-v1.5/webis-touche2020.parquet
 
-index_path: indexes/parquet/webis-touche2020
+index_path: indexes/lucene-hnsw.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/
 index_type: hnsw
 collection_class: ParquetDenseVectorCollection
 generator_class: ParquetDenseVectorDocumentGenerator
 index_threads: 16
-index_options: -M 16 -efC 100 -memoryBuffer 65536 -noMerge
+index_options: -M 16 -efC 100
 
 metrics:
-- metric: nDCG@10
-  command: bin/trec_eval
-  params: -c -m ndcg_cut.10
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@100
-  command: bin/trec_eval
-  params: -c -m recall.100
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
-- metric: R@1000
-  command: bin/trec_eval
-  params: -c -m recall.1000
-  separator: "\t"
-  parse_index: 2
-  metric_precision: 4
-  can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
 
 topic_reader: TsvString
 topics:
-- name: "BEIR (v1.0.0): Webis-Touche2020"
-  id: test
-  path: topics.beir-v1.0.0-webis-touche2020.test.tsv.gz
-  qrel: qrels.beir-v1.0.0-webis-touche2020.test.txt
+  - name: "BEIR (v1.0.0): Webis-Touche2020"
+    id: test
+    path: topics.beir-v1.0.0-webis-touche2020.test.tsv.gz
+    qrel: qrels.beir-v1.0.0-webis-touche2020.test.txt
 
 models:
-- name: bge-hnsw-onnx
-  display: BGE-base-en-v1.5
-  type: hnsw
-  params: -generator VectorQueryGenerator -topicField title -removeQuery -threads
-    16 -hits 1000 -efSearch 1000 -encoder BgeBaseEn15
-  results:
-    nDCG@10:
-    - 0.2570
-    R@100:
-    - 0.4857
-    R@1000:
-    - 0.8298
+  - name: bge-hnsw-onnx
+    display: BGE-base-en-v1.5
+    type: hnsw
+    params: -encoder BgeBaseEn15 -hits 1000 -efSearch 1000 -removeQuery -threads 16
+    results:
+      nDCG@10:
+        - 0.2570
+      R@100:
+        - 0.4857
+      R@1000:
+        - 0.8298
+    tolerance:
+      nDCG@10:
+        - 0.001
+      R@100:
+        - 0.002
+      R@1000:
+        - 0.001


### PR DESCRIPTION
{flat, hnsw} x {fp32, int8}: aligned scores, tolerances, etc.