### PR TITLE
Onboarding: Successful Anserini Reproduction

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -535,3 +535,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@a-y-m-a-n-c-h](https://github.com/a-y-m-a-n-c-h) on 2024-10-16 (commit [`0346842`](https://github.com/castorini/anserini/commit/03468423c820e1c0c38c9f48dc25d1f2f315831c))
 + Results reproduced by [@Samantha-Zhan](https://github.com/Samantha-Zhan) on 2024-10-20 (commit [`daceb40`](https://github.com/castorini/anserini/commit/daceb4084c8e8103e3e86c81a8e0d597d409220e))
 + Results reproduced by [@pxlin-09](https://github.com/pxlin-09) on 2024-10-26 (commit [`e2eb203`](https://github.com/castorini/anserini/commit/e2eb203b83dd643a356ee90f299c8877f6e108bd))
++ Results reproduced by [@Sinanmz](https://github.com/Sinanmz) on 2024-11-09 (commit [`7da90eb`](https://github.com/castorini/anserini/commit/7da90ebc9e005bb8243239cb38ce49192a50ed93))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -420,3 +420,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@a-y-m-a-n-c-h](https://github.com/a-y-m-a-n-c-h) on 2024-10-16 (commit [`0346842`](https://github.com/castorini/anserini/commit/03468423c820e1c0c38c9f48dc25d1f2f315831c))
 + Results reproduced by [@Samantha-Zhan](https://github.com/Samantha-Zhan) on 2024-10-20 (commit [`daceb40`](https://github.com/castorini/anserini/commit/daceb4084c8e8103e3e86c81a8e0d597d409220e))
 + Results reproduced by [@pxlin-09](https://github.com/pxlin-09) on 2024-10-26 (commit [`e2eb203`](https://github.com/castorini/anserini/commit/e2eb203b83dd643a356ee90f299c8877f6e108bd))
++ Results reproduced by [@Sinanmz](https://github.com/Sinanmz) on 2024-11-09 (commit [`7da90eb`](https://github.com/castorini/anserini/commit/7da90ebc9e005bb8243239cb38ce49192a50ed93))


### PR DESCRIPTION
Hi, 

I’m using a MacBook Pro with an M2 Pro chip, running:
- Python 3.9.20
- Maven 3.9.9
- Java 21.0.5

Everything was successful, but when running `mvn clean package`, 6 of the tests failed. I was able to proceed by using `mvn clean package -DskipTests` instead.