### PR TITLE
Add reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -562,3 +562,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@JJGreen0](https://github.com/JJGreen0) on 2025-02-16 (commit [`d5e1c96`](https://github.com/castorini/anserini/commit/d5e1c961df0e072478edea819214dec8c87f7a0a))
 + Results reproduced by [@lilyjge](https://github.com/lilyjge) on 2025-02-16 (commit [`0fe40c3`](https://github.com/castorini/anserini/commit/0fe40c32df4c61b8dfa7b332189a06ce00a38d85))
 + Results reproduced by [@clides](https://github.com/clides) on 2025-02-17 (commit [`d5e1c96`](https://github.com/castorini/anserini/commit/d5e1c961df0e072478edea819214dec8c87f7a0a))
++ Results reproduced by [@rbhard10](https://github.com/rbhard10) on 2025-03-19 (commit [`f7e6bb5`](https://github.com/castorini/anserini/commit/f7e6bb57))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -461,3 +461,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@mohammaderfankabir](https://github.com/mohammaderfankabir) on 2025-02-16 (commit [`0fe40c3`](https://github.com/castorini/anserini/commit/0fe40c32df4c61b8dfa7b332189a06ce00a38d85))
 + Results reproduced by [@JJGreen0](https://github.com/JJGreen0) on 2025-02-16 (commit [`d5e1c96`](https://github.com/castorini/anserini/commit/d5e1c961df0e072478edea819214dec8c87f7a0a))
 + Results reproduced by [@clides](https://github.com/clides) on 2025-02-17 (commit [`d5e1c96`](https://github.com/castorini/anserini/commit/d5e1c961df0e072478edea819214dec8c87f7a0a))
++ Results reproduced by [@rbhard10](https://github.com/rbhard10) on 2025-03-18 (commit [`f7e6bb5`](https://github.com/castorini/anserini/commit/f7e6bb57))


### PR DESCRIPTION
I've completed Tasks 1 and 2 of the onboarding path.

Environment:
- MacBook Air with Apple M1 chip
- macOS Sonoma
- Modified run.sh to use -Xmx6G instead of -Xmx192G for memory constraints
- Used Java 21 (installed via Homebrew)

Task 1 (Start Here):
Successfully explored the MS MARCO passage collection, understood its structure, and the relationships between queries, documents, and relevance judgments.

Task 2 (BM25 Baselines):
Successfully indexed the collection, performed retrieval with BM25, and evaluated the results. Obtained the following metrics:
- MRR @10: 0.18741227770955546
- MAP: 0.1957
- Recall@1000: 0.8573

These values match the expected results in the documentation.

Issues resolved:
- Updated Java version to 21 to match Anserini's requirements
- Modified memory allocation in run.sh to work with my system's constraints
- Reduced thread count for indexing to prevent out-of-memory errors