### PR TITLE
Add reproduction log entry for MS MARCO Passage (2025-10-15)

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -605,3 +605,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@samin-mehdizadeh](https://github.com/samin-mehdizadeh) on 2025-09-27 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
 + Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-09-27 (commit ['eeb7756'](https://github.com/castorini/anserini/commit/eeb775657e7fd4a6d70ad303b9f45b1b48f48a49))
 + Results reproduced by [@prav0761](https://github.com/prav0761) on 2025-10-13 (commit [`4a2f9a0`](https://github.com/castorini/anserini/commit/4a2f9a0022d50c743b3bb7f983c9c605d77fcb29))
++ Results reproduced by [@yazdanzv](https://github.com/yazdanzv) on 2025-10-15 (commit [`d6d8a3e7`](https://github.com/castorini/anserini/commit/d6d8a3e751993558f6a63b8cedcd1f339e1693ee))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -152,3 +152,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@samin-mehdizadeh](https://github.com/samin-mehdizadeh) on 2025-09-27 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
 + Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-09-27 (commit ['eeb7756'](https://github.com/castorini/anserini/commit/eeb775657e7fd4a6d70ad303b9f45b1b48f48a49))
 + Results reproduced by [@prav0761](https://github.com/prav0761) on 2025-10-13 (commit [`4a2f9a0`](https://github.com/castorini/anserini/commit/4a2f9a0022d50c743b3bb7f983c9c605d77fcb29))
++ Results reproduced by [@yazdanzv](https://github.com/yazdanzv) on 2025-10-15 (commit [`d6d8a3e7`](https://github.com/castorini/anserini/commit/d6d8a3e751993558f6a63b8cedcd1f339e1693ee))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -510,4 +510,5 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@samin-mehdizadeh](https://github.com/samin-mehdizadeh) on 2025-09-27 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
 + Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-09-23 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
 + Results reproduced by [@prav0761](https://github.com/prav0761) on 2025-10-13 (commit [`4a2f9a0`](https://github.com/castorini/anserini/commit/4a2f9a0022d50c743b3bb7f983c9c605d77fcb29))
++ Results reproduced by [@yazdanzv](https://github.com/yazdanzv) on 2025-10-15 (commit [`d6d8a3e7`](https://github.com/castorini/anserini/commit/d6d8a3e751993558f6a63b8cedcd1f339e1693ee))
 


### PR DESCRIPTION
This commit adds a new entry to the reproduction log in `docs/start.md` for the Tour of MS MARCO tutorial. The reproduction was performed on macOS following the official Anserini guide to ensure the baseline setup works as expected.

All steps including data download, JSONL conversion, query filtering, and validation of expected shard counts and qrels were completed successfully. No errors were encountered during the reproduction process.

Summary of reproduction details:

| Item                               | Details                                                                               
|-----------------------|-------------------------------------------------------------|
| Dataset                         | MS MARCO Passage (V1)                                       
| Commit hash                | `d6d8a3e7` (upstream master)                                 
| Date                               | 2025-10-15                                                  
| OS                                  | macOS 15.1.1                                                
| Python                           | 3.9.7                                                     
| Java                               | 21.0.1                                                    
| Maven                            | 3.9.9                                                       
| Steps verified                | Download, unpack, convert, filter queries, verify counts    
| Qrels dev small              | 6980 queries (as expected)                                  
| Indexing result               | 9 shards JSONL, matches expected line counts                
| Outcome                        | ✅ All steps completed successfully                         

This aligns with the contribution guidelines for logging successful reproductions and helps ensure reproducibility of MS MARCO baselines.