### PR TITLE
Upgrade djl artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -451,12 +451,12 @@
     <dependency>
       <groupId>ai.djl.huggingface</groupId>
       <artifactId>tokenizers</artifactId>
-      <version>0.28.0</version>
+      <version>0.33.0</version>
     </dependency>
     <dependency>
       <groupId>ai.djl</groupId>
       <artifactId>api</artifactId>
-      <version>0.31.1</version>
+      <version>0.33.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.gson</groupId>
@@ -471,7 +471,7 @@
     <dependency>
       <groupId>me.tongfei</groupId>
       <artifactId>progressbar</artifactId>
-      <version>0.10.0</version>
+      <version>0.10.1</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>


### PR DESCRIPTION
I'm looking at this: https://github.com/castorini/anserini/actions/runs/15882221286/job/44785316021

The stacktrace is here:

```
Error:  io.anserini.analysis.AutoCompositeAnalyzerTest.case1  Time elapsed: 0.093 s  <<< ERROR!
java.lang.RuntimeException: request error: Bad URL: failed to parse URL: RelativeUrlWithoutBase: relative URL without a base
	at ai.djl.huggingface.tokenizers.jni.TokenizersLibrary.createTokenizer(Native Method)
	at ai.djl.huggingface.tokenizers.HuggingFaceTokenizer.newInstance(HuggingFaceTokenizer.java:120)
	at io.anserini.analysis.CompositeAnalyzer.makeTokenizer(CompositeAnalyzer.java:57)
	at io.anserini.analysis.CompositeAnalyzer.<init>(CompositeAnalyzer.java:62)
	at io.anserini.analysis.AutoCompositeAnalyzer.getAnalyzer(AutoCompositeAnalyzer.java:93)
	at io.anserini.analysis.AutoCompositeAnalyzer.getAnalyzer(AutoCompositeAnalyzer.java:51)
	at io.anserini.analysis.AutoCompositeAnalyzerTest.case1(AutoCompositeAnalyzerTest.java:76)
```

Not even our code...

But upgrade version of djl artifact seems to have solved the issue...