### PR TITLE
Update experiments-msmarco-passage2.md

### DIFF
--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -108,4 +108,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 
 + Results reproduced by [@b8zhong](https://github.com/b8zhong) on 2025-02-23 (commit [`daceb40`](https://github.com/castorini/anserini/commit/daceb4084c8e8103e3e86c81a8e0d597d409220e))
 + Results reproduced by [@lilyjge](https://github.com/lilyjge) on 2025-02-23 (commit [`9b13fe4`](https://github.com/castorini/anserini/commit/9b13fe488d3227ba3a271366210eadfed521d0f5))
-
++ Results reproduced by [@JJGreen0](https://github.com/JJGreen0) on 2025-04-19 (commit [`2d8674c`](https://github.com/castorini/anserini/commit/2d8674c0cd741e1c407e0ac7cce8ea38fdd0bb97))


### PR DESCRIPTION
Student Linux Environment 

Exceeded the CPU time limit during retrieval run. Got to about 6000 queries processed before being killed.  

Chatgpt told me this: 
You’re hitting a hard CPU‐seconds quota on your student account: the cluster is limiting the sum of CPU time across all threads, not just wall‑clock time. By spinning up 4 threads, your 6000‑query run burned through that quota and got killed. You’re not permanently stuck—you just need to throttle back or split the work. Here are three easy workarounds: 

Reduce parallelism/threads 
 
I tried running with 1 thread and got “CPU time limit exceeded” at 6800 queries 

I tried running it again with literally no changes and managed to just finish the 6900 queries.  

Additionally, I’m not sure why we named our run outputs for the last guide to end with .trec but for this one they end with .txt (despite the qrels still being .trec). 

Otherwise, everything worked.