### PR TITLE
Add reproduction log entry for MS MARCO (Windows)

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -596,3 +596,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@Dinesh7K](https://github.com/Dinesh7K) on 2025-09-03(commit [`e7cb101`](https://github.com/castorini/anserini/commit/e7cb101ed451b3595c74c4502632aa708605fb07))
 + Results reproduced by [@NathanNCN](https://github.com/NathanNCN) on 2025-09-06(commit [`9e39f94`](https://github.com/castorini/anserini/commit/9e39f9463227b0100e0bbc4552895a394993754f))
 + Results reproduced by [@ShivamSingal](https://github.com/ShivamSingal) on 2025-09-07 (commit [`f59c8ee`](https://github.com/castorini/anserini/commit/f59c8ee05f5b61370874075c970f18c43ca41e37))
++ Results reproduced by [@shreyaadritabanik](https://github.com/shreyaadritabanik) on 2025-09-10 (commit [`676af03`](https://github.com/castorini/anserini/commit/676af034e8481d043880d22f8f2390ac56b8736d))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -597,3 +597,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@NathanNCN](https://github.com/NathanNCN) on 2025-09-06(commit [`9e39f94`](https://github.com/castorini/anserini/commit/9e39f9463227b0100e0bbc4552895a394993754f))
 + Results reproduced by [@ShivamSingal](https://github.com/ShivamSingal) on 2025-09-07 (commit [`f59c8ee`](https://github.com/castorini/anserini/commit/f59c8ee05f5b61370874075c970f18c43ca41e37))
 + Results reproduced by [@shreyaadritabanik](https://github.com/shreyaadritabanik) on 2025-09-10 (commit [`676af03`](https://github.com/castorini/anserini/commit/676af034e8481d043880d22f8f2390ac56b8736d))
++ Results reproduced by [@shreyaadritabanik](https://github.com/shreyaadritabanik) on 2025-09-11 (commit [`d777303`](https://github.com/castorini/anserini/commit/d7773031255eeec4cfdbb6e84f414761f0cf7c10))


### PR DESCRIPTION
Environment: Windows 10, Git Bash + Anaconda Python 3.9
Actions: Successfully unpacked MS MARCO, converted TSV to JSONL, filtered queries.
Issues: wget missing, used curl instead. Submodule clone stalled, fixed by manual scripts
Suggestion: Add curl instructions for Windows users in the guide.
