### PR TITLE
Splade-v3 Templates and Docs for BEIR

### DIFF
--- a/docs/regressions/regressions-beir-v1.0.0-arguana.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-arguana.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; ArguAna
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; ArguAna](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-arguana.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-arguana.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-arguana.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-arguana.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-arguana.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-arguana.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-arguana.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-arguana.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-arguana.splade-v3.splade-v3-cached.topics.beir-v1.0.0-arguana.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-arguana.test.txt runs/run.beir-v1.0.0-arguana.splade-v3.splade-v3-cached.topics.beir-v1.0.0-arguana.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-arguana.test.txt runs/run.beir-v1.0.0-arguana.splade-v3.splade-v3-cached.topics.beir-v1.0.0-arguana.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-arguana.test.txt runs/run.beir-v1.0.0-arguana.splade-v3.splade-v3-cached.topics.beir-v1.0.0-arguana.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): ArguAna                                                                                       | 0.4872    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): ArguAna                                                                                       | 0.9822    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): ArguAna                                                                                       | 0.9957    |

--- a/docs/regressions/regressions-beir-v1.0.0-arguana.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-arguana.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; ArguAna
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; ArguAna](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-arguana.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-arguana.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-arguana.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-arguana.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-arguana.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-arguana.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-arguana.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-arguana.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-arguana.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-arguana.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-arguana.test.txt runs/run.beir-v1.0.0-arguana.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-arguana.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-arguana.test.txt runs/run.beir-v1.0.0-arguana.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-arguana.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-arguana.test.txt runs/run.beir-v1.0.0-arguana.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-arguana.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): ArguAna                                                                                       | 0.4845    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): ArguAna                                                                                       | 0.9794    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): ArguAna                                                                                       | 0.9964    |

--- a/docs/regressions/regressions-beir-v1.0.0-bioasq.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-bioasq.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; BioASQ
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; BioASQ](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-bioasq.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-bioasq.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-bioasq.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-bioasq.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-bioasq.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-bioasq.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-bioasq.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-bioasq.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-bioasq.splade-v3.splade-v3-cached.topics.beir-v1.0.0-bioasq.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-bioasq.test.txt runs/run.beir-v1.0.0-bioasq.splade-v3.splade-v3-cached.topics.beir-v1.0.0-bioasq.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-bioasq.test.txt runs/run.beir-v1.0.0-bioasq.splade-v3.splade-v3-cached.topics.beir-v1.0.0-bioasq.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-bioasq.test.txt runs/run.beir-v1.0.0-bioasq.splade-v3.splade-v3-cached.topics.beir-v1.0.0-bioasq.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): BioASQ                                                                                        | 0.5142    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): BioASQ                                                                                        | 0.7647    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): BioASQ                                                                                        | 0.9018    |

--- a/docs/regressions/regressions-beir-v1.0.0-bioasq.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-bioasq.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; BioASQ
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; BioASQ](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-bioasq.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-bioasq.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-bioasq.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-bioasq.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-bioasq.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-bioasq.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-bioasq.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-bioasq.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-bioasq.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-bioasq.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-bioasq.test.txt runs/run.beir-v1.0.0-bioasq.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-bioasq.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-bioasq.test.txt runs/run.beir-v1.0.0-bioasq.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-bioasq.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-bioasq.test.txt runs/run.beir-v1.0.0-bioasq.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-bioasq.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): BioASQ                                                                                        | 0.5142    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): BioASQ                                                                                        | 0.7647    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): BioASQ                                                                                        | 0.9018    |

--- a/docs/regressions/regressions-beir-v1.0.0-climate-fever.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-climate-fever.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Climate-FEVER
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Climate-FEVER](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-climate-fever.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-climate-fever.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-climate-fever.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-climate-fever.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-climate-fever.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-climate-fever.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-climate-fever.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-climate-fever.splade-v3.splade-v3-cached.topics.beir-v1.0.0-climate-fever.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-climate-fever.test.txt runs/run.beir-v1.0.0-climate-fever.splade-v3.splade-v3-cached.topics.beir-v1.0.0-climate-fever.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-climate-fever.test.txt runs/run.beir-v1.0.0-climate-fever.splade-v3.splade-v3-cached.topics.beir-v1.0.0-climate-fever.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-climate-fever.test.txt runs/run.beir-v1.0.0-climate-fever.splade-v3.splade-v3-cached.topics.beir-v1.0.0-climate-fever.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): Climate-FEVER                                                                                 | 0.2625    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): Climate-FEVER                                                                                 | 0.5735    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): Climate-FEVER                                                                                 | 0.7831    |

--- a/docs/regressions/regressions-beir-v1.0.0-climate-fever.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-climate-fever.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Climate-FEVER
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Climate-FEVER](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-climate-fever.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-climate-fever.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-climate-fever.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-climate-fever.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-climate-fever.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-climate-fever.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-climate-fever.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-climate-fever.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-climate-fever.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-climate-fever.test.txt runs/run.beir-v1.0.0-climate-fever.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-climate-fever.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-climate-fever.test.txt runs/run.beir-v1.0.0-climate-fever.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-climate-fever.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-climate-fever.test.txt runs/run.beir-v1.0.0-climate-fever.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-climate-fever.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): Climate-FEVER                                                                                 | 0.2625    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): Climate-FEVER                                                                                 | 0.5737    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): Climate-FEVER                                                                                 | 0.7831    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-android
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-android](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-android.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-android.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-android.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-android.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-android.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-android.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-android.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-android.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-android.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-android.test.txt runs/run.beir-v1.0.0-cqadupstack-android.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-android.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-android.test.txt runs/run.beir-v1.0.0-cqadupstack-android.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-android.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-android.test.txt runs/run.beir-v1.0.0-cqadupstack-android.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-android.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-android                                                                           | 0.4109    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-android                                                                           | 0.7418    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-android                                                                           | 0.9205    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-android.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-android
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-android](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-android.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-android.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-android.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-android.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-android.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-android.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-android.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-android.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-android.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-android.test.txt runs/run.beir-v1.0.0-cqadupstack-android.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-android.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-android.test.txt runs/run.beir-v1.0.0-cqadupstack-android.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-android.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-android.test.txt runs/run.beir-v1.0.0-cqadupstack-android.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-android.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-android                                                                           | 0.4109    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-android                                                                           | 0.7418    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-android                                                                           | 0.9205    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-english
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-english](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-english.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-english.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-english.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-english.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-english.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-english.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-english.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-english.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-english.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-english.test.txt runs/run.beir-v1.0.0-cqadupstack-english.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-english.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-english.test.txt runs/run.beir-v1.0.0-cqadupstack-english.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-english.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-english.test.txt runs/run.beir-v1.0.0-cqadupstack-english.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-english.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-english                                                                           | 0.4255    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-english                                                                           | 0.6961    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-english                                                                           | 0.8384    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-english.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-english
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-english](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-english.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-english.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-english.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-english.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-english.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-english.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-english.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-english.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-english.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-english.test.txt runs/run.beir-v1.0.0-cqadupstack-english.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-english.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-english.test.txt runs/run.beir-v1.0.0-cqadupstack-english.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-english.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-english.test.txt runs/run.beir-v1.0.0-cqadupstack-english.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-english.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-english                                                                           | 0.4255    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-english                                                                           | 0.6961    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-english                                                                           | 0.8384    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-gaming
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-gaming](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-gaming.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-gaming.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-gaming.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-gaming.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-gaming.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-gaming.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-gaming.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-gaming.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-gaming.test.txt runs/run.beir-v1.0.0-cqadupstack-gaming.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-gaming.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-gaming.test.txt runs/run.beir-v1.0.0-cqadupstack-gaming.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-gaming.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-gaming.test.txt runs/run.beir-v1.0.0-cqadupstack-gaming.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-gaming.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-gaming                                                                            | 0.5193    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-gaming                                                                            | 0.8249    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-gaming                                                                            | 0.9338    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gaming.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-gaming
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-gaming](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-gaming.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-gaming.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-gaming.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-gaming.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-gaming.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-gaming.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-gaming.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-gaming.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-gaming.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-gaming.test.txt runs/run.beir-v1.0.0-cqadupstack-gaming.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-gaming.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-gaming.test.txt runs/run.beir-v1.0.0-cqadupstack-gaming.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-gaming.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-gaming.test.txt runs/run.beir-v1.0.0-cqadupstack-gaming.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-gaming.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-gaming                                                                            | 0.5193    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-gaming                                                                            | 0.8249    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-gaming                                                                            | 0.9338    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-gis
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-gis](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-gis.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-gis.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-gis.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-gis.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-gis.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-gis.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-gis.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-gis.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-gis.test.txt runs/run.beir-v1.0.0-cqadupstack-gis.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-gis.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-gis.test.txt runs/run.beir-v1.0.0-cqadupstack-gis.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-gis.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-gis.test.txt runs/run.beir-v1.0.0-cqadupstack-gis.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-gis.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-gis                                                                               | 0.3236    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-gis                                                                               | 0.6453    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-gis                                                                               | 0.8423    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-gis.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-gis
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-gis](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-gis.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-gis.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-gis.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-gis.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-gis.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-gis.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-gis.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-gis.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-gis.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-gis.test.txt runs/run.beir-v1.0.0-cqadupstack-gis.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-gis.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-gis.test.txt runs/run.beir-v1.0.0-cqadupstack-gis.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-gis.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-gis.test.txt runs/run.beir-v1.0.0-cqadupstack-gis.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-gis.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-gis                                                                               | 0.3236    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-gis                                                                               | 0.6442    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-gis                                                                               | 0.8423    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-mathematica
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-mathematica](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-mathematica.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-mathematica.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-mathematica.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-mathematica.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-mathematica.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-mathematica.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-mathematica.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-mathematica.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt runs/run.beir-v1.0.0-cqadupstack-mathematica.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-mathematica.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt runs/run.beir-v1.0.0-cqadupstack-mathematica.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-mathematica.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt runs/run.beir-v1.0.0-cqadupstack-mathematica.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-mathematica.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-mathematica                                                                       | 0.2445    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-mathematica                                                                       | 0.5774    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-mathematica                                                                       | 0.8003    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-mathematica.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-mathematica
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-mathematica](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-mathematica.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-mathematica.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-mathematica.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-mathematica.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-mathematica.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-mathematica.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-mathematica.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-mathematica.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-mathematica.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt runs/run.beir-v1.0.0-cqadupstack-mathematica.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-mathematica.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt runs/run.beir-v1.0.0-cqadupstack-mathematica.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-mathematica.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-mathematica.test.txt runs/run.beir-v1.0.0-cqadupstack-mathematica.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-mathematica.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-mathematica                                                                       | 0.2445    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-mathematica                                                                       | 0.5774    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-mathematica                                                                       | 0.8003    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-physics
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-physics](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-physics.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-physics.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-physics.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-physics.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-physics.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-physics.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-physics.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-physics.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-physics.test.txt runs/run.beir-v1.0.0-cqadupstack-physics.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-physics.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-physics.test.txt runs/run.beir-v1.0.0-cqadupstack-physics.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-physics.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-physics.test.txt runs/run.beir-v1.0.0-cqadupstack-physics.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-physics.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-physics                                                                           | 0.3753    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-physics                                                                           | 0.7248    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-physics                                                                           | 0.8983    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-physics.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-physics
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-physics](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-physics.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-physics.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-physics.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-physics.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-physics.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-physics.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-physics.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-physics.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-physics.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-physics.test.txt runs/run.beir-v1.0.0-cqadupstack-physics.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-physics.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-physics.test.txt runs/run.beir-v1.0.0-cqadupstack-physics.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-physics.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-physics.test.txt runs/run.beir-v1.0.0-cqadupstack-physics.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-physics.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-physics                                                                           | 0.3753    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-physics                                                                           | 0.7248    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-physics                                                                           | 0.8983    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-programmers
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-programmers](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-programmers.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-programmers.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-programmers.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-programmers.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-programmers.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-programmers.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-programmers.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-programmers.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-programmers.test.txt runs/run.beir-v1.0.0-cqadupstack-programmers.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-programmers.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-programmers.test.txt runs/run.beir-v1.0.0-cqadupstack-programmers.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-programmers.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-programmers.test.txt runs/run.beir-v1.0.0-cqadupstack-programmers.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-programmers.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-programmers                                                                       | 0.3387    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-programmers                                                                       | 0.6823    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-programmers                                                                       | 0.8643    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-programmers.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-programmers
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-programmers](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-programmers.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-programmers.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-programmers.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-programmers.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-programmers.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-programmers.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-programmers.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-programmers.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-programmers.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-programmers.test.txt runs/run.beir-v1.0.0-cqadupstack-programmers.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-programmers.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-programmers.test.txt runs/run.beir-v1.0.0-cqadupstack-programmers.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-programmers.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-programmers.test.txt runs/run.beir-v1.0.0-cqadupstack-programmers.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-programmers.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-programmers                                                                       | 0.3387    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-programmers                                                                       | 0.6823    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-programmers                                                                       | 0.8643    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-stats
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-stats](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-stats.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-stats.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-stats.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-stats.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-stats.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-stats.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-stats.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-stats.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-stats.test.txt runs/run.beir-v1.0.0-cqadupstack-stats.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-stats.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-stats.test.txt runs/run.beir-v1.0.0-cqadupstack-stats.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-stats.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-stats.test.txt runs/run.beir-v1.0.0-cqadupstack-stats.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-stats.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-stats                                                                             | 0.3137    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-stats                                                                             | 0.5957    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-stats                                                                             | 0.7869    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-stats.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-stats
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-stats](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-stats.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-stats.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-stats.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-stats.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-stats.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-stats.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-stats.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-stats.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-stats.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-stats.test.txt runs/run.beir-v1.0.0-cqadupstack-stats.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-stats.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-stats.test.txt runs/run.beir-v1.0.0-cqadupstack-stats.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-stats.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-stats.test.txt runs/run.beir-v1.0.0-cqadupstack-stats.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-stats.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-stats                                                                             | 0.3137    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-stats                                                                             | 0.5949    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-stats                                                                             | 0.7861    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-tex
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-tex](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-tex.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-tex.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-tex.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-tex.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-tex.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-tex.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-tex.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-tex.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-tex.test.txt runs/run.beir-v1.0.0-cqadupstack-tex.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-tex.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-tex.test.txt runs/run.beir-v1.0.0-cqadupstack-tex.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-tex.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-tex.test.txt runs/run.beir-v1.0.0-cqadupstack-tex.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-tex.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-tex                                                                               | 0.2493    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-tex                                                                               | 0.5263    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-tex                                                                               | 0.7517    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-tex.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-tex
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-tex](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-tex.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-tex.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-tex.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-tex.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-tex.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-tex.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-tex.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-tex.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-tex.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-tex.test.txt runs/run.beir-v1.0.0-cqadupstack-tex.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-tex.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-tex.test.txt runs/run.beir-v1.0.0-cqadupstack-tex.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-tex.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-tex.test.txt runs/run.beir-v1.0.0-cqadupstack-tex.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-tex.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-tex                                                                               | 0.2493    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-tex                                                                               | 0.5263    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-tex                                                                               | 0.7517    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-unix
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-unix](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-unix.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-unix.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-unix.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-unix.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-unix.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-unix.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-unix.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-unix.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-unix.test.txt runs/run.beir-v1.0.0-cqadupstack-unix.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-unix.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-unix.test.txt runs/run.beir-v1.0.0-cqadupstack-unix.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-unix.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-unix.test.txt runs/run.beir-v1.0.0-cqadupstack-unix.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-unix.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-unix                                                                              | 0.3196    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-unix                                                                              | 0.6251    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-unix                                                                              | 0.8319    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-unix.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-unix
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-unix](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-unix.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-unix.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-unix.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-unix.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-unix.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-unix.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-unix.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-unix.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-unix.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-unix.test.txt runs/run.beir-v1.0.0-cqadupstack-unix.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-unix.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-unix.test.txt runs/run.beir-v1.0.0-cqadupstack-unix.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-unix.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-unix.test.txt runs/run.beir-v1.0.0-cqadupstack-unix.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-unix.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-unix                                                                              | 0.3196    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-unix                                                                              | 0.6251    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-unix                                                                              | 0.8319    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-webmasters
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-webmasters](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-webmasters.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-webmasters.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-webmasters.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-webmasters.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-webmasters.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-webmasters.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-webmasters.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-webmasters.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt runs/run.beir-v1.0.0-cqadupstack-webmasters.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-webmasters.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt runs/run.beir-v1.0.0-cqadupstack-webmasters.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-webmasters.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt runs/run.beir-v1.0.0-cqadupstack-webmasters.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-webmasters.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-webmasters                                                                        | 0.3250    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-webmasters                                                                        | 0.6644    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-webmasters                                                                        | 0.8839    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-webmasters.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-webmasters
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-webmasters](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-webmasters.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-webmasters.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-webmasters.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-webmasters.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-webmasters.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-webmasters.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-webmasters.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-webmasters.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-webmasters.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt runs/run.beir-v1.0.0-cqadupstack-webmasters.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-webmasters.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt runs/run.beir-v1.0.0-cqadupstack-webmasters.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-webmasters.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-webmasters.test.txt runs/run.beir-v1.0.0-cqadupstack-webmasters.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-webmasters.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-webmasters                                                                        | 0.3250    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-webmasters                                                                        | 0.6644    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-webmasters                                                                        | 0.8839    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-wordpress
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-wordpress](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-wordpress.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-wordpress.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-wordpress.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-wordpress.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-wordpress.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-wordpress.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-wordpress.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-wordpress.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt runs/run.beir-v1.0.0-cqadupstack-wordpress.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-wordpress.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt runs/run.beir-v1.0.0-cqadupstack-wordpress.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-wordpress.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt runs/run.beir-v1.0.0-cqadupstack-wordpress.splade-v3.splade-v3-cached.topics.beir-v1.0.0-cqadupstack-wordpress.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-wordpress                                                                         | 0.2807    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-wordpress                                                                         | 0.5825    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-wordpress                                                                         | 0.8015    |

--- a/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-cqadupstack-wordpress.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-wordpress
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-wordpress](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-cqadupstack-wordpress.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-cqadupstack-wordpress.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-cqadupstack-wordpress.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-wordpress.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-cqadupstack-wordpress.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-cqadupstack-wordpress.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-cqadupstack-wordpress.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-cqadupstack-wordpress.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-wordpress.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt runs/run.beir-v1.0.0-cqadupstack-wordpress.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-wordpress.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt runs/run.beir-v1.0.0-cqadupstack-wordpress.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-wordpress.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-cqadupstack-wordpress.test.txt runs/run.beir-v1.0.0-cqadupstack-wordpress.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-cqadupstack-wordpress.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): CQADupStack-wordpress                                                                         | 0.2807    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-wordpress                                                                         | 0.5825    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): CQADupStack-wordpress                                                                         | 0.8015    |

--- a/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; DBPedia
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; DBPedia](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-dbpedia-entity.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-dbpedia-entity.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-dbpedia-entity.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-dbpedia-entity.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-dbpedia-entity.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-dbpedia-entity.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-dbpedia-entity.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-dbpedia-entity.splade-v3.splade-v3-cached.topics.beir-v1.0.0-dbpedia-entity.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-dbpedia-entity.test.txt runs/run.beir-v1.0.0-dbpedia-entity.splade-v3.splade-v3-cached.topics.beir-v1.0.0-dbpedia-entity.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-dbpedia-entity.test.txt runs/run.beir-v1.0.0-dbpedia-entity.splade-v3.splade-v3-cached.topics.beir-v1.0.0-dbpedia-entity.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-dbpedia-entity.test.txt runs/run.beir-v1.0.0-dbpedia-entity.splade-v3.splade-v3-cached.topics.beir-v1.0.0-dbpedia-entity.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): DBPedia                                                                                       | 0.4476    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): DBPedia                                                                                       | 0.5695    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): DBPedia                                                                                       | 0.7861    |

--- a/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-dbpedia-entity.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; DBPedia
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; DBPedia](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-dbpedia-entity.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-dbpedia-entity.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-dbpedia-entity.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-dbpedia-entity.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-dbpedia-entity.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-dbpedia-entity.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-dbpedia-entity.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-dbpedia-entity.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-dbpedia-entity.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-dbpedia-entity.test.txt runs/run.beir-v1.0.0-dbpedia-entity.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-dbpedia-entity.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-dbpedia-entity.test.txt runs/run.beir-v1.0.0-dbpedia-entity.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-dbpedia-entity.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-dbpedia-entity.test.txt runs/run.beir-v1.0.0-dbpedia-entity.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-dbpedia-entity.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): DBPedia                                                                                       | 0.4476    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): DBPedia                                                                                       | 0.5695    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): DBPedia                                                                                       | 0.7861    |

--- a/docs/regressions/regressions-beir-v1.0.0-fever.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fever.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; FEVER
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; FEVER](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-fever.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-fever.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-fever.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-fever.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-fever.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-fever.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-fever.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-fever.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-fever.splade-v3.splade-v3-cached.topics.beir-v1.0.0-fever.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-fever.test.txt runs/run.beir-v1.0.0-fever.splade-v3.splade-v3-cached.topics.beir-v1.0.0-fever.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-fever.test.txt runs/run.beir-v1.0.0-fever.splade-v3.splade-v3-cached.topics.beir-v1.0.0-fever.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-fever.test.txt runs/run.beir-v1.0.0-fever.splade-v3.splade-v3-cached.topics.beir-v1.0.0-fever.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): FEVER                                                                                         | 0.8015    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): FEVER                                                                                         | 0.9550    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): FEVER                                                                                         | 0.9741    |

--- a/docs/regressions/regressions-beir-v1.0.0-fever.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fever.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; FEVER
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; FEVER](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-fever.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-fever.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-fever.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-fever.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-fever.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-fever.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-fever.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-fever.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-fever.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-fever.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-fever.test.txt runs/run.beir-v1.0.0-fever.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-fever.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-fever.test.txt runs/run.beir-v1.0.0-fever.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-fever.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-fever.test.txt runs/run.beir-v1.0.0-fever.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-fever.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): FEVER                                                                                         | 0.8015    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): FEVER                                                                                         | 0.9550    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): FEVER                                                                                         | 0.9741    |

--- a/docs/regressions/regressions-beir-v1.0.0-fiqa.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fiqa.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; FiQA-2018
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; FiQA-2018](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-fiqa.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-fiqa.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-fiqa.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-fiqa.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-fiqa.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-fiqa.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-fiqa.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-fiqa.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-fiqa.splade-v3.splade-v3-cached.topics.beir-v1.0.0-fiqa.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-fiqa.test.txt runs/run.beir-v1.0.0-fiqa.splade-v3.splade-v3-cached.topics.beir-v1.0.0-fiqa.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-fiqa.test.txt runs/run.beir-v1.0.0-fiqa.splade-v3.splade-v3-cached.topics.beir-v1.0.0-fiqa.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-fiqa.test.txt runs/run.beir-v1.0.0-fiqa.splade-v3.splade-v3-cached.topics.beir-v1.0.0-fiqa.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): FiQA-2018                                                                                     | 0.3798    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): FiQA-2018                                                                                     | 0.6671    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): FiQA-2018                                                                                     | 0.8589    |

--- a/docs/regressions/regressions-beir-v1.0.0-fiqa.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-fiqa.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; FiQA-2018
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; FiQA-2018](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-fiqa.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-fiqa.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-fiqa.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-fiqa.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-fiqa.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-fiqa.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-fiqa.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-fiqa.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-fiqa.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-fiqa.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-fiqa.test.txt runs/run.beir-v1.0.0-fiqa.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-fiqa.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-fiqa.test.txt runs/run.beir-v1.0.0-fiqa.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-fiqa.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-fiqa.test.txt runs/run.beir-v1.0.0-fiqa.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-fiqa.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): FiQA-2018                                                                                     | 0.3798    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): FiQA-2018                                                                                     | 0.6671    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): FiQA-2018                                                                                     | 0.8589    |

--- a/docs/regressions/regressions-beir-v1.0.0-hotpotqa.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-hotpotqa.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; HotpotQA
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; HotpotQA](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-hotpotqa.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-hotpotqa.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-hotpotqa.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-hotpotqa.splade-pp-ed/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-hotpotqa.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-hotpotqa.splade-pp-ed/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-hotpotqa.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-hotpotqa.splade-v3.splade-v3-cached.topics.beir-v1.0.0-hotpotqa.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-hotpotqa.test.txt runs/run.beir-v1.0.0-hotpotqa.splade-v3.splade-v3-cached.topics.beir-v1.0.0-hotpotqa.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-hotpotqa.test.txt runs/run.beir-v1.0.0-hotpotqa.splade-v3.splade-v3-cached.topics.beir-v1.0.0-hotpotqa.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-hotpotqa.test.txt runs/run.beir-v1.0.0-hotpotqa.splade-v3.splade-v3-cached.topics.beir-v1.0.0-hotpotqa.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): HotpotQA                                                                                      | 0.6884    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): HotpotQA                                                                                      | 0.8215    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): HotpotQA                                                                                      | 0.8997    |

--- a/docs/regressions/regressions-beir-v1.0.0-hotpotqa.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-hotpotqa.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; HotpotQA
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; HotpotQA](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-hotpotqa.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-hotpotqa.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-hotpotqa.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-hotpotqa.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-hotpotqa.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-hotpotqa.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-hotpotqa.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-hotpotqa.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-hotpotqa.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-hotpotqa.test.txt runs/run.beir-v1.0.0-hotpotqa.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-hotpotqa.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-hotpotqa.test.txt runs/run.beir-v1.0.0-hotpotqa.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-hotpotqa.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-hotpotqa.test.txt runs/run.beir-v1.0.0-hotpotqa.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-hotpotqa.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): HotpotQA                                                                                      | 0.6884    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): HotpotQA                                                                                      | 0.8215    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): HotpotQA                                                                                      | 0.8997    |

--- a/docs/regressions/regressions-beir-v1.0.0-nfcorpus.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nfcorpus.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; NCorpus
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; NCorpus](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-nfcorpus.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-nfcorpus.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-nfcorpus.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-nfcorpus.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-nfcorpus.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-nfcorpus.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-nfcorpus.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-nfcorpus.splade-v3.splade-v3-cached.topics.beir-v1.0.0-nfcorpus.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-nfcorpus.test.txt runs/run.beir-v1.0.0-nfcorpus.splade-v3.splade-v3-cached.topics.beir-v1.0.0-nfcorpus.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-nfcorpus.test.txt runs/run.beir-v1.0.0-nfcorpus.splade-v3.splade-v3-cached.topics.beir-v1.0.0-nfcorpus.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-nfcorpus.test.txt runs/run.beir-v1.0.0-nfcorpus.splade-v3.splade-v3-cached.topics.beir-v1.0.0-nfcorpus.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): NFCorpus                                                                                      | 0.3629    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): NFCorpus                                                                                      | 0.2976    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): NFCorpus                                                                                      | 0.6179    |

--- a/docs/regressions/regressions-beir-v1.0.0-nfcorpus.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nfcorpus.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; NCorpus
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; NCorpus](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-nfcorpus.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-nfcorpus.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-nfcorpus.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-nfcorpus.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-nfcorpus.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-nfcorpus.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-nfcorpus.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-nfcorpus.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-nfcorpus.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-nfcorpus.test.txt runs/run.beir-v1.0.0-nfcorpus.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-nfcorpus.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-nfcorpus.test.txt runs/run.beir-v1.0.0-nfcorpus.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-nfcorpus.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-nfcorpus.test.txt runs/run.beir-v1.0.0-nfcorpus.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-nfcorpus.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): NFCorpus                                                                                      | 0.3629    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): NFCorpus                                                                                      | 0.2976    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): NFCorpus                                                                                      | 0.6179    |

--- a/docs/regressions/regressions-beir-v1.0.0-nq.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nq.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; NQ
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; NQ](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-nq.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-nq.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-nq.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-nq.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-nq.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-nq.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-nq.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-nq.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-nq.splade-v3.splade-v3-cached.topics.beir-v1.0.0-nq.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-nq.test.txt runs/run.beir-v1.0.0-nq.splade-v3.splade-v3-cached.topics.beir-v1.0.0-nq.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-nq.test.txt runs/run.beir-v1.0.0-nq.splade-v3.splade-v3-cached.topics.beir-v1.0.0-nq.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-nq.test.txt runs/run.beir-v1.0.0-nq.splade-v3.splade-v3-cached.topics.beir-v1.0.0-nq.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): NQ                                                                                            | 0.5842    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): NQ                                                                                            | 0.9438    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): NQ                                                                                            | 0.9889    |

--- a/docs/regressions/regressions-beir-v1.0.0-nq.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-nq.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; NQ
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; NQ](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-nq.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-nq.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-nq.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-nq.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-nq.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-nq.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-nq.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-nq.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-nq.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-nq.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-nq.test.txt runs/run.beir-v1.0.0-nq.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-nq.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-nq.test.txt runs/run.beir-v1.0.0-nq.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-nq.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-nq.test.txt runs/run.beir-v1.0.0-nq.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-nq.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): NQ                                                                                            | 0.5842    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): NQ                                                                                            | 0.9438    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): NQ                                                                                            | 0.9889    |

--- a/docs/regressions/regressions-beir-v1.0.0-quora.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-quora.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Quora
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Quora](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-quora.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-quora.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-quora.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-quora.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-quora.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-quora.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-quora.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-quora.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-quora.splade-v3.splade-v3-cached.topics.beir-v1.0.0-quora.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-quora.test.txt runs/run.beir-v1.0.0-quora.splade-v3.splade-v3-cached.topics.beir-v1.0.0-quora.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-quora.test.txt runs/run.beir-v1.0.0-quora.splade-v3.splade-v3-cached.topics.beir-v1.0.0-quora.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-quora.test.txt runs/run.beir-v1.0.0-quora.splade-v3.splade-v3-cached.topics.beir-v1.0.0-quora.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): Quora                                                                                         | 0.8141    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): Quora                                                                                         | 0.9858    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): Quora                                                                                         | 0.9988    |

--- a/docs/regressions/regressions-beir-v1.0.0-quora.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-quora.splade-v3.onnx.md
@@ -1,0 +1,84 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Quora
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Quora](http://beir.ai/).
+
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-quora.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-quora.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-quora.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-quora.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-quora.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-quora.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-quora.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-quora.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-quora.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-quora.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-quora.test.txt runs/run.beir-v1.0.0-quora.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-quora.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-quora.test.txt runs/run.beir-v1.0.0-quora.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-quora.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-quora.test.txt runs/run.beir-v1.0.0-quora.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-quora.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): Quora                                                                                         | 0.8141    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): Quora                                                                                         | 0.9858    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): Quora                                                                                         | 0.9988    |

--- a/docs/regressions/regressions-beir-v1.0.0-robust04.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-robust04.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Robust04
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Robust04](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-robust04.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-robust04.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-robust04.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-robust04.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-robust04.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-robust04.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-robust04.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-robust04.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-robust04.splade-v3.splade-v3-cached.topics.beir-v1.0.0-robust04.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-robust04.test.txt runs/run.beir-v1.0.0-robust04.splade-v3.splade-v3-cached.topics.beir-v1.0.0-robust04.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-robust04.test.txt runs/run.beir-v1.0.0-robust04.splade-v3.splade-v3-cached.topics.beir-v1.0.0-robust04.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-robust04.test.txt runs/run.beir-v1.0.0-robust04.splade-v3.splade-v3-cached.topics.beir-v1.0.0-robust04.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): Robust04                                                                                      | 0.4952    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): Robust04                                                                                      | 0.4337    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): Robust04                                                                                      | 0.6929    |

--- a/docs/regressions/regressions-beir-v1.0.0-robust04.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-robust04.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Robust04
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Robust04](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-robust04.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-robust04.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-robust04.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-robust04.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-robust04.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-robust04.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-robust04.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-robust04.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-robust04.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-robust04.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-robust04.test.txt runs/run.beir-v1.0.0-robust04.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-robust04.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-robust04.test.txt runs/run.beir-v1.0.0-robust04.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-robust04.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-robust04.test.txt runs/run.beir-v1.0.0-robust04.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-robust04.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): Robust04                                                                                      | 0.4952    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): Robust04                                                                                      | 0.4337    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): Robust04                                                                                      | 0.6929    |

--- a/docs/regressions/regressions-beir-v1.0.0-scidocs.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scidocs.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; SCIDOCS
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; SCIDOCS](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-scidocs.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-scidocs.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-scidocs.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-scidocs.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-scidocs.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-scidocs.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-scidocs.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-scidocs.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-scidocs.splade-v3.splade-v3-cached.topics.beir-v1.0.0-scidocs.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-scidocs.test.txt runs/run.beir-v1.0.0-scidocs.splade-v3.splade-v3-cached.topics.beir-v1.0.0-scidocs.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-scidocs.test.txt runs/run.beir-v1.0.0-scidocs.splade-v3.splade-v3-cached.topics.beir-v1.0.0-scidocs.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-scidocs.test.txt runs/run.beir-v1.0.0-scidocs.splade-v3.splade-v3-cached.topics.beir-v1.0.0-scidocs.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): SCIDOCS                                                                                       | 0.1567    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): SCIDOCS                                                                                       | 0.3673    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): SCIDOCS                                                                                       | 0.5984    |

--- a/docs/regressions/regressions-beir-v1.0.0-scidocs.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scidocs.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; SCIDOCS
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; SCIDOCS](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-scidocs.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-scidocs.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-scidocs.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-scidocs.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-scidocs.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-scidocs.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-scidocs.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-scidocs.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-scidocs.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-scidocs.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-scidocs.test.txt runs/run.beir-v1.0.0-scidocs.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-scidocs.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-scidocs.test.txt runs/run.beir-v1.0.0-scidocs.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-scidocs.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-scidocs.test.txt runs/run.beir-v1.0.0-scidocs.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-scidocs.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): SCIDOCS                                                                                       | 0.1567    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): SCIDOCS                                                                                       | 0.3673    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): SCIDOCS                                                                                       | 0.5982    |

--- a/docs/regressions/regressions-beir-v1.0.0-scifact.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scifact.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; SciFact
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; SciFact](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-scifact.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-scifact.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-scifact.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-scifact.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-scifact.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-scifact.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-scifact.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-scifact.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-scifact.splade-v3.splade-v3-cached.topics.beir-v1.0.0-scifact.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-scifact.test.txt runs/run.beir-v1.0.0-scifact.splade-v3.splade-v3-cached.topics.beir-v1.0.0-scifact.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-scifact.test.txt runs/run.beir-v1.0.0-scifact.splade-v3.splade-v3-cached.topics.beir-v1.0.0-scifact.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-scifact.test.txt runs/run.beir-v1.0.0-scifact.splade-v3.splade-v3-cached.topics.beir-v1.0.0-scifact.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): SciFact                                                                                       | 0.7140    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): SciFact                                                                                       | 0.9360    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): SciFact                                                                                       | 0.9967    |

--- a/docs/regressions/regressions-beir-v1.0.0-scifact.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-scifact.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; SciFact
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; SciFact](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-scifact.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-scifact.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-scifact.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-scifact.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-scifact.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-scifact.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-scifact.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-scifact.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-scifact.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-scifact.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-scifact.test.txt runs/run.beir-v1.0.0-scifact.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-scifact.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-scifact.test.txt runs/run.beir-v1.0.0-scifact.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-scifact.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-scifact.test.txt runs/run.beir-v1.0.0-scifact.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-scifact.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): SciFact                                                                                       | 0.7140    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): SciFact                                                                                       | 0.9360    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): SciFact                                                                                       | 0.9967    |

--- a/docs/regressions/regressions-beir-v1.0.0-signal1m.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-signal1m.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Signal-1M
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Signal-1M](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-signal1m.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-signal1m.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-signal1m.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-signal1m.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-signal1m.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-signal1m.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-signal1m.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-signal1m.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-signal1m.splade-v3.splade-v3-cached.topics.beir-v1.0.0-signal1m.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-signal1m.test.txt runs/run.beir-v1.0.0-signal1m.splade-v3.splade-v3-cached.topics.beir-v1.0.0-signal1m.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-signal1m.test.txt runs/run.beir-v1.0.0-signal1m.splade-v3.splade-v3-cached.topics.beir-v1.0.0-signal1m.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-signal1m.test.txt runs/run.beir-v1.0.0-signal1m.splade-v3.splade-v3-cached.topics.beir-v1.0.0-signal1m.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): Signal-1M                                                                                     | 0.2465    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): Signal-1M                                                                                     | 0.2979    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): Signal-1M                                                                                     | 0.5136    |

--- a/docs/regressions/regressions-beir-v1.0.0-signal1m.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-signal1m.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Signal-1M
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Signal-1M](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-signal1m.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-signal1m.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-signal1m.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-signal1m.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-signal1m.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-signal1m.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-signal1m.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-signal1m.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-signal1m.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-signal1m.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-signal1m.test.txt runs/run.beir-v1.0.0-signal1m.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-signal1m.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-signal1m.test.txt runs/run.beir-v1.0.0-signal1m.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-signal1m.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-signal1m.test.txt runs/run.beir-v1.0.0-signal1m.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-signal1m.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): Signal-1M                                                                                     | 0.2465    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): Signal-1M                                                                                     | 0.2979    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): Signal-1M                                                                                     | 0.5136    |

--- a/docs/regressions/regressions-beir-v1.0.0-trec-covid.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-covid.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; TREC-COVID
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; TREC-COVID](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-trec-covid.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-trec-covid.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-trec-covid.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-trec-covid.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-trec-covid.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-trec-covid.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-trec-covid.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-trec-covid.splade-v3.splade-v3-cached.topics.beir-v1.0.0-trec-covid.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-trec-covid.test.txt runs/run.beir-v1.0.0-trec-covid.splade-v3.splade-v3-cached.topics.beir-v1.0.0-trec-covid.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-trec-covid.test.txt runs/run.beir-v1.0.0-trec-covid.splade-v3.splade-v3-cached.topics.beir-v1.0.0-trec-covid.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-trec-covid.test.txt runs/run.beir-v1.0.0-trec-covid.splade-v3.splade-v3-cached.topics.beir-v1.0.0-trec-covid.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): TREC-COVID                                                                                    | 0.7299    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): TREC-COVID                                                                                    | 0.1409    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): TREC-COVID                                                                                    | 0.4819    |

--- a/docs/regressions/regressions-beir-v1.0.0-trec-covid.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-covid.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; TREC-COVID
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; TREC-COVID](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-trec-covid.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-trec-covid.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-trec-covid.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-trec-covid.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-trec-covid.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-trec-covid.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-trec-covid.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-trec-covid.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-trec-covid.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-trec-covid.test.txt runs/run.beir-v1.0.0-trec-covid.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-trec-covid.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-trec-covid.test.txt runs/run.beir-v1.0.0-trec-covid.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-trec-covid.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-trec-covid.test.txt runs/run.beir-v1.0.0-trec-covid.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-trec-covid.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): TREC-COVID                                                                                    | 0.7299    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): TREC-COVID                                                                                    | 0.1409    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): TREC-COVID                                                                                    | 0.4819    |

--- a/docs/regressions/regressions-beir-v1.0.0-trec-news.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-news.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; TREC-NEWS
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; TREC-NEWS](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-trec-news.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-trec-news.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-trec-news.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-trec-news.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-trec-news.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-trec-news.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-trec-news.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-trec-news.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-trec-news.splade-v3.splade-v3-cached.topics.beir-v1.0.0-trec-news.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-trec-news.test.txt runs/run.beir-v1.0.0-trec-news.splade-v3.splade-v3-cached.topics.beir-v1.0.0-trec-news.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-trec-news.test.txt runs/run.beir-v1.0.0-trec-news.splade-v3.splade-v3-cached.topics.beir-v1.0.0-trec-news.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-trec-news.test.txt runs/run.beir-v1.0.0-trec-news.splade-v3.splade-v3-cached.topics.beir-v1.0.0-trec-news.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): TREC-NEWS                                                                                     | 0.4365    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): TREC-NEWS                                                                                     | 0.4737    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): TREC-NEWS                                                                                     | 0.7404    |

--- a/docs/regressions/regressions-beir-v1.0.0-trec-news.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-trec-news.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; TREC-NEWS
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; TREC-NEWS](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-trec-news.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-trec-news.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-trec-news.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-trec-news.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-trec-news.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-trec-news.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-trec-news.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-trec-news.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-trec-news.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-trec-news.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-trec-news.test.txt runs/run.beir-v1.0.0-trec-news.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-trec-news.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-trec-news.test.txt runs/run.beir-v1.0.0-trec-news.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-trec-news.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-trec-news.test.txt runs/run.beir-v1.0.0-trec-news.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-trec-news.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): TREC-NEWS                                                                                     | 0.4365    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): TREC-NEWS                                                                                     | 0.4737    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): TREC-NEWS                                                                                     | 0.7404    |

--- a/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.splade-v3.cached.md
+++ b/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.splade-v3.cached.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Webis-Touche2020
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Webis-Touche2020](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-webis-touche2020.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-webis-touche2020.splade-v3.cached
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-webis-touche2020.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-webis-touche2020.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-webis-touche2020.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-webis-touche2020.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-webis-touche2020.test.splade-v3.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-webis-touche2020.splade-v3.splade-v3-cached.topics.beir-v1.0.0-webis-touche2020.test.splade-v3.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-webis-touche2020.test.txt runs/run.beir-v1.0.0-webis-touche2020.splade-v3.splade-v3-cached.topics.beir-v1.0.0-webis-touche2020.test.splade-v3.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-webis-touche2020.test.txt runs/run.beir-v1.0.0-webis-touche2020.splade-v3.splade-v3-cached.topics.beir-v1.0.0-webis-touche2020.test.splade-v3.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-webis-touche2020.test.txt runs/run.beir-v1.0.0-webis-touche2020.splade-v3.splade-v3-cached.topics.beir-v1.0.0-webis-touche2020.test.splade-v3.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): Webis-Touche2020                                                                              | 0.3086    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): Webis-Touche2020                                                                              | 0.5128    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): Webis-Touche2020                                                                              | 0.8435    |

--- a/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.splade-v3.onnx.md
+++ b/docs/regressions/regressions-beir-v1.0.0-webis-touche2020.splade-v3.onnx.md
@@ -1,0 +1,83 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Webis-Touche2020
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Webis-Touche2020](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](../../src/main/resources/regression/beir-v1.0.0-webis-touche2020.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-webis-touche2020.splade-v3.onnx
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 16 \
+  -collection JsonVectorCollection \
+  -input /path/to/beir-v1.0.0-webis-touche2020.splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.beir-v1.0.0-webis-touche2020.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.beir-v1.0.0-webis-touche2020.splade-v3 &
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.beir-v1.0.0-webis-touche2020.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.beir-v1.0.0-webis-touche2020.test.tsv.gz \
+  -topicReader TsvString \
+  -output runs/run.beir-v1.0.0-webis-touche2020.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-webis-touche2020.test.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+bin/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.beir-v1.0.0-webis-touche2020.test.txt runs/run.beir-v1.0.0-webis-touche2020.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-webis-touche2020.test.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.beir-v1.0.0-webis-touche2020.test.txt runs/run.beir-v1.0.0-webis-touche2020.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-webis-touche2020.test.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.beir-v1.0.0-webis-touche2020.test.txt runs/run.beir-v1.0.0-webis-touche2020.splade-v3.splade-v3-onnx.topics.beir-v1.0.0-webis-touche2020.test.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@10**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|-----------|
+| BEIR (v1.0.0): Webis-Touche2020                                                                              | 0.3086    |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| BEIR (v1.0.0): Webis-Touche2020                                                                              | 0.5128    |
+| **R@1000**                                                                                                   | **SPLADE-v3**|
+| BEIR (v1.0.0): Webis-Touche2020                                                                              | 0.8435    |

--- a/src/main/resources/docgen/templates/beir-v1.0.0-arguana.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-arguana.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; ArguAna
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; ArguAna](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-arguana.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-arguana.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; ArguAna
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; ArguAna](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; BioASQ
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; BioASQ](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-bioasq.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; BioASQ
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; BioASQ](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Climate-FEVER
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Climate-FEVER](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-climate-fever.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Climate-FEVER
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Climate-FEVER](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-android
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-android](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-android.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-android
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-android](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-english
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-english](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-english.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-english
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-english](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-gaming
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-gaming](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gaming.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-gaming
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-gaming](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-gis
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-gis](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-gis.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-gis
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-gis](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-mathematica
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-mathematica](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-mathematica.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-mathematica
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-mathematica](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-physics
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-physics](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-physics.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-physics
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-physics](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-programmers
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-programmers](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-programmers.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-programmers
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-programmers](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-stats
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-stats](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-stats.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-stats
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-stats](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-tex
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-tex](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-tex.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-tex
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-tex](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-unix
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-unix](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-unix.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-unix
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-unix](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-webmasters
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-webmasters](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-webmasters.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-webmasters
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-webmasters](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-wordpress
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-wordpress](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-cqadupstack-wordpress.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; CQADupStack-wordpress
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; CQADupStack-wordpress](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; DBPedia
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; DBPedia](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-dbpedia-entity.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; DBPedia
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; DBPedia](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fever.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fever.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; FEVER
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; FEVER](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fever.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fever.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; FEVER
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; FEVER](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; FiQA-2018
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; FiQA-2018](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-fiqa.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; FiQA-2018
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; FiQA-2018](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; HotpotQA
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; HotpotQA](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-hotpotqa.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; HotpotQA
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; HotpotQA](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; NCorpus
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; NCorpus](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nfcorpus.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; NCorpus
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; NCorpus](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nq.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nq.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; NQ
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; NQ](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-nq.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-nq.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; NQ
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; NQ](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-quora.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-quora.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Quora
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Quora](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-quora.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-quora.splade-v3.onnx.template
@@ -1,0 +1,64 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Quora
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Quora](http://beir.ai/).
+
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-robust04.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-robust04.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Robust04
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Robust04](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-robust04.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-robust04.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Robust04
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Robust04](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; SCIDOCS
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; SCIDOCS](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scidocs.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; SCIDOCS
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; SCIDOCS](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scifact.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scifact.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; SciFact
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; SciFact](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-scifact.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-scifact.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; SciFact
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; SciFact](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Signal-1M
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Signal-1M](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-signal1m.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Signal-1M
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Signal-1M](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; TREC-COVID
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; TREC-COVID](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-covid.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; TREC-COVID
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; TREC-COVID](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; TREC-NEWS
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; TREC-NEWS](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-trec-news.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; TREC-NEWS
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; TREC-NEWS](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.splade-v3.cached.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.splade-v3.cached.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Webis-Touche2020
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Webis-Touche2020](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.splade-v3.onnx.template
+++ b/src/main/resources/docgen/templates/beir-v1.0.0-webis-touche2020.splade-v3.onnx.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: BEIR (v1.0.0) &mdash; Webis-Touche2020
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments, integrated into Anserini's regression testing framework, using [SPLADE-v3](https://arxiv.org/abs/2403.06789) on [BEIR (v1.0.0) &mdash; Webis-Touche2020](http://beir.ai/).
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name}
+```
+
+All the BEIR corpora, encoded by the SPLADE-v3 model, are available for download:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/beir-v1.0.0-splade-v3.tar -P collections/
+tar xvf collections/beir-v1.0.0-splade-v3.tar -C collections/
+```
+
+The tarball is 55 GB and has MD5 checksum `37f294610af763ce48eed03afd9455df`.
+After download and unpacking the corpora, the `run_regression.py` command above should work without any issue.
+
+## Indexing
+
+Sample indexing command:
+
+```
+${index_cmds}
+```
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}


### PR DESCRIPTION
Added Splade-v3 templates (both cached and onnx) and generatede MD files from build for all BEIR corpus.

Ref: https://github.com/castorini/anserini/issues/2839