### PR TITLE
Remove exclude feature for BRIGHT from regression yamls

### DIFF
--- a/src/main/python/run_regression.py
+++ b/src/main/python/run_regression.py
@@ -197,7 +197,7 @@ def evaluate_and_verify(yaml_data, dry_run):
                 eval_cmd = [
                   os.path.join(metric['command']), metric['params'] if 'params' in metric and metric['params'] else '',
                   os.path.join('tools/topics-and-qrels', topic_set['qrel']) if 'qrel' in topic_set and topic_set['qrel'] else '',
-                  construct_runfile_path(yaml_data['index_path'], topic_set['id'], model['name']) + (yaml_data['conversions'][-1]['out_file_ext'] if 'conversions' in yaml_data and yaml_data['conversions'][-1]['out_file_ext'] else '' + '.filtered' if 'filter_cmd' in yaml_data and yaml_data['filter_cmd'] else ''),
+                  construct_runfile_path(yaml_data['index_path'], topic_set['id'], model['name']) + (yaml_data['conversions'][-1]['out_file_ext'] if 'conversions' in yaml_data and yaml_data['conversions'][-1]['out_file_ext'] else ''),
                 ]
                 if dry_run:
                     logger.info(' '.join(eval_cmd))
@@ -435,14 +435,5 @@ if __name__ == '__main__':
             else:
                 with Pool(args.convert_pool) as p:
                     p.map(run_convert, convert_cmds)
-
-        if 'filter_cmd' in yaml_data and yaml_data['filter_cmd']:
-            logger.info('='*10 + ' Filtering ' + '='*10)
-            cmd = yaml_data['filter_cmd']
-            if args.dry_run:
-                logger.info(cmd)
-            else:
-                logger.info(cmd)
-                call(cmd, shell=True)
 
         evaluate_and_verify(yaml_data, args.dry_run)

--- a/src/main/resources/regression/bright-aops.yaml
+++ b/src/main/resources/regression/bright-aops.yaml
@@ -12,8 +12,6 @@ index_stats:
   documents (non-empty): 188002
   total terms: 20699175
 
-filter_cmd: python src/main/python/bright/filter_run.py --run runs/run.inverted.bright-aops.topics.bm25 --split aops
-
 metrics:
   - metric: nDCG@10
     command: bin/trec_eval

--- a/src/main/resources/regression/bright-biology.yaml
+++ b/src/main/resources/regression/bright-biology.yaml
@@ -11,9 +11,7 @@ index_stats:
   documents: 57359
   documents (non-empty): 57030
   total terms: 2133799
-
-filter_cmd: python src/main/python/bright/filter_run.py --run runs/run.inverted.bright-biology.topics.bm25 --split biology
-
+  
 metrics:
   - metric: nDCG@10
     command: bin/trec_eval

--- a/src/main/resources/regression/bright-earth-science.yaml
+++ b/src/main/resources/regression/bright-earth-science.yaml
@@ -12,8 +12,6 @@ index_stats:
   documents (non-empty): 121205
   total terms: 4924837
 
-filter_cmd: python src/main/python/bright/filter_run.py --run runs/run.inverted.bright-earth-science.topics.bm25 --split earth_science
-
 metrics:
   - metric: nDCG@10
     command: bin/trec_eval

--- a/src/main/resources/regression/bright-economics.yaml
+++ b/src/main/resources/regression/bright-economics.yaml
@@ -12,8 +12,6 @@ index_stats:
   documents (non-empty): 49472
   total terms: 2209688
 
-filter_cmd: python src/main/python/bright/filter_run.py --run runs/run.inverted.bright-economics.topics.bm25 --split economics
-
 metrics:
   - metric: nDCG@10
     command: bin/trec_eval

--- a/src/main/resources/regression/bright-leetcode.yaml
+++ b/src/main/resources/regression/bright-leetcode.yaml
@@ -12,8 +12,6 @@ index_stats:
   documents (non-empty): 413932
   total terms: 35338566
 
-filter_cmd: python src/main/python/bright/filter_run.py --run runs/run.inverted.bright-leetcode.topics.bm25 --split leetcode
-
 metrics:
   - metric: nDCG@10
     command: bin/trec_eval

--- a/src/main/resources/regression/bright-pony.yaml
+++ b/src/main/resources/regression/bright-pony.yaml
@@ -12,8 +12,6 @@ index_stats:
   documents (non-empty): 7892
   total terms: 264645
 
-filter_cmd: python src/main/python/bright/filter_run.py --run runs/run.inverted.bright-pony.topics.bm25 --split pony
-
 metrics:
   - metric: nDCG@10
     command: bin/trec_eval

--- a/src/main/resources/regression/bright-psychology.yaml
+++ b/src/main/resources/regression/bright-psychology.yaml
@@ -12,8 +12,6 @@ index_stats:
   documents (non-empty): 52055
   total terms: 2206965
 
-filter_cmd: python src/main/python/bright/filter_run.py --run runs/run.inverted.bright-psychology.topics.bm25 --split psychology
-
 metrics:
   - metric: nDCG@10
     command: bin/trec_eval

--- a/src/main/resources/regression/bright-robotics.yaml
+++ b/src/main/resources/regression/bright-robotics.yaml
@@ -12,8 +12,6 @@ index_stats:
   documents (non-empty): 59732
   total terms: 1965313
 
-filter_cmd: python src/main/python/bright/filter_run.py --run runs/run.inverted.bright-robotics.topics.bm25 --split robotics
-
 metrics:
   - metric: nDCG@10
     command: bin/trec_eval

--- a/src/main/resources/regression/bright-stackoverflow.yaml
+++ b/src/main/resources/regression/bright-stackoverflow.yaml
@@ -12,8 +12,6 @@ index_stats:
   documents (non-empty): 106075
   total terms: 12612557
 
-filter_cmd: python src/main/python/bright/filter_run.py --run runs/run.inverted.bright-stackoverflow.topics.bm25 --split stackoverflow
-
 metrics:
   - metric: nDCG@10
     command: bin/trec_eval

--- a/src/main/resources/regression/bright-sustainable-living.yaml
+++ b/src/main/resources/regression/bright-sustainable-living.yaml
@@ -12,8 +12,6 @@ index_stats:
   documents (non-empty): 60179
   total terms: 2359358
 
-filter_cmd: python src/main/python/bright/filter_run.py --run runs/run.inverted.bright-sustainable-living.topics.bm25 --split sustainable_living
-
 metrics:
   - metric: nDCG@10
     command: bin/trec_eval

--- a/src/main/resources/regression/bright-theoremqa-questions.yaml
+++ b/src/main/resources/regression/bright-theoremqa-questions.yaml
@@ -12,8 +12,6 @@ index_stats:
   documents (non-empty): 188002
   total terms: 20699175
 
-filter_cmd: python src/main/python/bright/filter_run.py --run runs/run.inverted.bright-theoremqa-questions.topics.bm25 --split theoremqa_questions
-
 metrics:
   - metric: nDCG@10
     command: bin/trec_eval

--- a/src/main/resources/regression/bright-theoremqa-theorems.yaml
+++ b/src/main/resources/regression/bright-theoremqa-theorems.yaml
@@ -12,8 +12,6 @@ index_stats:
   documents (non-empty): 23839
   total terms: 2822888
 
-filter_cmd: python src/main/python/bright/filter_run.py --run runs/run.inverted.bright-theoremqa-theorems.topics.bm25 --split theoremqa_theorems
-
 metrics:
   - metric: nDCG@10
     command: bin/trec_eval


### PR DESCRIPTION
As of https://github.com/castorini/anserini/pull/2886, the exclusion command from regression yamls is no longer needed, so this PR removes them. 