### PR TITLE
Migration to org.sonatype.central requires this plugin as part of deploy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,15 @@
 
     <plugins>
       <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.8.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.12.1</version>


### PR DESCRIPTION
Message here: https://oss.sonatype.org/#welcome

The OSSRH service will reach end-of-life on June 30th, 2025.

Migrating to Central Publishing Portal.