### PR TITLE
Results reproduced by @RudraMantri123 

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -620,3 +620,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@xincanfeng](https://github.com/xincanfeng) on 2025-11-18 (commit [`9406dd8`](https://github.com/castorini/anserini/commit/9406dd893e02922cf2b690a8fabf181a14d36bf4))
 + Results reproduced by [@Blank9999](https://github.com/Blank9999) on 2025-11-18 (commit [`9406dd8`](https://github.com/castorini/anserini/commit/9406dd893e02922cf2b690a8fabf181a14d36bf4))
 + Results reproduced by [@ball2004244](https://github.com/ball2004244) on 2025-11-23 (commit [`9aea5f3`](https://github.com/castorini/anserini/commit/9aea5f357c4d1ff50bd8cdf4594c035631ca73a5))
++ Results reproduced by [@RudraMantri123](https://github.com/RudraMantri123) on 2025-11-28 (commit [`9aea5f3`](https://github.com/castorini/anserini/commit/9aea5f357c4d1ff50bd8cdf4594c035631ca73a5))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -168,3 +168,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@xincanfeng](https://github.com/xincanfeng) on 2025-11-18 (commit [`9406dd8`](https://github.com/castorini/anserini/commit/9406dd893e02922cf2b690a8fabf181a14d36bf4))
 + Results reproduced by [@Blank9999](https://github.com/Blank9999) on 2025-11-18 (commit [`9406dd8`](https://github.com/castorini/anserini/commit/9406dd893e02922cf2b690a8fabf181a14d36bf4))
 + Results reproduced by [@ball2004244](https://github.com/ball2004244) on 2025-11-23 (commit [`9aea5f3`](https://github.com/castorini/anserini/commit/9aea5f357c4d1ff50bd8cdf4594c035631ca73a5))
++ Results reproduced by [@RudraMantri123](https://github.com/RudraMantri123) on 2025-11-28 (commit [`9aea5f3`](https://github.com/castorini/anserini/commit/9aea5f357c4d1ff50bd8cdf4594c035631ca73a5))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -527,3 +527,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@xincanfeng](https://github.com/xincanfeng) on 2025-11-17 (commit [`9406dd8`](https://github.com/castorini/anserini/commit/9406dd893e02922cf2b690a8fabf181a14d36bf4))
 + Results reproduced by [@Blank9999](https://github.com/Blank9999) on 2025-11-18 (commit [`9406dd8`](https://github.com/castorini/anserini/commit/9406dd893e02922cf2b690a8fabf181a14d36bf4))
 + Results reproduced by [@ball2004244](https://github.com/ball2004244) on 2025-11-23 (commit [`9aea5f3`](https://github.com/castorini/anserini/commit/9aea5f357c4d1ff50bd8cdf4594c035631ca73a5))
++ Results reproduced by [@RudraMantri123](https://github.com/RudraMantri123) on 2025-11-28 (commit [`9aea5f3`](https://github.com/castorini/anserini/commit/9aea5f357c4d1ff50bd8cdf4594c035631ca73a5))


### PR DESCRIPTION
   ## Summary
- Reproduced the MS MARCO passage BM25 baseline using Anserini’s prebuilt `msmarco-v1-passage` index (JDK 21 on macOS).
- Evaluated the run with `trec_eval` and confirmed the documented MRR@10 of **0.1875**.
- Downloaded the 26 GB `msmarco-v1-passage.bge-base-en-v1.5.hnsw` index and ran `SearchHnswDenseVectors`, producing `run.msmarco-passage.dev.bge.txt`.
- Verified the dense run with `trec_eval` (MRR@10 **0.3521**).
- Added the 2025-11-19 reproduction log entry to both `docs/experiments-msmarco-passage.md` and `docs/start-here.md`.

## Setup
- macOS (Apple Silicon)
- Homebrew OpenJDK 21 (`/opt/homebrew/opt/openjdk@21`)
- Anserini 1.3.0 fatjar (prebuilt)
- Prebuilt indexes cached under `~/.cache/pyserini/indexes`

## Notes
- Dense-index download (26 GB) succeeded after running via `bin/run.sh` with the prebuilt fatjar path fix.
- No code changes beyond the run script adjustment and documentation update were needed.