### PR TITLE
reproduced beir fusion experiments

### DIFF
--- a/docs/experiments-beir-fusion.md
+++ b/docs/experiments-beir-fusion.md
@@ -196,4 +196,8 @@ do
 
     java -cp $ANSERINI_JAR trec_eval -c -m recall.1000 qrels.beir-v1.0.0-${c}.test.txt $OUTPUT_DIR/runs.fuse.norm.beir-v1.0.0-${c}.flat.bm25.bge-base-en-v1.5.bge-flat-onnx.topics.beir-v1.0.0-${c}.test.txt
 done
-```
+```  
+
+## Reproduction Log[*](reproducibility.md)
+
++ Results reproduced by [@FarmersWrap](https://github.com/FarmersWrap) on 2025-10-05 (commit [`10ae206`](https://github.com/castorini/anserini/commit/10ae2062a5d5607657ec6abf842b08e50bf151c4))


### PR DESCRIPTION
Reproduced the the results.  
NDCG@10 Results: All values match.  
Recall@100 Results: robust04:0.4465 vs 0.4474  
Recall@1000 Results: robust04: 0.7219 vs 0.7237  