### PR TITLE
Remove fastutil dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,11 +333,6 @@
       <version>1.7.32</version>
     </dependency>
     <dependency>
-      <groupId>it.unimi.dsi</groupId>
-      <artifactId>fastutil</artifactId>
-      <version>8.5.8</version>
-    </dependency>
-    <dependency>
         <groupId>com.carrotsearch</groupId>
         <artifactId>hppc</artifactId>
         <version>0.8.1</version>


### PR DESCRIPTION
Thanks to @JJGreen0 #2939 and @suraj-subrahmanyan #2945 - we've eliminated the fastutil dependency!

Fatjar size drops from 176mb to 155mb, yay!