### PR TITLE
Add evaluation_bm25_full.py for BM25 metric evaluation on dev queries

### DIFF
--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -495,4 +495,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@mindlesstruffle](https://github.com/mindlesstruffle) on 2025-07-08 (commit [`b3ab936`](https://github.com/castorini/anserini/commit/b3ab936b03e8af2e80be7bde861945c1920553f3))
 + Results reproduced by [@niruhan](https://github.com/niruhan) on 2025-07-16 (commit [`d6a8b36`](https://github.com/niruhan/anserini/commit/d6a8b36a6bc9a62b70d44412f6ebb2ca0bc709cd))
 + Results reproduced by [@br0mabs](https://github.com/br0mabs) on 2025-07-19 (commit [`b3ab936`](https://github.com/castorini/anserini/commit/b3ab936b03e8af2e80be7bde861945c1920553f3))
-+ Results reproduced by [@CereNova](https://github.com/CereNova) on 2025-08-22 (commit [`786504a`](https://github.com/castorini/anserini/commit/786504afbcf02abc31754058fb5aa62ebfac8521))
++ Results reproduced by [@CereNova](https://github.com/CereNova) on 2025-08-24 (commit [`5d40c8a`](https://github.com/castorini/anserini/commit/5d40c8aa29e546aa46e0564fc69ea443df1e1a61))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -495,3 +495,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@mindlesstruffle](https://github.com/mindlesstruffle) on 2025-07-08 (commit [`b3ab936`](https://github.com/castorini/anserini/commit/b3ab936b03e8af2e80be7bde861945c1920553f3))
 + Results reproduced by [@niruhan](https://github.com/niruhan) on 2025-07-16 (commit [`d6a8b36`](https://github.com/niruhan/anserini/commit/d6a8b36a6bc9a62b70d44412f6ebb2ca0bc709cd))
 + Results reproduced by [@br0mabs](https://github.com/br0mabs) on 2025-07-19 (commit [`b3ab936`](https://github.com/castorini/anserini/commit/b3ab936b03e8af2e80be7bde861945c1920553f3))
++ Results reproduced by [@CereNova](https://github.com/CereNova) on 2025-08-22 (commit [`c6ea078`](https://github.com/castorini/anserini/commit/c6ea078417e318e19fc868a5a911849067f80e10))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -495,4 +495,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@mindlesstruffle](https://github.com/mindlesstruffle) on 2025-07-08 (commit [`b3ab936`](https://github.com/castorini/anserini/commit/b3ab936b03e8af2e80be7bde861945c1920553f3))
 + Results reproduced by [@niruhan](https://github.com/niruhan) on 2025-07-16 (commit [`d6a8b36`](https://github.com/niruhan/anserini/commit/d6a8b36a6bc9a62b70d44412f6ebb2ca0bc709cd))
 + Results reproduced by [@br0mabs](https://github.com/br0mabs) on 2025-07-19 (commit [`b3ab936`](https://github.com/castorini/anserini/commit/b3ab936b03e8af2e80be7bde861945c1920553f3))
-+ Results reproduced by [@CereNova](https://github.com/CereNova) on 2025-08-22 (commit [`c6ea078`](https://github.com/castorini/anserini/commit/c6ea078417e318e19fc868a5a911849067f80e10))
++ Results reproduced by [@CereNova](https://github.com/CereNova) on 2025-08-22 (commit [`786504a`](https://github.com/castorini/anserini/commit/786504afbcf02abc31754058fb5aa62ebfac8521))

--- a/scripts/evaluation_bm25_full.py
+++ b/scripts/evaluation_bm25_full.py
@@ -1,0 +1,66 @@
+# evaluation_bm25_full.py
+# Compute MRR@10, MAP, and Recall@1000 for BM25 on all dev queries
+
+import os
+
+# --- 0. Define file paths relative to the project root ---
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+qrels_file = os.path.join(ROOT_DIR, "collections", "msmarco-passage", "qrels.dev.small.tsv")
+run_file = os.path.join(ROOT_DIR, "runs", "run.msmarco-passage.dev.bm25.tsv")
+
+# --- 1. Load qrels ---
+qrels = {}
+with open(qrels_file, encoding="utf-8") as f:
+    for line in f:
+        qid, _, docid, rel = line.strip().split()
+        rel = int(rel)
+        if rel > 0:
+            qrels.setdefault(qid, set()).add(docid)
+
+# --- 2. Load BM25 run output ---
+runs = {}
+with open(run_file, encoding="utf-8") as f:
+    for line in f:
+        qid, docid, rank = line.strip().split()
+        rank = int(rank)
+        runs.setdefault(qid, []).append(docid)
+
+# --- 3. Compute MRR@10 ---
+mrr_scores = []
+for qid, rel_docs in qrels.items():
+    rr = 0
+    for i, docid in enumerate(runs.get(qid, [])[:10], 1):
+        if docid in rel_docs:
+            rr = 1.0 / i
+            break
+    mrr_scores.append(rr)
+mrr_10 = sum(mrr_scores) / len(mrr_scores)
+print(f"✅ MRR@10: {mrr_10:.4f}")
+
+# --- 4. Compute MAP and Recall@1000 ---
+map_scores = []
+recall_scores = []
+for qid, rel_docs in qrels.items():
+    retrieved = runs.get(qid, [])[:1000]
+    num_rel = len(rel_docs)
+    num_rel_retrieved = 0
+    ap_sum = 0
+    for i, docid in enumerate(retrieved, 1):
+        if docid in rel_docs:
+            num_rel_retrieved += 1
+            ap_sum += num_rel_retrieved / i
+    if num_rel > 0:
+        map_scores.append(ap_sum / num_rel)
+        recall_scores.append(num_rel_retrieved / num_rel)
+    else:
+        map_scores.append(0)
+        recall_scores.append(0)
+
+map_val = sum(map_scores) / len(map_scores)
+recall_val = sum(recall_scores) / len(recall_scores)
+print(f"✅ MAP: {map_val:.4f}")
+print(f"✅ Recall@1000: {recall_val:.4f}")
+
+# --- 5. Number of queries processed ---
+print(f"Queries evaluated: {len(qrels)}")


### PR DESCRIPTION
This PR adds a new script scripts/evaluation_bm25_full.py to evaluate BM25 retrieval results on the MS MARCO passage dev set.

**Features:**
Computes MRR@10, MAP, and Recall@1000.
Uses paths relative to the project root for better portability.
Can be added directly to the repository without submodule issues.
BM25 is run using anserini-0.24.1-fatjar.jar to match the official Anserini version.

**Usage:**

`python scripts/evaluation_bm25_full.py
`

This script provides a quick and reproducible way to evaluate the BM25 baseline on all dev queries.