### PR TITLE
Replace ThreadPoolExecutor with newWorkStealingPool

### DIFF
--- a/src/main/java/io/anserini/index/AbstractIndexer.java
+++ b/src/main/java/io/anserini/index/AbstractIndexer.java
@@ -244,8 +244,6 @@ public abstract class AbstractIndexer implements Runnable {
     final int segmentCnt = segmentPaths.size();
     AtomicInteger completionCount = new AtomicInteger(0);
 
-    final ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(args.threads);
-    LOG.info(String.format("Thread pool with %s threads initialized.", args.threads));
     LOG.info(String.format("%,d %s found in %s", segmentCnt, (segmentCnt == 1 ? "file" : "files"), collectionPath));
     LOG.info("Starting to index...");
 

--- a/src/main/java/io/anserini/index/AbstractIndexer.java
+++ b/src/main/java/io/anserini/index/AbstractIndexer.java
@@ -359,7 +359,6 @@ public abstract class AbstractIndexer implements Runnable {
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException("Processing of segments interrupted", e);
     }
   }
 

--- a/src/main/java/io/anserini/index/AbstractIndexer.java
+++ b/src/main/java/io/anserini/index/AbstractIndexer.java
@@ -42,10 +42,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract class AbstractIndexer implements Runnable {
@@ -339,7 +336,7 @@ public abstract class AbstractIndexer implements Runnable {
       });
     }
 
-    try (ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newWorkStealingPool()) {
+    try (ExecutorService executor = Executors.newWorkStealingPool()) {
       // block until all tasks are completed
       executor.invokeAll(tasks);
     } catch (InterruptedException e) {

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -43,10 +43,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public final class IndexCollection extends AbstractIndexer {
@@ -285,8 +282,29 @@ public final class IndexCollection extends AbstractIndexer {
       });
     }
 
-    try (ExecutorService executor = Executors.newWorkStealingPool()) {
+    try (
+            ExecutorService executor = Executors.newWorkStealingPool();
+            ScheduledExecutorService monitor = Executors.newSingleThreadScheduledExecutor()
+    ) {
+        // Log progress every minute
+      int segmentCnt = segmentPaths.size();
+      monitor.scheduleAtFixedRate(() -> {
+        if (segmentCnt == 1) {
+          LOG.info(String.format("%,d documents indexed", counters.indexed.get()));
+        } else {
+          double percent = (double) completionCount.get() / segmentCnt * 100.0;
+          LOG.info(String.format("%.2f%% of files completed, %,d documents indexed",
+                  percent, counters.indexed.get()));
+          }
+        }, 1, 1, TimeUnit.MINUTES);
+
+      // block until all tasks are completed
       executor.invokeAll(tasks);
+      monitor.shutdown();
+
+      if (!monitor.awaitTermination(5, TimeUnit.SECONDS)) {
+        monitor.shutdownNow();
+      }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new RuntimeException("Processing of segments interrupted", e);

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -307,7 +307,6 @@ public final class IndexCollection extends AbstractIndexer {
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException("Processing of segments interrupted", e);
     }
   }
 

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -16,12 +16,7 @@
 
 package io.anserini.index;
 
-import io.anserini.analysis.AnalyzerMap;
-import io.anserini.analysis.AutoCompositeAnalyzer;
-import io.anserini.analysis.CompositeAnalyzer;
-import io.anserini.analysis.DefaultEnglishAnalyzer;
-import io.anserini.analysis.HuggingFaceTokenizerAnalyzer;
-import io.anserini.analysis.TweetAnalyzer;
+import io.anserini.analysis.*;
 import io.anserini.collection.SourceDocument;
 import io.anserini.index.generator.LuceneDocumentGenerator;
 import io.anserini.search.similarity.AccurateBM25Similarity;
@@ -31,7 +26,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
-import org.apache.lucene.codecs.lucene99.Lucene99Codec;
 import org.apache.lucene.index.ConcurrentMergeScheduler;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -48,11 +42,7 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ThreadPoolExecutor;
 
 public final class IndexCollection extends AbstractIndexer {

--- a/src/main/java/io/anserini/index/SimpleIndexer.java
+++ b/src/main/java/io/anserini/index/SimpleIndexer.java
@@ -230,7 +230,7 @@ public class SimpleIndexer {
       });
     }
 
-    try (ExecutorService executor = Executors.newWorkStealingPool()) {
+    try (ExecutorService executor = Executors.newWorkStealingPool(threads)) {
       // blocks until all tasks complete
       executor.invokeAll(tasks);
     } catch (InterruptedException e) {

--- a/src/main/java/io/anserini/index/SimpleIndexer.java
+++ b/src/main/java/io/anserini/index/SimpleIndexer.java
@@ -40,10 +40,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -216,34 +215,28 @@ public class SimpleIndexer {
 
   @SuppressWarnings("unchecked")
   private <T> int addToIndex(T[] objects, Function<T, JsonCollection.Document> func) {
-    ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(threads);
     AtomicInteger cnt = new AtomicInteger();
+    List<Callable<Void>> tasks = new ArrayList<>(objects.length);
 
     for (T object : objects) {
-      executor.execute(() -> {
+      tasks.add(() -> {
         try {
           writer.addDocument(generator.createDocument(func.apply(object)));
           cnt.incrementAndGet();
-        } catch (GeneratorException e) {
-          throw new CompletionException(e);
-        } catch (IOException e) {
+        } catch (GeneratorException | IOException e) {
           throw new CompletionException(e);
         }
+
+        return null;
       });
     }
 
-    executor.shutdown();
-
-    try {
-      // Wait for existing tasks to terminate
-      while (!executor.awaitTermination(1, TimeUnit.MINUTES)) {
-        // Opportunity to perform status logging, but no-op here because logging interferes with Python tqdm
-      }
-    } catch (InterruptedException ie) {
-      // (Re-)Cancel if current thread also interrupted
-      executor.shutdownNow();
-      // Preserve interrupt status
+    try (ExecutorService executor = Executors.newWorkStealingPool()) {
+      // blocks until all tasks complete
+      executor.invokeAll(tasks);
+    } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
+      throw new RuntimeException("Indexing of documents was interrupted", e);
     }
 
     return cnt.get();

--- a/src/main/java/io/anserini/index/SimpleIndexer.java
+++ b/src/main/java/io/anserini/index/SimpleIndexer.java
@@ -226,7 +226,6 @@ public class SimpleIndexer {
         } catch (GeneratorException | IOException e) {
           throw new CompletionException(e);
         }
-
         return null;
       });
     }
@@ -236,7 +235,6 @@ public class SimpleIndexer {
       executor.invokeAll(tasks);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException("Indexing of documents was interrupted", e);
     }
 
     return cnt.get();

--- a/src/main/java/io/anserini/search/FlatDenseSearcher.java
+++ b/src/main/java/io/anserini/search/FlatDenseSearcher.java
@@ -146,7 +146,7 @@ public class FlatDenseSearcher<K extends Comparable<K>> extends BaseSearcher<K> 
       });
     }
 
-    try (ExecutorService executor = Executors.newWorkStealingPool()) {
+    try (ExecutorService executor = Executors.newWorkStealingPool(threads)) {
       // block until all tasks are completed
       executor.invokeAll(tasks);
     } catch (InterruptedException e) {

--- a/src/main/java/io/anserini/search/FlatDenseSearcher.java
+++ b/src/main/java/io/anserini/search/FlatDenseSearcher.java
@@ -151,7 +151,6 @@ public class FlatDenseSearcher<K extends Comparable<K>> extends BaseSearcher<K> 
       executor.invokeAll(tasks);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException("Batch search of queries is interrupted", e);
     }
 
     final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);

--- a/src/main/java/io/anserini/search/HnswDenseSearcher.java
+++ b/src/main/java/io/anserini/search/HnswDenseSearcher.java
@@ -158,7 +158,6 @@ public class HnswDenseSearcher<K extends Comparable<K>> extends BaseSearcher<K> 
       executor.invokeAll(tasks);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException("Batch search of queries interrupted", e);
     }
 
     final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);

--- a/src/main/java/io/anserini/search/HnswDenseSearcher.java
+++ b/src/main/java/io/anserini/search/HnswDenseSearcher.java
@@ -154,7 +154,8 @@ public class HnswDenseSearcher<K extends Comparable<K>> extends BaseSearcher<K> 
     }
 
     try (ExecutorService executor = Executors.newWorkStealingPool()) {
-      executor.invokeAll(tasks);  // blocks until all tasks complete
+      // block until all tasks are completed
+      executor.invokeAll(tasks);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new RuntimeException("Batch search of queries interrupted", e);

--- a/src/main/java/io/anserini/search/HnswDenseSearcher.java
+++ b/src/main/java/io/anserini/search/HnswDenseSearcher.java
@@ -120,10 +120,10 @@ public class HnswDenseSearcher<K extends Comparable<K>> extends BaseSearcher<K> 
    * @param queries list of queries
    * @param qids list of unique query ids
    * @param k number of hits
-   * @param threadsIgnored number of threads
+   * @param threads number of threads
    * @return a map of query id to search results
    */
-  public SortedMap<K, ScoredDoc[]> batch_search(List<String> queries, List<K> qids, int k, int threadsIgnored) {
+  public SortedMap<K, ScoredDoc[]> batch_search(List<String> queries, List<K> qids, int k, int threads) {
     // threadsIgnored parameter has been retained for backward compatibility
     final SortedMap<K, ScoredDoc[]> results = new ConcurrentSkipListMap<>();
     final AtomicInteger cnt = new AtomicInteger();
@@ -153,7 +153,7 @@ public class HnswDenseSearcher<K extends Comparable<K>> extends BaseSearcher<K> 
       });
     }
 
-    try (ExecutorService executor = Executors.newWorkStealingPool()) {
+    try (ExecutorService executor = Executors.newWorkStealingPool(threads)) {
       // block until all tasks are completed
       executor.invokeAll(tasks);
     } catch (InterruptedException e) {

--- a/src/main/java/io/anserini/search/HnswDenseSearcher.java
+++ b/src/main/java/io/anserini/search/HnswDenseSearcher.java
@@ -157,7 +157,7 @@ public class HnswDenseSearcher<K extends Comparable<K>> extends BaseSearcher<K> 
       executor.invokeAll(tasks);  // blocks until all tasks complete
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      LOG.error("Batch search of queries interrupted", e);
+      throw new RuntimeException("Batch search of queries interrupted", e);
     }
 
     final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);

--- a/src/main/java/io/anserini/search/InvertedDenseSearcher.java
+++ b/src/main/java/io/anserini/search/InvertedDenseSearcher.java
@@ -138,7 +138,7 @@ public class InvertedDenseSearcher<K extends Comparable<K>> extends BaseSearcher
       });
     }
 
-    try (ExecutorService executor = Executors.newWorkStealingPool()) {
+    try (ExecutorService executor = Executors.newWorkStealingPool(threads)) {
       // block until all tasks are completed
       executor.invokeAll(tasks);
     } catch (InterruptedException e) {

--- a/src/main/java/io/anserini/search/InvertedDenseSearcher.java
+++ b/src/main/java/io/anserini/search/InvertedDenseSearcher.java
@@ -143,7 +143,6 @@ public class InvertedDenseSearcher<K extends Comparable<K>> extends BaseSearcher
       executor.invokeAll(tasks);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException("Batch search of queries interrupted", e);
     }
 
     final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -911,7 +911,6 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
         executor.invokeAll(tasks);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-        throw new RuntimeException("Interruption when processing queries", e);
       }
 
       final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
@@ -1353,7 +1352,6 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
       executor.invokeAll(tasks);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException("Launching of search threads interrupted", e);
     }
   }
 

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -1348,7 +1348,7 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
       }
     }
 
-    try (ExecutorService executor = Executors.newWorkStealingPool(args.threads)) {
+    try (ExecutorService executor = Executors.newWorkStealingPool(args.parallelism)) {
       // block until all tasks are completed
       executor.invokeAll(tasks);
     } catch (InterruptedException e) {

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -110,11 +110,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -845,18 +841,17 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
       // A short descriptor of the ranking setup.
       final String desc = String.format("ranker: %s, reranker: %s", taggedSimilarity.getTag(), cascade.getTag());
 
-      // ThreadPool for parallelizing the execution of individual queries:
-      ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(args.threads);
       // Data structure for holding the per-query results:
       ConcurrentSkipListMap<T, ScoredDoc[]> results = new ConcurrentSkipListMap<>();
       AtomicInteger cnt = new AtomicInteger();
+      List<Callable<Void>> tasks = new ArrayList<>();
 
       final long start = System.nanoTime();
       for (Map.Entry<T, Map<String, String>> entry : topics.entrySet()) {
         T qid = entry.getKey();
 
-        // This is the per-query execution, in parallel.
-        executor.execute(() -> {
+
+        tasks.add(() -> {
           try {
             StringBuilder queryString = new StringBuilder();
             if (args.topicField.contains("+")) {
@@ -906,20 +901,19 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
           }  catch (Exception e) {
             throw new CompletionException(e);
           }
+
+          return null;
         });
       }
 
-      executor.shutdown();
-
-      try {
-        // Wait for existing tasks to terminate.
-        while (!executor.awaitTermination(1, TimeUnit.MINUTES)) ;
-      } catch (InterruptedException ie) {
-        // (Re-)Cancel if current thread also interrupted.
-        executor.shutdownNow();
-        // Preserve interrupt status.
+      try (ExecutorService executor = Executors.newWorkStealingPool()) {
+        // block until all tasks are completed
+        executor.invokeAll(tasks);
+      } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        throw new RuntimeException("Interruption when processing queries", e);
       }
+
       final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
 
       LOG.info(desc + ": " + topics.size() + " queries processed in " +

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -906,7 +906,7 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
         });
       }
 
-      try (ExecutorService executor = Executors.newWorkStealingPool()) {
+      try (ExecutorService executor = Executors.newWorkStealingPool(args.threads)) {
         // block until all tasks are completed
         executor.invokeAll(tasks);
       } catch (InterruptedException e) {

--- a/src/main/java/io/anserini/search/SimpleImpactSearcher.java
+++ b/src/main/java/io/anserini/search/SimpleImpactSearcher.java
@@ -52,11 +52,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 
@@ -421,39 +418,37 @@ public class SimpleImpactSearcher implements Closeable {
       searcher.setSimilarity(similarity);
     }
 
-    ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(threads);
     ConcurrentHashMap<String, ScoredDoc[]> results = new ConcurrentHashMap<>();
-
     int queryCnt = encoded_queries.size();
+    List<Callable<Void>> tasks = new ArrayList<>(queryCnt);
+    AtomicInteger completionCount = new AtomicInteger();
+
+
     for (int q = 0; q < queryCnt; ++q) {
       Map<String, Integer> query = encoded_queries.get(q);
       String qid = qids.get(q);
-      executor.execute(() -> {
+      tasks.add(() -> {
         try {
           results.put(qid, search(query, k));
+          completionCount.incrementAndGet();
         } catch (IOException | OrtException e) {
           throw new CompletionException(e);
         }
+        return null;
       });
     }
 
-    executor.shutdown();
-
-    try {
-      // Wait for existing tasks to terminate
-      while (!executor.awaitTermination(1, TimeUnit.MINUTES)) {
-        // Opportunity to perform status logging, but no-op here because logging interferes with Python tqdm
-      }
-    } catch (InterruptedException ie) {
-      // (Re-)Cancel if current thread also interrupted
-      executor.shutdownNow();
-      // Preserve interrupt status
+    try (ExecutorService executor = Executors.newWorkStealingPool()) {
+      // block until all tasks are completed
+      executor.invokeAll(tasks);
+    } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
+      throw new RuntimeException("Batch search of encoded queries is interrupted", e);
     }
 
-    if (queryCnt != executor.getCompletedTaskCount()) {
+    if (queryCnt != completionCount.get()) {
       throw new RuntimeException("queryCount = " + queryCnt +
-          " is not equal to completedTaskCount =  " + executor.getCompletedTaskCount());
+          " is not equal to completedTaskCount =  " + completionCount.get());
     }
 
     return results;

--- a/src/main/java/io/anserini/search/SimpleImpactSearcher.java
+++ b/src/main/java/io/anserini/search/SimpleImpactSearcher.java
@@ -443,7 +443,6 @@ public class SimpleImpactSearcher implements Closeable {
       executor.invokeAll(tasks);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException("Batch search of encoded queries is interrupted", e);
     }
 
     if (queryCnt != completionCount.get()) {
@@ -499,7 +498,6 @@ public class SimpleImpactSearcher implements Closeable {
       executor.invokeAll(tasks);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException("Batch search of queries interrupted", e);
     }
 
     if (queryCnt != completionCount.get()) {

--- a/src/main/java/io/anserini/search/SimpleSearcher.java
+++ b/src/main/java/io/anserini/search/SimpleSearcher.java
@@ -553,7 +553,6 @@ public class SimpleSearcher implements Closeable {
       executor.invokeAll(tasks);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException("Batch search of provided fields interrupted", e);
     }
 
     if (queryCnt != completionCount.get()) {
@@ -791,7 +790,6 @@ public class SimpleSearcher implements Closeable {
       executor.invokeAll(tasks);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException("Batch retrieval of documents is interrupted", e);
     }
     return results;
   }

--- a/src/main/java/io/anserini/search/SimpleSearcher.java
+++ b/src/main/java/io/anserini/search/SimpleSearcher.java
@@ -78,6 +78,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Class that exposes basic search functionality, designed specifically to provide the bridge between Java and Python
@@ -524,43 +525,40 @@ public class SimpleSearcher implements Closeable {
       searcher.setSimilarity(similarity);
     }
 
-    ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(threads);
     ConcurrentHashMap<String, ScoredDoc[]> results = new ConcurrentHashMap<>();
-
     int queryCnt = queries.size();
+    List<Callable<Void>> tasks = new ArrayList<>(queryCnt);
+    AtomicInteger completionCount = new AtomicInteger();
+
     for (int q = 0; q < queryCnt; ++q) {
       String query = queries.get(q);
       String qid = qids.get(q);
-      executor.execute(() -> {
+      tasks.add(() -> {
         try {
           if (fields.size() > 0) {
             results.put(qid, search_fields(generator, query, fields, k));
           } else {
             results.put(qid, search(generator, query, k));
           }
+          completionCount.incrementAndGet();
         } catch (IOException e) {
           throw new CompletionException(e);
         }
+        return null;
       });
     }
 
-    executor.shutdown();
-
-    try {
-      // Wait for existing tasks to terminate
-      while (!executor.awaitTermination(1, TimeUnit.MINUTES)) {
-        // Opportunity to perform status logging, but no-op here because logging interferes with Python tqdm
-      }
-    } catch (InterruptedException ie) {
-      // (Re-)Cancel if current thread also interrupted
-      executor.shutdownNow();
-      // Preserve interrupt status
+    try (ExecutorService executor = Executors.newWorkStealingPool()) {
+      // block until all tasks are completed
+      executor.invokeAll(tasks);
+    } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
+      throw new RuntimeException("Batch search of provided fields interrupted", e);
     }
 
-    if (queryCnt != executor.getCompletedTaskCount()) {
+    if (queryCnt != completionCount.get()) {
       throw new RuntimeException("queryCount = " + queryCnt +
-              " is not equal to completedTaskCount =  " + executor.getCompletedTaskCount());
+              " is not equal to completedTaskCount =  " + completionCount.get());
     }
 
     return results;

--- a/src/main/java/io/anserini/util/BenchmarkCollectionReader.java
+++ b/src/main/java/io/anserini/util/BenchmarkCollectionReader.java
@@ -144,7 +144,6 @@ public final class BenchmarkCollectionReader {
       monitor.awaitTermination(5, TimeUnit.SECONDS);
     } catch (InterruptedException ie) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException("Mapping collections interrupted", ie);
     }
 
     if (segmentCnt != completionCount.get()) {

--- a/src/main/java/io/anserini/util/BenchmarkCollectionReader.java
+++ b/src/main/java/io/anserini/util/BenchmarkCollectionReader.java
@@ -31,10 +31,9 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 // Simple program to benchmark IO performance, reading collections from disk.
@@ -113,34 +112,44 @@ public final class BenchmarkCollectionReader {
     final long start = System.nanoTime();
     LOG.info("Starting MapCollections...");
 
-    int numThreads = args.threads;
-    final ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(numThreads);
     final List segmentPaths = collection.getSegmentPaths();
-
     final int segmentCnt = segmentPaths.size();
+    AtomicInteger completionCount = new AtomicInteger(0);
+
     LOG.info(segmentCnt + " files found in " + collectionPath.toString());
+
+    List<Callable<Void>> tasks = new ArrayList<>(segmentCnt);
     for (int i = 0; i < segmentCnt; i++) {
-      executor.execute(new ReaderThread(collection, (Path) segmentPaths.get(i)));
+      int finalI = i;
+      tasks.add(() -> {
+        new ReaderThread(collection, (Path) segmentPaths.get(finalI)).run();
+        completionCount.incrementAndGet();
+        return null;
+      });
     }
 
-    executor.shutdown();
+    // Work-stealing executor + progress logger
+    try (
+            ExecutorService executor = Executors.newWorkStealingPool();
+            ScheduledExecutorService monitor = Executors.newSingleThreadScheduledExecutor()
+    ) {
+      // log progress every minute
+      monitor.scheduleAtFixedRate(() -> {
+        double pct = (double) completionCount.get() / segmentCnt * 100.0d;
+        LOG.info(String.format("%.2f percent completed", pct));
+      }, 1, 1, TimeUnit.MINUTES);
 
-    try {
-      // Wait for existing tasks to terminate
-      while (!executor.awaitTermination(1, TimeUnit.MINUTES)) {
-        LOG.info(String.format("%.2f percent completed",
-            (double) executor.getCompletedTaskCount() / segmentCnt * 100.0d));
-      }
+      executor.invokeAll(tasks);      // blocks until every task is done
+      monitor.shutdown();             // stop the progress logger
+      monitor.awaitTermination(5, TimeUnit.SECONDS);
     } catch (InterruptedException ie) {
-      // (Re-)Cancel if current thread also interrupted
-      executor.shutdownNow();
-      // Preserve interrupt status
       Thread.currentThread().interrupt();
+      throw new RuntimeException("Mapping collections interrupted", ie);
     }
 
-    if (segmentCnt != executor.getCompletedTaskCount()) {
+    if (segmentCnt != completionCount.get()) {
       throw new RuntimeException("totalFiles = " + segmentCnt +
-          " is not equal to completedTaskCount =  " + executor.getCompletedTaskCount());
+          " is not equal to completedTaskCount =  " + completionCount.get());
     }
 
     final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);


### PR DESCRIPTION
The goal of this work is to resolve this [issue](https://github.com/castorini/anserini/issues/2579)

In this work, all instances of __ThreadPoolExecutor__ have been replaced with __newWorkStealingPool__  in the codebase with the benefit of maximizing CPU utilization. In addition, `executor.invokeAll(tasks)` has been used in place of different instances of `executor.awaitTermination(), executor.shutdown() and executor.shutdownNow()` necessary for ensuring complete execution of multiple tasks before moving unto other code executions in a file.

I have also added a `monitor` in `BenchmarkCollectionReader, AbstractIndexer, and IndexCollection` class to maintain the existing INFO logs in the process of refactor.

Finally, I have also left in `processSegments(executor, segmentpaths)` for backward compatibility as I am not sure if `anserini` is being consumed in another library that I am not aware of.

__All tests are currently passing locally__.