### PR TITLE
Fix tarball names and MD5 checksums for MS MARCO v2 {doc, segmented doc}

### DIFF
--- a/src/main/java/io/anserini/index/IndexInfo.java
+++ b/src/main/java/io/anserini/index/IndexInfo.java
@@ -295,13 +295,13 @@ public enum IndexInfo {
 
   MSMARCO_V2_DOC("msmarco-v2-doc",
       "Lucene index of the MS MARCO V2 document corpus.",
-      "lucene-index.msmarco-v2-doc.20220808.4d6d2a.tar.gz",
+      "lucene-inverted.msmarco-v2-doc.20220808.4d6d2a.tar.gz",
       "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/lucene-inverted.msmarco-v2-doc.20220808.4d6d2a.README.md",
       "MS MARCO V2 Doc",
       "BM25",
       new String[] {
           "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene/lucene-inverted.msmarco-v2-doc.20220808.4d6d2a.tar.gz" },
-      "0599bd6ed5ee28390b279eb398ef0267",
+      "11017a76d2927294977c360a174ba1be",
       IndexType.SPARSE_INVERTED,
       null,
       null,
@@ -323,13 +323,13 @@ public enum IndexInfo {
 
   MSMARCO_V2_DOC_SEGMENTED("msmarco-v2-doc-segmented",
       "Lucene index of the MS MARCO V2 segmented document corpus.",
-      "lucene-index.msmarco-v2-doc-segmented.20220808.4d6d2a.tar.gz",
+      "lucene-inverted.msmarco-v2-doc-segmented.20220808.4d6d2a.tar.gz",
       "https://github.com/castorini/pyserini/blob/master/pyserini/resources/index-metadata/lucene-inverted.msmarco-v2-doc-segmented.20220808.4d6d2a.README.md",
       "MS MARCO V2 Segmented Doc",
       "BM25",
       new String[] {
           "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene/lucene-inverted.msmarco-v2-doc-segmented.20220808.4d6d2a.tar.gz" },
-      "8a5f444fa5a63cc5d4ddc3e6dd15faa0",
+      "42a0d23366e3dbdfecba1df2eb163ab2",
       IndexType.SPARSE_INVERTED,
       null,
       null,


### PR DESCRIPTION
Hi @lilyjge - I found a mismatch vs. Pyserini: https://github.com/castorini/pyserini/blob/master/pyserini/prebuilt_index_info.py

This PR aligns the file names and MD5 checksums.

```
    # MS MARCO V2 document corpus, three indexes with different amounts of information (and sizes).
    "msmarco-v2-doc": {
        "description": "Lucene index of the MS MARCO V2 document corpus.",
        "filename": "lucene-inverted.msmarco-v2-doc.20220808.4d6d2a.tar.gz",
        "readme": "lucene-inverted.msmarco-v2-doc.20220808.4d6d2a.README.md",
        "urls": [
            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene/lucene-inverted.msmarco-v2-doc.20220808.4d6d2a.tar.gz",
        ],
        "md5": "11017a76d2927294977c360a174ba1be",
        "size compressed (bytes)": 63431305265,
        "total_terms": 14165667143,
        "documents": 11959635,
        "unique_terms": 44860768,
        "downloaded": False
    },

    # MS MARCO V2 segmented document corpus, three indexes with different amounts of information (and sizes).
    "msmarco-v2-doc-segmented": {
        "description": "Lucene index of the MS MARCO V2 segmented document corpus.",
        "filename": "lucene-inverted.msmarco-v2-doc-segmented.20220808.4d6d2a.tar.gz",
        "readme": "lucene-inverted.msmarco-v2-doc-segmented.20220808.4d6d2a.README.md",
        "urls": [
            "https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene/lucene-inverted.msmarco-v2-doc-segmented.20220808.4d6d2a.tar.gz"
        ],
        "md5": "42a0d23366e3dbdfecba1df2eb163ab2",
        "size compressed (bytes)": 109269075564,
        "total_terms": 24780918039,
        "documents": 124131414,
        "unique_terms": 29265408,
        "downloaded": False
    },	
```
