### PR TITLE
Refactor ONNX encoders

### DIFF
--- a/src/main/java/io/anserini/encoder/OnnxEncoder.java
+++ b/src/main/java/io/anserini/encoder/OnnxEncoder.java
@@ -38,6 +38,11 @@ public abstract class OnnxEncoder<T> implements AutoCloseable {
 
   private static final String CACHE_DIR = Path.of(System.getProperty("user.home"), ".cache", "pyserini", "encoders").toString();
 
+  private final String modelName;
+  private final String modelUrl;
+  private final String vocabName;
+  private final String vocabUrl;
+
   protected final BertFullTokenizer tokenizer;
 
   protected final DefaultVocabulary vocab;
@@ -119,6 +124,11 @@ public abstract class OnnxEncoder<T> implements AutoCloseable {
     this.environment = OrtEnvironment.getEnvironment();
     this.session = environment.createSession(getModelPath(modelName, modelURL).toString(),
         new OrtSession.SessionOptions());
+
+    this.modelName = modelName;
+    this.modelUrl = modelURL;
+    this.vocabName = vocabName;
+    this.vocabUrl = vocabURL;
   }
 
   public void close() {
@@ -129,5 +139,9 @@ public abstract class OnnxEncoder<T> implements AutoCloseable {
       // Nothing we can do at this point, so log and move on.
       LOG.error("Error closing session: {}", e.getMessage());
     }
+  }
+
+  public Path getModelPath() throws IOException, URISyntaxException {
+    return OnnxEncoder.getModelPath(modelName, modelUrl);
   }
 }

--- a/src/main/java/io/anserini/encoder/OnnxEncoder.java
+++ b/src/main/java/io/anserini/encoder/OnnxEncoder.java
@@ -38,6 +38,10 @@ public abstract class OnnxEncoder<T> implements AutoCloseable {
 
   private static final String CACHE_DIR = Path.of(System.getProperty("user.home"), ".cache", "pyserini", "encoders").toString();
 
+  protected static final String CLS = "[CLS]";
+  protected static final String SEP = "[SEP]";
+  protected static final String PAD = "[PAD]";
+
   private final String modelName;
   private final String modelUrl;
   private final String vocabName;

--- a/src/main/java/io/anserini/encoder/OnnxEncoder.java
+++ b/src/main/java/io/anserini/encoder/OnnxEncoder.java
@@ -44,11 +44,9 @@ public abstract class OnnxEncoder<T> implements AutoCloseable {
   private final String vocabUrl;
 
   protected final BertFullTokenizer tokenizer;
-
   protected final DefaultVocabulary vocab;
 
   protected final OrtEnvironment environment;
-
   protected final OrtSession session;
 
   static protected Path getVocabPath(String vocabName, String vocabURL) throws URISyntaxException, IOException {
@@ -77,7 +75,7 @@ public abstract class OnnxEncoder<T> implements AutoCloseable {
     return modelFile.toPath();
   }
 
-  protected static long[] convertTokensToIds(BertFullTokenizer tokenizer, List<String> tokens, Vocabulary vocab, int maxLen) {
+  protected static long[] convertTokensToIds(List<String> tokens, Vocabulary vocab, int maxLen) {
     int numTokens = Math.min(tokens.size(), maxLen);
     long[] tokenIds = new long[numTokens];
     for (int i = 0; i < numTokens; ++i) {
@@ -86,7 +84,7 @@ public abstract class OnnxEncoder<T> implements AutoCloseable {
     return tokenIds;
   }
 
-  protected static long[] convertTokensToIds(BertFullTokenizer tokenizer, List<String> tokens, Vocabulary vocab) {
+  protected static long[] convertTokensToIds(List<String> tokens, Vocabulary vocab) {
     int numTokens = tokens.size();
     long[] tokenIds = new long[numTokens];
     for (int i = 0; i < numTokens; ++i) {
@@ -95,40 +93,23 @@ public abstract class OnnxEncoder<T> implements AutoCloseable {
     return tokenIds;
   }
 
-  /*
-   * Normalize a vector using L2 norm
-   */
-  public static float[] normalize(float[] vector) {
-    final float EPS = 1e-12f;
-    float norm = 0;
-    for (float v : vector) {
-      norm += v * v;
-    }
-    norm = (float) Math.sqrt(norm);
-
-    for (int i = 0; i < vector.length; i++) {
-      vector[i] = vector[i] / (norm + EPS);
-    }
-    return vector;
-  }
-
   public abstract T encode(String query) throws OrtException;
 
-  public OnnxEncoder(String modelName, String modelURL, String vocabName, String vocabURL)
+  public OnnxEncoder(String modelName, String modelUrl, String vocabName, String vocabUrl)
       throws IOException, OrtException, URISyntaxException {
     this.vocab = DefaultVocabulary.builder()
-        .addFromTextFile(getVocabPath(vocabName, vocabURL))
+        .addFromTextFile(getVocabPath(vocabName, vocabUrl))
         .optUnknownToken("[UNK]")
         .build();
     this.tokenizer = new BertFullTokenizer(vocab, true);
+
     this.environment = OrtEnvironment.getEnvironment();
-    this.session = environment.createSession(getModelPath(modelName, modelURL).toString(),
-        new OrtSession.SessionOptions());
+    this.session = environment.createSession(getModelPath(modelName, modelUrl).toString(), new OrtSession.SessionOptions());
 
     this.modelName = modelName;
-    this.modelUrl = modelURL;
+    this.modelUrl = modelUrl;
     this.vocabName = vocabName;
-    this.vocabUrl = vocabURL;
+    this.vocabUrl = vocabUrl;
   }
 
   public void close() {

--- a/src/main/java/io/anserini/encoder/dense/ArcticEmbedLEncoder.java
+++ b/src/main/java/io/anserini/encoder/dense/ArcticEmbedLEncoder.java
@@ -51,7 +51,7 @@ import java.util.Map;
      queryTokens.add("[SEP]");
  
      Map<String, OnnxTensor> inputs = new HashMap<>();
-     long[] queryTokenIds = convertTokensToIds(tokenizer, queryTokens, vocab, MAX_SEQ_LEN);
+     long[] queryTokenIds = convertTokensToIds(queryTokens, vocab, MAX_SEQ_LEN);
      long[][] inputTokenIds = new long[1][queryTokenIds.length];
      inputTokenIds[0] = queryTokenIds;
  
@@ -65,11 +65,10 @@ import java.util.Map;
  
      float[] embeddings = new float[EMBEDDING_DIM];
      try (OrtSession.Result results = session.run(inputs)) {
-       float[][][] tensorData = (float[][][]) ((OnnxTensor) results.get(0)).getValue();
+       float[][][] tensorData = (float[][][]) results.get(0).getValue();
        System.arraycopy(tensorData[0][0], 0, embeddings, 0, EMBEDDING_DIM);
+
        return normalize(embeddings);
-     } catch (OrtException e) {
-       throw e;
      }
    }
  }

--- a/src/main/java/io/anserini/encoder/dense/ArcticEmbedLEncoder.java
+++ b/src/main/java/io/anserini/encoder/dense/ArcticEmbedLEncoder.java
@@ -19,6 +19,7 @@
 import ai.onnxruntime.OnnxTensor;
 import ai.onnxruntime.OrtException;
 import ai.onnxruntime.OrtSession;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -44,14 +45,14 @@ import java.util.Map;
    }
  
    @Override
-   public float[] encode(String query) throws OrtException {
+   public float[] encode(@NotNull String query) throws OrtException {
      List<String> queryTokens = new ArrayList<>();
      queryTokens.add("[CLS]");
      queryTokens.addAll(tokenizer.tokenize(INSTRUCTION + query));
      queryTokens.add("[SEP]");
  
      Map<String, OnnxTensor> inputs = new HashMap<>();
-     long[] queryTokenIds = convertTokensToIds(queryTokens, vocab, MAX_SEQ_LEN);
+     long[] queryTokenIds = convertTokensToIds(queryTokens, MAX_SEQ_LEN);
      long[][] inputTokenIds = new long[1][queryTokenIds.length];
      inputTokenIds[0] = queryTokenIds;
  

--- a/src/main/java/io/anserini/encoder/dense/BgeBaseEn15Encoder.java
+++ b/src/main/java/io/anserini/encoder/dense/BgeBaseEn15Encoder.java
@@ -50,19 +50,17 @@ public class BgeBaseEn15Encoder extends DenseEncoder {
     queryTokens.add("[SEP]");
     
     Map<String, OnnxTensor> inputs = new HashMap<>();
-    long[] queryTokenIds = convertTokensToIds(this.tokenizer, queryTokens, this.vocab, MAX_SEQ_LEN);
+    long[] queryTokenIds = convertTokensToIds(queryTokens, this.vocab, MAX_SEQ_LEN);
     long[][] inputTokenIds = new long[1][queryTokenIds.length];
 
     inputTokenIds[0] = queryTokenIds;
     inputs.put("input_ids", OnnxTensor.createTensor(this.environment, inputTokenIds));
     float[] weights = null;
     try (OrtSession.Result results = this.session.run(inputs)) {
+      assert (results.get("last_hidden_state").isPresent());
       weights = ((float[][][]) results.get("last_hidden_state").get().getValue())[0][0];
-      weights = normalize(weights);
-    } catch (OrtException e) {
-      e.printStackTrace();
-    }
-    return weights;
-  }
 
+      return normalize(weights);
+    }
+  }
 }

--- a/src/main/java/io/anserini/encoder/dense/BgeBaseEn15Encoder.java
+++ b/src/main/java/io/anserini/encoder/dense/BgeBaseEn15Encoder.java
@@ -19,6 +19,7 @@ package io.anserini.encoder.dense;
 import ai.onnxruntime.OnnxTensor;
 import ai.onnxruntime.OrtException;
 import ai.onnxruntime.OrtSession;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -43,14 +44,14 @@ public class BgeBaseEn15Encoder extends DenseEncoder {
   }
 
   @Override
-  public float[] encode(String query) throws OrtException {
+  public float[] encode(@NotNull String query) throws OrtException {
     List<String> queryTokens = new ArrayList<>();
     queryTokens.add("[CLS]");
     queryTokens.addAll(this.tokenizer.tokenize(INSTRUCTION + query));
     queryTokens.add("[SEP]");
     
     Map<String, OnnxTensor> inputs = new HashMap<>();
-    long[] queryTokenIds = convertTokensToIds(queryTokens, this.vocab, MAX_SEQ_LEN);
+    long[] queryTokenIds = convertTokensToIds(queryTokens, MAX_SEQ_LEN);
     long[][] inputTokenIds = new long[1][queryTokenIds.length];
 
     inputTokenIds[0] = queryTokenIds;

--- a/src/main/java/io/anserini/encoder/dense/CosDprDistilEncoder.java
+++ b/src/main/java/io/anserini/encoder/dense/CosDprDistilEncoder.java
@@ -46,18 +46,15 @@ public class CosDprDistilEncoder extends DenseEncoder {
     queryTokens.add("[SEP]");
     
     Map<String, OnnxTensor> inputs = new HashMap<>();
-    long[] queryTokenIds = convertTokensToIds(this.tokenizer, queryTokens, this.vocab);
+    long[] queryTokenIds = convertTokensToIds(queryTokens, this.vocab);
     long[][] inputTokenIds = new long[1][queryTokenIds.length];
 
     inputTokenIds[0] = queryTokenIds;
     inputs.put("input_ids", OnnxTensor.createTensor(this.environment, inputTokenIds));
-    float[] weights = null;
     try (OrtSession.Result results = this.session.run(inputs)) {
-      weights = ((float[][]) results.get("pooler_output").get().getValue())[0];
-    } catch (OrtException e) {
-      e.printStackTrace();
-    }
-    return weights;
-  }
+      assert (results.get("pooler_output").isPresent());
 
+      return ((float[][]) results.get("pooler_output").get().getValue())[0];
+    }
+  }
 }

--- a/src/main/java/io/anserini/encoder/dense/CosDprDistilEncoder.java
+++ b/src/main/java/io/anserini/encoder/dense/CosDprDistilEncoder.java
@@ -19,6 +19,7 @@ package io.anserini.encoder.dense;
 import ai.onnxruntime.OnnxTensor;
 import ai.onnxruntime.OrtException;
 import ai.onnxruntime.OrtSession;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -39,14 +40,14 @@ public class CosDprDistilEncoder extends DenseEncoder {
   }
 
   @Override
-  public float[] encode(String query) throws OrtException {
+  public float[] encode(@NotNull String query) throws OrtException {
     List<String> queryTokens = new ArrayList<>();
     queryTokens.add("[CLS]");
     queryTokens.addAll(this.tokenizer.tokenize(query));
     queryTokens.add("[SEP]");
     
     Map<String, OnnxTensor> inputs = new HashMap<>();
-    long[] queryTokenIds = convertTokensToIds(queryTokens, this.vocab);
+    long[] queryTokenIds = convertTokensToIds(queryTokens);
     long[][] inputTokenIds = new long[1][queryTokenIds.length];
 
     inputTokenIds[0] = queryTokenIds;

--- a/src/main/java/io/anserini/encoder/dense/DenseEncoder.java
+++ b/src/main/java/io/anserini/encoder/dense/DenseEncoder.java
@@ -27,4 +27,18 @@ public abstract class DenseEncoder extends OnnxEncoder<float[]> {
       throws IOException, OrtException, URISyntaxException {
     super(modelName, modelURL, vocabName, vocabURL);
   }
+
+  public static float[] normalize(float[] vector) {
+    final float EPS = 1e-12f;
+    float norm = 0;
+    for (float v : vector) {
+      norm += v * v;
+    }
+    norm = (float) Math.sqrt(norm);
+
+    for (int i = 0; i < vector.length; i++) {
+      vector[i] = vector[i] / (norm + EPS);
+    }
+    return vector;
+  }
 }

--- a/src/main/java/io/anserini/encoder/sparse/SparseEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/SparseEncoder.java
@@ -61,17 +61,6 @@ public abstract class SparseEncoder extends OnnxEncoder<Map<String, Integer>> {
     return tokenIntWeights;
   }
 
-//  public Map<String, Integer> quantizeFloatWeights(Map<String, Float> tokenFloatWeights) {
-//    Map<String, Integer> tokenIntWeights = new HashMap<>();
-//    for (Map.Entry<String, Float> entry : tokenFloatWeights.entrySet()) {
-//      String token = entry.getKey();
-//      int weightQuantized = Math.round(entry.getValue() / weightRange * quantRange);
-//
-//      tokenIntWeights.put(token, weightQuantized);
-//    }
-//    return tokenIntWeights;
-//  }
-
   @Override
   public Map<String, Integer> encode(@NotNull String query) throws OrtException {
     return quantizeFloatWeights(computeFloatWeights(query));
@@ -79,9 +68,9 @@ public abstract class SparseEncoder extends OnnxEncoder<Map<String, Integer>> {
 
   public long[] tokenizeToIds(String query) {
     List<String> queryTokens = new ArrayList<>();
-    queryTokens.add("[CLS]");
+    queryTokens.add(CLS);
     queryTokens.addAll(tokenizer.tokenize(query));
-    queryTokens.add("[SEP]");
+    queryTokens.add(SEP);
 
     return convertTokensToIds(queryTokens);
   }

--- a/src/main/java/io/anserini/encoder/sparse/SparseEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/SparseEncoder.java
@@ -27,34 +27,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public abstract class SparseEncoder extends OnnxEncoder<String> {
+public abstract class SparseEncoder extends OnnxEncoder<Map<String, Integer>> {
 
   protected int weightRange;
   protected int quantRange;
 
-  public SparseEncoder(int weightRange, int quantRange,
-                       @NotNull String vocabName, @NotNull String vocabUrl,
-                       @NotNull String modelName, @NotNull String modelUrl)
-      throws IOException, OrtException, URISyntaxException {
-    super(vocabName, vocabUrl, modelName, modelUrl);
-    this.weightRange = weightRange;
-    this.quantRange = quantRange;
-  }
-
-//  protected String generateEncodedQuery(Map<String, Float> tokenWeightMap) {
-//    List<String> encodedQuery = new ArrayList<>();
-//    for (Map.Entry<String, Float> entry : tokenWeightMap.entrySet()) {
-//      String token = entry.getKey();
-//      Float tokenWeight = entry.getValue();
-//      int weightQuantized = Math.round(tokenWeight / weightRange * quantRange);
-//      for (int i = 0; i < weightQuantized; ++i) {
-//        encodedQuery.add(token);
-//      }
-//    }
-//    return String.join(" ", encodedQuery);
-//  }
-
-  public String flatten(Map<String, Integer> intWeights) {
+  public static String flatten(Map<String, Integer> intWeights) {
     List<String> tokens = new ArrayList<>();
     for (Map.Entry<String, Integer> entry : intWeights.entrySet()) {
       String token = entry.getKey();
@@ -67,7 +45,16 @@ public abstract class SparseEncoder extends OnnxEncoder<String> {
     return String.join(" ", tokens);
   }
 
-  public Map<String, Integer> quantizeFloatWeights(Map<String, Float> tokenWeightMap) throws OrtException {
+  public SparseEncoder(int weightRange, int quantRange,
+                       @NotNull String vocabName, @NotNull String vocabUrl,
+                       @NotNull String modelName, @NotNull String modelUrl)
+      throws IOException, OrtException, URISyntaxException {
+    super(vocabName, vocabUrl, modelName, modelUrl);
+    this.weightRange = weightRange;
+    this.quantRange = quantRange;
+  }
+
+  public Map<String, Integer> quantizeFloatWeights(Map<String, Float> tokenWeightMap) {
     Map<String, Integer> encodedQuery = new HashMap<>();
     for (Map.Entry<String, Float> entry : tokenWeightMap.entrySet()) {
       String token = entry.getKey();
@@ -78,7 +65,8 @@ public abstract class SparseEncoder extends OnnxEncoder<String> {
     return encodedQuery;
   }
 
-  public Map<String, Integer> encodeIntWeights(String query) throws OrtException {
+  @Override
+  public Map<String, Integer> encode(@NotNull String query) throws OrtException {
     Map<String, Float> tokenWeightMap = computeFloatWeights(query);
     return quantizeFloatWeights(tokenWeightMap);
   }

--- a/src/main/java/io/anserini/encoder/sparse/SparseEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/SparseEncoder.java
@@ -54,21 +54,27 @@ public abstract class SparseEncoder extends OnnxEncoder<Map<String, Integer>> {
     this.quantRange = quantRange;
   }
 
-  public Map<String, Integer> quantizeFloatWeights(Map<String, Float> tokenWeightMap) {
-    Map<String, Integer> encodedQuery = new HashMap<>();
-    for (Map.Entry<String, Float> entry : tokenWeightMap.entrySet()) {
-      String token = entry.getKey();
-      Float tokenWeight = entry.getValue();
-      int weightQuantized = Math.round(tokenWeight / weightRange * quantRange);
-      encodedQuery.put(token, weightQuantized);
-    }
-    return encodedQuery;
+  public Map<String, Integer> quantizeFloatWeights(Map<String, Float> tokenFloatWeights) {
+    Map<String, Integer> tokenIntWeights = new HashMap<>();
+    tokenFloatWeights.forEach((token, weight) -> tokenIntWeights.put(token, Math.round(weight / weightRange * quantRange)));
+
+    return tokenIntWeights;
   }
+
+//  public Map<String, Integer> quantizeFloatWeights(Map<String, Float> tokenFloatWeights) {
+//    Map<String, Integer> tokenIntWeights = new HashMap<>();
+//    for (Map.Entry<String, Float> entry : tokenFloatWeights.entrySet()) {
+//      String token = entry.getKey();
+//      int weightQuantized = Math.round(entry.getValue() / weightRange * quantRange);
+//
+//      tokenIntWeights.put(token, weightQuantized);
+//    }
+//    return tokenIntWeights;
+//  }
 
   @Override
   public Map<String, Integer> encode(@NotNull String query) throws OrtException {
-    Map<String, Float> tokenWeightMap = computeFloatWeights(query);
-    return quantizeFloatWeights(tokenWeightMap);
+    return quantizeFloatWeights(computeFloatWeights(query));
   }
 
   public long[] tokenizeToIds(String query) {

--- a/src/main/java/io/anserini/encoder/sparse/SparseEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/SparseEncoder.java
@@ -16,36 +16,29 @@
 
 package io.anserini.encoder.sparse;
 
-import ai.djl.modality.nlp.DefaultVocabulary;
 import ai.onnxruntime.OrtException;
 import io.anserini.encoder.OnnxEncoder;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 public abstract class SparseEncoder extends OnnxEncoder<String> {
 
   protected int weightRange;
-
   protected int quantRange;
 
-  public SparseEncoder(int weightRange, int quantRange, String vocabName, String vocabURL, String modelName,
-                       String modelURL) throws IOException, OrtException, URISyntaxException {
-    super(vocabName, vocabURL, modelName, modelURL);
+  public SparseEncoder(int weightRange, int quantRange, String vocabName, String vocabUrl, String modelName, String modelUrl)
+      throws IOException, OrtException, URISyntaxException {
+    super(vocabName, vocabUrl, modelName, modelUrl);
     this.weightRange = weightRange;
     this.quantRange = quantRange;
   }
 
   public String generateEncodedQuery(Map<String, Float> tokenWeightMap) {
-    /*
-     * This function generates the encoded query.
-     */
     List<String> encodedQuery = new ArrayList<>();
     for (Map.Entry<String, Float> entry : tokenWeightMap.entrySet()) {
       String token = entry.getKey();
@@ -63,8 +56,8 @@ public abstract class SparseEncoder extends OnnxEncoder<String> {
     for (Map.Entry<String, Float> entry : tokenWeightMap.entrySet()) {
       String token = entry.getKey();
       Float tokenWeight = entry.getValue();
-      int weightQuanted = Math.round(tokenWeight / weightRange * quantRange);
-      encodedQuery.put(token, weightQuanted);
+      int weightQuantized = Math.round(tokenWeight / weightRange * quantRange);
+      encodedQuery.put(token, weightQuantized);
     }
     return encodedQuery;
   }
@@ -72,6 +65,15 @@ public abstract class SparseEncoder extends OnnxEncoder<String> {
   public Map<String, Integer> getEncodedQueryMap(String query) throws OrtException {
     Map<String, Float> tokenWeightMap = getTokenWeightMap(query);
     return getEncodedQueryMap(tokenWeightMap);
+  }
+
+  public long[] tokenizeToIds(String query) {
+    List<String> queryTokens = new ArrayList<>();
+    queryTokens.add("[CLS]");
+    queryTokens.addAll(tokenizer.tokenize(query));
+    queryTokens.add("[SEP]");
+
+    return convertTokensToIds(queryTokens, vocab);
   }
 
   protected abstract Map<String, Float> getTokenWeightMap(String query) throws OrtException;

--- a/src/main/java/io/anserini/encoder/sparse/SparseEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/SparseEncoder.java
@@ -36,7 +36,7 @@ public abstract class SparseEncoder extends OnnxEncoder<String> {
   protected int quantRange;
 
   public SparseEncoder(int weightRange, int quantRange, String vocabName, String vocabURL, String modelName,
-      String modelURL) throws IOException, OrtException, URISyntaxException {
+                       String modelURL) throws IOException, OrtException, URISyntaxException {
     super(vocabName, vocabURL, modelName, modelURL);
     this.weightRange = weightRange;
     this.quantRange = quantRange;
@@ -75,6 +75,4 @@ public abstract class SparseEncoder extends OnnxEncoder<String> {
   }
 
   protected abstract Map<String, Float> getTokenWeightMap(String query) throws OrtException;
-
-  public abstract Path getModelPath() throws IOException, URISyntaxException;
 }

--- a/src/main/java/io/anserini/encoder/sparse/SparseEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/SparseEncoder.java
@@ -41,20 +41,33 @@ public abstract class SparseEncoder extends OnnxEncoder<String> {
     this.quantRange = quantRange;
   }
 
-  public String generateEncodedQuery(Map<String, Float> tokenWeightMap) {
-    List<String> encodedQuery = new ArrayList<>();
-    for (Map.Entry<String, Float> entry : tokenWeightMap.entrySet()) {
+//  protected String generateEncodedQuery(Map<String, Float> tokenWeightMap) {
+//    List<String> encodedQuery = new ArrayList<>();
+//    for (Map.Entry<String, Float> entry : tokenWeightMap.entrySet()) {
+//      String token = entry.getKey();
+//      Float tokenWeight = entry.getValue();
+//      int weightQuantized = Math.round(tokenWeight / weightRange * quantRange);
+//      for (int i = 0; i < weightQuantized; ++i) {
+//        encodedQuery.add(token);
+//      }
+//    }
+//    return String.join(" ", encodedQuery);
+//  }
+
+  public String flatten(Map<String, Integer> intWeights) {
+    List<String> tokens = new ArrayList<>();
+    for (Map.Entry<String, Integer> entry : intWeights.entrySet()) {
       String token = entry.getKey();
-      Float tokenWeight = entry.getValue();
-      int weightQuantized = Math.round(tokenWeight / weightRange * quantRange);
-      for (int i = 0; i < weightQuantized; ++i) {
-        encodedQuery.add(token);
+      int weight = entry.getValue();
+      for (int i = 0; i < weight; i++) {
+        tokens.add(token);
       }
     }
-    return String.join(" ", encodedQuery);
+
+    return String.join(" ", tokens);
   }
 
-  public Map<String, Integer> getEncodedQueryMap(Map<String, Float> tokenWeightMap) throws OrtException {
+  public Map<String, Integer> quantizeFloatWeights(Map<String, Float> tokenWeightMap) throws OrtException {
     Map<String, Integer> encodedQuery = new HashMap<>();
     for (Map.Entry<String, Float> entry : tokenWeightMap.entrySet()) {
       String token = entry.getKey();
@@ -65,9 +78,9 @@ public abstract class SparseEncoder extends OnnxEncoder<String> {
     return encodedQuery;
   }
 
-  public Map<String, Integer> getEncodedQueryMap(String query) throws OrtException {
-    Map<String, Float> tokenWeightMap = getTokenWeightMap(query);
-    return getEncodedQueryMap(tokenWeightMap);
+  public Map<String, Integer> encodeIntWeights(String query) throws OrtException {
+    Map<String, Float> tokenWeightMap = computeFloatWeights(query);
+    return quantizeFloatWeights(tokenWeightMap);
   }
 
   public long[] tokenizeToIds(String query) {
@@ -79,5 +92,5 @@ public abstract class SparseEncoder extends OnnxEncoder<String> {
     return convertTokensToIds(queryTokens);
   }
 
-  protected abstract Map<String, Float> getTokenWeightMap(String query) throws OrtException;
+  protected abstract Map<String, Float> computeFloatWeights(String query) throws OrtException;
 }

--- a/src/main/java/io/anserini/encoder/sparse/SparseEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/SparseEncoder.java
@@ -18,6 +18,7 @@ package io.anserini.encoder.sparse;
 
 import ai.onnxruntime.OrtException;
 import io.anserini.encoder.OnnxEncoder;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -31,7 +32,9 @@ public abstract class SparseEncoder extends OnnxEncoder<String> {
   protected int weightRange;
   protected int quantRange;
 
-  public SparseEncoder(int weightRange, int quantRange, String vocabName, String vocabUrl, String modelName, String modelUrl)
+  public SparseEncoder(int weightRange, int quantRange,
+                       @NotNull String vocabName, @NotNull String vocabUrl,
+                       @NotNull String modelName, @NotNull String modelUrl)
       throws IOException, OrtException, URISyntaxException {
     super(vocabName, vocabUrl, modelName, modelUrl);
     this.weightRange = weightRange;
@@ -73,7 +76,7 @@ public abstract class SparseEncoder extends OnnxEncoder<String> {
     queryTokens.addAll(tokenizer.tokenize(query));
     queryTokens.add("[SEP]");
 
-    return convertTokensToIds(queryTokens, vocab);
+    return convertTokensToIds(queryTokens);
   }
 
   protected abstract Map<String, Float> getTokenWeightMap(String query) throws OrtException;

--- a/src/main/java/io/anserini/encoder/sparse/SparseEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/SparseEncoder.java
@@ -74,22 +74,6 @@ public abstract class SparseEncoder extends OnnxEncoder<String> {
     return getEncodedQueryMap(tokenWeightMap);
   }
 
-  static protected Map<String, Float> getTokenWeightMap(long[] indexes, float[] computedWeights,
-      DefaultVocabulary vocab) {
-    /*
-     * This function returns a map of token to its weight.
-     */
-    Map<String, Float> tokenWeightMap = new LinkedHashMap<>();
-
-    for (int i = 0; i < indexes.length; i++) {
-      if (indexes[i] == 101 || indexes[i] == 102 || indexes[i] == 0) {
-        continue;
-      }
-      tokenWeightMap.put(vocab.getToken(indexes[i]), computedWeights[i]);
-    }
-    return tokenWeightMap;
-  }
-
   protected abstract Map<String, Float> getTokenWeightMap(String query) throws OrtException;
 
   public abstract Path getModelPath() throws IOException, URISyntaxException;

--- a/src/main/java/io/anserini/encoder/sparse/SpladePlusPlusEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/SpladePlusPlusEncoder.java
@@ -45,15 +45,6 @@ public abstract class SpladePlusPlusEncoder extends SparseEncoder {
     return generateEncodedQuery(tokenWeightMap);
   }
 
-  public long[] tokenizeToIds(String query) {
-    List<String> queryTokens = new ArrayList<>();
-    queryTokens.add("[CLS]");
-    queryTokens.addAll(tokenizer.tokenize(query));
-    queryTokens.add("[SEP]");
-
-    return convertTokensToIds(tokenizer, queryTokens, vocab);
-  }
-
   @Override
   protected Map<String, Float> getTokenWeightMap(String query) throws OrtException {
     List<String> queryTokens = new ArrayList<>();
@@ -62,7 +53,7 @@ public abstract class SpladePlusPlusEncoder extends SparseEncoder {
     queryTokens.add("[SEP]");
 
     Map<String, OnnxTensor> inputs = new HashMap<>();
-    long[] queryTokenIds = convertTokensToIds(tokenizer, queryTokens, vocab, MAX_SEQ_LEN);
+    long[] queryTokenIds = convertTokensToIds(queryTokens, vocab, MAX_SEQ_LEN);
     long[][] inputTokenIds = new long[1][queryTokenIds.length];
 
     inputTokenIds[0] = queryTokenIds;

--- a/src/main/java/io/anserini/encoder/sparse/SpladePlusPlusEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/SpladePlusPlusEncoder.java
@@ -43,12 +43,12 @@ public abstract class SpladePlusPlusEncoder extends SparseEncoder {
 
   @Override
   public String encode(@NotNull String query) throws OrtException {
-    Map<String, Float> tokenWeightMap = getTokenWeightMap(query);
-    return generateEncodedQuery(tokenWeightMap);
+    Map<String, Float> tokenWeightMap = computeFloatWeights(query);
+    return flatten(quantizeFloatWeights(tokenWeightMap));
   }
 
   @Override
-  protected Map<String, Float> getTokenWeightMap(String query) throws OrtException {
+  protected Map<String, Float> computeFloatWeights(String query) throws OrtException {
     List<String> queryTokens = new ArrayList<>();
     queryTokens.add("[CLS]");
     queryTokens.addAll(tokenizer.tokenize(query));

--- a/src/main/java/io/anserini/encoder/sparse/SpladePlusPlusEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/SpladePlusPlusEncoder.java
@@ -19,6 +19,7 @@ package io.anserini.encoder.sparse;
 import ai.onnxruntime.OnnxTensor;
 import ai.onnxruntime.OrtException;
 import ai.onnxruntime.OrtSession;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -34,13 +35,14 @@ public abstract class SpladePlusPlusEncoder extends SparseEncoder {
   static private final int QUANT_RANGE = 256;
   static private final int MAX_SEQ_LEN = 512;
 
-  protected SpladePlusPlusEncoder(String modelName, String modelUrl, String vocabName, String vocabUrl)
+  protected SpladePlusPlusEncoder(@NotNull String modelName, @NotNull String modelUrl,
+                                  @NotNull String vocabName, @NotNull String vocabUrl)
       throws IOException, OrtException, URISyntaxException {
     super(WEIGHT_RANGE, QUANT_RANGE, modelName, modelUrl, vocabName, vocabUrl);
   }
 
   @Override
-  public String encode(String query) throws OrtException {
+  public String encode(@NotNull String query) throws OrtException {
     Map<String, Float> tokenWeightMap = getTokenWeightMap(query);
     return generateEncodedQuery(tokenWeightMap);
   }
@@ -53,7 +55,7 @@ public abstract class SpladePlusPlusEncoder extends SparseEncoder {
     queryTokens.add("[SEP]");
 
     Map<String, OnnxTensor> inputs = new HashMap<>();
-    long[] queryTokenIds = convertTokensToIds(queryTokens, vocab, MAX_SEQ_LEN);
+    long[] queryTokenIds = convertTokensToIds(queryTokens, MAX_SEQ_LEN);
     long[][] inputTokenIds = new long[1][queryTokenIds.length];
 
     inputTokenIds[0] = queryTokenIds;

--- a/src/main/java/io/anserini/encoder/sparse/SpladePlusPlusEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/SpladePlusPlusEncoder.java
@@ -1,0 +1,96 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.encoder.sparse;
+
+import ai.onnxruntime.OnnxTensor;
+import ai.onnxruntime.OrtException;
+import ai.onnxruntime.OrtSession;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class SpladePlusPlusEncoder extends SparseEncoder {
+  static private final int WEIGHT_RANGE = 5;
+  static private final int QUANT_RANGE = 256;
+  static private final int MAX_SEQ_LEN = 512;
+
+  protected SpladePlusPlusEncoder(String modelName, String modelUrl, String vocabName, String vocabUrl)
+      throws IOException, OrtException, URISyntaxException {
+    super(WEIGHT_RANGE, QUANT_RANGE, modelName, modelUrl, vocabName, vocabUrl);
+  }
+
+  @Override
+  public String encode(String query) throws OrtException {
+    Map<String, Float> tokenWeightMap = getTokenWeightMap(query);
+    return generateEncodedQuery(tokenWeightMap);
+  }
+
+  public long[] tokenizeToIds(String query) {
+    List<String> queryTokens = new ArrayList<>();
+    queryTokens.add("[CLS]");
+    queryTokens.addAll(tokenizer.tokenize(query));
+    queryTokens.add("[SEP]");
+
+    return convertTokensToIds(tokenizer, queryTokens, vocab);
+  }
+
+  @Override
+  protected Map<String, Float> getTokenWeightMap(String query) throws OrtException {
+    List<String> queryTokens = new ArrayList<>();
+    queryTokens.add("[CLS]");
+    queryTokens.addAll(tokenizer.tokenize(query));
+    queryTokens.add("[SEP]");
+
+    Map<String, OnnxTensor> inputs = new HashMap<>();
+    long[] queryTokenIds = convertTokensToIds(tokenizer, queryTokens, vocab, MAX_SEQ_LEN);
+    long[][] inputTokenIds = new long[1][queryTokenIds.length];
+
+    inputTokenIds[0] = queryTokenIds;
+    long[][] attentionMask = new long[1][queryTokenIds.length];
+    long[][] tokenTypeIds = new long[1][queryTokenIds.length];
+
+    // Initialize attention mask with all 1s.
+    Arrays.fill(attentionMask[0], 1);
+    inputs.put("input_ids", OnnxTensor.createTensor(environment, inputTokenIds));
+    inputs.put("token_type_ids", OnnxTensor.createTensor(environment, tokenTypeIds));
+    inputs.put("attention_mask", OnnxTensor.createTensor(environment, attentionMask));
+
+    try (OrtSession.Result results = session.run(inputs)) {
+      assert (results.get("output_idx").isPresent());
+      assert (results.get("output_weights").isPresent());
+
+      long[] indexes = (long[]) results.get("output_idx").get().getValue();
+      float[] weights = (float[]) results.get("output_weights").get().getValue();
+
+      Map<String, Float> tokenFloatWeights = new LinkedHashMap<>();
+      for (int i = 0; i < indexes.length; i++) {
+        if (indexes[i] == 101 || indexes[i] == 102 || indexes[i] == 0) {
+          continue;
+        }
+        tokenFloatWeights.put(vocab.getToken(indexes[i]), weights[i]);
+      }
+
+      return tokenFloatWeights;
+    }
+  }
+}

--- a/src/main/java/io/anserini/encoder/sparse/SpladePlusPlusEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/SpladePlusPlusEncoder.java
@@ -42,12 +42,6 @@ public abstract class SpladePlusPlusEncoder extends SparseEncoder {
   }
 
   @Override
-  public String encode(@NotNull String query) throws OrtException {
-    Map<String, Float> tokenWeightMap = computeFloatWeights(query);
-    return flatten(quantizeFloatWeights(tokenWeightMap));
-  }
-
-  @Override
   protected Map<String, Float> computeFloatWeights(String query) throws OrtException {
     List<String> queryTokens = new ArrayList<>();
     queryTokens.add("[CLS]");

--- a/src/main/java/io/anserini/encoder/sparse/SpladePlusPlusEnsembleDistilEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/SpladePlusPlusEnsembleDistilEncoder.java
@@ -17,11 +17,9 @@
 package io.anserini.encoder.sparse;
 
 import ai.onnxruntime.OrtException;
-import io.anserini.encoder.OnnxEncoder;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Path;
 
 public class SpladePlusPlusEnsembleDistilEncoder extends SpladePlusPlusEncoder {
   static private final String MODEL_URL = "https://rgw.cs.uwaterloo.ca/pyserini/data/splade-pp-ed-optimized.onnx";
@@ -32,9 +30,5 @@ public class SpladePlusPlusEnsembleDistilEncoder extends SpladePlusPlusEncoder {
 
   public SpladePlusPlusEnsembleDistilEncoder() throws IOException, OrtException, URISyntaxException {
     super(MODEL_NAME, MODEL_URL, VOCAB_NAME, VOCAB_URL);
-  }
-
-  public Path getModelPath() throws IOException, URISyntaxException {
-    return OnnxEncoder.getModelPath(MODEL_NAME, MODEL_URL);
   }
 }

--- a/src/main/java/io/anserini/encoder/sparse/SpladePlusPlusSelfDistilEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/SpladePlusPlusSelfDistilEncoder.java
@@ -16,80 +16,22 @@
 
 package io.anserini.encoder.sparse;
 
-import ai.onnxruntime.OnnxTensor;
 import ai.onnxruntime.OrtException;
-import ai.onnxruntime.OrtSession;
 import io.anserini.encoder.OnnxEncoder;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
-public class SpladePlusPlusSelfDistilEncoder extends SparseEncoder {
+public class SpladePlusPlusSelfDistilEncoder extends SpladePlusPlusEncoder {
   static private final String MODEL_URL = "https://rgw.cs.uwaterloo.ca/pyserini/data/splade-pp-sd-optimized.onnx";
   static private final String VOCAB_URL = "https://rgw.cs.uwaterloo.ca/pyserini/data/wordpiece-vocab.txt";
 
   static private final String MODEL_NAME = "splade-pp-sd-optimized.onnx";
   static private final String VOCAB_NAME = "splade-pp-sd-vocab.txt";
 
-  static private final int MAX_SEQ_LEN = 512;
-
   public SpladePlusPlusSelfDistilEncoder() throws IOException, OrtException, URISyntaxException {
-    super(5, 256, MODEL_NAME, MODEL_URL, VOCAB_NAME, VOCAB_URL);
-  }
-
-  @Override
-  public String encode(String query) throws OrtException {
-    Map<String, Float> tokenWeightMap = getTokenWeightMap(query);
-    return generateEncodedQuery(tokenWeightMap);
-  }
-
-  public long[] tokenizeToIds(String query) {
-    List<String> queryTokens = new ArrayList<>();
-    queryTokens.add("[CLS]");
-    queryTokens.addAll(tokenizer.tokenize(query));
-    queryTokens.add("[SEP]");
-
-    return convertTokensToIds(tokenizer, queryTokens, vocab);
-  }
-
-  @Override
-  protected Map<String, Float> getTokenWeightMap(String query) throws OrtException {
-    List<String> queryTokens = new ArrayList<>();
-    queryTokens.add("[CLS]");
-    queryTokens.addAll(tokenizer.tokenize(query));
-    queryTokens.add("[SEP]");
-
-    Map<String, OnnxTensor> inputs = new HashMap<>();
-    long[] queryTokenIds = convertTokensToIds(tokenizer, queryTokens, vocab, MAX_SEQ_LEN);
-    long[][] inputTokenIds = new long[1][queryTokenIds.length];
-
-    inputTokenIds[0] = queryTokenIds;
-    long[][] attentionMask = new long[1][queryTokenIds.length];
-    long[][] tokenTypeIds = new long[1][queryTokenIds.length];
-
-    // initialize attention mask with all 1s
-    Arrays.fill(attentionMask[0], 1);
-    inputs.put("input_ids", OnnxTensor.createTensor(environment, inputTokenIds));
-    inputs.put("token_type_ids", OnnxTensor.createTensor(environment, tokenTypeIds));
-    inputs.put("attention_mask", OnnxTensor.createTensor(environment, attentionMask));
-
-    Map<String, Float> tokenFloatWeights;
-    try (OrtSession.Result results = session.run(inputs)) {
-      assert (results.get("output_idx").isPresent());
-      assert (results.get("output_weights").isPresent());
-
-      long[] indexes = (long[]) results.get("output_idx").get().getValue();
-      float[] weights = (float[]) results.get("output_weights").get().getValue();
-      tokenFloatWeights = getTokenWeightMap(indexes, weights, vocab);
-    }
-
-    return tokenFloatWeights;
+    super(MODEL_NAME, MODEL_URL, VOCAB_NAME, VOCAB_URL);
   }
 
   public Path getModelPath() throws IOException, URISyntaxException {

--- a/src/main/java/io/anserini/encoder/sparse/SpladePlusPlusSelfDistilEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/SpladePlusPlusSelfDistilEncoder.java
@@ -17,11 +17,9 @@
 package io.anserini.encoder.sparse;
 
 import ai.onnxruntime.OrtException;
-import io.anserini.encoder.OnnxEncoder;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Path;
 
 public class SpladePlusPlusSelfDistilEncoder extends SpladePlusPlusEncoder {
   static private final String MODEL_URL = "https://rgw.cs.uwaterloo.ca/pyserini/data/splade-pp-sd-optimized.onnx";
@@ -32,9 +30,5 @@ public class SpladePlusPlusSelfDistilEncoder extends SpladePlusPlusEncoder {
 
   public SpladePlusPlusSelfDistilEncoder() throws IOException, OrtException, URISyntaxException {
     super(MODEL_NAME, MODEL_URL, VOCAB_NAME, VOCAB_URL);
-  }
-
-  public Path getModelPath() throws IOException, URISyntaxException {
-    return OnnxEncoder.getModelPath(MODEL_NAME, MODEL_URL);
   }
 }

--- a/src/main/java/io/anserini/encoder/sparse/UniCoilEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/UniCoilEncoder.java
@@ -110,13 +110,12 @@ public class UniCoilEncoder extends SparseEncoder {
     inputTokenIds[0] = queryTokenIds;
     inputs.put("inputIds", OnnxTensor.createTensor(environment, inputTokenIds));
 
-    Map<String, Float> tokenWeightMap = null;
+    Map<String, Float> tokenWeightMap;
     try (OrtSession.Result results = session.run(inputs)) {
       float[] computedWeights = flatten(results.get(0).getValue());
       tokenWeightMap = getTokenWeightMap(queryTokens, computedWeights);
-    } catch (OrtException e) {
-      e.printStackTrace();
     }
+
     return tokenWeightMap;
   }
 

--- a/src/main/java/io/anserini/encoder/sparse/UniCoilEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/UniCoilEncoder.java
@@ -19,6 +19,7 @@ package io.anserini.encoder.sparse;
 import ai.onnxruntime.OnnxTensor;
 import ai.onnxruntime.OrtException;
 import ai.onnxruntime.OrtSession;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -40,7 +41,7 @@ public class UniCoilEncoder extends SparseEncoder {
   }
 
   @Override
-  public String encode(String query) throws OrtException {
+  public String encode(@NotNull String query) throws OrtException {
     String encodedQuery = "";
     Map<String, Float> tokenWeightMap = getTokenWeightMap(query);
     encodedQuery = generateEncodedQuery(tokenWeightMap);
@@ -94,7 +95,7 @@ public class UniCoilEncoder extends SparseEncoder {
     queryTokens.add("[SEP]");
 
     Map<String, OnnxTensor> inputs = new HashMap<>();
-    long[] queryTokenIds = convertTokensToIds(queryTokens, vocab);
+    long[] queryTokenIds = convertTokensToIds(queryTokens);
     long[][] inputTokenIds = new long[1][queryTokenIds.length];
     inputTokenIds[0] = queryTokenIds;
     inputs.put("inputIds", OnnxTensor.createTensor(environment, inputTokenIds));

--- a/src/main/java/io/anserini/encoder/sparse/UniCoilEncoder.java
+++ b/src/main/java/io/anserini/encoder/sparse/UniCoilEncoder.java
@@ -42,10 +42,8 @@ public class UniCoilEncoder extends SparseEncoder {
 
   @Override
   public String encode(@NotNull String query) throws OrtException {
-    String encodedQuery = "";
-    Map<String, Float> tokenWeightMap = getTokenWeightMap(query);
-    encodedQuery = generateEncodedQuery(tokenWeightMap);
-    return encodedQuery;
+    Map<String, Float> tokenWeightMap = computeFloatWeights(query);
+    return flatten(quantizeFloatWeights(tokenWeightMap));
   }
 
   private float[] flatten(Object obj) {
@@ -88,7 +86,7 @@ public class UniCoilEncoder extends SparseEncoder {
   }
 
   @Override
-  protected Map<String, Float> getTokenWeightMap(String query) throws OrtException {
+  protected Map<String, Float> computeFloatWeights(String query) throws OrtException {
     List<String> queryTokens = new ArrayList<>();
     queryTokens.add("[CLS]");
     queryTokens.addAll(tokenizer.tokenize(query));

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -868,7 +868,7 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
             }
 
             if (queryEncoder != null) {
-              queryString = new StringBuilder(queryEncoder.encode(queryString.toString()));
+              queryString = new StringBuilder(SparseEncoder.flatten(queryEncoder.encode(queryString.toString())));
             }
 
             ScoredDocs queryQrels = null;

--- a/src/main/java/io/anserini/search/SimpleImpactSearcher.java
+++ b/src/main/java/io/anserini/search/SimpleImpactSearcher.java
@@ -532,7 +532,7 @@ public class SimpleImpactSearcher implements Closeable {
       return queryTokens.stream().collect(Collectors.toMap(e->e, (a)->1, Integer::sum));
     }
 
-    return this.queryEncoder.encodeIntWeights(queryString);
+    return this.queryEncoder.encode(queryString);
   }
 
   /**

--- a/src/main/java/io/anserini/search/SimpleImpactSearcher.java
+++ b/src/main/java/io/anserini/search/SimpleImpactSearcher.java
@@ -532,7 +532,7 @@ public class SimpleImpactSearcher implements Closeable {
       return queryTokens.stream().collect(Collectors.toMap(e->e, (a)->1, Integer::sum));
     }
 
-    return this.queryEncoder.getEncodedQueryMap(queryString);
+    return this.queryEncoder.encodeIntWeights(queryString);
   }
 
   /**

--- a/src/test/java/io/anserini/encoder/dense/ArcticEmbedLEncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/dense/ArcticEmbedLEncoderInferenceTest.java
@@ -901,7 +901,7 @@ public class ArcticEmbedLEncoderInferenceTest extends DenseEncoderInferenceTest 
           float[] weights = new float[EMBEDDING_DIM];
           System.arraycopy(embeddings[0][0], 0, weights, 0, 1024);
 
-          weights = OnnxEncoder.normalize(weights);
+          weights = DenseEncoder.normalize(weights);
           assertArrayEquals(expectedEmbeddings, weights, 1e-4f);
         }
       }

--- a/src/test/java/io/anserini/encoder/sparse/BaseSparseEncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/sparse/BaseSparseEncoderInferenceTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertEquals;
 public class BaseSparseEncoderInferenceTest {
   public void testExamples(SparseExampleOutputPair[] examples, SparseEncoder encoder) throws OrtException {
     for (SparseExampleOutputPair pair : examples) {
-      Map<String, Integer> outputs = encoder.encodeIntWeights(pair.example());
+      Map<String, Integer> outputs = encoder.encode(pair.example());
       Map<String, Integer> expectedWeights = pair.output();
 
       assertEquals(expectedWeights.size(), outputs.size());

--- a/src/test/java/io/anserini/encoder/sparse/BaseSparseEncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/sparse/BaseSparseEncoderInferenceTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertEquals;
 public class BaseSparseEncoderInferenceTest {
   public void testExamples(SparseExampleOutputPair[] examples, SparseEncoder encoder) throws OrtException {
     for (SparseExampleOutputPair pair : examples) {
-      Map<String, Integer> outputs = encoder.getEncodedQueryMap(pair.example());
+      Map<String, Integer> outputs = encoder.encodeIntWeights(pair.example());
       Map<String, Integer> expectedWeights = pair.output();
 
       assertEquals(expectedWeights.size(), outputs.size());


### PR DESCRIPTION
+ `SpladePlusPlusEnsembleDistilEncoder` and `SpladePlusPlusEnsembleDistilEncoder` can share the same impl except for the actual models.
+ Refactor sparse encoders to generate `Map<String, Integer>`.
+ Extensive cleanup of both dense and sparse encoders.