### PR TITLE
added repro log

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -572,3 +572,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@MINGYISU](https://github.com/MINGYISU) on 2025-05-14 (commit [`bd4c3c7`](https://github.com/castorini/anserini/commit/bd4c3c78823e26bf5ea2ae81a89ab69e1b630575))
 + Results reproduced by [@Armd04](https://github.com/Armd04) on 2025-05-16 (commit [`bd4c3c7`](https://github.com/castorini/anserini/commit/bd4c3c78823e26bf5ea2ae81a89ab69e1b630575))
 + Results reproduced by [@Cassidy-Li](https://github.com/Cassidy-Li) on 2025-05-20 (commit [`a6fe05c`](https://github.com/castorini/anserini/commit/a6fe05ccd6921c5241ea717146ac37ce1eabc8b2))
++ Results reproduced by [@Roselynzzz](https://github.com/Roselynzzz) on 2025-05-26 (commit [`ef25129`](https://github.com/castorini/anserini/commit/ef2512948a40550f9ff1121ecb785fd74b3ebad4))


### PR DESCRIPTION
## Something found during reproduction
1. Compilation with ```mvn clean package``` got error:
```
[ERROR] Failures: 
[ERROR]   ExtractTopDfTermsTest The test or suite printed 9548 bytes to stdout and stderr, even though the limit was set to 8192 bytes. Increase the limit with @Limit, ignore it completely with @SuppressSysoutChecks or run with -Dtests.verbose=true
[INFO] 
[ERROR] Tests run: 751, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:49 min
[INFO] Finished at: 2025-05-26T17:11:47-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.1.0:test (default-test) on project anserini: There are test failures.
[ERROR] 
[ERROR] Please refer to /Users/roselynzhang/Desktop/ResearchUW/anserini/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```
However, this should be a minor error. This is caused by one of the tests (```ExtractTopDfTermsTest```) printed more output (9548 bytes) than allowed (limit: 8192 bytes) to stdout/stderr.
Changed to use ```mvn clean package -DskipTests``` and compiled successfully.

2. 
  ```
  % du -h indexes
  4.4G    indexes/msmarco-passage/lucene-index-msmarco
  4.4G    indexes/msmarco-passage
  4.4G    indexes
  ```
  instead of 4.3G
  
## System
OS: MacOS 15.5 (24F74)
Python: Python 3.10.14
Memory: 24G

## Others
```
bin/run.sh io.anserini.index.IndexCollection \
  -collection JsonCollection \
  -input collections/msmarco-passage/collection_jsonl \
  -index indexes/msmarco-passage/lucene-index-msmarco \
  -generator DefaultLuceneDocumentGenerator \
  -threads 9 -storePositions -storeDocvectors -storeRaw
  ``` 
  in the instruction took 3min to run on my laptop.

## Note on this commit
Cassidy's lines are exactly the same, I accidentally deleted it but added back.
