### PR TITLE
Fix PrebuiltIndexTest by closing connections

### DIFF
--- a/src/test/java/io/anserini/index/PrebuiltIndexTest.java
+++ b/src/test/java/io/anserini/index/PrebuiltIndexTest.java
@@ -48,6 +48,7 @@ public class PrebuiltIndexTest {
           final URL requestUrl = new URI(url).toURL();
           final HttpURLConnection con = (HttpURLConnection) requestUrl.openConnection();
           assertEquals(200, con.getResponseCode());
+          con.disconnect();
         } catch (IOException e) {
           throw new RuntimeException("Error connecting to " + url, e);
         } catch (Exception e) {


### PR DESCRIPTION
Fixes #2800 by closing the URL connection after each URL is tested so it doesn't reach the rate limit.