### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -533,4 +533,5 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@sisixili](https://github.com/sisixili) on 2024-10-01 (commit [`25523b4`](https://github.com/castorini/anserini/commit/25523b48597b4f061f7d016f888a124028b9b01f))
 + Results reproduced by [@Raghav0005](https://github.com/Raghav0005) on 2024-10-07 (commit [`ee97c1d`](https://github.com/castorini/anserini/commit/ee97c1d5deeb684748723179711128f67557832c))
 + Results reproduced by [@a-y-m-a-n-c-h](https://github.com/a-y-m-a-n-c-h) on 2024-10-16 (commit [`0346842`](https://github.com/castorini/anserini/commit/03468423c820e1c0c38c9f48dc25d1f2f315831c))
++ Results reproduced by [@Samantha-Zhan](https://github.com/Samantha-Zhan) on 2024-10-20 (commit [`daceb40`](https://github.com/castorini/anserini/commit/daceb4084c8e8103e3e86c81a8e0d597d409220e))
  

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -418,4 +418,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@Raghav0005](https://github.com/Raghav0005) on 2024-10-06 (commit [`ee97c1d
 `](https://github.com/castorini/anserini/commit/ee97c1d5deeb684748723179711128f67557832c))
 + Results reproduced by [@a-y-m-a-n-c-h](https://github.com/a-y-m-a-n-c-h) on 2024-10-16 (commit [`0346842`](https://github.com/castorini/anserini/commit/03468423c820e1c0c38c9f48dc25d1f2f315831c))
-
++ Results reproduced by [@Samantha-Zhan](https://github.com/Samantha-Zhan) on 2024-10-20 (commit [`daceb40`](https://github.com/castorini/anserini/commit/daceb4084c8e8103e3e86c81a8e0d597d409220e))


### PR DESCRIPTION
Details on my setup (e.g., operating system, environment and configuration, etc.):
- Windows Ubuntu 24.04.1 LTS (WSL2)
- Java 21

The setup actually took me quite some time for a couple of reasons:
1. I jumped straight into [start-here](https://github.com/castorini/anserini/blob/master/docs/start-here.md) by clicking on links inside the [ura doc](https://github.com/castorini/onboarding/blob/master/ura.md) without reading [readme](https://github.com/castorini/anserini); therefore, I had the repo setup locally on my windows for the first task, only to redo everything on Ubuntu for the second task.
2. My Ubuntu had Java 11, and when I tried to build I got `Fatal error compiling: invalid target release: 21`. Referencing to [an internal post](https://github.com/castorini/anserini/issues/748), I was able to update Java version to 21, following [these steps](https://stackoverflow.com/questions/53365643/windows-subsystem-for-linux-not-recognizing-java-home-environmental-variable).
3. I also got an additional build failure, where build took 13 minutes and the error was: `Crashed tests: io.anserini.search.SimpleImpactSearcherTest`. I actually was not able to locate the exact cause of this issue, and instead continue building with `mvn clean package -DskipTests -Dmaven.javadoc.skip=true` instead of `mvn clean package`, since this is irrelevant to current tasks.
![image](https://github.com/user-attachments/assets/c29cc7a2-960a-41fb-b05c-0d47bf44fa34)
4. In addition, when I am trying to run `bin/run.sh` script to create inverted index, I got `java.lang.SecurityException` for `anserini-0.38.1-SNAPSHOT-fatjar.jar` file. I had to manually unzip the jar, remove the signatures, and zip it back up.
5. Following `experiments-msmarco-passage.md`, when created inverted index, I had to modify `run.sh` to change the -Xms option to 2GB and -Xmx to 6GB due to insufficient memory.

With that said, the actual theoretical knowledge and scripts in the tasks are very easy to follow and understand; I was also able to figure out unexplained terms and configurations through a quick google search.
