### PR TITLE
Anserini reproduction confirmation

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -578,3 +578,5 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@Vik7am10](https://github.com/Vik7am10) on 2025-06-02 (commit [`b216a5f`](https://github.com/castorini/anserini/commit/b216a5f715f3a6e947389459fef3c2711b85b46e))
 + Results reproduced by [@kevin-zkc](https://github.com/kevin-zkc) on 2025-06-05 (commit [`173312d`](https://github.com/castorini/anserini/commit/173312d7798c343b3cc1d7a3988b213b044eda82))
 + Results reproduced by [@erfan-yazdanparast](https://github.com/erfan-yazdanparast) on 2025-06-08 (commit [`2201471`](https://github.com/castorini/anserini/commit/22014714d2aa12229cfecdb87005f28db66f9caa))
++ Results reproduced by [@nahalhz](https://github.com/nahalhz) on 2025-06-09 (commit [`c07454b`](https://github.com/castorini/anserini/commit/c07454b7c64422789834314d97348907c8c66842))
+

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -125,3 +125,5 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@Vik7am10](https://github.com/Vik7am10) on 2025-06-03 (commit [`b216a5f`](https://github.com/castorini/anserini/commit/b216a5f715f3a6e947389459fef3c2711b85b46e))
 + Results reproduced by [@kevin-zkc](https://github.com/kevin-zkc) on 2025-06-05 (commit [`173312d`](https://github.com/castorini/anserini/commit/173312d7798c343b3cc1d7a3988b213b044eda82))
 + Results reproduced by [@erfan-yazdanparast](https://github.com/erfan-yazdanparast) on 2025-06-08 (commit [`2201471`](https://github.com/castorini/anserini/commit/22014714d2aa12229cfecdb87005f28db66f9caa))
++ Results reproduced by [@nahalhz](https://github.com/nahalhz) on 2025-06-09 (commit [`c07454b`](https://github.com/castorini/anserini/commit/c07454b7c64422789834314d97348907c8c66842))
+

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -477,3 +477,5 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@Vik7am10](https://github.com/Vik7am10) on 2025-06-02 (commit [`b216a5f`](https://github.com/castorini/anserini/commit/b216a5f715f3a6e947389459fef3c2711b85b46e))
 + Results reproduced by [@kevin-zkc](https://github.com/kevin-zkc) on 2025-05-28 (commit [`847378d`](https://github.com/castorini/anserini/commit/847378da49168629bee56e9e82ff8c1a94a87ef4))
 + Results reproduced by [@erfan-yazdanparast](https://github.com/erfan-yazdanparast) on 2025-06-08 (commit [`2201471`](https://github.com/castorini/anserini/commit/22014714d2aa12229cfecdb87005f28db66f9caa))
++ Results reproduced by [@nahalhz](https://github.com/nahalhz) on 2025-06-09 (commit [`c07454b`](https://github.com/castorini/anserini/commit/c07454b7c64422789834314d97348907c8c66842))
+


### PR DESCRIPTION
This pull request adds reproduction log entries to the following documentation files:
- `start-here.md`
- `experiments-msmarco-passage.md`
- `experiments-msmarco-passage2.md`

System Environment:
- **OS:** macOS 14.4.1
- **Python:** 3.9.13
- **Java:** OpenJDK 23.0.2 (via Homebrew)
- **Commit reproduced:** [`c07454b`](https://github.com/castorini/anserini/commit/c07454b7c64422789834314d97348907c8c66842)

Results:
All experiments were successfully reproduced as described. No errors encountered.
