### PR TITLE
Add repro log 2984

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -602,4 +602,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@mahdi-behnam](https://github.com/mahdi-behnam) on 2025-09-19 (commit [`6799a7d`](https://github.com/castorini/anserini/commit/6799a7d5ebca4c332d38bcafbc3a9a938a38d7e2))
 + Results reproduced by [@rashadjn](https://github.com/rashadjn) on 2025-09-24 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
 + Results reproduced by [@samin-mehdizadeh](https://github.com/samin-mehdizadeh) on 2025-09-27 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
-+ Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-09-27 (commit ['9a6b7c4'](https://github.com/castorini/anserini/commit/9a6b7c4d0e2be61337f9aec07e1fbbdcad5fdcdf))
++ Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-09-27 (commit ['9c370e5'](https://github.com/castorini/anserini/commit/9c370e52bc60bf2c8693c30cff74810bddd68ede))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -602,3 +602,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@mahdi-behnam](https://github.com/mahdi-behnam) on 2025-09-19 (commit [`6799a7d`](https://github.com/castorini/anserini/commit/6799a7d5ebca4c332d38bcafbc3a9a938a38d7e2))
 + Results reproduced by [@rashadjn](https://github.com/rashadjn) on 2025-09-24 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
 + Results reproduced by [@samin-mehdizadeh](https://github.com/samin-mehdizadeh) on 2025-09-27 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
++ Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-09-27 (commit ['9a6b7c4'](https://github.com/castorini/anserini/commit/9a6b7c4d0e2be61337f9aec07e1fbbdcad5fdcdf))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -149,4 +149,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@mahdi-behnam](https://github.com/mahdi-behnam) on 2025-09-19 (commit [`6799a7d`](https://github.com/castorini/anserini/commit/6799a7d5ebca4c332d38bcafbc3a9a938a38d7e2))
 + Results reproduced by [@rashadjn](https://github.com/rashadjn) on 2025-09-19 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
 + Results reproduced by [@samin-mehdizadeh](https://github.com/samin-mehdizadeh) on 2025-09-27 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
-+ Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-09-27 (commit ['9a6b7c4'](https://github.com/castorini/anserini/commit/9a6b7c4d0e2be61337f9aec07e1fbbdcad5fdcdf))
++ Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-09-27 (commit ['9c370e5'](https://github.com/castorini/anserini/commit/9c370e52bc60bf2c8693c30cff74810bddd68ede))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -149,3 +149,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@mahdi-behnam](https://github.com/mahdi-behnam) on 2025-09-19 (commit [`6799a7d`](https://github.com/castorini/anserini/commit/6799a7d5ebca4c332d38bcafbc3a9a938a38d7e2))
 + Results reproduced by [@rashadjn](https://github.com/rashadjn) on 2025-09-19 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
 + Results reproduced by [@samin-mehdizadeh](https://github.com/samin-mehdizadeh) on 2025-09-27 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
++ Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-09-27 (commit ['9a6b7c4'](https://github.com/castorini/anserini/commit/9a6b7c4d0e2be61337f9aec07e1fbbdcad5fdcdf))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -505,3 +505,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@shreyaadritabanik](https://github.com/shreyaadritabanik) on 2025-09-10 (commit [`3112afd`](https://github.com/castorini/anserini/commit/3112afd2eff0997b8fe6a3ad7ead20cd8f81ec09))
 + Results reproduced by [@k464wang](https://github.com/k464wang) on 2025-09-18 (commit [`df3b06c`](https://github.com/castorini/anserini/commit/df3b06c375f42b7ac85ef5d9edb74273428956e0))
 + Results reproduced by [@mahdi-behnam](https://github.com/mahdi-behnam) on 2025-09-19 (commit [`6799a7d`](https://github.com/castorini/anserini/commit/6799a7d5ebca4c332d38bcafbc3a9a938a38d7e2))
++ Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-09-23 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -313,7 +313,7 @@ $ wc collections/msmarco-passage/qrels.dev.small.tsv
 7437   29748  143300 collections/msmarco-passage/qrels.dev.small.tsv
 ```
 
-This means that we have only about one relevance judgments per query.
+This means that we have only about one relevance judgment per query.
 We call these **sparse judgments**, i.e., where we have relatively few relevance judgments per query (here, just about one relevance judgment per query).
 In other cases, where we have many relevance judgments per query (potentially hundreds or even more), we call those **dense judgments**.
 There are important implications when using sparse vs. dense judgments, but that's for another time...
@@ -507,4 +507,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@mahdi-behnam](https://github.com/mahdi-behnam) on 2025-09-19 (commit [`6799a7d`](https://github.com/castorini/anserini/commit/6799a7d5ebca4c332d38bcafbc3a9a938a38d7e2))
 + Results reproduced by [@rashadjn](https://github.com/rashadjn) on 2025-09-24 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
 + Results reproduced by [@samin-mehdizadeh](https://github.com/samin-mehdizadeh) on 2025-09-27 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
-+ Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-09-23 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
++ Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-09-23 (commit [`9c370e5`](https://github.com/castorini/anserini/commit/9c370e52bc60bf2c8693c30cff74810bddd68ede))


### PR DESCRIPTION
Operating System: macOs Sequoia 15.3.1

Working Environment: Visual Studio Code Version: 1.104.0

Successfully reproduced all the results on the Anserini files part of the onboarding process (specifically docs/start-here.md, docs/experiments-msmarco-passage.md, and docs/experiments-msmarco-passage2.md).

Faced and resolved initial installation issues with Anserini (notably mvn clean package).

Updated fork and merged changes to preserve previously added reproduction logs and incorporate the latest commits from the main repository.

Fixed a potential typo on the page docs/start-here.md, changed the line

"This means that we have only about one relevance judgments per query." to

"This means that we have only about one relevance judgment per query."