### PR TITLE
Refactor ThreadPool and WorkStealingPool in SearchCollection

### DIFF
--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -689,7 +689,7 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
         if (hasRelDocs) {
           scoredFbDocs = queryQrels;
         } else {//if no relevant documents, only perform score based tie breaking next
-          LOG.info("No relevant documents for " + qid.toString());
+          LOG.info("No relevant documents for {}", qid.toString());
           scoredFbDocs = ScoredDocs.fromTopDocs(rs, getIndexSearcher());
           cascade = new RerankerCascade();
           cascade.add(new ScoreTiesAdjusterReranker());
@@ -800,7 +800,7 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
     }
   }
 
-  private final class SearcherThread<T extends Comparable<T>> extends Thread {
+  private final class SearchWorker<T extends Comparable<T>> extends Thread {
     final private Searcher<T> searcher;
     final private SortedMap<T, Map<String, String>> topics;
     final private TaggedSimilarity taggedSimilarity;
@@ -808,11 +808,11 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
     final private String outputPath;
     final private SparseEncoder queryEncoder;
 
-    private SearcherThread(IndexReader reader,
-                           SortedMap<T, Map<String, String>> topics,
-                           TaggedSimilarity taggedSimilarity,
-                           RerankerCascade cascade,
-                           String outputPath) {
+    private SearchWorker(IndexReader reader,
+                         SortedMap<T, Map<String, String>> topics,
+                         TaggedSimilarity taggedSimilarity,
+                         RerankerCascade cascade,
+                         String outputPath) {
       // We need to pass in the topics because for tweets, we need to extract the tweet time.
       this.topics = topics;
       this.taggedSimilarity = taggedSimilarity;
@@ -851,7 +851,6 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
       for (Map.Entry<T, Map<String, String>> entry : topics.entrySet()) {
         T qid = entry.getKey();
 
-
         tasks.add(() -> {
           try {
             StringBuilder queryString = new StringBuilder();
@@ -886,7 +885,6 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
               docs = searcher.search(qid, queryString.toString(), cascade, queryQrels, hasRelDocs);
             }
 
-
             // If JSON output is requested, we retain references to the Lucene documents.
             // Note we do *not* want to retain references to the Lucene documents unless requested since it's a waste of memory.
             if (args.outputRerankerRequests != null) {
@@ -897,7 +895,7 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
 
             int n = cnt.incrementAndGet();
             if (n % 100 == 0) {
-              LOG.info(String.format("%s: %d queries processed", desc, n));
+              LOG.info("{}: {} queries processed", desc, n);
             }
           }  catch (Exception e) {
             throw new CompletionException(e);
@@ -908,7 +906,6 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
       }
 
       try (ExecutorService executor = Executors.newWorkStealingPool(args.threads)) {
-        // block until all tasks are completed
         executor.invokeAll(tasks);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
@@ -916,8 +913,8 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
 
       final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
 
-      LOG.info(desc + ": " + topics.size() + " queries processed in " +
-          DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss") +
+      LOG.info("{}: {} queries processed in {}{}", desc, topics.size(),
+          DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss"),
           String.format(" = ~%.2f q/s", topics.size() / (durationMillis / 1000.0)));
       
       String name = null;
@@ -925,7 +922,7 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
         name = args.topics[0];
       }
       // Now we write the results to a run file.
-      try(RunOutputWriter<T> out = new RunOutputWriter<>(outputPath, args.format, args.runtag, args.outputRerankerRequests, name)) {
+      try (RunOutputWriter<T> out = new RunOutputWriter<>(outputPath, args.format, args.runtag, args.outputRerankerRequests, name)) {
         // Here's a really screwy corner case that we have to manually hack around: for MS MARCO V1, the query file is not
         // sorted by qid, but the topic representation internally is (i.e., K is a comparable). The original query runner
         // SearchMsmarco retained the order of the queries; however, this class does not. Thus, the run files list the
@@ -942,9 +939,9 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
             topics.keySet().size() == 5193;
 
         if (isMSMARCOv1_passage || isMAMARCOv1_doc) {
-          try(InputStream inputStream = isMSMARCOv1_passage ?
-              Files.newInputStream(TopicReader.getTopicPath(Path.of(Topics.MSMARCO_PASSAGE_DEV_SUBSET.path)), StandardOpenOption.READ):
-              Files.newInputStream(TopicReader.getTopicPath(Path.of(Topics.MSMARCO_DOC_DEV.path)), StandardOpenOption.READ) ) {
+          try (InputStream inputStream = isMSMARCOv1_passage ?
+                Files.newInputStream(TopicReader.getTopicPath(Path.of(Topics.MSMARCO_PASSAGE_DEV_SUBSET.path)), StandardOpenOption.READ):
+                Files.newInputStream(TopicReader.getTopicPath(Path.of(Topics.MSMARCO_DOC_DEV.path)), StandardOpenOption.READ) ) {
             BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
             String line;
             while ((line = reader.readLine()) != null) {
@@ -958,10 +955,10 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
         } else {
             results.forEach((qid, hits) -> {
               try {
-                  out.writeTopic(qid, topics.get(qid).get("title"), results.get(qid));
+                out.writeTopic(qid, topics.get(qid).get("title"), results.get(qid));
               } catch (JsonProcessingException e) {
-                  // Handle the exception or rethrow as unchecked
-                  throw new RuntimeException(e);
+                // Handle the exception or rethrow as unchecked.
+                throw new RuntimeException(e);
               }
           });
         }
@@ -988,11 +985,11 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
     Path indexPath = IndexReaderUtils.getIndex(args.index);
 
     LOG.info("============ Initializing Searcher ============");
-    LOG.info("Index: " + indexPath);
+    LOG.info("Index: {}", indexPath);
     this.reader = DirectoryReader.open(FSDirectory.open(indexPath));
 
-    LOG.info("Threads: " + args.threads);
-    LOG.info("Fields: " + Arrays.toString(args.fields));
+    LOG.info("Threads: {}", args.threads);
+    LOG.info("Fields: {}", Arrays.toString(args.fields));
     if (args.fields.length != 0) {
       // The -fields argument should be in the form of "field1=weight1 field2=weight2...".
       // Try to parse, and throw exception if anything goes wrong.
@@ -1006,12 +1003,12 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
       }
     }
 
-    LOG.info("MaxPassage: " + args.selectMaxPassage);
+    LOG.info("MaxPassage: {}", args.selectMaxPassage);
     if (args.selectMaxPassage) {
-      LOG.info("MaxPassage delimiter: " + args.selectMaxPassageDelimiter);
-      LOG.info("MaxPassage hits: " + args.selectMaxPassageHits);
+      LOG.info("MaxPassage delimiter: {}", args.selectMaxPassageDelimiter);
+      LOG.info("MaxPassage hits: {}", args.selectMaxPassageHits);
     }
-    LOG.info("Hits: " + args.hits);
+    LOG.info("Hits: {}", args.hits);
 
     // get collection class if available
     if (args.collectionClass != null) {
@@ -1024,7 +1021,7 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
     } else {
       this.collectionClass = null;
     }
-    LOG.info("Collection class: " + this.collectionClass);
+    LOG.info("Collection class: {}", this.collectionClass);
 
     this.isRerank = args.rm3 || args.axiom || args.bm25prf || args.rocchio;
     this.analyzer = getAnalyzer();
@@ -1050,7 +1047,7 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
       Path topicsFilePath = Paths.get(topicsFile);
       if (!Files.exists(topicsFilePath) || !Files.isRegularFile(topicsFilePath) || !Files.isReadable(topicsFilePath)) {
         Topics ref = Topics.getByName(topicsFile);
-        if (ref==null) {
+        if (ref == null) {
           throw new IllegalArgumentException(String.format("\"%s\" does not refer to valid topics.", topicsFilePath));
         } else {
           topics.putAll(TopicReader.getTopics(ref));
@@ -1248,7 +1245,7 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
 
   private void loadQrels(String rf_qrels) throws IOException {
     LOG.info("============ Loading qrels ============");
-    LOG.info("rf_qrels: " + rf_qrels);
+    LOG.info("rf_qrels: {}", rf_qrels);
     Path rfQrelsFilePath = Paths.get(rf_qrels);
     if (!Files.exists(rfQrelsFilePath) || !Files.isRegularFile(rfQrelsFilePath) || !Files.isReadable(rfQrelsFilePath)) {
       throw new IllegalArgumentException("Qrels file : " + rfQrelsFilePath + " does not exist or is not a (readable) file.");
@@ -1296,14 +1293,14 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
         } else {
           languageSpecificAnalyzer = new WhitespaceAnalyzer();
         }
-        String message = "Using CompositeAnalyzer with HF Tokenizer: %s & Analyzer %s";
-        LOG.info(String.format(message, args.analyzeWithHuggingFaceTokenizer, languageSpecificAnalyzer.getClass().getName()));
+        LOG.info("Using CompositeAnalyzer with HF Tokenizer {} and Analyzer {}",
+            args.analyzeWithHuggingFaceTokenizer, languageSpecificAnalyzer.getClass().getName());
         return new CompositeAnalyzer(args.analyzeWithHuggingFaceTokenizer, languageSpecificAnalyzer);
       } else if (args.analyzeWithHuggingFaceTokenizer != null) {
         return new HuggingFaceTokenizerAnalyzer(args.analyzeWithHuggingFaceTokenizer);
       } else if (AnalyzerMap.analyzerMap.containsKey(args.language)) {
         LOG.info("Using language-specific analyzer");
-        LOG.info("Language: " + args.language);
+        LOG.info("Language: {}", args.language);
         return AnalyzerMap.getLanguageSpecificAnalyzer(args.language);
       } else if (Arrays.asList("ha","so","sw","yo").contains(args.language)) {
         return new WhitespaceAnalyzer();
@@ -1312,9 +1309,9 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
       } else {
         // Default to English
         LOG.info("Using DefaultEnglishAnalyzer");
-        LOG.info("Stemmer: " + args.stemmer);
-        LOG.info("Keep stopwords? " + args.keepStopwords);
-        LOG.info("Stopwords file: " + args.stopwords);
+        LOG.info("Stemmer: {}", args.stemmer);
+        LOG.info("Keep stopwords? {}", args.keepStopwords);
+        LOG.info("Stopwords file: {}", args.stopwords);
         return DefaultEnglishAnalyzer.fromArguments(args.stemmer, args.keepStopwords, args.stopwords);
       }
     } catch (Exception e) {
@@ -1325,7 +1322,7 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
   @Override
   public void run() {
     LOG.info("============ Launching Search Threads ============");
-    LOG.info("runtag: " + args.runtag);
+    LOG.info("runtag: {}", args.runtag);
 
     List<Callable<Void>> tasks = new ArrayList<>();
 
@@ -1340,20 +1337,19 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
         }
 
         if (args.skipExists && new File(outputPath).exists()) {
-          LOG.info("Run already exists, skipping: " + outputPath);
+          LOG.info("Run already exists, skipping: {}", outputPath);
           continue;
         }
 
         tasks.add (() -> {
-          new SearcherThread<>(reader, topics, taggedSimilarity, cascade, outputPath).run();
+          new SearchWorker<>(reader, topics, taggedSimilarity, cascade, outputPath).run();
           return null;
         });
-
       }
     }
 
-    try (ExecutorService executor = Executors.newWorkStealingPool(args.parallelism)) {
-      // block until all tasks are completed
+    // We want predictable thread count since each of the workers will spawn multiple threads.
+    try (ExecutorService executor = Executors.newFixedThreadPool(args.parallelism)) {
       executor.invokeAll(tasks);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -1390,13 +1386,13 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
 
     // We're at top-level already inside a main; makes no sense to propagate exceptions further, so reformat the
     // exception messages and display on console.
-    try(SearchCollection<?> searcher = new SearchCollection<>(searchArgs)) {
+    try (SearchCollection<?> searcher = new SearchCollection<>(searchArgs)) {
       searcher.run();
     } catch (IllegalArgumentException e) {
       System.err.printf("Error: %s\n", e.getMessage());
     }
 
     final long durationMillis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
-    LOG.info("Total run time: " + DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss"));
+    LOG.info("Total run time: {}", DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss"));
   }
 }


### PR DESCRIPTION
This is a follow up to https://github.com/castorini/anserini/pull/2883

Requires a bit of explanation: Currently `SearchCollection` has a feature to explore multiple parameters in parallel. So, if you specify multiple values of `k1` for BM25 (for example), it'll run them in parallel, controlled by the `parallelism` parameter. Note that each of these parameter configs can run across multiple threads, controlled by the `threads` parameter.

Previously, both were implemented with `ThreadPool`s, which yielded a predictable number of threads, e.g., `parallelism` 8 and `threads` 4 led to 32 threads running.

In the above PR #2883 - both were changed to `WorkStealingPool`, which causes excessive load (due to underlying implementation and the way we were configuring the executors).

In this PR, I changed the outer one (i.e., parallelism across multiple configs) back to `ThreadPool`. This seems to yield more predictable load (i.e,. no longer generates excessive load).

---

PR has other minor non-consequential refactoring.

---

Testing PR right now, leaving as draft - will report back.