### PR TITLE
Remove 'NoMerge' statement in docs for BEIR

### DIFF
--- a/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-arguana.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-arguana.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-arguana.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-arguana.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-arguana.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-arguana.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-arguana.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-bioasq.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-bioasq.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-bioasq.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-bioasq.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-bioasq.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-bioasq.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-bioasq.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-bioasq.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-climate-fever.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-climate-fever.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-climate-fever.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-climate-fever.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-climate-fever.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-climate-fever.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-climate-fever.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-climate-fever.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-fever.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-fever.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-fever.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-fever.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-fever.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-fever.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-fever.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-fever.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-fiqa.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-fiqa.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-fiqa.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-fiqa.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-fiqa.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-fiqa.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-fiqa.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-fiqa.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-hotpotqa.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-hotpotqa.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-hotpotqa.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-hotpotqa.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-hotpotqa.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-hotpotqa.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-hotpotqa.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-hotpotqa.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-nfcorpus.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-nfcorpus.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-nfcorpus.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-nfcorpus.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-nfcorpus.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-nfcorpus.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-nfcorpus.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-nfcorpus.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-nq.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-nq.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-nq.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-nq.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-nq.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-nq.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-nq.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-nq.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-quora.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-quora.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-quora.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-quora.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-quora.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-quora.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-quora.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-quora.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-robust04.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-robust04.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-robust04.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-robust04.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-robust04.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-robust04.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-robust04.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-robust04.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-scidocs.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-scidocs.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-scidocs.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-scidocs.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-scidocs.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-scidocs.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-scidocs.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-scidocs.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-scifact.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-scifact.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-scifact.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-scifact.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-scifact.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-scifact.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-scifact.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-scifact.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-signal1m.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-signal1m.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-signal1m.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-signal1m.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-signal1m.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-signal1m.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-signal1m.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-signal1m.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-trec-covid.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-trec-covid.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-trec-covid.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-trec-covid.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-trec-covid.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-trec-covid.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-trec-covid.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-trec-covid.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-trec-news.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-trec-news.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-trec-news.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-trec-news.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-trec-news.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-trec-news.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-trec-news.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-trec-news.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw-int8.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw-int8.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw.cached.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw.onnx.md
@@ -43,8 +43,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 ```
 
 The path `/path/to/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-bge-base-en-v1.5/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-bge-base-en-v1.5/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw.cached.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-bge-base-en-v1.5/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-dl19-passage.bge-base-en-v1.5.hnsw.onnx.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-bge-base-en-v1.5/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
@@ -60,8 +60,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cohere-embed-english-v3.0/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-dl19-passage.cohere-embed-english-v3.0.hnsw.cached.md
+++ b/docs/regressions/regressions-dl19-passage.cohere-embed-english-v3.0.hnsw.cached.md
@@ -60,8 +60,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cohere-embed-english-v3.0/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw-int8.cached.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw-int8.onnx.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw.cached.md
+++ b/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw.cached.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw.onnx.md
+++ b/docs/regressions/regressions-dl19-passage.cos-dpr-distil.hnsw.onnx.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-dl19-passage.openai-ada2.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl19-passage.openai-ada2.hnsw-int8.cached.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-openai-ada2/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/docs/regressions/regressions-dl19-passage.openai-ada2.hnsw.cached.md
+++ b/docs/regressions/regressions-dl19-passage.openai-ada2.hnsw.cached.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-openai-ada2/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-bge-base-en-v1.5/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-bge-base-en-v1.5/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw.cached.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-bge-base-en-v1.5/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-dl20-passage.bge-base-en-v1.5.hnsw.onnx.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-bge-base-en-v1.5/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
@@ -60,8 +60,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cohere-embed-english-v3.0/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-dl20-passage.cohere-embed-english-v3.0.hnsw.cached.md
+++ b/docs/regressions/regressions-dl20-passage.cohere-embed-english-v3.0.hnsw.cached.md
@@ -60,8 +60,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cohere-embed-english-v3.0/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw-int8.cached.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw-int8.onnx.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw.cached.md
+++ b/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw.cached.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw.onnx.md
+++ b/docs/regressions/regressions-dl20-passage.cos-dpr-distil.hnsw.onnx.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-dl20-passage.openai-ada2.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-dl20-passage.openai-ada2.hnsw-int8.cached.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-openai-ada2/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/docs/regressions/regressions-dl20-passage.openai-ada2.hnsw.cached.md
+++ b/docs/regressions/regressions-dl20-passage.openai-ada2.hnsw.cached.md
@@ -65,8 +65,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-openai-ada2/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.cached.md
@@ -62,8 +62,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-bge-base-en-v1.5/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.md
@@ -62,8 +62,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-bge-base-en-v1.5/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw.cached.md
@@ -62,8 +62,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-bge-base-en-v1.5/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.md
@@ -62,8 +62,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-bge-base-en-v1.5/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-msmarco-v1-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cohere-embed-english-v3.0.hnsw-int8.cached.md
@@ -60,8 +60,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cohere-embed-english-v3.0/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/docs/regressions/regressions-msmarco-v1-passage.cohere-embed-english-v3.0.hnsw.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cohere-embed-english-v3.0.hnsw.cached.md
@@ -60,8 +60,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cohere-embed-english-v3.0/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw-int8.cached.md
@@ -62,8 +62,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.md
@@ -62,8 +62,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw.cached.md
@@ -62,8 +62,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.md
@@ -62,8 +62,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-cos-dpr-distil/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/docs/regressions/regressions-msmarco-v1-passage.openai-ada2.hnsw-int8.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.openai-ada2.hnsw-int8.cached.md
@@ -62,8 +62,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-openai-ada2/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/docs/regressions/regressions-msmarco-v1-passage.openai-ada2.hnsw.cached.md
+++ b/docs/regressions/regressions-msmarco-v1-passage.openai-ada2.hnsw.cached.md
@@ -62,8 +62,6 @@ bin/run.sh io.anserini.index.IndexHnswDenseVectors \
 The path `/path/to/msmarco-passage-openai-ada2/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-arguana.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fever.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fever.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fever.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fever.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fever.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fever.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fever.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fever.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fever.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nq.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nq.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nq.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nq.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nq.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nq.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nq.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nq.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nq.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-quora.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-quora.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-quora.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-quora.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-quora.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-quora.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-quora.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-quora.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-quora.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-robust04.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scifact.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw-int8.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw-int8.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw.cached.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw.onnx.template
@@ -36,8 +36,6 @@ ${index_cmds}
 ```
 
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/dl19-passage.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/dl19-passage.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/src/main/resources/docgen/templates/dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/src/main/resources/docgen/templates/dl19-passage.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/dl19-passage.bge-base-en-v1.5.hnsw.cached.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/dl19-passage.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage.bge-base-en-v1.5.hnsw.onnx.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/dl19-passage.cohere-embed-english-v3.0.hnsw-int8.cached.template
@@ -53,8 +53,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/dl19-passage.cohere-embed-english-v3.0.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/dl19-passage.cohere-embed-english-v3.0.hnsw.cached.template
@@ -53,8 +53,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/dl19-passage.cos-dpr-distil.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/dl19-passage.cos-dpr-distil.hnsw-int8.cached.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/src/main/resources/docgen/templates/dl19-passage.cos-dpr-distil.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage.cos-dpr-distil.hnsw-int8.onnx.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/src/main/resources/docgen/templates/dl19-passage.cos-dpr-distil.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/dl19-passage.cos-dpr-distil.hnsw.cached.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/dl19-passage.cos-dpr-distil.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/dl19-passage.cos-dpr-distil.hnsw.onnx.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/dl19-passage.openai-ada2.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/dl19-passage.openai-ada2.hnsw-int8.cached.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/src/main/resources/docgen/templates/dl19-passage.openai-ada2.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/dl19-passage.openai-ada2.hnsw.cached.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/dl20-passage.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/dl20-passage.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/src/main/resources/docgen/templates/dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/src/main/resources/docgen/templates/dl20-passage.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/dl20-passage.bge-base-en-v1.5.hnsw.cached.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/dl20-passage.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage.bge-base-en-v1.5.hnsw.onnx.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/dl20-passage.cohere-embed-english-v3.0.hnsw-int8.cached.template
@@ -53,8 +53,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/dl20-passage.cohere-embed-english-v3.0.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/dl20-passage.cohere-embed-english-v3.0.hnsw.cached.template
@@ -53,8 +53,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/dl20-passage.cos-dpr-distil.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/dl20-passage.cos-dpr-distil.hnsw-int8.cached.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/src/main/resources/docgen/templates/dl20-passage.cos-dpr-distil.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage.cos-dpr-distil.hnsw-int8.onnx.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/src/main/resources/docgen/templates/dl20-passage.cos-dpr-distil.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/dl20-passage.cos-dpr-distil.hnsw.cached.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/dl20-passage.cos-dpr-distil.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/dl20-passage.cos-dpr-distil.hnsw.onnx.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/dl20-passage.openai-ada2.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/dl20-passage.openai-ada2.hnsw-int8.cached.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/src/main/resources/docgen/templates/dl20-passage.openai-ada2.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/dl20-passage.openai-ada2.hnsw.cached.template
@@ -58,8 +58,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.cached.template
@@ -55,8 +55,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.template
@@ -55,8 +55,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.bge-base-en-v1.5.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.bge-base-en-v1.5.hnsw.cached.template
@@ -55,8 +55,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.template
@@ -55,8 +55,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.cohere-embed-english-v3.0.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.cohere-embed-english-v3.0.hnsw-int8.cached.template
@@ -53,8 +53,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.cohere-embed-english-v3.0.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.cohere-embed-english-v3.0.hnsw.cached.template
@@ -53,8 +53,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.cos-dpr-distil.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.cos-dpr-distil.hnsw-int8.cached.template
@@ -55,8 +55,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.template
@@ -55,8 +55,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.cos-dpr-distil.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.cos-dpr-distil.hnsw.cached.template
@@ -55,8 +55,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.template
@@ -55,8 +55,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.openai-ada2.hnsw-int8.cached.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.openai-ada2.hnsw-int8.cached.template
@@ -55,8 +55,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 Furthermore, we are using Lucene's [Automatic Byte Quantization](https://www.elastic.co/search-labs/blog/articles/scalar-quantization-in-lucene) feature, which increase the on-disk footprint of the indexes since we're storing both the int8 quantized vectors and the float32 vectors, but only the int8 quantized vectors need to be loaded into memory.
 See [issue #2292](https://github.com/castorini/anserini/issues/2292) for some experiments reporting the performance impact.
 

--- a/src/main/resources/docgen/templates/msmarco-v1-passage.openai-ada2.hnsw.cached.template
+++ b/src/main/resources/docgen/templates/msmarco-v1-passage.openai-ada2.hnsw.cached.template
@@ -55,8 +55,6 @@ ${index_cmds}
 The path `/path/to/${corpus}/` should point to the corpus downloaded above.
 Upon completion, we should have an index with 8,841,823 documents.
 
-Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments.
-This is because merging index segments is a costly operation and not worthwhile given our query set.
 
 ## Retrieval
 


### PR DESCRIPTION
This isn't true anymore... so removing:

> Note that here we are explicitly using Lucene's `NoMergePolicy` merge policy, which suppresses any merging of index segments. This is because merging index segments is a costly operation and not worthwhile given our query set.
