### PR TITLE
Skip tests on x86_64 on Mac because native libs are no longer provided

### DIFF
--- a/src/test/java/io/anserini/analysis/AutoCompositeAnalyzerTest.java
+++ b/src/test/java/io/anserini/analysis/AutoCompositeAnalyzerTest.java
@@ -23,6 +23,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -87,6 +88,11 @@ public class AutoCompositeAnalyzerTest extends StdOutStdErrRedirectableLuceneTes
   
   @Test
   public void case1() throws Exception {
+    // Not available on x86_64 on Mac, so skip tests
+    // ai.djl.engine.EngineException: Failed to load Huggingface native library.
+    Assume.assumeFalse(System.getProperty("os.arch").equalsIgnoreCase("x86_64")
+        && System.getProperty("os.name").toLowerCase().contains("mac"));
+
     String language = "fi";
     Object[][] example = examples.get(language);
     Analyzer analyzer = AutoCompositeAnalyzer.getAnalyzer(language);
@@ -99,6 +105,11 @@ public class AutoCompositeAnalyzerTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void case2() throws Exception {
+    // Not available on x86_64 on Mac, so skip tests
+    // ai.djl.engine.EngineException: Failed to load Huggingface native library.
+    Assume.assumeFalse(System.getProperty("os.arch").equalsIgnoreCase("x86_64")
+        && System.getProperty("os.name").toLowerCase().contains("mac"));
+
     String language = "yo";
     Object[][] example = examples.get(language);
     Analyzer analyzer = AutoCompositeAnalyzer.getAnalyzer(language);
@@ -110,6 +121,11 @@ public class AutoCompositeAnalyzerTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void case3() throws Exception {
+    // Not available on x86_64 on Mac, so skip tests
+    // ai.djl.engine.EngineException: Failed to load Huggingface native library.
+    Assume.assumeFalse(System.getProperty("os.arch").equalsIgnoreCase("x86_64")
+        && System.getProperty("os.name").toLowerCase().contains("mac"));
+
     String language = "ha";
     Object[][] example = examples.get(language);
     Analyzer analyzer = AutoCompositeAnalyzer.getAnalyzer(language);
@@ -121,6 +137,11 @@ public class AutoCompositeAnalyzerTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void case4() throws Exception {
+    // Not available on x86_64 on Mac, so skip tests
+    // ai.djl.engine.EngineException: Failed to load Huggingface native library.
+    Assume.assumeFalse(System.getProperty("os.arch").equalsIgnoreCase("x86_64")
+        && System.getProperty("os.name").toLowerCase().contains("mac"));
+
     String language = "es";
     Analyzer analyzer = AutoCompositeAnalyzer.getAnalyzer(language);
     Object[][] example = examples.get(language);

--- a/src/test/java/io/anserini/analysis/CompositeAnalyzerTest.java
+++ b/src/test/java/io/anserini/analysis/CompositeAnalyzerTest.java
@@ -27,6 +27,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -57,6 +58,11 @@ public class CompositeAnalyzerTest extends SuppresedLoggingLuceneTestCase {
 
   @Test
   public void basic() throws Exception {
+    // Not available on x86_64 on Mac, so skip tests
+    // ai.djl.engine.EngineException: Failed to load Huggingface native library.
+    Assume.assumeFalse(System.getProperty("os.arch").equalsIgnoreCase("x86_64")
+        && System.getProperty("os.name").toLowerCase().contains("mac"));
+
     Analyzer analyzer = new CompositeAnalyzer(huggingFaceModelId, new WhitespaceAnalyzer());
 
     for (int i = 0; i < examples.length; i++) {

--- a/src/test/java/io/anserini/analysis/HuggingFaceTokenizerAnalyzerTest.java
+++ b/src/test/java/io/anserini/analysis/HuggingFaceTokenizerAnalyzerTest.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -49,6 +50,11 @@ public class HuggingFaceTokenizerAnalyzerTest extends SuppresedLoggingLuceneTest
   
   @Test
   public void basic() throws Exception {
+    // Not available on x86_64 on Mac, so skip tests
+    // ai.djl.engine.EngineException: Failed to load Huggingface native library.
+    Assume.assumeFalse(System.getProperty("os.arch").equalsIgnoreCase("x86_64")
+        && System.getProperty("os.name").toLowerCase().contains("mac"));
+
     Analyzer analyzer = new HuggingFaceTokenizerAnalyzer(huggingFaceModelId);
     
     for (int i = 0; i < examples.length; i++) {

--- a/src/test/java/io/anserini/integration/HuggingFaceTokenizerEndToEndTest.java
+++ b/src/test/java/io/anserini/integration/HuggingFaceTokenizerEndToEndTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
@@ -53,6 +54,11 @@ public class HuggingFaceTokenizerEndToEndTest extends EndToEndTest {
   
   @Override
   protected void setCheckIndexGroundTruth() {
+    // Not available on x86_64 on Mac, so skip tests
+    // ai.djl.engine.EngineException: Failed to load Huggingface native library.
+    Assume.assumeFalse(System.getProperty("os.arch").equalsIgnoreCase("x86_64")
+        && System.getProperty("os.name").toLowerCase().contains("mac"));
+
     docCount = 2;
     docFieldCount = 3; // id, raw, contents
     
@@ -80,6 +86,11 @@ public class HuggingFaceTokenizerEndToEndTest extends EndToEndTest {
   
   @Override
   protected void setSearchGroundTruth() {
+    // Not available on x86_64 on Mac, so skip tests
+    // ai.djl.engine.EngineException: Failed to load Huggingface native library.
+    Assume.assumeFalse(System.getProperty("os.arch").equalsIgnoreCase("x86_64")
+        && System.getProperty("os.name").toLowerCase().contains("mac"));
+
     topicReader = "TsvInt";
     topicFile = "src/test/resources/sample_topics/json_topics5.tsv";
     SearchCollection.Args searchArg = createDefaultSearchArgs().bm25();
@@ -91,5 +102,4 @@ public class HuggingFaceTokenizerEndToEndTest extends EndToEndTest {
         "1048585 Q0 7187163 2 0.456700 Anserini"
     });
   }
-  
 }


### PR DESCRIPTION
See: https://github.com/langchain4j/langchain4j/issues/2144#issuecomment-2489656466

> macos intel is no longer supported from djl version 0.29.0
