### PR TITLE
Move MSMARCO v1 prebuilt indexes on Hugging Face

### DIFF
--- a/src/main/java/io/anserini/index/IndexInfo.java
+++ b/src/main/java/io/anserini/index/IndexInfo.java
@@ -46,7 +46,7 @@ public enum IndexInfo {
       "MS MARCO V1 Passage",
       "BM25",
       new String[] {
-          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1-passage/resolve/main/lucene-inverted/tf/lucene-inverted.msmarco-v1-passage.20221004.252b5e.tar.gz" },
+          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1/resolve/main/passage/original/lucene-inverted/tf/lucene-inverted.msmarco-v1-passage.20221004.252b5e.tar.gz" },
       "678876e8c99a89933d553609a0fd8793",
       IndexType.SPARSE_INVERTED,
       null,
@@ -60,7 +60,7 @@ public enum IndexInfo {
       "MS MARCO V1 Passage",
       "SPLADE++ EnsembleDistil",
       new String[] {
-          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1-passage/resolve/main/lucene-inverted/splade-pp-ed/lucene-inverted.msmarco-v1-passage.splade-pp-ed.20230524.a59610.tar.gz" },
+          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1/resolve/main/passage/original/lucene-inverted/splade-pp/lucene-inverted.msmarco-v1-passage.splade-pp-ed.20230524.a59610.tar.gz" },
       "2c008fc36131e27966a72292932358e6",
       IndexType.SPARSE_IMPACT ,
       SpladePlusPlusEnsembleDistilEncoder.class.getSimpleName(),
@@ -74,7 +74,7 @@ public enum IndexInfo {
       "MS MARCO V1 Passage",
       "SPLADEv3",
       new String[] {
-          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1-passage/resolve/main/lucene-inverted/splade-v3/lucene-inverted.msmarco-v1-passage.splade-v3.20250329.4f4c68.tar.gz" },
+          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1/resolve/main/passage/original/lucene-inverted/splade-v3/lucene-inverted.msmarco-v1-passage.splade-v3.20250329.4f4c68.tar.gz" },
       "52f4b59d236547f570555715ed314311",
       IndexType.SPARSE_IMPACT ,
       SpladeV3Encoder.class.getSimpleName(),
@@ -88,7 +88,7 @@ public enum IndexInfo {
       "MS MARCO V1 Passage",
       "cosDPR-distil w/ HNSW fp32",
       new String[] {
-          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1-passage/resolve/main/lucene-hnsw/cosdpr-distil/lucene-hnsw.msmarco-v1-passage.cosdpr-distil.20240108.825148.tar.gz" },
+          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1/resolve/main/passage/original/lucene-hnsw/cosdpr-distil/lucene-hnsw.msmarco-v1-passage.cosdpr-distil.20240108.825148.tar.gz" },
       "df4c60fa1f3804fa409499824d12d035",
       IndexType.DENSE_HNSW,
       "CosDprDistilEncoder",
@@ -102,7 +102,7 @@ public enum IndexInfo {
       "MS MARCO V1 Passage",
       "cosDPR-distil w/ HNSW int8",
       new String[] {
-          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1-passage/resolve/main/lucene-hnsw/cosdpr-distil/lucene-hnsw-int8.msmarco-v1-passage.cosdpr-distil.20240108.825148.tar.gz" },
+          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1/resolve/main/passage/original/lucene-hnsw/cosdpr-distil/lucene-hnsw-int8.msmarco-v1-passage.cosdpr-distil.20240108.825148.tar.gz" },
       "119124ad358bb81e6a203b04d1b99a9c",
       IndexType.DENSE_HNSW_INT8,
       "CosDprDistilEncoder",
@@ -116,7 +116,7 @@ public enum IndexInfo {
       "MS MARCO V1 Passage",
       "bge-base-en-v1.5 w/ HNSW fp32",
       new String[] {
-          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1-passage/resolve/main/lucene-hnsw/bge-base-en-v1.5/lucene-hnsw.msmarco-v1-passage.bge-base-en-v1.5.20240117.53514b.tar.gz" },
+          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1/resolve/main/passage/original/lucene-hnsw/bge-base-en-v1.5/lucene-hnsw.msmarco-v1-passage.bge-base-en-v1.5.20240117.53514b.tar.gz" },
       "00a577f689d90f95e6c5611438b0af3d",
       IndexType.DENSE_HNSW,
       BgeBaseEn15Encoder.class.getSimpleName(),
@@ -130,7 +130,7 @@ public enum IndexInfo {
       "MS MARCO V1 Passage",
       "bge-base-en-v1.5 w/ HNSW int8",
       new String[] {
-          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1-passage/resolve/main/lucene-hnsw/bge-base-en-v1.5/lucene-hnsw-int8.msmarco-v1-passage.bge-base-en-v1.5.20240117.53514b.tar.gz" },
+          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1/resolve/main/passage/original/lucene-hnsw/bge-base-en-v1.5/lucene-hnsw-int8.msmarco-v1-passage.bge-base-en-v1.5.20240117.53514b.tar.gz" },
       "7830712459cf124c96fd058bb0a405b7",
       IndexType.DENSE_HNSW_INT8,
       BgeBaseEn15Encoder.class.getSimpleName(),
@@ -144,7 +144,7 @@ public enum IndexInfo {
       "MS MARCO V1 Passage",
       "cohere-embed-english-v3.0 w/ HNSW fp32",
       new String[] {
-          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1-passage/resolve/main/lucene-hnsw/cohere-embed-english/lucene-hnsw.msmarco-v1-passage.cohere-embed-english-v3.0.20240228.eacd13.tar.gz" },
+          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1/resolve/main/passage/original/lucene-hnsw/cohere-embed-english/lucene-hnsw.msmarco-v1-passage.cohere-embed-english-v3.0.20240228.eacd13.tar.gz" },
       "c7294ca988ae1b812d427362ffca1ee2",
       IndexType.DENSE_HNSW,
       null,
@@ -158,7 +158,7 @@ public enum IndexInfo {
       "MS MARCO V1 Passage",
       "cohere-embed-english-v3.0 w/ HNSW fp32",
       new String[] {
-          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1-passage/resolve/main/lucene-hnsw/cohere-embed-english/lucene-hnsw-int8.msmarco-v1-passage.cohere-embed-english-v3.0.20240228.eacd13.tar.gz" },
+          "https://huggingface.co/datasets/castorini/prebuilt-indexes-msmarco-v1/resolve/main/passage/original/lucene-hnsw/cohere-embed-english/lucene-hnsw-int8.msmarco-v1-passage.cohere-embed-english-v3.0.20240228.eacd13.tar.gz" },
       "dbaca578cc8495f504cdd0a7187f4c36",
       IndexType.DENSE_HNSW_INT8,
       null,


### PR DESCRIPTION
Addresses https://github.com/castorini/pyserini/issues/2155. Pyserini has more prebuilt indexes for MSMARCOv1 than Anserini, so a new Hugging Face repo for MSMARCOv1 was made in accordance with Pyserini. The Anserini indexes have been reorganized to fit into that, so the previous repo for MSMARCOv1 passage can be deleted once this PR is merged. 