### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -74,6 +74,8 @@ bin/run.sh io.anserini.search.SearchHnswDenseVectors \
   -encoder BgeBaseEn15 -hits 1000 -threads 4
 ```
 
+> Note: If you encounter encoder loading errors, clear the cache at `~/.cache/pyserini/encoders`.
+
 Instead of `SearchCollection`, we use `SearchHnswDenseVectors` since it's a different type of index.
 We are using a prebuilt index, specified as `-index msmarco-v1-passage.bge-base-en-v1.5.hnsw`.
 The above retrieval command automatically downloads the HNSW index for the MS MARCO passage collection.
@@ -82,7 +84,7 @@ Beware, it's 26 GB:
 ```bash
 % du -h ~/.cache/pyserini/indexes/lucene-hnsw.msmarco-v1-passage.bge-base-en-v1.5.20240117.53514b.00a577f689d90f95e6c5611438b0af3d
 26G	~/.cache/pyserini/indexes/lucene-hnsw.msmarco-v1-passage.bge-base-en-v1.5.20240117.53514b.00a577f689d90f95e6c5611438b0af3d
-````
+```
 
 For reference: on a circa 2022 MacBook Air with an Apple M2 processor and 24 GB RAM, the retrieval run takes around X minutes.
 

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -109,3 +109,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 
 ## Reproduction Log[*](reproducibility.md)
 
++ Results reproduced by [@b8zhong](https://github.com/b8zhong) on 2025-02-23 (commit [`daceb40`](https://github.com/castorini/anserini/commit/daceb4084c8e8103e3e86c81a8e0d597d409220e))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -74,7 +74,7 @@ bin/run.sh io.anserini.search.SearchHnswDenseVectors \
   -encoder BgeBaseEn15 -hits 1000 -threads 4
 ```
 
-> Note: If you encounter encoder loading errors, clear the cache at `~/.cache/pyserini/encoders`.
+Note: If you encounter encoder loading errors, clear the cache at `~/.cache/pyserini/encoders`.
 
 Instead of `SearchCollection`, we use `SearchHnswDenseVectors` since it's a different type of index.
 We are using a prebuilt index, specified as `-index msmarco-v1-passage.bge-base-en-v1.5.hnsw`.


### PR DESCRIPTION
No issues; add note about clearing Encoder cache.

For reference in the future, if it pops up again:

```
bin/run.sh io.anserini.search.SearchHnswDenseVectors \
  -index msmarco-v1-passage.bge-base-en-v1.5.hnsw \
  -topics collections/msmarco-passage/queries.dev.small.tsv \
  -topicReader TsvInt \
  -output runs/run.msmarco-passage.dev.bge.txt \
  -encoder BgeBaseEn15 -hits 1000 -threads 4
WARNING: Using incubator modules: jdk.incubator.vector
Index file already exists! Skip downloading.
Index folder already exists!
Feb 23, 2025 11:42:31 A.M. org.apache.lucene.store.MemorySegmentIndexInputProvider <init>
INFO: Using MemorySegmentIndexInput with Java 21; to disable start with -Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false
Error: Unable to load Encoder "BgeBaseEn15".
```