### PR TITLE
Add prebuilt index for ACL Anthology

### DIFF
--- a/src/main/java/io/anserini/index/IndexInfo.java
+++ b/src/main/java/io/anserini/index/IndexInfo.java
@@ -38,6 +38,24 @@ public enum IndexInfo {
       null,
       "cacm"),
 
+  ACL_ANTHOLOGY("acl-anthology",
+      "Lucene index of the ACL Anthology",
+      "lucene-inverted.acl-anthology.20250715.75a6cd.tar.gz",
+      "",
+      "ACL Anthology",
+      "BM25",
+      new String[] {
+          "https://huggingface.co/datasets/castorini/prebuilt-indexes-acl-anthology/resolve/main/lucene-inverted/tf/lucene-inverted.acl-anthology.20250715.75a6cd.tar.gz"},
+      "5b3e8afc65db20058f0d6e6e991424a4",
+      IndexType.SPARSE_INVERTED,
+      null,
+      null,
+      "acl-anthology",
+      92835645L,
+      6622060L,
+      108329,
+      79122L),
+
   // MS MARCO V1
   MSMARCO_V1_PASSAGE("msmarco-v1-passage",
       "Lucene index of the MS MARCO V1 passage corpus.",

--- a/src/test/java/io/anserini/index/PrebuiltIndexTest.java
+++ b/src/test/java/io/anserini/index/PrebuiltIndexTest.java
@@ -61,6 +61,6 @@ public class PrebuiltIndexTest {
   // test number of prebuilt-indexes
   @Test
   public void testNumPrebuiltIndexes() {
-    assertEquals(212, IndexInfo.values().length);
+    assertEquals(213, IndexInfo.values().length);
   }
 }


### PR DESCRIPTION
Lucene inverted BM25 index for ACL Anthology. To make sure all fields are indexed without getting flagged as 'empty', empty abstracts and authors have 'n/a' as placeholders. Fields are title, contents (abstract), authors (name, variations separated by commas; institution after name after semicolon. authors separated by periods), venue (name of conference/journal), and year. IDs are the 'bibkey', guaranteed to be [unique across the Anthology](https://acl-anthology.readthedocs.io/py-v0.5.2/api/collections.paper/#acl_anthology.collections.paper.Paper).