### PR TITLE
Add onboarding reproduction log entries

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -592,3 +592,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@br0mabs](https://github.com/br0mabs) on 2025-07-19 (commit [`b3ab936`](https://github.com/castorini/anserini/commit/b3ab936b03e8af2e80be7bde861945c1920553f3))
 + Results reproduced by [@bikram993298](https://github.com/bikram993298) on 2025-08-19 (commit [`c6ea078`](https://github.com/castorini/anserini/commit/c6ea078417e318e19fc868a5a911849067f80e10))
 + Results reproduced by [@JoshElkind](https://github.com/JoshElkind) on 2025-08-24 (commit [`7c3010f`](https://github.com/castorini/anserini/commit/7c3010fbda4618bea07ea372017e9e1e604f3d8b))
++ Results reproduced by [@Dinesh7K](https://github.com/Dinesh7K) on 2025-09-03(commit [`e7cb101`](https://github.com/castorini/anserini/commit/e7cb101ed451b3595c74c4502632aa708605fb07))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -139,3 +139,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@br0mabs](https://github.com/br0mabs) on 2025-07-19 (commit [`b3ab936`](https://github.com/castorini/anserini/commit/b3ab936b03e8af2e80be7bde861945c1920553f3))
 + Results reproduced by [@bikram993298](https://github.com/bikram993298) on 2025-08-19 (commit [`c6ea078`](https://github.com/castorini/anserini/commit/c6ea078417e318e19fc868a5a911849067f80e10))
 + Results reproduced by [@JoshElkind](https://github.com/JoshElkind) on 2025-08-24 (commit [`7c3010f`](https://github.com/castorini/anserini/commit/7c3010fbda4618bea07ea372017e9e1e604f3d8b))
++ Results reproduced by [@Dinesh7K](https://github.com/Dinesh7K) on 2025-09-03(commit [`e7cb101`](https://github.com/castorini/anserini/commit/e7cb101ed451b3595c74c4502632aa708605fb07))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -497,3 +497,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@br0mabs](https://github.com/br0mabs) on 2025-07-19 (commit [`b3ab936`](https://github.com/castorini/anserini/commit/b3ab936b03e8af2e80be7bde861945c1920553f3))
 + Results reproduced by [@bikram993298](https://github.com/bikram993298) on 2025-08-19 (commit [`c6ea078`](https://github.com/castorini/anserini/commit/c6ea078417e318e19fc868a5a911849067f80e10))
 + Results reproduced by [@JoshElkind](https://github.com/JoshElkind) on 2025-08-24 (commit [`7c3010f`](https://github.com/castorini/anserini/commit/7c3010fbda4618bea07ea372017e9e1e604f3d8b))
++ Results reproduced by [@Dinesh7K](https://github.com/Dinesh7K) on 2025-09-02(commit [`e7cb101`](https://github.com/castorini/anserini/commit/e7cb101ed451b3595c74c4502632aa708605fb07))


### PR DESCRIPTION
## Setup Details

- **OS**: macOS 15.5 (Apple Silicon M2)
- **Hardware**: MacBook Pro, 16GB RAM
- **Java**: 21.0.1
- **Python**: 3.11.9
- **Environment**: Standard terminal(zsh)

## Results

**Successfully reproduced BM25 baseline:**
- MRR@10: 0.1875
- MAP: 0.1957
- Recall@1000: 0.8573

**Successfully reproduced dense retrieval with BGE-base-en-v1.5.hnsw:**
- MRR@10: 0.3521

 **Confirmed dense retrieval outperforms BM25** 
  (0.3521 vs 0.1875 MRR@10, ~87% improvement)

