### PR TITLE
Update experiments-msmarco-passage.md

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -535,3 +535,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@a-y-m-a-n-c-h](https://github.com/a-y-m-a-n-c-h) on 2024-10-16 (commit [`0346842`](https://github.com/castorini/anserini/commit/03468423c820e1c0c38c9f48dc25d1f2f315831c))
 + Results reproduced by [@Samantha-Zhan](https://github.com/Samantha-Zhan) on 2024-10-20 (commit [`daceb40`](https://github.com/castorini/anserini/commit/daceb4084c8e8103e3e86c81a8e0d597d409220e))
 + Results reproduced by [@pxlin-09](https://github.com/pxlin-09) on 2024-10-26 (commit [`e2eb203`](https://github.com/castorini/anserini/commit/e2eb203b83dd643a356ee90f299c8877f6e108bd))
++ Results reproduced by [@Divyajyoti02](https://github.com/Divyajyoti02) on 2024-11-23 (commit [`3bc1f8b`](https://github.com/castorini/anserini/commit/3bc1f8ba6c2eb4da6a1761938fc16631bcc3d6dd))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -420,3 +420,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@a-y-m-a-n-c-h](https://github.com/a-y-m-a-n-c-h) on 2024-10-16 (commit [`0346842`](https://github.com/castorini/anserini/commit/03468423c820e1c0c38c9f48dc25d1f2f315831c))
 + Results reproduced by [@Samantha-Zhan](https://github.com/Samantha-Zhan) on 2024-10-20 (commit [`daceb40`](https://github.com/castorini/anserini/commit/daceb4084c8e8103e3e86c81a8e0d597d409220e))
 + Results reproduced by [@pxlin-09](https://github.com/pxlin-09) on 2024-10-26 (commit [`e2eb203`](https://github.com/castorini/anserini/commit/e2eb203b83dd643a356ee90f299c8877f6e108bd))
++ Results reproduced by [@Divyajyoti02](https://github.com/Divyajyoti02) on 2024-11-22 (commit [`3bc1f8b`](https://github.com/castorini/anserini/commit/3bc1f8ba6c2eb4da6a1761938fc16631bcc3d6dd))


### PR DESCRIPTION
There were issues in building the Anserini package on the Macbook Air M2 chip with 16 GB RAM and 256 GB memory. On building the package with maven (mvn clean package), the following error happens:

[ERROR] Failures: 
[ERROR]   ControllerTest.testSearch:42 expected:<10> but was:<0>

The error went away when I passed the DskipTests flag. The results were then reproducible successfully.

Also, it would be better for beginners if it is explained why an inverted index is necessary.