### PR TITLE
BM25 Tuning (Second Step) PR

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-java -cp `ls target/*-fatjar.jar` -Xms512M -Xmx192G --add-modules jdk.incubator.vector $@
+java -cp `ls target/*-fatjar.jar` -Xms512M -Xmx16G --add-modules jdk.incubator.vector $@

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -605,3 +605,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@samin-mehdizadeh](https://github.com/samin-mehdizadeh) on 2025-09-27 (commit [`a92e25c`](https://github.com/castorini/anserini/commit/a92e25c0775cec601776f15154f85d69dac62108))
 + Results reproduced by [@AniruddhThakur](https://github.com/AniruddhThakur) on 2025-09-27 (commit ['eeb7756'](https://github.com/castorini/anserini/commit/eeb775657e7fd4a6d70ad303b9f45b1b48f48a49))
 + Results reproduced by [@prav0761](https://github.com/prav0761) on 2025-10-13 (commit [`4a2f9a0`](https://github.com/castorini/anserini/commit/4a2f9a0022d50c743b3bb7f983c9c605d77fcb29))
++ Results reproduced by [@yazdanzv](https://github.com/yazdanzv) on 2025-10-16 (commit [`d6d8a3e7`](https://github.com/castorini/anserini/commit/d6d8a3e751993558f6a63b8cedcd1f339e1693ee))


### PR DESCRIPTION
This commit adds a new entry to the reproduction log in `docs/experiments-msmarco-passage.md` for the Tour of MS MARCO tutorial, documenting the Anserini building, indexing, retrieval, and evaluation steps performed using Anserini on macOS.

The goal of this reproduction was to verify the end-to-end indexing and retrieval pipeline after data preparation. The process included building the inverted index, running retrieval using BM25, and validating output statistics and evaluation metrics against expected baselines.

During the indexing step, the process initially failed due to excessive memory allocation (`-Xmx192G`) in `bin/run.sh`. This was resolved by lowering the memory settings to `-Xmx16G` and reducing the number of indexing threads from 9 to 3. After this adjustment, indexing completed successfully without out-of-memory issues.

All retrieval and evaluation steps were executed using the official MS MARCO queries and qrels. Results matched expected counts and metrics, confirming a successful reproduction.

Summary of reproduction details:

| Item                        | Details                                                                                       |
|-----------------------------|------------------------------------------------------------------------------------------------|
| Dataset                     | MS MARCO Passage (V1)                                                                         |
| Commit hash                 | `d6d8a3e7 ` (upstream master)                                                        |
| Date                        | 2025-10-16                                                                                    |
| OS                          | macOS 15.1.1                                                                                  |
| Python                      | 3.9.7                                                                                        |
| Java                        | 21.0.1                                                                                       |
| Maven                       | 3.9.9                                                                                        |
| Indexing threads            | 3                                                                                            |
| JVM memory                  | `-Xmx16G`                                                                                    |
| Steps verified              | Anserini building, Indexing, retrieval, evaluation                                                               |
| Docs indexed                | 8,841,823                                                                                    |
| Qrels dev small             | 6980 queries                                                                                |
| Run file                    | `runs/run.msmarco-passage.dev.bm25.tsv`                                                      |
| Evaluation metric           | MRR@10                                                                                       |
| MRR@10                      | 0.1874                                                                                       |
| Outcome                     | ✅ Successful Anserini building, indexing and retrieval, metrics matched expected values                          |

This aligns with the contribution guidelines for logging successful reproductions and helps ensure reproducibility of MS MARCO baselines. In addition, the note about memory tuning during indexing should help future contributors avoid the same out-of-memory issue on similar hardware.