### PR TITLE
Reproducing BM25 Baselines for MS MARCO

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -541,3 +541,5 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@nihalmenon](https://github.com/nihalmenon) on 2024-11-29 (commit [`aa91e2db`](https://github.com/castorini/anserini/commit/aa91e2db224c752cc6a947bdf66bdbf9ce90af25))
 + Results reproduced by [@sherloc512](https://github.com/sherloc512) on 2024-12-04 (commit [`9e55b1c`](https://github.com/castorini/anserini/commit/9e55b1c97fced46530dac1f78975d19635ffaf7a))
 + Results reproduced by [@zdann15](https://github.com/zdann15) on 2024-12-04 (commit [`9d311b4`](https://github.com/castorini/anserini/commit/9d311b4409a9ff3d79b01910178eaec3931f0abe))
++ Results reproduced by [@Alireza-Zwolf](https://github.com/Alireza-Zwolf) on 2024-12-15 (commit [`c7dff5f`](https://github.com/castorini/anserini/commit/c7dff5f8417905612ad9f97e85012440e9e16087))
+


### PR DESCRIPTION
Macbook Air M3 (macOS 14.6)
Python 3.13.1
Java openJDK 23.0.1
Maven 3.9.9

All the results were reproduced without any problem. However during the build time using Maven I encountered errors on 5 test cases on these classes: 
- JsonVectorCollectionDocumentObjectTest
- BM25StatTest, 
- BigramFeaturesTest,
- LmDirTest, 
- ExtractTopDfTermsTest

and the errors were like this:
- [ERROR]   JsonVectorCollectionDocumentObjectTest The test or suite printed 16688 bytes to stdout and stderr, even though the limit was set to 8192 bytes. Increase the limit with @Limit, ignore it completely with @SuppressSysoutChecks or run with -Dtests.verbose=true

Basically the errors indicate that the tests are failing because the amount of output printed to stdout and stderr during the test execution exceeded the allowed default limit of 8192 bytes. It can be solved by increasing the stdout buffer limit (adding @Limit(bytes = 30000) on top of each mentioned classes) or simply build the project using Maven with -Dtests.verbose=true flag which ignore the system's buffer limit.