### PR TITLE
Normalize Method for Fusion with ONNX

### DIFF
--- a/docs/experiments-beir-fusion.md
+++ b/docs/experiments-beir-fusion.md
@@ -13,7 +13,7 @@ Currently, Anserini provides support for the following fusion methods:
 
 For all experiments recorded here, the values k = 1000, depth = 1000, rrf_k = 60, and alpha = 0.5 were used.
 
-The runs of two models were fused: flat BM25 and flat bge-base-en-v1.5 with cached queries.
+The runs of two models were fused: flat BM25 and flat bge-base-en-v1.5 with ONNX.
 
 Since there were only two runs fused, the average and interpolation methods produced the same results.
 
@@ -25,67 +25,67 @@ The table below reports the effectiveness of the methods with the nDCG@10 metric
 |---------------------------|-------:|--------:|--------------:|
 | `trec-covid`              | 0.8041 |  0.6567 |     0.6567    |
 | `bioasq`                  | 0.5278 |  0.5308 |     0.5308    |
-| `nfcorpus`                | 0.3729 |  0.3415 |     0.3415    |
-| `nq`                      | 0.4832 |  0.3242 |     0.3242    |
+| `nfcorpus`                | 0.3725 |  0.3416 |     0.3416    |
+| `nq`                      | 0.4831 |  0.3241 |     0.3241    |
 | `hotpotqa`                | 0.7389 |  0.6497 |     0.6497    |
 | `fiqa`                    | 0.3671 |  0.2470 |     0.2470    |
-| `signal1m`                | 0.3527 |  0.3466 |     0.3466    |
-| `trec-news`               | 0.4864 |  0.4162 |     0.4162    |
+| `signal1m`                | 0.3533 |  0.3463 |     0.3463    |
+| `trec-news`               | 0.4855 |  0.4162 |     0.4162    |
 | `robust04`                | 0.5087 |  0.4327 |     0.4327    |
-| `arguana`                 | 0.5659 |  0.3986 |     0.3986    |
-| `webis-touche2020`        | 0.3759 |  0.4519 |     0.4519    |
+| `arguana`                 | 0.5586 |  0.3986 |     0.3986    |
+| `webis-touche2020`        | 0.3771 |  0.4510 |     0.4510    |
 | `cqadupstack-android`     | 0.4652 |  0.3872 |     0.3872    |
-| `cqadupstack-english`     | 0.4460 |  0.3601 |     0.3601    |
-| `cqadupstack-gaming`      | 0.5613 |  0.4886 |     0.4886    |
+| `cqadupstack-english`     | 0.4461 |  0.3601 |     0.3601    |
+| `cqadupstack-gaming`      | 0.5615 |  0.4886 |     0.4886    |
 | `cqadupstack-gis`         | 0.3679 |  0.2948 |     0.2948    |
-| `cqadupstack-mathematica` | 0.2747 |  0.2084 |     0.2084    |
-| `cqadupstack-physics`     | 0.4143 |  0.3285 |     0.3285    |
-| `cqadupstack-programmers` | 0.3718 |  0.2891 |     0.2891    |
+| `cqadupstack-mathematica` | 0.2751 |  0.2084 |     0.2084    |
+| `cqadupstack-physics`     | 0.4143 |  0.3283 |     0.3283    |
+| `cqadupstack-programmers` | 0.3715 |  0.2891 |     0.2891    |
 | `cqadupstack-stats`       | 0.3414 |  0.2796 |     0.2796    |
 | `cqadupstack-tex`         | 0.2931 |  0.2332 |     0.2332    |
-| `cqadupstack-unix`        | 0.3601 |  0.2829 |     0.2829    |
-| `cqadupstack-webmasters`  | 0.3710 |  0.3130 |     0.3130    |
+| `cqadupstack-unix`        | 0.3597 |  0.2829 |     0.2829    |
+| `cqadupstack-webmasters`  | 0.3711 |  0.3130 |     0.3130    |
 | `cqadupstack-wordpress`   | 0.3353 |  0.2625 |     0.2625    |
-| `quora`                   | 0.8714 |  0.8019 |     0.8019    |
+| `quora`                   | 0.8682 |  0.8009 |     0.8009    |
 | `dbpedia-entity`          | 0.4190 |  0.3365 |     0.3365    |
 | `scidocs`                 | 0.1948 |  0.1527 |     0.1527    |
 | `fever`                   | 0.8108 |  0.6688 |     0.6688    |
-| `climate-fever`           | 0.2812 |  0.1741 |     0.1741    |
-| `scifact`                 | 0.7417 |  0.6806 |     0.6806    |
+| `climate-fever`           | 0.2812 |  0.1742 |     0.1742    |
+| `scifact`                 | 0.7420 |  0.6806 |     0.6806    |
 
 
 The table below reports the effectiveness of the methods with the R@100 metric:
 
 | Corpus                    |    RRF | Average | Interpolation |
 |---------------------------|-------:|--------:|--------------:|
-| `trec-covid`              | 0.1466 |  0.1255 |     0.1255    |
+| `trec-covid`              | 0.1467 |  0.1255 |     0.1255    |
 | `bioasq`                  | 0.8128 |  0.7869 |     0.7869    |
-| `nfcorpus`                | 0.3392 |  0.3003 |     0.3003    |
-| `nq`                      | 0.9412 |  0.7922 |     0.7922    |
-| `hotpotqa`                | 0.8918 |  0.8184 |     0.8184    |
-| `fiqa`                    | 0.7153 |  0.5639 |     0.5639    |
+| `nfcorpus`                | 0.3391 |  0.3003 |     0.3003    |
+| `nq`                      | 0.9415 |  0.7922 |     0.7922    |
+| `hotpotqa`                | 0.8917 |  0.8184 |     0.8184    |
+| `fiqa`                    | 0.7160 |  0.5639 |     0.5639    |
 | `signal1m`                | 0.4008 |  0.4077 |     0.4077    |
 | `trec-news`               | 0.5545 |  0.4751 |     0.4751    |
 | `robust04`                | 0.4474 |  0.3963 |     0.3963    |
-| `arguana`                 | 0.9865 |  0.9331 |     0.9331    |
+| `arguana`                 | 0.9879 |  0.9331 |     0.9331    |
 | `webis-touche2020`        | 0.6169 |  0.5878 |     0.5878    |
-| `cqadupstack-android`     | 0.8218 |  0.7076 |     0.7076    |
+| `cqadupstack-android`     | 0.8203 |  0.7076 |     0.7076    |
 | `cqadupstack-english`     | 0.7520 |  0.6022 |     0.6022    |
-| `cqadupstack-gaming`      | 0.8931 |  0.7956 |     0.7956    |
+| `cqadupstack-gaming`      | 0.8933 |  0.7956 |     0.7956    |
 | `cqadupstack-gis`         | 0.7621 |  0.6487 |     0.6487    |
 | `cqadupstack-mathematica` | 0.6666 |  0.5173 |     0.5173    |
-| `cqadupstack-physics`     | 0.7922 |  0.6549 |     0.6549    |
+| `cqadupstack-physics`     | 0.7921 |  0.6549 |     0.6549    |
 | `cqadupstack-programmers` | 0.7530 |  0.5993 |     0.5993    |
-| `cqadupstack-stats`       | 0.6624 |  0.5650 |     0.5650    |
+| `cqadupstack-stats`       | 0.6616 |  0.5650 |     0.5650    |
 | `cqadupstack-tex`         | 0.6331 |  0.5004 |     0.5004    |
-| `cqadupstack-unix`        | 0.7482 |  0.5798 |     0.5798    |
-| `cqadupstack-webmasters`  | 0.7534 |  0.6127 |     0.6127    |
+| `cqadupstack-unix`        | 0.7481 |  0.5798 |     0.5798    |
+| `cqadupstack-webmasters`  | 0.7543 |  0.6127 |     0.6127    |
 | `cqadupstack-wordpress`   | 0.6869 |  0.5488 |     0.5488    |
-| `quora`                   | 0.9966 |  0.9801 |     0.9801    |
-| `dbpedia-entity`          | 0.5986 |  0.5019 |     0.5019    |
+| `quora`                   | 0.9966 |  0.9793 |     0.9793    |
+| `dbpedia-entity`          | 0.5985 |  0.5019 |     0.5019    |
 | `scidocs`                 | 0.4751 |  0.3735 |     0.3735    |
 | `fever`                   | 0.9731 |  0.9317 |     0.9317    |
-| `climate-fever`           | 0.6287 |  0.4590 |     0.4590    |
+| `climate-fever`           | 0.6288 |  0.4590 |     0.4590    |
 | `scifact`                 | 0.9767 |  0.9327 |     0.9327    |
 
 
@@ -93,34 +93,34 @@ The table below reports the effectiveness of the methods with the R@1000 metric:
 
 | Corpus                    |    RRF | Average | Interpolation |
 |---------------------------|-------:|--------:|--------------:|
-| `trec-covid`              | 0.5030 |  0.3955 |     0.3955    |
+| `trec-covid`              | 0.5029 |  0.3955 |     0.3955    |
 | `bioasq`                  | 0.9281 |  0.9030 |     0.9030    |
-| `nfcorpus`                | 0.6541 |  0.6423 |     0.6423    |
+| `nfcorpus`                | 0.6540 |  0.6422 |     0.6422    |
 | `nq`                      | 0.9874 |  0.8958 |     0.8958    |
-| `hotpotqa`                | 0.9472 |  0.8820 |     0.8820    |
+| `hotpotqa`                | 0.9473 |  0.8820 |     0.8820    |
 | `fiqa`                    | 0.8979 |  0.7402 |     0.7402    |
 | `signal1m`                | 0.6139 |  0.5642 |     0.5642    |
 | `trec-news`               | 0.8169 |  0.7051 |     0.7051    |
 | `robust04`                | 0.7237 |  0.6345 |     0.6345    |
-| `arguana`                 | 0.9964 |  0.9879 |     0.9879    |
+| `arguana`                 | 0.9964 |  0.9893 |     0.9893    |
 | `webis-touche2020`        | 0.8912 |  0.8621 |     0.8621    |
 | `cqadupstack-android`     | 0.9537 |  0.8646 |     0.8646    |
 | `cqadupstack-english`     | 0.8751 |  0.7394 |     0.7394    |
 | `cqadupstack-gaming`      | 0.9661 |  0.8952 |     0.8952    |
 | `cqadupstack-gis`         | 0.9054 |  0.8174 |     0.8174    |
 | `cqadupstack-mathematica` | 0.8781 |  0.7298 |     0.7298    |
-| `cqadupstack-physics`     | 0.9327 |  0.8375 |     0.8375    |
+| `cqadupstack-physics`     | 0.9337 |  0.8375 |     0.8375    |
 | `cqadupstack-programmers` | 0.9272 |  0.7745 |     0.7745    |
-| `cqadupstack-stats`       | 0.8370 |  0.7310 |     0.7310    |
+| `cqadupstack-stats`       | 0.8363 |  0.7310 |     0.7310    |
 | `cqadupstack-tex`         | 0.8430 |  0.6907 |     0.6907    |
-| `cqadupstack-unix`        | 0.9093 |  0.7626 |     0.7626    |
+| `cqadupstack-unix`        | 0.9097 |  0.7626 |     0.7626    |
 | `cqadupstack-webmasters`  | 0.9369 |  0.8088 |     0.8088    |
-| `cqadupstack-wordpress`   | 0.8755 |  0.7571 |     0.7571    |
+| `cqadupstack-wordpress`   | 0.8761 |  0.7571 |     0.7571    |
 | `quora`                   | 0.9999 |  0.9950 |     0.9950    |
-| `dbpedia-entity`          | 0.8095 |  0.6773 |     0.6773    |
+| `dbpedia-entity`          | 0.8096 |  0.6773 |     0.6773    |
 | `scidocs`                 | 0.7477 |  0.5652 |     0.5652    |
 | `fever`                   | 0.9859 |  0.9589 |     0.9589    |
-| `climate-fever`           | 0.8218 |  0.6324 |     0.6324    |
+| `climate-fever`           | 0.8220 |  0.6324 |     0.6324    |
 | `scifact`                 | 0.9967 |  0.9800 |     0.9800    |
 
 
@@ -145,16 +145,16 @@ do
     java -cp $ANSERINI_JAR --add-modules jdk.incubator.vector io.anserini.search.SearchCollection -index beir-v1.0.0-${c}.flat -topics beir-${c} -output $OUTPUT_DIR/run.inverted.beir-v1.0.0-${c}.flat.test.bm25 -bm25 -removeQuery -hits 1000
 
     # bge 
-    java -cp $ANSERINI_JAR --add-modules jdk.incubator.vector io.anserini.search.SearchFlatDenseVectors -index beir-v1.0.0-${c}.bge-base-en-v1.5.flat -topics beir-${c}.bge-base-en-v1.5 -output $OUTPUT_DIR/run.flat.beir-v1.0.0-${c}.bge-base-en-v1.5.test.bge-flat-cached -hits 1000 -removeQuery -threads 16
+    java -cp $ANSERINI_JAR --add-modules jdk.incubator.vector io.anserini.search.SearchFlatDenseVectors -index beir-v1.0.0-${c}.bge-base-en-v1.5.flat -topics beir-${c} -encoder BgeBaseEn15 -output $OUTPUT_DIR/run.flat.beir-v1.0.0-${c}.bge-base-en-v1.5.test.bge-flat-onnx -hits 1000 -removeQuery -threads 16
     
     # rrf fuse
-    java -cp $ANSERINI_JAR --add-modules jdk.incubator.vector io.anserini.fusion.FuseTrecRuns -runs $OUTPUT_DIR/run.inverted.beir-v1.0.0-${c}.flat.test.bm25 $OUTPUT_DIR/run.flat.beir-v1.0.0-${c}.bge-base-en-v1.5.test.bge-flat-cached -output $OUTPUT_DIR/runs.fuse.rrf.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-${c}.test.txt -method rrf -k 1000 -depth 1000 -rrf_k 60 -alpha 0.5
+    java -cp $ANSERINI_JAR --add-modules jdk.incubator.vector io.anserini.fusion.FuseTrecRuns -runs $OUTPUT_DIR/run.inverted.beir-v1.0.0-${c}.flat.test.bm25 $OUTPUT_DIR/run.flat.beir-v1.0.0-${c}.bge-base-en-v1.5.test.bge-flat-onnx -output $OUTPUT_DIR/runs.fuse.rrf.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt -method rrf -k 1000 -depth 1000 -rrf_k 60 -alpha 0.5
 
     # avg fuse
-    java -cp $ANSERINI_JAR --add-modules jdk.incubator.vector io.anserini.fusion.FuseTrecRuns -runs $OUTPUT_DIR/run.inverted.beir-v1.0.0-${c}.flat.test.bm25 $OUTPUT_DIR/run.flat.beir-v1.0.0-${c}.bge-base-en-v1.5.test.bge-flat-cached -output $OUTPUT_DIR/runs.fuse.avg.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-${c}.test.txt -method average -k 1000 -depth 1000 -rrf_k 60 -alpha 0.5
+    java -cp $ANSERINI_JAR --add-modules jdk.incubator.vector io.anserini.fusion.FuseTrecRuns -runs $OUTPUT_DIR/run.inverted.beir-v1.0.0-${c}.flat.test.bm25 $OUTPUT_DIR/run.flat.beir-v1.0.0-${c}.bge-base-en-v1.5.test.bge-flat-onnx -output $OUTPUT_DIR/runs.fuse.avg.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt -method average -k 1000 -depth 1000 -rrf_k 60 -alpha 0.5
 
     # interp fuse
-    java -cp $ANSERINI_JAR --add-modules jdk.incubator.vector io.anserini.fusion.FuseTrecRuns -runs $OUTPUT_DIR/run.inverted.beir-v1.0.0-${c}.flat.test.bm25 $OUTPUT_DIR/run.flat.beir-v1.0.0-${c}.bge-base-en-v1.5.test.bge-flat-cached -output $OUTPUT_DIR/runs.fuse.interp.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-${c}.test.txt -method interpolation -k 1000 -depth 1000 -rrf_k 60 -alpha 0.5
+    java -cp $ANSERINI_JAR --add-modules jdk.incubator.vector io.anserini.fusion.FuseTrecRuns -runs $OUTPUT_DIR/run.inverted.beir-v1.0.0-${c}.flat.test.bm25 $OUTPUT_DIR/run.flat.beir-v1.0.0-${c}.bge-base-en-v1.5.test.bge-flat-onnx -output $OUTPUT_DIR/runs.fuse.interp.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt -method interpolation -k 1000 -depth 1000 -rrf_k 60 -alpha 0.5
 done
 ```
 
@@ -165,24 +165,24 @@ CORPORA=(trec-covid bioasq nfcorpus nq hotpotqa fiqa signal1m trec-news robust04
 do
     echo $c
     echo rrf
-    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.rrf.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-${c}.test.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.rrf.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
 
-    java -cp $ANSERINI_JAR trec_eval -c -m recall.100 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.rrf.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-${c}.test.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m recall.100 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.rrf.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
 
-    java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.rrf.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-${c}.test.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.rrf.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
 
     echo avg
-    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.avg.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-${c}.test.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.avg.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
 
-    java -cp $ANSERINI_JAR trec_eval -c -m recall.100 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.avg.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-${c}.test.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m recall.100 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.avg.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
 
-    java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.avg.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-${c}.test.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.avg.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
     
     echo interp
-    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.interp.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-${c}.test.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.interp.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
 
-    java -cp $ANSERINI_JAR trec_eval -c -m recall.100 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.interp.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-${c}.test.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m recall.100 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.interp.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
 
-    java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.interp.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-${c}.test.txt
+    java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.interp.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
 done
 ```

--- a/docs/experiments-beir-fusion.md
+++ b/docs/experiments-beir-fusion.md
@@ -7,6 +7,7 @@ Currently, Anserini provides support for the following fusion methods:
 + RRF = Reciprocal Rank Fusion
 + Average = averaging scores on a list of runs, CombSUM
 + Interpolation = Weighted sum of two runs
++ Normalize = average of scores normalized between [0, 1]
 
 
 ## Results 
@@ -19,109 +20,109 @@ Since there were only two runs fused, the average and interpolation methods prod
 
 Three metrics were used for evaluation: nDCG@10, R@100, and R@1000.
 
-The table below reports the effectiveness of the methods with the nDCG@10 metric:
+The table below reports the effectiveness of the methods with the nDCG@10 metric and the base runs fused for reference:
 
-| Corpus                    |    RRF | Average | Interpolation |
-|---------------------------|-------:|--------:|--------------:|
-| `trec-covid`              | 0.8041 |  0.6567 |     0.6567    |
-| `bioasq`                  | 0.5278 |  0.5308 |     0.5308    |
-| `nfcorpus`                | 0.3725 |  0.3416 |     0.3416    |
-| `nq`                      | 0.4831 |  0.3241 |     0.3241    |
-| `hotpotqa`                | 0.7389 |  0.6497 |     0.6497    |
-| `fiqa`                    | 0.3671 |  0.2470 |     0.2470    |
-| `signal1m`                | 0.3533 |  0.3463 |     0.3463    |
-| `trec-news`               | 0.4855 |  0.4162 |     0.4162    |
-| `robust04`                | 0.5087 |  0.4327 |     0.4327    |
-| `arguana`                 | 0.5586 |  0.3986 |     0.3986    |
-| `webis-touche2020`        | 0.3771 |  0.4510 |     0.4510    |
-| `cqadupstack-android`     | 0.4652 |  0.3872 |     0.3872    |
-| `cqadupstack-english`     | 0.4461 |  0.3601 |     0.3601    |
-| `cqadupstack-gaming`      | 0.5615 |  0.4886 |     0.4886    |
-| `cqadupstack-gis`         | 0.3679 |  0.2948 |     0.2948    |
-| `cqadupstack-mathematica` | 0.2751 |  0.2084 |     0.2084    |
-| `cqadupstack-physics`     | 0.4143 |  0.3283 |     0.3283    |
-| `cqadupstack-programmers` | 0.3715 |  0.2891 |     0.2891    |
-| `cqadupstack-stats`       | 0.3414 |  0.2796 |     0.2796    |
-| `cqadupstack-tex`         | 0.2931 |  0.2332 |     0.2332    |
-| `cqadupstack-unix`        | 0.3597 |  0.2829 |     0.2829    |
-| `cqadupstack-webmasters`  | 0.3711 |  0.3130 |     0.3130    |
-| `cqadupstack-wordpress`   | 0.3353 |  0.2625 |     0.2625    |
-| `quora`                   | 0.8682 |  0.8009 |     0.8009    |
-| `dbpedia-entity`          | 0.4190 |  0.3365 |     0.3365    |
-| `scidocs`                 | 0.1948 |  0.1527 |     0.1527    |
-| `fever`                   | 0.8108 |  0.6688 |     0.6688    |
-| `climate-fever`           | 0.2812 |  0.1742 |     0.1742    |
-| `scifact`                 | 0.7420 |  0.6806 |     0.6806    |
+| Corpus                    |    RRF | Average | Interpolation | Normalize |   BM25 |    BGE |
+|---------------------------|-------:|--------:|--------------:|----------:|-------:|-------:|
+| `trec-covid`              | 0.8041 |  0.6567 |     0.6567    |   0.7956  | 0.5947 | 0.7815 |
+| `bioasq`                  | 0.5278 |  0.5308 |     0.5308    |   0.5428  | 0.5225 | 0.4148 |
+| `nfcorpus`                | 0.3725 |  0.3416 |     0.3416    |   0.3657  | 0.3218 | 0.3735 |
+| `nq`                      | 0.4831 |  0.3241 |     0.3241    |   0.5183  | 0.3055 | 0.5415 |
+| `hotpotqa`                | 0.7389 |  0.6497 |     0.6497    |   0.7658  | 0.6330 | 0.7259 |
+| `fiqa`                    | 0.3671 |  0.2470 |     0.2470    |   0.3942  | 0.2361 | 0.4065 |
+| `signal1m`                | 0.3533 |  0.3463 |     0.3463    |   0.3629  | 0.3304 | 0.2886 |
+| `trec-news`               | 0.4855 |  0.4162 |     0.4162    |   0.5008  | 0.3952 | 0.4424 |
+| `robust04`                | 0.5087 |  0.4327 |     0.4327    |   0.5127  | 0.4070 | 0.4435 |
+| `arguana`                 | 0.5586 |  0.3986 |     0.3986    |   0.5694  | 0.3970 | 0.6228 |
+| `webis-touche2020`        | 0.3771 |  0.4510 |     0.4510    |   0.3753  | 0.4422 | 0.2571 |
+| `cqadupstack-android`     | 0.4652 |  0.3872 |     0.3872    |   0.4868  | 0.3801 | 0.5076 |
+| `cqadupstack-english`     | 0.4461 |  0.3601 |     0.3601    |   0.4671  | 0.3453 | 0.4857 |
+| `cqadupstack-gaming`      | 0.5615 |  0.4886 |     0.4886    |   0.5818  | 0.4822 | 0.5967 |
+| `cqadupstack-gis `        | 0.3679 |  0.2948 |     0.2948    |   0.3937  | 0.2901 | 0.4131 |
+| `cqadupstack-mathematica` | 0.2751 |  0.2084 |     0.2084    |   0.2951  | 0.2015 | 0.3163 |
+| `cqadupstack-physics`     | 0.4143 |  0.3283 |     0.3283    |   0.4375  | 0.3214 | 0.4724 |
+| `cqadupstack-programmers` | 0.3715 |  0.2891 |     0.2891    |   0.4005  | 0.2802 | 0.4238 |
+| `cqadupstack-stats`       | 0.3414 |  0.2796 |     0.2796    |   0.3534  | 0.2711 | 0.3728 |
+| `cqadupstack-tex`         | 0.2931 |  0.2332 |     0.2332    |   0.3090  | 0.2244 | 0.3115 |
+| `cqadupstack-unix`        | 0.3597 |  0.2829 |     0.2829    |   0.3853  | 0.2749 | 0.4220 |
+| `cqadupstack-webmasters`  | 0.3711 |  0.3130 |     0.3130    |   0.3857  | 0.3059 | 0.4072 |
+| `cqadupstack-wordpress`   | 0.3353 |  0.2625 |     0.2625    |   0.3546  | 0.2483 | 0.3547 |
+| `quora`                   | 0.8682 |  0.8009 |     0.8009    |   0.8859  | 0.7886 | 0.8876 |
+| `dbpedia-entity`          | 0.4190 |  0.3365 |     0.3365    |   0.4374  | 0.3180 | 0.4073 |
+| `scidocs`                 | 0.1948 |  0.1527 |     0.1527    |   0.2019  | 0.1490 | 0.2172 |
+| `fever`                   | 0.8108 |  0.6688 |     0.6688    |   0.8584  | 0.6513 | 0.8629 |
+| `climate-fever`           | 0.2812 |  0.1742 |     0.1742    |   0.2946  | 0.1651 | 0.3117 |
+| `scifact`                 | 0.7420 |  0.6806 |     0.6806    |   0.7472  | 0.6789 | 0.7408 |
 
 
 The table below reports the effectiveness of the methods with the R@100 metric:
 
-| Corpus                    |    RRF | Average | Interpolation |
-|---------------------------|-------:|--------:|--------------:|
-| `trec-covid`              | 0.1467 |  0.1255 |     0.1255    |
-| `bioasq`                  | 0.8128 |  0.7869 |     0.7869    |
-| `nfcorpus`                | 0.3391 |  0.3003 |     0.3003    |
-| `nq`                      | 0.9415 |  0.7922 |     0.7922    |
-| `hotpotqa`                | 0.8917 |  0.8184 |     0.8184    |
-| `fiqa`                    | 0.7160 |  0.5639 |     0.5639    |
-| `signal1m`                | 0.4008 |  0.4077 |     0.4077    |
-| `trec-news`               | 0.5545 |  0.4751 |     0.4751    |
-| `robust04`                | 0.4474 |  0.3963 |     0.3963    |
-| `arguana`                 | 0.9879 |  0.9331 |     0.9331    |
-| `webis-touche2020`        | 0.6169 |  0.5878 |     0.5878    |
-| `cqadupstack-android`     | 0.8203 |  0.7076 |     0.7076    |
-| `cqadupstack-english`     | 0.7520 |  0.6022 |     0.6022    |
-| `cqadupstack-gaming`      | 0.8933 |  0.7956 |     0.7956    |
-| `cqadupstack-gis`         | 0.7621 |  0.6487 |     0.6487    |
-| `cqadupstack-mathematica` | 0.6666 |  0.5173 |     0.5173    |
-| `cqadupstack-physics`     | 0.7921 |  0.6549 |     0.6549    |
-| `cqadupstack-programmers` | 0.7530 |  0.5993 |     0.5993    |
-| `cqadupstack-stats`       | 0.6616 |  0.5650 |     0.5650    |
-| `cqadupstack-tex`         | 0.6331 |  0.5004 |     0.5004    |
-| `cqadupstack-unix`        | 0.7481 |  0.5798 |     0.5798    |
-| `cqadupstack-webmasters`  | 0.7543 |  0.6127 |     0.6127    |
-| `cqadupstack-wordpress`   | 0.6869 |  0.5488 |     0.5488    |
-| `quora`                   | 0.9966 |  0.9793 |     0.9793    |
-| `dbpedia-entity`          | 0.5985 |  0.5019 |     0.5019    |
-| `scidocs`                 | 0.4751 |  0.3735 |     0.3735    |
-| `fever`                   | 0.9731 |  0.9317 |     0.9317    |
-| `climate-fever`           | 0.6288 |  0.4590 |     0.4590    |
-| `scifact`                 | 0.9767 |  0.9327 |     0.9327    |
+| Corpus                    |    RRF | Average | Interpolation | Normalize |   BM25 |    BGE |
+|---------------------------|-------:|--------:|--------------:|----------:|-------:|-------:|
+| `trec-covid`              | 0.1467 |  0.1255 |     0.1255    |   0.1519  | 0.1091 | 0.1406 |
+| `bioasq`                  | 0.8128 |  0.7869 |     0.7869    |   0.8143  | 0.7687 | 0.6316 |
+| `nfcorpus`                | 0.3391 |  0.3003 |     0.3003    |   0.3288  | 0.2457 | 0.3368 |
+| `nq`                      | 0.9415 |  0.7922 |     0.7922    |   0.9372  | 0.7513 | 0.9414 |
+| `hotpotqa`                | 0.8917 |  0.8184 |     0.8184    |   0.8919  | 0.7957 | 0.8726 |
+| `fiqa`                    | 0.7160 |  0.5639 |     0.5639    |   0.7041  | 0.5395 | 0.7415 |
+| `signal1m`                | 0.4008 |  0.4077 |     0.4077    |   0.3947  | 0.3703 | 0.3112 |
+| `trec-news`               | 0.5545 |  0.4751 |     0.4751    |   0.5564  | 0.4469 | 0.4992 |
+| `robust04`                | 0.4474 |  0.3963 |     0.3963    |   0.4434  | 0.3746 | 0.3510 |
+| `arguana`                 | 0.9879 |  0.9331 |     0.9331    |   0.9879  | 0.9324 | 0.9716 |
+| `webis-touche2020`        | 0.6169 |  0.5878 |     0.5878    |   0.6039  | 0.5822 | 0.4867 |
+| `cqadupstack-android`     | 0.8203 |  0.7076 |     0.7076    |   0.8155  | 0.6829 | 0.8454 |
+| `cqadupstack-english`     | 0.7520 |  0.6022 |     0.6022    |   0.7429  | 0.5757 | 0.7586 |
+| `cqadupstack-gaming`      | 0.8933 |  0.7956 |     0.7956    |   0.8906  | 0.7651 | 0.9036 |
+| `cqadupstack-gis`         | 0.7621 |  0.6487 |     0.6487    |   0.7635  | 0.6119 | 0.7682 |
+| `cqadupstack-mathematica` | 0.6666 |  0.5173 |     0.5173    |   0.6725  | 0.4877 | 0.6922 |
+| `cqadupstack-physics`     | 0.7921 |  0.6549 |     0.6549    |   0.7859  | 0.6326 | 0.8078 |
+| `cqadupstack-programmers` | 0.7530 |  0.5993 |     0.5993    |   0.7593  | 0.5588 | 0.7856 |
+| `cqadupstack-stats`       | 0.6616 |  0.5650 |     0.5650    |   0.6644  | 0.5338 | 0.6719 |
+| `cqadupstack-tex`         | 0.6331 |  0.5004 |     0.5004    |   0.6298  | 0.4686 | 0.6489 |
+| `cqadupstack-unix`        | 0.7481 |  0.5798 |     0.5798    |   0.7363  | 0.5417 | 0.7797 |
+| `cqadupstack-webmasters`  | 0.7543 |  0.6127 |     0.6127    |   0.7371  | 0.5820 | 0.7774 |
+| `cqadupstack-wordpress`   | 0.6869 |  0.5488 |     0.5488    |   0.6794  | 0.5152 | 0.7047 |
+| `quora`                   | 0.9966 |  0.9793 |     0.9793    |   0.9958  | 0.9733 | 0.9968 |
+| `dbpedia-entity`          | 0.5985 |  0.5019 |     0.5019    |   0.5951  | 0.4682 | 0.5298 |
+| `scidocs`                 | 0.4751 |  0.3735 |     0.3735    |   0.4830  | 0.3477 | 0.4959 |
+| `fever`                   | 0.9731 |  0.9317 |     0.9317    |   0.9712  | 0.9185 | 0.9719 |
+| `climate-fever`           | 0.6288 |  0.4590 |     0.4590    |   0.6324  | 0.4249 | 0.6354 |
+| `scifact`                 | 0.9767 |  0.9327 |     0.9327    |   0.9700  | 0.9253 | 0.9667 |
 
 
 The table below reports the effectiveness of the methods with the R@1000 metric:
 
-| Corpus                    |    RRF | Average | Interpolation |
-|---------------------------|-------:|--------:|--------------:|
-| `trec-covid`              | 0.5029 |  0.3955 |     0.3955    |
-| `bioasq`                  | 0.9281 |  0.9030 |     0.9030    |
-| `nfcorpus`                | 0.6540 |  0.6422 |     0.6422    |
-| `nq`                      | 0.9874 |  0.8958 |     0.8958    |
-| `hotpotqa`                | 0.9473 |  0.8820 |     0.8820    |
-| `fiqa`                    | 0.8979 |  0.7402 |     0.7402    |
-| `signal1m`                | 0.6139 |  0.5642 |     0.5642    |
-| `trec-news`               | 0.8169 |  0.7051 |     0.7051    |
-| `robust04`                | 0.7237 |  0.6345 |     0.6345    |
-| `arguana`                 | 0.9964 |  0.9893 |     0.9893    |
-| `webis-touche2020`        | 0.8912 |  0.8621 |     0.8621    |
-| `cqadupstack-android`     | 0.9537 |  0.8646 |     0.8646    |
-| `cqadupstack-english`     | 0.8751 |  0.7394 |     0.7394    |
-| `cqadupstack-gaming`      | 0.9661 |  0.8952 |     0.8952    |
-| `cqadupstack-gis`         | 0.9054 |  0.8174 |     0.8174    |
-| `cqadupstack-mathematica` | 0.8781 |  0.7298 |     0.7298    |
-| `cqadupstack-physics`     | 0.9337 |  0.8375 |     0.8375    |
-| `cqadupstack-programmers` | 0.9272 |  0.7745 |     0.7745    |
-| `cqadupstack-stats`       | 0.8363 |  0.7310 |     0.7310    |
-| `cqadupstack-tex`         | 0.8430 |  0.6907 |     0.6907    |
-| `cqadupstack-unix`        | 0.9097 |  0.7626 |     0.7626    |
-| `cqadupstack-webmasters`  | 0.9369 |  0.8088 |     0.8088    |
-| `cqadupstack-wordpress`   | 0.8761 |  0.7571 |     0.7571    |
-| `quora`                   | 0.9999 |  0.9950 |     0.9950    |
-| `dbpedia-entity`          | 0.8096 |  0.6773 |     0.6773    |
-| `scidocs`                 | 0.7477 |  0.5652 |     0.5652    |
-| `fever`                   | 0.9859 |  0.9589 |     0.9589    |
-| `climate-fever`           | 0.8220 |  0.6324 |     0.6324    |
-| `scifact`                 | 0.9967 |  0.9800 |     0.9800    |
+| Corpus                    |    RRF | Average | Interpolation | Normalize |   BM25 |    BGE |
+|---------------------------|-------:|--------:|--------------:|----------:|-------:|-------:|
+| `trec-covid`              | 0.5029 |  0.3955 |     0.3955    |   0.5010  | 0.3955 | 0.4765 |
+| `bioasq`                  | 0.9281 |  0.9030 |     0.9030    |   0.9281  | 0.9030 | 0.8062 |
+| `nfcorpus`                | 0.6540 |  0.6422 |     0.6422    |   0.6563  | 0.3704 | 0.6622 |
+| `nq`                      | 0.9874 |  0.8958 |     0.8958    |   0.9870  | 0.8958 | 0.9859 |
+| `hotpotqa`                | 0.9473 |  0.8820 |     0.8820    |   0.9477  | 0.8820 | 0.9423 |
+| `fiqa`                    | 0.8979 |  0.7402 |     0.7402    |   0.9011  | 0.7393 | 0.9083 |
+| `signal1m`                | 0.6139 |  0.5642 |     0.5642    |   0.6097  | 0.5642 | 0.5331 |
+| `trec-news`               | 0.8169 |  0.7051 |     0.7051    |   0.8158  | 0.7051 | 0.7875 |
+| `robust04`                | 0.7237 |  0.6345 |     0.6345    |   0.7200  | 0.6345 | 0.5961 |
+| `arguana`                 | 0.9964 |  0.9893 |     0.9893    |   0.9964  | 0.9872 | 0.9929 |
+| `webis-touche2020`        | 0.8912 |  0.8621 |     0.8621    |   0.8896  | 0.8621 | 0.8298 |
+| `cqadupstack-android`     | 0.9537 |  0.8646 |     0.8646    |   0.9550  | 0.8632 | 0.9611 |
+| `cqadupstack-english`     | 0.8751 |  0.7394 |     0.7394    |   0.8751  | 0.7323 | 0.8839 |
+| `cqadupstack-gaming`      | 0.9661 |  0.8952 |     0.8952    |   0.9641  | 0.8945 | 0.9719 |
+| `cqadupstack-gis`         | 0.9054 |  0.8174 |     0.8174    |   0.9064  | 0.8174 | 0.9117 |
+| `cqadupstack-mathematica` | 0.8781 |  0.7298 |     0.7298    |   0.8787  | 0.7221 | 0.8810 |
+| `cqadupstack-physics`     | 0.9337 |  0.8375 |     0.8375    |   0.9340  | 0.8340 | 0.9415 |
+| `cqadupstack-programmers` | 0.9272 |  0.7745 |     0.7745    |   0.9275  | 0.7734 | 0.9353 |
+| `cqadupstack-stats`       | 0.8363 |  0.7310 |     0.7310    |   0.8336  | 0.7310 | 0.8445 |
+| `cqadupstack-tex`         | 0.8430 |  0.6907 |     0.6907    |   0.8430  | 0.6907 | 0.8538 |
+| `cqadupstack-unix`        | 0.9097 |  0.7626 |     0.7626    |   0.9132  | 0.7616 | 0.9235 |
+| `cqadupstack-webmasters`  | 0.9369 |  0.8088 |     0.8088    |   0.9334  | 0.8066 | 0.9380 |
+| `cqadupstack-wordpress`   | 0.8761 |  0.7571 |     0.7571    |   0.8782  | 0.7552 | 0.8861 |
+| `quora`                   | 0.9999 |  0.9950 |     0.9950    |   0.9999  | 0.9950 | 0.9999 |
+| `dbpedia-entity `         | 0.8096 |  0.6773 |     0.6773    |   0.8089  | 0.6760 | 0.7833 |
+| `scidocs`                 | 0.7477 |  0.5652 |     0.5652    |   0.7561  | 0.5638 | 0.7824 |
+| `fever`                   | 0.9859 |  0.9589 |     0.9589    |   0.9859  | 0.9589 | 0.9855 |
+| `climate-fever`           | 0.8220 |  0.6324 |     0.6324    |   0.8210  | 0.6324 | 0.8306 |
+| `scifact`                 | 0.9967 |  0.9800 |     0.9800    |   0.9967  | 0.9767 | 0.9967 |
 
 
 ## Run and Evaluate
@@ -131,11 +132,11 @@ The table below reports the effectiveness of the methods with the R@1000 metric:
 Let's start out by setting the `ANSERINI_JAR` and the `OUTPUT_DIR`. Note that the jar must be post v0.39.0. The following is an example from the root directory of Anserini after building.
 
 ```bash
-export ANSERINI_JAR="target/anserini-0.39.1-SNAPSHOT-fatjar.jar"
+export ANSERINI_JAR="./target/anserini-0.39.1-SNAPSHOT-fatjar.jar"
 export OUTPUT_DIR="./runs"
 ```
 
-The following snippet will generate the complete set of results that corresponds to the above table:
+The following snippet will generate the complete set of fusion results that corresponds to the above table:
 
 ```bash
 CORPORA=(trec-covid bioasq nfcorpus nq hotpotqa fiqa signal1m trec-news robust04 arguana webis-touche2020 cqadupstack-android cqadupstack-english cqadupstack-gaming cqadupstack-gis cqadupstack-mathematica cqadupstack-physics cqadupstack-programmers cqadupstack-stats cqadupstack-tex cqadupstack-unix cqadupstack-webmasters cqadupstack-wordpress quora dbpedia-entity scidocs fever climate-fever scifact); for c in "${CORPORA[@]}"
@@ -155,6 +156,9 @@ do
 
     # interp fuse
     java -cp $ANSERINI_JAR --add-modules jdk.incubator.vector io.anserini.fusion.FuseTrecRuns -runs $OUTPUT_DIR/run.inverted.beir-v1.0.0-${c}.flat.test.bm25 $OUTPUT_DIR/run.flat.beir-v1.0.0-${c}.bge-base-en-v1.5.test.bge-flat-onnx -output $OUTPUT_DIR/runs.fuse.interp.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt -method interpolation -k 1000 -depth 1000 -rrf_k 60 -alpha 0.5
+
+    # normalize fuse
+    java -cp $ANSERINI_JAR --add-modules jdk.incubator.vector io.anserini.fusion.FuseTrecRuns -runs $OUTPUT_DIR/run.inverted.beir-v1.0.0-${c}.flat.test.bm25 $OUTPUT_DIR/run.flat.beir-v1.0.0-${c}.bge-base-en-v1.5.test.bge-flat-onnx -output $OUTPUT_DIR/runs.fuse.norm.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt -method interpolation -k 1000 -depth 1000 -rrf_k 60 -alpha 0.5
 done
 ```
 
@@ -171,18 +175,25 @@ do
 
     java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.rrf.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
 
-    echo avg
+    echo average
     java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.avg.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
 
     java -cp $ANSERINI_JAR trec_eval -c -m recall.100 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.avg.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
 
     java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.avg.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
     
-    echo interp
+    echo interpolation
     java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.interp.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
 
     java -cp $ANSERINI_JAR trec_eval -c -m recall.100 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.interp.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
 
     java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.interp.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
+
+    echo normalize
+    java -cp $ANSERINI_JAR trec_eval -c -m ndcg_cut.10 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.norm.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
+
+    java -cp $ANSERINI_JAR trec_eval -c -m recall.100 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.norm.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
+
+    java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.norm.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
 done
 ```

--- a/src/main/java/io/anserini/fusion/TrecRun.java
+++ b/src/main/java/io/anserini/fusion/TrecRun.java
@@ -237,8 +237,8 @@ public class TrecRun {
 
     Set<String> topics = runs.stream().flatMap(run -> run.getTopics().stream()).collect(Collectors.toSet());
 
-    topics.forEach(topic -> {
-      Map<String, Double> docScores = new HashMap<>();
+    topics.forEach(topic -> { // for every query
+      Map<String, Double> docScores = new HashMap<>(); // doc id, total score across runs
       for (TrecRun run : runs) {
         run.getDocsByTopic(topic, depth != null ? depth : Integer.MAX_VALUE).forEach(record -> {
           String docId = (String) record.get(Column.DOCID);

--- a/src/main/java/io/anserini/fusion/TrecRunFuser.java
+++ b/src/main/java/io/anserini/fusion/TrecRunFuser.java
@@ -32,6 +32,7 @@ public class TrecRunFuser {
   private static final String METHOD_RRF = "rrf";
   private static final String METHOD_INTERPOLATION = "interpolation";
   private static final String METHOD_AVERAGE = "average";
+  private static final String METHOD_NORMALIZE = "normalize";
 
   public static class Args {
     @Option(name = "-output", metaVar = "[output]", required = true, usage = "Path to save the output")
@@ -97,6 +98,23 @@ public class TrecRunFuser {
   }
 
   /**
+   * Perform fusion by normalizing scores and taking the average. 
+   *
+   * @param runs List of TrecRun objects.
+   * @param depth Maximum number of results from each input run to consider. Set to Integer.MAX_VALUE by default, which indicates that the complete list of results is considered.
+   * @param k Length of final results list. Set to Integer.MAX_VALUE by default, which indicates that the union of all input documents are ranked.
+   * @return Output TrecRun that combines input runs via reciprocal rank fusion.
+   */
+  public static TrecRun normalize(List<TrecRun> runs, int depth, int k) {
+    
+    for (TrecRun run : runs) {
+      run.rescore(RescoreMethod.NORMALIZE, 0, 0);
+    }
+
+    return average(runs, depth, k);
+  }
+
+  /**
    * Perform fusion by interpolation on a list of exactly two TrecRun objects.
    * new_score = first_run_score * alpha + (1 - alpha) * second_run_score.
    *
@@ -142,6 +160,9 @@ public class TrecRunFuser {
         break;
       case METHOD_AVERAGE:
         fusedRun = average(runs, args.depth, args.k);
+        break;
+      case METHOD_NORMALIZE:
+        fusedRun = normalize(runs, args.depth, args.k);
         break;
       default:
         throw new IllegalArgumentException("Unknown fusion method: " + args.method + 

--- a/src/main/python/beir/generate_yaml_fusion.py
+++ b/src/main/python/beir/generate_yaml_fusion.py
@@ -87,16 +87,16 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-{corpus_short}.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-{corpus_short}.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-{corpus_short}.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-{corpus_short}.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-{corpus_short}.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-{corpus_short}.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-{corpus_short}.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-{corpus_short}.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-{corpus_short}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-{corpus_short}.test.txt
     results:
       nDCG@10:
         - 0.8714
@@ -105,7 +105,7 @@ methods:
       R@1000:
         - 0.9999
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-{corpus_short}.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-{corpus_short}.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-{corpus_short}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-{corpus_short}.test.txt
     results:
       nDCG@10:
         - 0.8019
@@ -115,7 +115,7 @@ methods:
         - 0.9950
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-{corpus_short}.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-{corpus_short}.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-{corpus_short}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-{corpus_short}.test.txt
     results:      
       nDCG@10:
         - 0.8019

--- a/src/main/resources/fuse_regression/beir-v1.0.0-arguana.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-arguana.yaml
@@ -37,39 +37,39 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-arguana.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-arguana.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-arguana.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-arguana.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-arguana.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-arguana.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-arguana.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-arguana.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-arguana.test.txt
     results:
       nDCG@10:
-        - 0.5659
+        - 0.5586
       R@100:
-        - 0.9865
+        - 0.9879
       R@1000:
         - 0.9964
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-arguana.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-arguana.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-arguana.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-arguana.test.txt
     results:
       nDCG@10:
         - 0.3986
       R@100:
         - 0.9331
       R@1000:
-        - 0.9879
+        - 0.9893
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-arguana.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-arguana.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-arguana.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-arguana.test.txt
     results:      
       nDCG@10:
         - 0.3986
       R@100:
         - 0.9331
       R@1000:
-        - 0.9879
+        - 0.9893

--- a/src/main/resources/fuse_regression/beir-v1.0.0-arguana.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-arguana.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.9331
       R@1000:
         - 0.9893
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-arguana.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-arguana.test.txt
+    results:      
+      nDCG@10:
+        - 0.5694
+      R@100:
+        - 0.9879
+      R@1000:
+        - 0.9964

--- a/src/main/resources/fuse_regression/beir-v1.0.0-bioasq.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-bioasq.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.7869
       R@1000:
         - 0.9030
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-bioasq.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-bioasq.test.txt
+    results:      
+      nDCG@10:
+        - 0.5428
+      R@100:
+        - 0.8143
+      R@1000:
+        - 0.9281

--- a/src/main/resources/fuse_regression/beir-v1.0.0-bioasq.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-bioasq.yaml
@@ -37,16 +37,16 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-bioasq.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-bioasq.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-bioasq.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-bioasq.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-bioasq.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-bioasq.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-bioasq.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-bioasq.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-bioasq.test.txt
     results:
       nDCG@10:
         - 0.5278
@@ -55,7 +55,7 @@ methods:
       R@1000:
         - 0.9281
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-bioasq.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-bioasq.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-bioasq.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-bioasq.test.txt
     results:
       nDCG@10:
         - 0.5308
@@ -65,7 +65,7 @@ methods:
         - 0.9030
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-bioasq.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-bioasq.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-bioasq.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-bioasq.test.txt
     results:      
       nDCG@10:
         - 0.5308

--- a/src/main/resources/fuse_regression/beir-v1.0.0-climate-fever.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-climate-fever.yaml
@@ -37,38 +37,38 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-climate-fever.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-climate-fever.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-climate-fever.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-climate-fever.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-climate-fever.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-climate-fever.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-climate-fever.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-climate-fever.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-climate-fever.test.txt
     results:
       nDCG@10:
         - 0.2812
       R@100:
-        - 0.6287
+        - 0.6288
       R@1000:
-        - 0.8218
+        - 0.8220
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-climate-fever.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-climate-fever.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-climate-fever.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-climate-fever.test.txt
     results:
       nDCG@10:
-        - 0.1741
+        - 0.1742
       R@100:
         - 0.4590
       R@1000:
         - 0.6324
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-climate-fever.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-climate-fever.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-climate-fever.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-climate-fever.test.txt
     results:      
       nDCG@10:
-        - 0.1741
+        - 0.1742
       R@100:
         - 0.4590
       R@1000:

--- a/src/main/resources/fuse_regression/beir-v1.0.0-climate-fever.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-climate-fever.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.4590
       R@1000:
         - 0.6324
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-climate-fever.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-climate-fever.test.txt
+    results:      
+      nDCG@10:
+        - 0.2946
+      R@100:
+        - 0.6324
+      R@1000:
+        - 0.8210

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-android.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-android.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.7076
       R@1000:
         - 0.8646
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-cqadupstack-android.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-android.test.txt
+    results:      
+      nDCG@10:
+        - 0.4868
+      R@100:
+        - 0.8155
+      R@1000:
+        - 0.9550

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-android.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-android.yaml
@@ -37,25 +37,25 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-cqadupstack-android.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-cqadupstack-android.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-android.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-android.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-android.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-android.test.txt
     results:
       nDCG@10:
         - 0.4652
       R@100:
-        - 0.8218
+        - 0.8203
       R@1000:
         - 0.9537
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-android.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-android.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-android.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-android.test.txt
     results:
       nDCG@10:
         - 0.3872
@@ -65,7 +65,7 @@ methods:
         - 0.8646
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-android.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-android.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-android.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-android.test.txt
     results:      
       nDCG@10:
         - 0.3872

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-english.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-english.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.6022
       R@1000:
         - 0.7394
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-cqadupstack-english.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-english.test.txt
+    results:      
+      nDCG@10:
+        - 0.4671
+      R@100:
+        - 0.7429
+      R@1000:
+        - 0.8751

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-english.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-english.yaml
@@ -37,25 +37,25 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-cqadupstack-english.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-cqadupstack-english.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-english.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-english.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-english.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-english.test.txt
     results:
       nDCG@10:
-        - 0.4460
+        - 0.4461
       R@100:
         - 0.7520
       R@1000:
         - 0.8751
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-english.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-english.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-english.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-english.test.txt
     results:
       nDCG@10:
         - 0.3601
@@ -65,7 +65,7 @@ methods:
         - 0.7394
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-english.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-english.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-english.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-english.test.txt
     results:      
       nDCG@10:
         - 0.3601

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-gaming.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-gaming.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.7956
       R@1000:
         - 0.8952
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-cqadupstack-gaming.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-gaming.test.txt
+    results:      
+      nDCG@10:
+        - 0.5818
+      R@100:
+        - 0.8906
+      R@1000:
+        - 0.9641

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-gaming.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-gaming.yaml
@@ -37,25 +37,25 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-cqadupstack-gaming.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-cqadupstack-gaming.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-gaming.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-gaming.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-gaming.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-gaming.test.txt
     results:
       nDCG@10:
-        - 0.5613
+        - 0.5615
       R@100:
-        - 0.8931
+        - 0.8933
       R@1000:
         - 0.9661
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-gaming.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-gaming.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-gaming.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-gaming.test.txt
     results:
       nDCG@10:
         - 0.4886
@@ -65,7 +65,7 @@ methods:
         - 0.8952
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-gaming.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-gaming.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-gaming.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-gaming.test.txt
     results:      
       nDCG@10:
         - 0.4886

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-gis.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-gis.yaml
@@ -37,16 +37,16 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-cqadupstack-gis.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-cqadupstack-gis.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-gis.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-gis.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-gis.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-gis.test.txt
     results:
       nDCG@10:
         - 0.3679
@@ -55,7 +55,7 @@ methods:
       R@1000:
         - 0.9054
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-gis.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-gis.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-gis.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-gis.test.txt
     results:
       nDCG@10:
         - 0.2948
@@ -65,7 +65,7 @@ methods:
         - 0.8174
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-gis.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-gis.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-gis.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-gis.test.txt
     results:      
       nDCG@10:
         - 0.2948

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-gis.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-gis.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.6487
       R@1000:
         - 0.8174
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-cqadupstack-gis.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-gis.test.txt
+    results:      
+      nDCG@10:
+        - 0.3937
+      R@100:
+        - 0.7635
+      R@1000:
+        - 0.9064

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-mathematica.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-mathematica.yaml
@@ -37,25 +37,25 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-cqadupstack-mathematica.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-cqadupstack-mathematica.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-mathematica.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-mathematica.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-mathematica.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-mathematica.test.txt
     results:
       nDCG@10:
-        - 0.2747
+        - 0.2751
       R@100:
         - 0.6666
       R@1000:
         - 0.8781
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-mathematica.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-mathematica.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-mathematica.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-mathematica.test.txt
     results:
       nDCG@10:
         - 0.2084
@@ -65,7 +65,7 @@ methods:
         - 0.7298
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-mathematica.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-mathematica.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-mathematica.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-mathematica.test.txt
     results:      
       nDCG@10:
         - 0.2084

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-mathematica.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-mathematica.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.5173
       R@1000:
         - 0.7298
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-cqadupstack-mathematica.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-mathematica.test.txt
+    results:      
+      nDCG@10:
+        - 0.2951
+      R@100:
+        - 0.6725
+      R@1000:
+        - 0.8787

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-physics.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-physics.yaml
@@ -37,38 +37,38 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-cqadupstack-physics.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-cqadupstack-physics.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-physics.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-physics.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-physics.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-physics.test.txt
     results:
       nDCG@10:
         - 0.4143
       R@100:
-        - 0.7922
+        - 0.7921
       R@1000:
-        - 0.9327
+        - 0.9337
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-physics.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-physics.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-physics.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-physics.test.txt
     results:
       nDCG@10:
-        - 0.3285
+        - 0.3283
       R@100:
         - 0.6549
       R@1000:
         - 0.8375
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-physics.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-physics.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-physics.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-physics.test.txt
     results:      
       nDCG@10:
-        - 0.3285
+        - 0.3283
       R@100:
         - 0.6549
       R@1000:

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-physics.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-physics.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.6549
       R@1000:
         - 0.8375
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-cqadupstack-physics.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-physics.test.txt
+    results:      
+      nDCG@10:
+        - 0.4375
+      R@100:
+        - 0.7859
+      R@1000:
+        - 0.9340

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-programmers.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-programmers.yaml
@@ -37,25 +37,25 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-cqadupstack-programmers.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-cqadupstack-programmers.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-programmers.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-programmers.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-programmers.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-programmers.test.txt
     results:
       nDCG@10:
-        - 0.3718
+        - 0.3715
       R@100:
         - 0.7530
       R@1000:
         - 0.9272
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-programmers.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-programmers.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-programmers.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-programmers.test.txt
     results:
       nDCG@10:
         - 0.2891
@@ -65,7 +65,7 @@ methods:
         - 0.7745
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-programmers.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-programmers.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-programmers.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-programmers.test.txt
     results:      
       nDCG@10:
         - 0.2891

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-programmers.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-programmers.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.5993
       R@1000:
         - 0.7745
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-cqadupstack-programmers.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-programmers.test.txt
+    results:      
+      nDCG@10:
+        - 0.4005
+      R@100:
+        - 0.7593
+      R@1000:
+        - 0.9275

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-stats.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-stats.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.5650
       R@1000:
         - 0.7310
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-cqadupstack-stats.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-stats.test.txt
+    results:      
+      nDCG@10:
+        - 0.3534
+      R@100:
+        - 0.6644
+      R@1000:
+        - 0.8336

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-stats.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-stats.yaml
@@ -37,25 +37,25 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-cqadupstack-stats.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-cqadupstack-stats.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-stats.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-stats.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-stats.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-stats.test.txt
     results:
       nDCG@10:
         - 0.3414
       R@100:
-        - 0.6624
+        - 0.6616
       R@1000:
-        - 0.8370
+        - 0.8363
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-stats.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-stats.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-stats.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-stats.test.txt
     results:
       nDCG@10:
         - 0.2796
@@ -65,7 +65,7 @@ methods:
         - 0.7310
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-stats.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-stats.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-stats.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-stats.test.txt
     results:      
       nDCG@10:
         - 0.2796

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-tex.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-tex.yaml
@@ -37,16 +37,16 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-cqadupstack-tex.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-cqadupstack-tex.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-tex.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-tex.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-tex.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-tex.test.txt
     results:
       nDCG@10:
         - 0.2931
@@ -55,7 +55,7 @@ methods:
       R@1000:
         - 0.8430
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-tex.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-tex.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-tex.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-tex.test.txt
     results:
       nDCG@10:
         - 0.2332
@@ -65,7 +65,7 @@ methods:
         - 0.6907
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-tex.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-tex.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-tex.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-tex.test.txt
     results:      
       nDCG@10:
         - 0.2332

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-tex.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-tex.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.5004
       R@1000:
         - 0.6907
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-cqadupstack-tex.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-tex.test.txt
+    results:      
+      nDCG@10:
+        - 0.3090
+      R@100:
+        - 0.6298
+      R@1000:
+        - 0.8430

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-unix.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-unix.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.5798
       R@1000:
         - 0.7626
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-cqadupstack-unix.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-unix.test.txt
+    results:      
+      nDCG@10:
+        - 0.3853
+      R@100:
+        - 0.7363
+      R@1000:
+        - 0.9132

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-unix.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-unix.yaml
@@ -37,25 +37,25 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-cqadupstack-unix.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-cqadupstack-unix.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-unix.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-unix.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-unix.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-unix.test.txt
     results:
       nDCG@10:
-        - 0.3601
+        - 0.3597
       R@100:
-        - 0.7482
+        - 0.7481
       R@1000:
-        - 0.9093
+        - 0.9097
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-unix.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-unix.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-unix.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-unix.test.txt
     results:
       nDCG@10:
         - 0.2829
@@ -65,7 +65,7 @@ methods:
         - 0.7626
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-unix.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-unix.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-unix.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-unix.test.txt
     results:      
       nDCG@10:
         - 0.2829

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-webmasters.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-webmasters.yaml
@@ -37,25 +37,25 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-cqadupstack-webmasters.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-cqadupstack-webmasters.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-webmasters.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-webmasters.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-webmasters.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-webmasters.test.txt
     results:
       nDCG@10:
-        - 0.3710
+        - 0.3711
       R@100:
-        - 0.7534
+        - 0.7543
       R@1000:
         - 0.9369
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-webmasters.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-webmasters.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-webmasters.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-webmasters.test.txt
     results:
       nDCG@10:
         - 0.3130
@@ -65,7 +65,7 @@ methods:
         - 0.8088
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-webmasters.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-webmasters.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-webmasters.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-webmasters.test.txt
     results:      
       nDCG@10:
         - 0.3130

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-webmasters.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-webmasters.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.6127
       R@1000:
         - 0.8088
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-cqadupstack-webmasters.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-webmasters.test.txt
+    results:      
+      nDCG@10:
+        - 0.3857
+      R@100:
+        - 0.7371
+      R@1000:
+        - 0.9334

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-wordpress.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-wordpress.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.5488
       R@1000:
         - 0.7571
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-cqadupstack-wordpress.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-wordpress.test.txt
+    results:      
+      nDCG@10:
+        - 0.3546
+      R@100:
+        - 0.6794
+      R@1000:
+        - 0.8782

--- a/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-wordpress.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-cqadupstack-wordpress.yaml
@@ -37,25 +37,25 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-cqadupstack-wordpress.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-cqadupstack-wordpress.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-wordpress.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-wordpress.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-cqadupstack-wordpress.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-wordpress.test.txt
     results:
       nDCG@10:
         - 0.3353
       R@100:
         - 0.6869
       R@1000:
-        - 0.8755
+        - 0.8761
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-wordpress.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-wordpress.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-cqadupstack-wordpress.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-wordpress.test.txt
     results:
       nDCG@10:
         - 0.2625
@@ -65,7 +65,7 @@ methods:
         - 0.7571
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-wordpress.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-cqadupstack-wordpress.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-cqadupstack-wordpress.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-cqadupstack-wordpress.test.txt
     results:      
       nDCG@10:
         - 0.2625

--- a/src/main/resources/fuse_regression/beir-v1.0.0-dbpedia-entity.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-dbpedia-entity.yaml
@@ -37,25 +37,25 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-dbpedia-entity.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-dbpedia-entity.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-dbpedia-entity.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-dbpedia-entity.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-dbpedia-entity.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-dbpedia-entity.test.txt
     results:
       nDCG@10:
         - 0.4190
       R@100:
-        - 0.5986
+        - 0.5985
       R@1000:
-        - 0.8095
+        - 0.8096
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-dbpedia-entity.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-dbpedia-entity.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-dbpedia-entity.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-dbpedia-entity.test.txt
     results:
       nDCG@10:
         - 0.3365
@@ -65,7 +65,7 @@ methods:
         - 0.6773
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-dbpedia-entity.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-dbpedia-entity.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-dbpedia-entity.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-dbpedia-entity.test.txt
     results:      
       nDCG@10:
         - 0.3365

--- a/src/main/resources/fuse_regression/beir-v1.0.0-dbpedia-entity.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-dbpedia-entity.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.5019
       R@1000:
         - 0.6773
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-dbpedia-entity.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-dbpedia-entity.test.txt
+    results:      
+      nDCG@10:
+        - 0.4374
+      R@100:
+        - 0.5951
+      R@1000:
+        - 0.8089

--- a/src/main/resources/fuse_regression/beir-v1.0.0-fever.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-fever.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.9317
       R@1000:
         - 0.9589
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-fever.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-fever.test.txt
+    results:      
+      nDCG@10:
+        - 0.8584
+      R@100:
+        - 0.9712
+      R@1000:
+        - 0.9859

--- a/src/main/resources/fuse_regression/beir-v1.0.0-fever.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-fever.yaml
@@ -37,16 +37,16 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-fever.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-fever.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-fever.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-fever.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-fever.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-fever.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-fever.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-fever.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-fever.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-fever.test.txt
     results:
       nDCG@10:
         - 0.8108
@@ -55,7 +55,7 @@ methods:
       R@1000:
         - 0.9859
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-fever.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-fever.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-fever.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-fever.test.txt
     results:
       nDCG@10:
         - 0.6688
@@ -65,7 +65,7 @@ methods:
         - 0.9589
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-fever.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-fever.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-fever.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-fever.test.txt
     results:      
       nDCG@10:
         - 0.6688

--- a/src/main/resources/fuse_regression/beir-v1.0.0-fiqa.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-fiqa.yaml
@@ -37,25 +37,25 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-fiqa.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-fiqa.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-fiqa.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-fiqa.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-fiqa.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-fiqa.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-fiqa.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-fiqa.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-fiqa.test.txt
     results:
       nDCG@10:
         - 0.3671
       R@100:
-        - 0.7153
+        - 0.7160
       R@1000:
         - 0.8979
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-fiqa.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-fiqa.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-fiqa.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-fiqa.test.txt
     results:
       nDCG@10:
         - 0.2470
@@ -65,7 +65,7 @@ methods:
         - 0.7402
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-fiqa.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-fiqa.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-fiqa.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-fiqa.test.txt
     results:      
       nDCG@10:
         - 0.2470

--- a/src/main/resources/fuse_regression/beir-v1.0.0-fiqa.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-fiqa.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.5639
       R@1000:
         - 0.7402
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-fiqa.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-fiqa.test.txt
+    results:      
+      nDCG@10:
+        - 0.3942
+      R@100:
+        - 0.7041
+      R@1000:
+        - 0.9011

--- a/src/main/resources/fuse_regression/beir-v1.0.0-hotpotqa.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-hotpotqa.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.8184
       R@1000:
         - 0.8820
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-hotpotqa.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-hotpotqa.test.txt
+    results:      
+      nDCG@10:
+        - 0.7658
+      R@100:
+        - 0.8919
+      R@1000:
+        - 0.9477

--- a/src/main/resources/fuse_regression/beir-v1.0.0-hotpotqa.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-hotpotqa.yaml
@@ -37,25 +37,25 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-hotpotqa.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-hotpotqa.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-hotpotqa.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-hotpotqa.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-hotpotqa.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-hotpotqa.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-hotpotqa.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-hotpotqa.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-hotpotqa.test.txt
     results:
       nDCG@10:
         - 0.7389
       R@100:
-        - 0.8918
+        - 0.8917
       R@1000:
-        - 0.9472
+        - 0.9473
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-hotpotqa.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-hotpotqa.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-hotpotqa.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-hotpotqa.test.txt
     results:
       nDCG@10:
         - 0.6497
@@ -65,7 +65,7 @@ methods:
         - 0.8820
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-hotpotqa.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-hotpotqa.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-hotpotqa.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-hotpotqa.test.txt
     results:      
       nDCG@10:
         - 0.6497

--- a/src/main/resources/fuse_regression/beir-v1.0.0-nfcorpus.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-nfcorpus.yaml
@@ -37,39 +37,39 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-nfcorpus.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-nfcorpus.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-nfcorpus.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-nfcorpus.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-nfcorpus.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-nfcorpus.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-nfcorpus.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-nfcorpus.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-nfcorpus.test.txt
     results:
       nDCG@10:
-        - 0.3729
+        - 0.3725
       R@100:
-        - 0.3392
+        - 0.3391
       R@1000:
-        - 0.6541
+        - 0.6540
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-nfcorpus.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-nfcorpus.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-nfcorpus.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-nfcorpus.test.txt
     results:
       nDCG@10:
-        - 0.3415
+        - 0.3416
       R@100:
         - 0.3003
       R@1000:
-        - 0.6423
+        - 0.6422
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-nfcorpus.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-nfcorpus.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-nfcorpus.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-nfcorpus.test.txt
     results:      
       nDCG@10:
-        - 0.3415
+        - 0.3416
       R@100:
         - 0.3003
       R@1000:
-        - 0.6423
+        - 0.6422

--- a/src/main/resources/fuse_regression/beir-v1.0.0-nfcorpus.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-nfcorpus.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.3003
       R@1000:
         - 0.6422
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-nfcorpus.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-nfcorpus.test.txt
+    results:      
+      nDCG@10:
+        - 0.3657
+      R@100:
+        - 0.3288
+      R@1000:
+        - 0.6563

--- a/src/main/resources/fuse_regression/beir-v1.0.0-nq.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-nq.yaml
@@ -37,38 +37,38 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-nq.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-nq.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-nq.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-nq.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-nq.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-nq.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-nq.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-nq.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-nq.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-nq.test.txt
     results:
       nDCG@10:
-        - 0.4832
+        - 0.4831
       R@100:
-        - 0.9412
+        - 0.9415
       R@1000:
         - 0.9874
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-nq.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-nq.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-nq.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-nq.test.txt
     results:
       nDCG@10:
-        - 0.3242
+        - 0.3241
       R@100:
         - 0.7922
       R@1000:
         - 0.8958
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-nq.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-nq.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-nq.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-nq.test.txt
     results:      
       nDCG@10:
-        - 0.3242
+        - 0.3241
       R@100:
         - 0.7922
       R@1000:

--- a/src/main/resources/fuse_regression/beir-v1.0.0-nq.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-nq.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.7922
       R@1000:
         - 0.8958
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-nq.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-nq.test.txt
+    results:      
+      nDCG@10:
+        - 0.5183
+      R@100:
+        - 0.9372
+      R@1000:
+        - 0.9870

--- a/src/main/resources/fuse_regression/beir-v1.0.0-quora.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-quora.yaml
@@ -37,39 +37,39 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-quora.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-quora.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-quora.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-quora.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-quora.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-quora.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-quora.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-quora.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-quora.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-quora.test.txt
     results:
       nDCG@10:
-        - 0.8714
+        - 0.8682
       R@100:
         - 0.9966
       R@1000:
         - 0.9999
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-quora.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-quora.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-quora.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-quora.test.txt
     results:
       nDCG@10:
-        - 0.8019
+        - 0.8009
       R@100:
-        - 0.9801
+        - 0.9793
       R@1000:
         - 0.9950
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-quora.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-quora.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-quora.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-quora.test.txt
     results:      
       nDCG@10:
-        - 0.8019
+        - 0.8009
       R@100:
-        - 0.9801
+        - 0.9793
       R@1000:
         - 0.9950

--- a/src/main/resources/fuse_regression/beir-v1.0.0-quora.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-quora.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.9793
       R@1000:
         - 0.9950
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-quora.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-quora.test.txt
+    results:      
+      nDCG@10:
+        - 0.8859
+      R@100:
+        - 0.9958
+      R@1000:
+        - 0.9999

--- a/src/main/resources/fuse_regression/beir-v1.0.0-robust04.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-robust04.yaml
@@ -37,16 +37,16 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-robust04.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-robust04.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-robust04.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-robust04.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-robust04.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-robust04.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-robust04.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-robust04.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-robust04.test.txt
     results:
       nDCG@10:
         - 0.5070
@@ -55,7 +55,7 @@ methods:
       R@1000:
         - 0.7219
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-robust04.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-robust04.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-robust04.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-robust04.test.txt
     results:
       nDCG@10:
         - 0.4324
@@ -65,7 +65,7 @@ methods:
         - 0.6345
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-robust04.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-robust04.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-robust04.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-robust04.test.txt
     results:      
       nDCG@10:
         - 0.4324

--- a/src/main/resources/fuse_regression/beir-v1.0.0-robust04.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-robust04.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.3963
       R@1000:
         - 0.6345
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-robust04.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-robust04.test.txt
+    results:      
+      nDCG@10:
+        - 0.5127
+      R@100:
+        - 0.4434
+      R@1000:
+        - 0.7200

--- a/src/main/resources/fuse_regression/beir-v1.0.0-scidocs.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-scidocs.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.3735
       R@1000:
         - 0.5652
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-scidocs.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-scidocs.test.txt
+    results:      
+      nDCG@10:
+        - 0.2019
+      R@100:
+        - 0.4830
+      R@1000:
+        - 0.7561

--- a/src/main/resources/fuse_regression/beir-v1.0.0-scidocs.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-scidocs.yaml
@@ -37,16 +37,16 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-scidocs.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-scidocs.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-scidocs.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-scidocs.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-scidocs.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-scidocs.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-scidocs.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-scidocs.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-scidocs.test.txt
     results:
       nDCG@10:
         - 0.1948
@@ -55,7 +55,7 @@ methods:
       R@1000:
         - 0.7477
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-scidocs.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-scidocs.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-scidocs.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-scidocs.test.txt
     results:
       nDCG@10:
         - 0.1527
@@ -65,7 +65,7 @@ methods:
         - 0.5652
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-scidocs.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-scidocs.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-scidocs.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-scidocs.test.txt
     results:      
       nDCG@10:
         - 0.1527

--- a/src/main/resources/fuse_regression/beir-v1.0.0-scifact.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-scifact.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.9327
       R@1000:
         - 0.9800
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-scifact.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-scifact.test.txt
+    results:      
+      nDCG@10:
+        - 0.7472
+      R@100:
+        - 0.9700
+      R@1000:
+        - 0.9967

--- a/src/main/resources/fuse_regression/beir-v1.0.0-scifact.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-scifact.yaml
@@ -37,25 +37,25 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-scifact.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-scifact.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-scifact.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-scifact.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-scifact.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-scifact.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-scifact.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-scifact.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-scifact.test.txt
     results:
       nDCG@10:
-        - 0.7417
+        - 0.7420
       R@100:
         - 0.9767
       R@1000:
         - 0.9967
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-scifact.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-scifact.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-scifact.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-scifact.test.txt
     results:
       nDCG@10:
         - 0.6806
@@ -65,7 +65,7 @@ methods:
         - 0.9800
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-scifact.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-scifact.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-scifact.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-scifact.test.txt
     results:      
       nDCG@10:
         - 0.6806

--- a/src/main/resources/fuse_regression/beir-v1.0.0-signal1m.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-signal1m.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.4077
       R@1000:
         - 0.5642
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-signal1m.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-signal1m.test.txt
+    results:      
+      nDCG@10:
+        - 0.3629
+      R@100:
+        - 0.3947
+      R@1000:
+        - 0.6097

--- a/src/main/resources/fuse_regression/beir-v1.0.0-signal1m.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-signal1m.yaml
@@ -37,38 +37,38 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-signal1m.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-signal1m.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-signal1m.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-signal1m.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-signal1m.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-signal1m.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-signal1m.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-signal1m.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-signal1m.test.txt
     results:
       nDCG@10:
-        - 0.3527
+        - 0.3533
       R@100:
         - 0.4008
       R@1000:
         - 0.6139
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-signal1m.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-signal1m.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-signal1m.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-signal1m.test.txt
     results:
       nDCG@10:
-        - 0.3466
+        - 0.3463
       R@100:
         - 0.4077
       R@1000:
         - 0.5642
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-signal1m.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-signal1m.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-signal1m.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-signal1m.test.txt
     results:      
       nDCG@10:
-        - 0.3466
+        - 0.3463
       R@100:
         - 0.4077
       R@1000:

--- a/src/main/resources/fuse_regression/beir-v1.0.0-trec-covid.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-trec-covid.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.1255
       R@1000:
         - 0.3955
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-trec-covid.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-trec-covid.test.txt
+    results:      
+      nDCG@10:
+        - 0.7956
+      R@100:
+        - 0.1519
+      R@1000:
+        - 0.5010

--- a/src/main/resources/fuse_regression/beir-v1.0.0-trec-covid.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-trec-covid.yaml
@@ -37,25 +37,25 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-trec-covid.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-trec-covid.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-trec-covid.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-trec-covid.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-trec-covid.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-trec-covid.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-trec-covid.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-trec-covid.test.txt
     results:
       nDCG@10:
         - 0.8041
       R@100:
-        - 0.1466
+        - 0.1467
       R@1000:
-        - 0.5030
+        - 0.5029
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-trec-covid.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-trec-covid.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-trec-covid.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-trec-covid.test.txt
     results:
       nDCG@10:
         - 0.6567
@@ -65,7 +65,7 @@ methods:
         - 0.3955
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-trec-covid.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-trec-covid.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-trec-covid.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-trec-covid.test.txt
     results:      
       nDCG@10:
         - 0.6567

--- a/src/main/resources/fuse_regression/beir-v1.0.0-trec-news.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-trec-news.yaml
@@ -37,25 +37,25 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-trec-news.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-trec-news.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-trec-news.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-trec-news.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-trec-news.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-trec-news.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-trec-news.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-trec-news.test.txt
     results:
       nDCG@10:
-        - 0.4864
+        - 0.4855
       R@100:
         - 0.5545
       R@1000:
         - 0.8169
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-trec-news.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-trec-news.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-trec-news.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-trec-news.test.txt
     results:
       nDCG@10:
         - 0.4162
@@ -65,7 +65,7 @@ methods:
         - 0.7051
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-trec-news.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-trec-news.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-trec-news.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-trec-news.test.txt
     results:      
       nDCG@10:
         - 0.4162

--- a/src/main/resources/fuse_regression/beir-v1.0.0-trec-news.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-trec-news.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.4751
       R@1000:
         - 0.7051
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-trec-news.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-trec-news.test.txt
+    results:      
+      nDCG@10:
+        - 0.5008
+      R@100:
+        - 0.5564
+      R@1000:
+        - 0.8158

--- a/src/main/resources/fuse_regression/beir-v1.0.0-webis-touche2020.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-webis-touche2020.yaml
@@ -37,38 +37,38 @@ runs:
   - name: flat-bm25
     dependency: beir-v1.0.0-webis-touche2020.flat.yaml
     file: runs/run.inverted.beir-v1.0.0-webis-touche2020.flat.test.bm25
-  - name: bge-flat-cached
-    dependency: beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.flat.cached.yaml
-    file: runs/run.flat.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.test.bge-flat-cached
+  - name: bge-flat-onnx
+    dependency: beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.flat.onnx.yaml
+    file: runs/run.flat.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.test.bge-flat-onnx
 
 methods:
   - name: rrf
     k: 1000
     depth: 1000
     rrf_k: 60
-    output: runs/runs.fuse.rrf.beir-v1.0.0-webis-touche2020.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-webis-touche2020.test.txt
+    output: runs/runs.fuse.rrf.beir-v1.0.0-webis-touche2020.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-webis-touche2020.test.txt
     results:
       nDCG@10:
-        - 0.3759
+        - 0.3771
       R@100:
         - 0.6169
       R@1000:
         - 0.8912
   - name: average
-    output: runs/runs.fuse.avg.beir-v1.0.0-webis-touche2020.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-webis-touche2020.test.txt
+    output: runs/runs.fuse.avg.beir-v1.0.0-webis-touche2020.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-webis-touche2020.test.txt
     results:
       nDCG@10:
-        - 0.4519
+        - 0.4510
       R@100:
         - 0.5878
       R@1000:
         - 0.8621
   - name: interpolation
     alpha: 0.5
-    output: runs/runs.fuse.interp.beir-v1.0.0-webis-touche2020.flat.bm25.bge-base-en-v1.5.bge-flat-cached.topics.beir-v1.0.0-webis-touche2020.test.txt
+    output: runs/runs.fuse.interp.beir-v1.0.0-webis-touche2020.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-webis-touche2020.test.txt
     results:      
       nDCG@10:
-        - 0.4519
+        - 0.4510
       R@100:
         - 0.5878
       R@1000:

--- a/src/main/resources/fuse_regression/beir-v1.0.0-webis-touche2020.yaml
+++ b/src/main/resources/fuse_regression/beir-v1.0.0-webis-touche2020.yaml
@@ -73,3 +73,12 @@ methods:
         - 0.5878
       R@1000:
         - 0.8621
+  - name: normalize
+    output: runs/runs.fuse.norm.beir-v1.0.0-webis-touche2020.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-webis-touche2020.test.txt
+    results:      
+      nDCG@10:
+        - 0.3753
+      R@100:
+        - 0.6039
+      R@1000:
+        - 0.8896


### PR DESCRIPTION
Reran previous BEIR fusion experiments using ONNX for BGE instead of cached queries. Updated results in documentation and YAMLs. Also added the scores of base runs to tables in the documentation for easier reference.

Integrated the existing normalize method for fusion to be usable. Ran it on the BEIR datasets and recorded results in documentation and YAMLs.

Added ranx comparison for normalize in regression to verify results. Results match. 