### PR TITLE
Move batch run sequence for BRIGHT

### DIFF
--- a/src/main/python/regressions-batch04.txt
+++ b/src/main/python/regressions-batch04.txt
@@ -1,16 +1,3 @@
-python src/main/python/run_regression.py --index --verify --search --regression bright-aops > logs/log.bright-aops.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression bright-biology > logs/log.bright-biology.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression bright-earth-science > logs/log.bright-earth-science.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression bright-economics > logs/log.bright-economics.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression bright-leetcode > logs/log.bright-leetcode.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression bright-pony > logs/log.bright-pony.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression bright-psychology > logs/log.bright-psychology.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression bright-robotics > logs/log.bright-robotics.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression bright-stackoverflow > logs/log.bright-stackoverflow.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression bright-sustainable-living > logs/log.bright-sustainable-living.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression bright-theoremqa-questions > logs/log.bright-theoremqa-questions.txt 2>&1
-python src/main/python/run_regression.py --index --verify --search --regression bright-theoremqa-theorems > logs/log.bright-theoremqa-theorems.txt 2>&1
-
 # BEIR w/ parquet
 python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-trec-covid.splade-v3.onnx > logs/log.beir-v1.0.0-trec-covid.splade-v3.onnx.txt 2>&1
 python src/main/python/run_regression.py --index --verify --search --regression beir-v1.0.0-bioasq.splade-v3.onnx > logs/log.beir-v1.0.0-bioasq.splade-v3.onnx.txt 2>&1
@@ -281,6 +268,20 @@ python src/main/python/run_regression.py --verify --search --regression beir-v1.
 python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw-int8.cached > logs/log.beir-v1.0.0-trec-covid.bge-base-en-v1.5.parquet.hnsw-int8.cached.txt 2>&1
 python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw-int8.cached > logs/log.beir-v1.0.0-trec-news.bge-base-en-v1.5.parquet.hnsw-int8.cached.txt 2>&1
 python src/main/python/run_regression.py --verify --search --regression beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw-int8.cached > logs/log.beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.parquet.hnsw-int8.cached.txt 2>&1
+
+# BRIGHT
+python src/main/python/run_regression.py --index --verify --search --regression bright-aops > logs/log.bright-aops.txt 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression bright-biology > logs/log.bright-biology.txt 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression bright-earth-science > logs/log.bright-earth-science.txt 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression bright-economics > logs/log.bright-economics.txt 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression bright-leetcode > logs/log.bright-leetcode.txt 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression bright-pony > logs/log.bright-pony.txt 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression bright-psychology > logs/log.bright-psychology.txt 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression bright-robotics > logs/log.bright-robotics.txt 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression bright-stackoverflow > logs/log.bright-stackoverflow.txt 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression bright-sustainable-living > logs/log.bright-sustainable-living.txt 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression bright-theoremqa-questions > logs/log.bright-theoremqa-questions.txt 2>&1
+python src/main/python/run_regression.py --index --verify --search --regression bright-theoremqa-theorems > logs/log.bright-theoremqa-theorems.txt 2>&1
 
 # MIRACL
 python src/main/python/run_regression.py --index --verify --search --regression miracl-v1.0-ar > logs/log.miracl-v1.0-ar.txt 2>&1


### PR DESCRIPTION
Staggering BRIGHT tests - current sequence of regressions causes OOM errors on `tuna`.