### PR TITLE
Replace fastutil with HPPC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,11 @@
       <version>8.5.8</version>
     </dependency>
     <dependency>
+        <groupId>com.carrotsearch</groupId>
+        <artifactId>hppc</artifactId>
+        <version>0.8.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.wikiclean</groupId>
       <artifactId>wikiclean</artifactId>
       <version>1.1</version>

--- a/src/main/java/io/anserini/index/generator/TweetGenerator.java
+++ b/src/main/java/io/anserini/index/generator/TweetGenerator.java
@@ -16,13 +16,13 @@
 
 package io.anserini.index.generator;
 
-import com.twitter.twittertext.Extractor;
-import com.twitter.twittertext.TwitterTextParseResults;
-import com.twitter.twittertext.TwitterTextParser;
-import io.anserini.collection.TweetCollection;
-import io.anserini.index.Constants;
-import io.anserini.index.IndexCollection;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.List;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.document.Document;
@@ -36,12 +36,14 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.tools.bzip2.CBZip2InputStream;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.List;
+import com.carrotsearch.hppc.LongHashSet;
+import com.twitter.twittertext.Extractor;
+import com.twitter.twittertext.TwitterTextParseResults;
+import com.twitter.twittertext.TwitterTextParser;
+
+import io.anserini.collection.TweetCollection;
+import io.anserini.index.Constants;
+import io.anserini.index.IndexCollection;
 
 /**
  * Converts a {@link TweetCollection.Document} into a Lucene {@link Document}, ready to be indexed.
@@ -51,7 +53,7 @@ public class TweetGenerator implements LuceneDocumentGenerator<TweetCollection.D
 
   private IndexCollection.Args args;
 
-  private LongOpenHashSet deletes = null;
+  private LongHashSet deletes = null;
 
   public enum TweetField {
     ID_LONG("id_long"),
@@ -78,7 +80,7 @@ public class TweetGenerator implements LuceneDocumentGenerator<TweetCollection.D
     this.args = args;
 
     if (!args.tweetDeletedIdsFile.isEmpty()) {
-      deletes = new LongOpenHashSet();
+      deletes = new LongHashSet();
       File deletesFile = new File(args.tweetDeletedIdsFile);
       if (!deletesFile.exists()) {
         System.err.println("Error: " + deletesFile + " does not exist!");


### PR DESCRIPTION
This PR is addresses issue #2937 . I ran a JMH microbenchmark on deletes.contains() line as it runs for each tweet processed.

Speed Comparison:
```
A: Set Size = 10,000 IDs, Hit Ratio = 10%
-[Java HashSet] Lookup Perf: 50,000 lookups in 2.103 ms (23.78 Mops/s)
-[FastUtil] Lookup Perf: 50,000 lookups in 2.243 ms (22.29 Mops/s)
-[HPPC] Lookup Perf: 50,000 lookups in 2.475 ms (20.20 Mops/s)

B: Set Size = 50,000 IDs, Hit Ratio = 15%
-[Java HashSet] Lookup Perf: 50,000 lookups in 55.943 ms (0.894 Mops/s)
-[FastUtil] Lookup Perf: 50,000 lookups in 39.959 ms (1.251 Mops/s)
-[HPPC] Lookup Perf: 50,000 lookups in 34.732 ms (1.440 Mops/s)
```
Not included here, but in a JVM benchmark, Java HashSet had a much high memory consumption and is inconsistent. 

Size comparison:
| Name                               | Size    |
| :-------------------------------------- | :------ |
| **Current Anserini Fat JAR** | **177MB** |
| **HPPC Dependency Net Contribution** | **<1MB** |
| **FastUtil Dependency (for reference)** | **23MB** |

Since com.carrotsearch.hppc dependency is small and has the relative performance of fastutil, it is a good replacement. Also, com.carrotsearch.hppc is more stable than Lucene's org.apache.lucene.internal.hppc.LongHashSet since it is public library.