### PR TITLE
Move regression order to avoid conflicts

### DIFF
--- a/docs/regressions-log.md
+++ b/docs/regressions-log.md
@@ -3,6 +3,12 @@
 The following change log details commits to regression tests that alter effectiveness and the addition of new regression tests.
 This documentation is useful for figuring why results may have changed over time.
 
+### February 14, 2025
+
++ commit [`d1585e`](https://github.com/castorini/anserini/commit/d1585ed640a11d8d9a6b1af499195525d78a03ae) (2025/02/14)
+
+Installed LexicalLSH and FakeWords Parquet regressions for MS MARCO Passage V1.
+
 ### December 7, 2024
 
 + commit [`f9f73c`](https://github.com/castorini/anserini/commit/f9f73c280ed51c9c816418be23f098ab17cf64ee) (2024/12/07)

--- a/src/main/python/regressions-batch03.txt
+++ b/src/main/python/regressions-batch03.txt
@@ -196,23 +196,15 @@ python src/main/python/run_regression.py --verify --search --regression dl20-doc
 python src/main/python/run_regression.py --verify --search --regression dl20-doc-segmented.unicoil.cached > logs/log.dl20-doc-segmented.unicoil.cached.txt 2>&1
 python src/main/python/run_regression.py --verify --search --regression dl20-doc-segmented.unicoil-noexp.cached > logs/log.dl20-doc-segmented.unicoil-noexp.cached.txt 2>&1
 
-# MS MARCO V1, full indexing, json
+# MS MARCO V1, full indexing, json dense vectors (cached)
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.cos-dpr-distil.flat.cached > logs/log.msmarco-v1-passage.cos-dpr-distil.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.cos-dpr-distil.flat.onnx > logs/log.msmarco-v1-passage.cos-dpr-distil.flat.onnx.txt 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.cos-dpr-distil.flat-int8.cached > logs/log.msmarco-v1-passage.cos-dpr-distil.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.cos-dpr-distil.flat-int8.onnx > logs/log.msmarco-v1-passage.cos-dpr-distil.flat-int8.onnx.txt 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.cos-dpr-distil.hnsw.cached > logs/log.msmarco-v1-passage.cos-dpr-distil.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.cos-dpr-distil.hnsw.onnx > logs/log.msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.txt 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.cos-dpr-distil.hnsw-int8.cached > logs/log.msmarco-v1-passage.cos-dpr-distil.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx > logs/log.msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.txt 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.bge-base-en-v1.5.flat.cached > logs/log.msmarco-v1-passage.bge-base-en-v1.5.flat.cached.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.bge-base-en-v1.5.flat.onnx > logs/log.msmarco-v1-passage.bge-base-en-v1.5.flat.onnx.txt 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.bge-base-en-v1.5.flat-int8.cached > logs/log.msmarco-v1-passage.bge-base-en-v1.5.flat-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.bge-base-en-v1.5.flat-int8.onnx > logs/log.msmarco-v1-passage.bge-base-en-v1.5.flat-int8.onnx.txt 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.bge-base-en-v1.5.hnsw.cached > logs/log.msmarco-v1-passage.bge-base-en-v1.5.hnsw.cached.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx > logs/log.msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.txt 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.cached > logs/log.msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.cached.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx > logs/log.msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.txt 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.openai-ada2.flat.cached > logs/log.msmarco-v1-passage.openai-ada2.flat.cached.txt 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.openai-ada2.flat-int8.cached > logs/log.msmarco-v1-passage.openai-ada2.flat-int8.cached.txt 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression msmarco-v1-passage.openai-ada2.hnsw.cached > logs/log.msmarco-v1-passage.openai-ada2.hnsw.cached.txt 2>&1
@@ -282,7 +274,17 @@ python src/main/python/run_regression.py --verify --search --regression dl23-doc
 python src/main/python/run_regression.py --verify --search --regression dl23-doc-segmented.unicoil-noexp-0shot-v2.cached > logs/log.dl23-doc-segmented.unicoil-noexp-0shot-v2.cached.txt 2>&1
 python src/main/python/run_regression.py --verify --search --regression dl23-doc-segmented.unicoil-0shot-v2.cached > logs/log.dl23-doc-segmented.unicoil-0shot-v2.cached.txt 2>&1
 
-# Just retrieval, json
+# MS MARCO V1, just retrieval, json dense vectors (onnx)
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.cos-dpr-distil.flat.onnx > logs/log.msmarco-v1-passage.cos-dpr-distil.flat.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.cos-dpr-distil.flat-int8.onnx > logs/log.msmarco-v1-passage.cos-dpr-distil.flat-int8.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.cos-dpr-distil.hnsw.onnx > logs/log.msmarco-v1-passage.cos-dpr-distil.hnsw.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx > logs/log.msmarco-v1-passage.cos-dpr-distil.hnsw-int8.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.bge-base-en-v1.5.flat.onnx > logs/log.msmarco-v1-passage.bge-base-en-v1.5.flat.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.bge-base-en-v1.5.flat-int8.onnx > logs/log.msmarco-v1-passage.bge-base-en-v1.5.flat-int8.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx > logs/log.msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.txt 2>&1
+python src/main/python/run_regression.py --verify --search --regression msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx > logs/log.msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.txt 2>&1
+
+# Just retrieval, json dense vectors
 python src/main/python/run_regression.py --verify --search --regression dl19-passage.cos-dpr-distil.flat.cached > logs/log.dl19-passage.cos-dpr-distil.flat.cached.txt 2>&1
 python src/main/python/run_regression.py --verify --search --regression dl19-passage.cos-dpr-distil.flat.onnx > logs/log.dl19-passage.cos-dpr-distil.flat.onnx.txt 2>&1
 python src/main/python/run_regression.py --verify --search --regression dl19-passage.cos-dpr-distil.flat-int8.cached > logs/log.dl19-passage.cos-dpr-distil.flat-int8.cached.txt 2>&1


### PR DESCRIPTION
Before, running the cached and onnx versions of the regressions was causing conflicts because they were both trying to write to the same index location. Instead, spread them out.

Also, add docs for lexlsh/fw regressions.
