### PR TITLE
compute-index-size table

### DIFF
--- a/src/main/java/io/anserini/reproduce/RunRepro.java
+++ b/src/main/java/io/anserini/reproduce/RunRepro.java
@@ -122,9 +122,13 @@ public class RunRepro {
           Path prebuiltPath = expectedPrebuiltPath(idx);
           if (prebuiltPath != null && Files.exists(prebuiltPath)) {
             long sz = IndexReaderUtils.findDirectorySize(prebuiltPath);
-            totalBytes += sz;
-            presentCount++;
-            System.out.printf("  - %s: present in cache at %s (size: %s)%n", idx, prebuiltPath.toAbsolutePath(), IndexReaderUtils.formatSize(sz));
+            if (sz <= 0L) {
+              System.out.printf("  - %s: not downloaded (expected cache path: %s)%n", idx, prebuiltPath.toAbsolutePath());
+            } else {
+              totalBytes += sz;
+              presentCount++;
+              System.out.printf("  - %s: present in cache at %s (size: %s)%n", idx, prebuiltPath.toAbsolutePath(), IndexReaderUtils.formatSize(sz));
+            }
             continue;
           }
           // Fall back to local path if provided as a directory.


### PR DESCRIPTION
compute-index-size now outputs a table and accounts for empty .cache indexes

Example output:

```
(venv) j33green@ubuntu2204-006:~/castorini/anserini$ bin/run.sh io.anserini.reproduce.RunBright -dryRun -computeIndexSize
WARNING: Using incubator modules: jdk.incubator.vector
Indexes referenced by this run (24 total):
name                                                                    size on disk  download size  path
----------------------------------------------------------------------  ------------  ------------  ------------------------------
bright-biology                                                               32.1 MB       23.9 MB  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-biology.20250705.44ae8e.28e2dabd2f3e57dec3f627351f8c4b11
bright-earth-science                                                         68.6 MB       50.9 MB  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-earth-science.20250705.44ae8e.beb1d21fcf297de450271361667f2992
bright-economics                                                             30.5 MB       50.9 MB  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-economics.20250705.44ae8e.59b9d0751eb933de06c2bd9ca815a620
bright-psychology                                                            31.6 MB       23.9 MB  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-psychology.20250705.44ae8e.92cfe0528ec00992539c5d71e43132b5
bright-robotics                                                              24.7 MB       17.6 MB  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-robotics.20250705.44ae8e.798ffdc9f8156f87092dab7222fc7015
bright-stackoverflow                                                        134.5 MB       90.7 MB  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-stackoverflow.20250705.44ae8e.228efa0a5f694e21ec72b8701cea544d
bright-sustainable-living                                                    33.0 MB       24.4 MB  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-sustainable-living.20250705.44ae8e.e2bd3276a1a95f899a285199a32ace2e
bright-pony                                                                   3.2 MB        2.3 MB  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-pony.20250705.44ae8e.3cc53b8606c82f6ccbd1fe03deca42f5
bright-leetcode                                                             472.9 MB      377.8 MB  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-leetcode.20250705.44ae8e.8f0c4fdbaf6fac01b3450da1ddfd91bc
bright-aops                                                                 157.7 MB      130.4 MB  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-aops.20250705.44ae8e.2427dbdd4e64c27a3fb86901f88ba72f
bright-theoremqa-questions                                                  157.7 MB      130.4 MB  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-theoremqa-questions.20250705.44ae8e.c5754371fb34423abf64c48b22b906d2
bright-theoremqa-theorems                                                    19.3 MB       16.0 MB  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-theoremqa-theorems.20250705.44ae8e.4b576146c71acde1045dbbc502b64a76
bright-biology.splade-v3                                                     22.6 MB             -  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-biology.splade-v3.20250808.c6674a.559813ffede15ba7080af05383b64bde
bright-earth-science.splade-v3                                               52.8 MB             -  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-earth-science.splade-v3.20250808.c6674a.d87652fb3467cb0140c4514d1839d3c3
bright-economics.splade-v3                                                   17.4 MB             -  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-economics.splade-v3.20250808.c6674a.1df6c938e454c3ac2091a90e00fe51bc
bright-psychology.splade-v3                                                  18.8 MB             -  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-psychology.splade-v3.20250808.c6674a.1ecb0fae06945e508da2d6e4f5e7e977
bright-robotics.splade-v3                                                    18.6 MB             -  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-robotics.splade-v3.20250808.c6674a.3d63591bbb4393a0eb24f807b37a5f36
bright-stackoverflow.splade-v3                                               47.4 MB             -  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-stackoverflow.splade-v3.20250808.c6674a.a79e44dc17c8150ca2caa78902fd38c8
bright-sustainable-living.splade-v3                                          20.5 MB             -  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-sustainable-living.splade-v3.20250808.c6674a.2a3ed996f75bfa01a4684c446b0bc48f
bright-pony.splade-v3                                                         2.9 MB             -  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-pony.splade-v3.20250808.c6674a.95040fadfc7eeb594609abe05ab7a694
bright-leetcode.splade-v3                                                   195.0 MB             -  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-leetcode.splade-v3.20250808.c6674a.6e585d1d9012c220b52c6bb9306360f8
bright-aops.splade-v3                                                              -             -  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-aops.splade-v3.20250808.c6674a.294aa5f3dbd9a3a2c435e97e7937ccb1
bright-theoremqa-questions.splade-v3                                               -             -  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-theoremqa-questions.splade-v3.20250808.c6674a.bd21607333fcf7379320363959b02bf4
bright-theoremqa-theorems.splade-v3                                                -             -  /u5/j33green/.cache/pyserini/indexes/lucene-inverted.bright-theoremqa-theorems.splade-v3.20250808.c6674a.726c22edd0d50fd9b5b86b69984c3a48

Total size across 21 of 24 indexes: 1.5 GB

```

Before running this I ran 
`bin/run.sh io.anserini.reproduce.RunBright`
and stopped it after a while so some of the indexes were saved in cache. (which is why it's 21 of 24)