### PR TITLE
Trigger the log message from KnnFloatVectorQuery during setup

### DIFF
--- a/src/main/java/io/anserini/search/HnswDenseSearcher.java
+++ b/src/main/java/io/anserini/search/HnswDenseSearcher.java
@@ -143,7 +143,7 @@ public class HnswDenseSearcher<K extends Comparable<K>> extends BaseSearcher<K> 
 
     // Trigger the log message during setup, preventing it from interrupting the tqdm progress bar in Pyserini.
     // Link to the issue: https://github.com/castorini/pyserini/issues/2097#issuecomment-2952431298
-    KnnFloatVectorQuery _dummyInstance = new KnnFloatVectorQuery(Constants.VECTOR, new float[0], ((Args) args).efSearch);
+    KnnFloatVectorQuery dummyInstance = new KnnFloatVectorQuery(Constants.VECTOR, new float[0], ((Args) args).efSearch);
   }
 
   /**


### PR DESCRIPTION
Initialize a dummy instance of `KnnFloatVectorQuery` within the `HnswDenseSearcher` constructor to prevent it from interrupting the tqdm progress bar in PySerini. ( [Issue in Pyserini](https://github.com/castorini/pyserini/issues/2097#issuecomment-2954106876) )

<img width="1234" alt="Screenshot 2025-06-08 at 11 10 14 PM" src="https://github.com/user-attachments/assets/41032195-5f22-46b3-b71d-ebcc791fea23" />
