### PR TITLE
Add to Onboarding Reproduction Logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -548,3 +548,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@nourj98](https://github.com/nourj98) on 2025-01-06 (commit [`d970628`](https://github.com/castorini/anserini/commit/d9706285de2c3a80a25ed5d6218d899f46108adc))
 + Results reproduced by [@mithildamani256](https://github.com/mithildamani256) on 2025-01-11 (commit [`8ea0eab`](https://github.com/castorini/anserini/commit/8ea0eab950f86ed0ddd19ad49c165c7a3ae4b370))
 + Results reproduced by [@Alexisfine](https://github.com/Alexisfine) on 2025-01-12 (commit [`697ae8f`](https://github.com/Alexisfine/anserini/commit/697ae8f239a53baa4a119c57009cffb60aac1a0c))
++ Results reproduced by [@ezafar](https://github.com/ezafar) on 2025-01-14 (commit [`f18bc80`](https://github.com/castorini/anserini/commit/f18bc8010ddfc341e83e39973c11620260846310))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -432,3 +432,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@nourj98](https://github.com/nourj98) on 2025-01-06 (commit [`d970628`](https://github.com/castorini/anserini/commit/d9706285de2c3a80a25ed5d6218d899f46108adc))
 + Results reproduced by [@mithildamani256](https://github.com/mithildamani256) on 2025-01-10 (commit [`8ea0eab`](https://github.com/mithildamani256/anserini/commit/8ea0eab950f86ed0ddd19ad49c165c7a3ae4b370))
 + Results reproduced by [@Alexisfine](https://github.com/Alexisfine) on 2025-01-12 (commit [`697ae8f`](https://github.com/Alexisfine/anserini/commit/697ae8f239a53baa4a119c57009cffb60aac1a0c))
++ Results reproduced by [@ezafar](https://github.com/ezafar) on 2025-01-14 (commit [`f18bc80`](https://github.com/castorini/anserini/commit/f18bc8010ddfc341e83e39973c11620260846310))


### PR DESCRIPTION
System: Apple Macbook Pro 2020
OS: MacOS Sonoma 14.7.2
Python: 3.10.13
Maven: 3.9.9
Java: openjdk 21.0.5

---

I encountered some issues during the [Installation](https://github.com/castorini/anserini?tab=readme-ov-file#-installation) of Anserini, specifically before the Indexing step.

In hindsight, I likely overlooked the strict requirement mentioned in the documentation:
> "You'll need Java 21 and Maven 3.9+ to build Anserini."

Since I had never configured Java locally on my system before, it took me quite a time to resolve the setup issues. Here are the key challenges I faced and how I addressed them:

1) Incorrect Java Version

Initially, my system was running an older Java version (java version "1.8.0_421"), which caused the installation process to fail.

After realizing this, I (re)-installed Java using `brew uninstall openjdk`. However, the next Java version installed was Java 23 (java version "23.0.1"), which also caused errors because Anserini explicitly requires Java 21.
Finally, after carefully re-reading the installation guide, I installed the correct version with `brew install openjdk@21`

2) Mismatch Between Maven and Java Versions

Even after installing Java 21, I encountered issues because mvn (Maven) was still pointing to Java 23 instead of the desired Java 21. Running mvn -version revealed the mismatch:
```
> mvn -version
Apache Maven 3.9.9 (8e8579a9e76f7d015ee5ec7bfcdc97d260186937)
Maven home: /usr/local/Cellar/maven/3.9.9/libexec
Java version: 23.0.1
...
```

To resolve this, I had to configure my `.bashrc` file to explicitly set Java 21 as the default version for both java and mvn.

Although these issues were partly due to my initial unfamiliarity with Java configurations, I believe the installation process could be made more user-friendly by adding some simple checks before running `mvn clean package` :

```bash
java -version
mvn -version
```
to (1) verify that the correct versions of Java and Maven are installed and (2) ensure Maven is pointing to the correct version of Java.


**Error Messages**
Below, I’ve included the some error messages I encountered when I ran with wrong version of Java:

1. Test Failures during Build
```
INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   JsonVectorCollectionDocumentObjectTest The test or suite printed 16688 bytes to stdout and stderr, even though the limit was set to 8192 bytes. Increase the limit with @Limit, ignore it completely with @SuppressSysoutChecks or run with -Dtests.verbose=true
[ERROR]   BM25StatTest The test or suite printed 8793 bytes to stdout and stderr, even though the limit was set to 8192 bytes. Increase the limit with @Limit, ignore it completely with @SuppressSysoutChecks or run with -Dtests.verbose=true
[ERROR]   BigramFeaturesTest The test or suite printed 8763 bytes to stdout and stderr, even though the limit was set to 8192 bytes. Increase the limit with @Limit, ignore it completely with @SuppressSysoutChecks or run with -Dtests.verbose=true
[ERROR]   LmDirTest The test or suite printed 8790 bytes to stdout and stderr, even though the limit was set to 8192 bytes. Increase the limit with @Limit, ignore it completely with @SuppressSysoutChecks or run with -Dtests.verbose=true
[ERROR]   ExtractTopDfTermsTest The test or suite printed 28289 bytes to stdout and stderr, even though the limit was set to 8192 bytes. Increase the limit with @Limit, ignore it completely with @SuppressSysoutChecks or run with -Dtests.verbose=true
[INFO] 
[ERROR] Tests run: 822, Failures: 5, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  08:43 min
[INFO] Finished at: 2025-01-14T22:44:31-05:00
[INFO] ------------------------------------------------------------------------
```

2. `target/*-fatjar.jar` Files needed by `bin/run.sh` not being created.
```
$ bin/run.sh io.anserini. index. IndexCollection \
    -collection JsonCollection \
    -index codexes osmarco-passages eene-ede msmarco \
    -generator DefaultLuceneDocumentGenerator \
    -threads 9 -storePositions -storeDocvectors -storeRaw

ls: target/*-fatjar.jar: No such file or directory
Unrecognized option: --add-modules
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```



