### PR TITLE
Reproducibility - experiments-20newsgroups.md

### DIFF
--- a/docs/experiments-20newsgroups.md
+++ b/docs/experiments-20newsgroups.md
@@ -41,7 +41,7 @@ Now you should see the train and test splits merged into one folder in `collecti
 To index train and test together:
 
 ```bash
-java -cp target/anserini-*-fatjar.jar io.anserini.index.IndexCollection \
+bin/run.sh io.anserini.index.IndexCollection \
   -collection TwentyNewsgroupsCollection \
   -input collections/20newsgroups/20news-bydate \
   -index indexes/lucene-index.20newsgroups.all \
@@ -52,7 +52,7 @@ java -cp target/anserini-*-fatjar.jar io.anserini.index.IndexCollection \
 To index just the train set:
 
 ```bash
-java -cp target/anserini-*-fatjar.jar io.anserini.index.IndexCollection \
+bin/run.sh io.anserini.index.IndexCollection \
   -collection TwentyNewsgroupsCollection \
   -input collections/20newsgroups/20news-bydate-train \
   -index indexes/lucene-index.20newsgroups.train \
@@ -63,7 +63,7 @@ java -cp target/anserini-*-fatjar.jar io.anserini.index.IndexCollection \
 To index just the test set:
 
 ```bash
-java -cp target/anserini-*-fatjar.jar io.anserini.index.IndexCollection \
+bin/run.sh io.anserini.index.IndexCollection \
   -collection TwentyNewsgroupsCollection \
   -input collections/20newsgroups/20news-bydate-test \
   -index indexes/lucene-index.20newsgroups.test \
@@ -76,7 +76,7 @@ Indexing should take just a few seconds.
 You can check the document count (for train and test together, or train/test individually) with:
 
 ```bash
-java -cp target/anserini-*-fatjar.jar io.anserini.index.IndexReaderUtils \
+bin/run.sh io.anserini.index.IndexReaderUtils \
   -index indexes/lucene-index.20newsgroups.all \
   -stats
 ```

--- a/docs/experiments-20newsgroups.md
+++ b/docs/experiments-20newsgroups.md
@@ -82,4 +82,5 @@ For convenience, we also provide pre-built indexes above.
 ## Reproduction Log[*](reproducibility.md)
 
 + Results reproduced by [@stephaniewhoo](http://github.com/stephaniewhoo) on 2020-11-24 (commit [`b7f1f08`](https://github.com/castorini/anserini/commit/b7f1f08689014159c1d5b2c9b9905b363af1cbbf))
++ Results reproduced by [@b8zhong](http://github.com/b8zhong) on 2024-11-27 (commit [`a5e6771`](https://github.com/castorini/anserini/commit/a5e6771a0aedcfb1c394e345636236d536c8c57d))
 

--- a/docs/experiments-20newsgroups.md
+++ b/docs/experiments-20newsgroups.md
@@ -41,34 +41,57 @@ Now you should see the train and test splits merged into one folder in `collecti
 To index train and test together:
 
 ```bash
-sh target/appassembler/bin/IndexCollection -collection TwentyNewsgroupsCollection \
- -input collections/20newsgroups/20news-bydate \
- -index indexes/lucene-index.20newsgroups.all \
- -generator DefaultLuceneDocumentGenerator -threads 2 \
- -storePositions -storeDocvectors -storeRaw -optimize
+java -cp target/anserini-*-fatjar.jar io.anserini.index.IndexCollection \
+  -collection TwentyNewsgroupsCollection \
+  -input collections/20newsgroups/20news-bydate \
+  -index indexes/lucene-index.20newsgroups.all \
+  -generator DefaultLuceneDocumentGenerator -threads 2 \
+  -storePositions -storeDocvectors -storeRaw -optimize
 ```
 
 To index just the train set:
 
 ```bash
-sh target/appassembler/bin/IndexCollection -collection TwentyNewsgroupsCollection \
- -input collections/20newsgroups/20news-bydate-train \
- -index indexes/lucene-index.20newsgroups.train \
- -generator DefaultLuceneDocumentGenerator -threads 2 \
- -storePositions -storeDocvectors -storeRaw -optimize
+java -cp target/anserini-*-fatjar.jar io.anserini.index.IndexCollection \
+  -collection TwentyNewsgroupsCollection \
+  -input collections/20newsgroups/20news-bydate-train \
+  -index indexes/lucene-index.20newsgroups.train \
+  -generator DefaultLuceneDocumentGenerator -threads 2 \
+  -storePositions -storeDocvectors -storeRaw -optimize
 ```
 
 To index just the test set:
 
 ```bash
-sh target/appassembler/bin/IndexCollection -collection TwentyNewsgroupsCollection \
- -input collections/20newsgroups/20news-bydate-test \
- -index indexes/lucene-index.20newsgroups.test \
- -generator DefaultLuceneDocumentGenerator -threads 2 \
- -storePositions -storeDocvectors -storeRaw -optimize
+java -cp target/anserini-*-fatjar.jar io.anserini.index.IndexCollection \
+  -collection TwentyNewsgroupsCollection \
+  -input collections/20newsgroups/20news-bydate-test \
+  -index indexes/lucene-index.20newsgroups.test \
+  -generator DefaultLuceneDocumentGenerator -threads 2 \
+  -storePositions -storeDocvectors -storeRaw -optimize
 ```
 
 Indexing should take just a few seconds.
+
+You can check the document count (for train and test together, or train/test individually) with:
+
+```bash
+java -cp target/anserini-*-fatjar.jar io.anserini.index.IndexReaderUtils \
+  -index indexes/lucene-index.20newsgroups.all \
+  -stats
+```
+
+Which should output:
+
+```
+Index statistics
+----------------
+documents:             18846
+documents (non-empty): 18846
+unique terms:          165633
+total terms:           4219956
+```
+
 For reference, the number of docs indexed should be exactly as follows:
 
 |               | # of docs | pre-built index |


### PR DESCRIPTION
# Issue: Build Failure with `mvn clean appassembler:assemble`

## Summary

I wanted to reproduce this (indexing works as expected when I directly used the fatjar), but I ran into the following using the commands in the guide.

Similar to this issue: https://github.com/castorini/anserini/issues/1107, but I don't have the `JAVA_HOME` error.

The `mvn clean appassembler:assemble` command fails with the following error:

```
Failed to execute goal org.codehaus.mojo:appassembler-maven-plugin:2.1.0:assemble on project anserini: The parameters ‘programs’ for goal org.codehaus.mojo:appassembler-maven-plugin:2.1.0:assemble are missing or invalid
```

## Steps to Reproduce

To index train and test together:

```bash
sh target/appassembler/bin/IndexCollection \
  -collection TwentyNewsgroupsCollection \
  -input collections/20newsgroups/20news-bydate \
  -index indexes/lucene-index.20newsgroups.all \
  -generator DefaultLuceneDocumentGenerator \
  -threads 2 \
  -storePositions -storeDocvectors -storeRaw -optimize
```

Error encountered:

```
sh: target/appassembler/bin/IndexCollection: No such file or directory
```

Running the following commands:

```bash
mvn clean appassembler:assemble -DskipTests

java -cp target/anserini-*-fatjar.jar io.anserini.index.IndexCollection \
  -collection TwentyNewsgroupsCollection \
  -input collections/20newsgroups/20news-bydate \
  -index indexes/lucene-index.20newsgroups.all \
  -generator DefaultLuceneDocumentGenerator \
  -threads 6 \
  -storePositions -storeDocvectors -storeRaw -optimize
```

Second error encountered (running with `mvn clean appassembler:assemble -DskipTests -e -X`)

```
...

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.983 s
[INFO] Finished at: 2024-11-27T21:20:10-05:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.codehaus.mojo:appassembler-maven-plugin:2.1.0:assemble (default-cli) on project anserini: The parameters 'programs' for goal org.codehaus.mojo:appassembler-maven-plugin:2.1.0:assemble are missing or invalid -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.codehaus.mojo:appassembler-maven-plugin:2.1.0:assemble (default-cli) on project anserini: The parameters 'programs' for goal org.codehaus.mojo:appassembler-maven-plugin:2.1.0:assemble are missing or invalid
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:333)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:261)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:906)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:283)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:206)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke (Method.java:580)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:361)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
Caused by: org.apache.maven.plugin.PluginParameterException: The parameters 'programs' for goal org.codehaus.mojo:appassembler-maven-plugin:2.1.0:assemble are missing or invalid
    at org.apache.maven.plugin.internal.DefaultMavenPluginManager.populateMojoExecutionFields (DefaultMavenPluginManager.java:624)
    at org.apache.maven.plugin.internal.DefaultMavenPluginManager.getConfiguredMojo (DefaultMavenPluginManager.java:573)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:114)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:328)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:261)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:906)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:283)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:206)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke (Method.java:580)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:361)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
[ERROR] 
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginParameterException
[DEBUG] Shutting down adapter factory; available factories [file-lock, rwlock-local, semaphore-local, noop]; available name mappers [discriminating, file-gav, file-hgav, file-static, gav, static]
[DEBUG] Shutting down 'file-lock' factory
[DEBUG] Shutting down 'rwlock-local' factory
[DEBUG] Shutting down 'semaphore-local' factory
[DEBUG] Shutting down 'noop' factory
```
Maybe it's just a build issue from my end? Or maybe `pom.xml` needs the programs element

## Environment

- **Operating System**: macOS 15.1.1
- **Java Version**: OpenJDK 21.0.5 (set via JAVA_HOME)
- **Maven Version**: 3.9.9