### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -532,3 +532,5 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@AhmedEssam19](https://github.com/AhmedEssam19) on 2024-09-27 (commit [`25523b4`](https://github.com/castorini/anserini/commit/25523b48597b4f061f7d016f888a124028b9b01f))
 + Results reproduced by [@sisixili](https://github.com/sisixili) on 2024-10-01 (commit [`25523b4`](https://github.com/castorini/anserini/commit/25523b48597b4f061f7d016f888a124028b9b01f))
 + Results reproduced by [@Raghav0005](https://github.com/Raghav0005) on 2024-10-07 (commit [`ee97c1d`](https://github.com/castorini/anserini/commit/ee97c1d5deeb684748723179711128f67557832c))
++ Results reproduced by [@a-y-m-a-n-c-h](https://github.com/a-y-m-a-n-c-h) on 2024-10-16 (commit [`0346842`](https://github.com/castorini/anserini/commit/03468423c820e1c0c38c9f48dc25d1f2f315831c))
+ 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -417,3 +417,5 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@sisixili](https://github.com/sisixili) on 2024-10-01 (commit [`25523b4`](https://github.com/castorini/anserini/commit/25523b48597b4f061f7d016f888a124028b9b01f))
 + Results reproduced by [@Raghav0005](https://github.com/Raghav0005) on 2024-10-06 (commit [`ee97c1d
 `](https://github.com/castorini/anserini/commit/ee97c1d5deeb684748723179711128f67557832c))
++ Results reproduced by [@a-y-m-a-n-c-h](https://github.com/a-y-m-a-n-c-h) on 2024-10-16 (commit [`0346842`](https://github.com/castorini/anserini/commit/03468423c820e1c0c38c9f48dc25d1f2f315831c))
+


### PR DESCRIPTION
Operating System and Setup:

I am using a MacBook Pro M1 with 16 GB of RAM, running macOS. The environment I used includes OpenJDK 21.0.4 and Maven 3.9.9.

Description of Issues and Solution:

While following the guide, I encountered some issues when using the latest commit from the repository. Specifically, I faced errors during the build process, and even when the build succeeded, I encountered an exception when running the bin/run.sh command to build the Lucene inverted index from the JSON collection.

The error message I encountered was:
Error: A JNI error has occurred, please check your installation and try again
Exception in thread "main" java.lang.SecurityException: Invalid signature file digest for Manifest main attributes
    at java.base/sun.security.util.SignatureFileVerifier.processImpl(SignatureFileVerifier.java:340)
    at java.base/sun.security.util.SignatureFileVerifier.process(SignatureFileVerifier.java:282)
    ...

Upon investigation, I discovered that the run.sh script was referencing a file named anserini-0.38.1-SNAPSHOT-fatjar.jar, indicating that it was a development snapshot rather than a stable release.

Solution:

To resolve the issue, I decided to manually download the stable version of the fatjar using:

wget https://repo1.maven.org/maven2/io/anserini/anserini/0.38.0/anserini-0.38.0-fatjar.jar

This allowed me to successfully build the inverted index.
However, when I ran the retrieval process and executed:

cut -f 1 runs/run.msmarco-passage.dev.small.tsv | uniq | wc

I noticed that only 5,000 queries were listed, instead of the expected 6,980.

To resolve this, I ultimately decided to use the entire repository from the stable commit for version v0.38.0 (the same version as the stable fatjar). After switching to this version, everything worked as expected, and I was able to reproduce the correct results.

Suggestions:
Overall, the guide was very helpful, but I would suggest:

- Adding a note about potential issues with the development version (SNAPSHOT builds).
- Recommending the use of the stable version (v0.38.0) for those encountering similar issues.