### PR TITLE
Added Anserini logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -605,3 +605,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@samin-mehdizadeh](https://github.com/samin-mehdizadeh) on 2025-09-27 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
 + Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-09-27 (commit ['eeb7756'](https://github.com/castorini/anserini/commit/eeb775657e7fd4a6d70ad303b9f45b1b48f48a49))
 + Results reproduced by [@prav0761](https://github.com/prav0761) on 2025-10-13 (commit [`4a2f9a0`](https://github.com/castorini/anserini/commit/4a2f9a0022d50c743b3bb7f983c9c605d77fcb29))
++ Results reproduced by [@henry4516](https://github.com/henry4516) on 2025-10-14 (commit [`338ac0e`] (https://github.com/castorini/anserini/commit/338ac0e333204a7cb2bb625be11ce6846ff8f170))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -152,3 +152,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@samin-mehdizadeh](https://github.com/samin-mehdizadeh) on 2025-09-27 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
 + Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-09-27 (commit ['eeb7756'](https://github.com/castorini/anserini/commit/eeb775657e7fd4a6d70ad303b9f45b1b48f48a49))
 + Results reproduced by [@prav0761](https://github.com/prav0761) on 2025-10-13 (commit [`4a2f9a0`](https://github.com/castorini/anserini/commit/4a2f9a0022d50c743b3bb7f983c9c605d77fcb29))
++ Results reproduced by [@henry4516](https://github.com/henry4516) on 2025-10-14 (commit [`338ac0e`] (https://github.com/castorini/anserini/commit/338ac0e333204a7cb2bb625be11ce6846ff8f170))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -510,4 +510,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@samin-mehdizadeh](https://github.com/samin-mehdizadeh) on 2025-09-27 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
 + Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-09-23 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
 + Results reproduced by [@prav0761](https://github.com/prav0761) on 2025-10-13 (commit [`4a2f9a0`](https://github.com/castorini/anserini/commit/4a2f9a0022d50c743b3bb7f983c9c605d77fcb29))
-
++ Results reproduced by [@henry4516](https://github.com/henry4516) on 2025-10-14 (commit [`338ac0e`] (https://github.com/castorini/anserini/commit/338ac0e333204a7cb2bb625be11ce6846ff8f170))


### PR DESCRIPTION
Machine:
Was: MacOS Sequoia 15.6.1
Now: UWaterloo student linux server
openjdk 21
Python 3.13.2

The data preparation process worked well, however, in the instructions that compile anserini, when running MS MARCO en v1.5, the downloading process was interrupted by accident (on my fault, since I didn't expect it to be long and didn't apply the caffeinate command). That said, the index file exists, but is incomplete. When I tried to run it again, it says the index file exists, skipping the download, and then starts to decompress the file, leading to errors. I was trying to find out which file it is, delete it and then re-download it, but I couldn't find the specific file. I might not understand it correctly, but I would suggest adding a detection section to check the integrity of the downloaded files instead of directly using them.
When running maven, the progress seemed ok but the compiled anserini didn't give the desired result. For instance, in the indexing section, it gave only 1G index data instead of the expected 4.3G. I "git back" to previous versions, but still not working even when I re-performed everything, including the data. I thought it was due to the OS, so I switched to linux from MacOS. To be consistent with the program version, I also re-downloaded java jdk 21 and configured the setups, which took some time.

The programs ran well after switching to the Linux server, except for the CPU runtime limits, especially for indexing and retrieval. I remembered that for retrieval, I changed the threads in order to pass the time requirements and found out 4 is too much, 1 is too slow, and 2 is good enough.

