### PR TITLE
Complete onboarding for Anserini

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -550,5 +550,6 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@Alexisfine](https://github.com/Alexisfine) on 2025-01-12 (commit [`697ae8f`](https://github.com/Alexisfine/anserini/commit/697ae8f239a53baa4a119c57009cffb60aac1a0c))
 + Results reproduced by [@ezafar](https://github.com/ezafar) on 2025-01-14 (commit [`f18bc80`](https://github.com/castorini/anserini/commit/f18bc8010ddfc341e83e39973c11620260846310))
 + Results reproduced by [@ErfanSadraiye](https://github.com/ErfanSadraiye) on 2025-01-16 (commit [`7c1de0e`](https://github.com/castorini/anserini/commit/7c1de0eb94781e5868ee9962d9019e4474bd1ce7))
-+ Results reproduced by [@Taqvis](https://github.com/Taqvis) on 2025-02-08 (commit [`817fb66`](https://github.com/castorini/anserini/commit/817fb669291c487e07826430b3d7a60fa0fae746)))
++ Results reproduced by [@Taqvis](https://github.com/Taqvis) on 2025-02-08 (commit [`817fb66`](https://github.com/castorini/anserini/commit/817fb669291c487e07826430b3d7a60fa0fae746))
 + Results reproduced by [@jazyz](https://github.com/jazyz) on 2025-02-13 (commit [`864f647`](https://github.com/castorini/anserini/commit/864f647d5fdb684a34ec70367d3aa45f894ecdce))
++ Results reproduced by [@mohammaderfankabir](https://github.com/mohammaderfankabir) on 2025-02-16 (commit [`0fe40c3`](https://github.com/castorini/anserini/commit/0fe40c32df4c61b8dfa7b332189a06ce00a38d85))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -434,5 +434,6 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@Alexisfine](https://github.com/Alexisfine) on 2025-01-12 (commit [`697ae8f`](https://github.com/Alexisfine/anserini/commit/697ae8f239a53baa4a119c57009cffb60aac1a0c))
 + Results reproduced by [@ezafar](https://github.com/ezafar) on 2025-01-14 (commit [`f18bc80`](https://github.com/castorini/anserini/commit/f18bc8010ddfc341e83e39973c11620260846310))
 + Results reproduced by [@ErfanSadraiye](https://github.com/ErfanSadraiye) on 2025-01-16 (commit [`7c1de0e`](https://github.com/castorini/anserini/commit/7c1de0eb94781e5868ee9962d9019e4474bd1ce7))
-+ Results reproduced by [@Taqvis](https://github.com/Taqvis) on 2025-02-08 (commit [`817fb66`](https://github.com/castorini/anserini/commit/817fb669291c487e07826430b3d7a60fa0fae746)))
++ Results reproduced by [@Taqvis](https://github.com/Taqvis) on 2025-02-08 (commit [`817fb66`](https://github.com/castorini/anserini/commit/817fb669291c487e07826430b3d7a60fa0fae746))
 + Results reproduced by [@jazyz](https://github.com/jazyz) on 2025-02-13 (commit [`864f647`](https://github.com/castorini/anserini/commit/864f647d5fdb684a34ec70367d3aa45f894ecdce))
++ Results reproduced by [@mohammaderfankabir](https://github.com/mohammaderfankabir) on 2025-02-16 (commit [`0fe40c3`](https://github.com/castorini/anserini/commit/0fe40c32df4c61b8dfa7b332189a06ce00a38d85))


### PR DESCRIPTION
Environment: Google IDX Project (RAM ≤ 8GB)

Successfully onboarded Anserini. Everything worked except `mvn clean package`, which had to be run differently to avoid resource overhead:

    $ mvn clean package -DskipTests -Dmaven.test.skip=true -Dgpg.skip=true

Note: The `-Dgpg.skip=true` flag was added to resolve an issue with GitHub Codespace and can be ignored.