### PR TITLE
Add to reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -618,3 +618,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@AdrianGri](https://github.com/adriangri) on 2025-11-12 (commit [`c19077b`](https://github.com/castorini/anserini/commit/c19077b36a471263742cf63ac4d9b9ce57b7118d))
 + Results reproduced by [@xincanfeng](https://github.com/xincanfeng) on 2025-11-18 (commit [`9406dd8`](https://github.com/castorini/anserini/commit/9406dd893e02922cf2b690a8fabf181a14d36bf4))
 + Results reproduced by [@Blank9999](https://github.com/Blank9999) on 2025-11-18 (commit [`9406dd8`](https://github.com/castorini/anserini/commit/9406dd893e02922cf2b690a8fabf181a14d36bf4))
++ Results reproduced by [@ball2004244](https://github.com/ball2004244) on 2025-11-23 (commit [`9aea5f3`](https://github.com/castorini/anserini/commit/9aea5f357c4d1ff50bd8cdf4594c035631ca73a5))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -166,3 +166,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@AdrianGri](https://github.com/adriangri) on 2025-11-12 (commit [`c19077b`](https://github.com/castorini/anserini/commit/c19077b36a471263742cf63ac4d9b9ce57b7118d))
 + Results reproduced by [@xincanfeng](https://github.com/xincanfeng) on 2025-11-18 (commit [`9406dd8`](https://github.com/castorini/anserini/commit/9406dd893e02922cf2b690a8fabf181a14d36bf4))
 + Results reproduced by [@Blank9999](https://github.com/Blank9999) on 2025-11-18 (commit [`9406dd8`](https://github.com/castorini/anserini/commit/9406dd893e02922cf2b690a8fabf181a14d36bf4))
++ Results reproduced by [@ball2004244](https://github.com/ball2004244) on 2025-11-23 (commit [`9aea5f3`](https://github.com/castorini/anserini/commit/9aea5f357c4d1ff50bd8cdf4594c035631ca73a5))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -525,3 +525,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@AdrianGri](https://github.com/adriangri) on 2025-11-12 (commit [`c19077b`](https://github.com/castorini/anserini/commit/c19077b36a471263742cf63ac4d9b9ce57b7118d))
 + Results reproduced by [@xincanfeng](https://github.com/xincanfeng) on 2025-11-17 (commit [`9406dd8`](https://github.com/castorini/anserini/commit/9406dd893e02922cf2b690a8fabf181a14d36bf4))
 + Results reproduced by [@Blank9999](https://github.com/Blank9999) on 2025-11-18 (commit [`9406dd8`](https://github.com/castorini/anserini/commit/9406dd893e02922cf2b690a8fabf181a14d36bf4))
++ Results reproduced by [@ball2004244](https://github.com/ball2004244) on 2025-11-23 (commit [`9aea5f3`](https://github.com/castorini/anserini/commit/9aea5f357c4d1ff50bd8cdf4594c035631ca73a5))


### PR DESCRIPTION
Add to Anserini Reproduction Log

## Reproduction Details

Username: [@ball2004244](https://github.com/ball2004244)
Date: 2025-11-23
Commit: [`9aea5f3`](https://github.com/castorini/anserini/commit/9aea5f357c4d1ff50bd8cdf4594c035631ca73a5)

## System Environment

Operating System: Ubuntu 22.04.5 LTS (x86_64)
Java Version: openjdk 21.0.9 (conda)
Maven Version: 3.9.11 (conda)
Python Version: 3.11.14 (conda)

## Hardware Specifications

CPU: Intel(R) Xeon(R) Platinum 8160 CPU @ 2.10GHz (96 threads)
RAM: 1.5 TB

## Reproduction Status

The reproduction was successful.

However, I encountered minor issues when compiling Anserini and running the `trec_eval` binary. This happened due to the `noexec` properties of the default `/tmp` directory, which is a safety mechanism for network restricted environments.

To solve these issues, I change the `TMPDIR` environment variables. Here are the commands I used prior to the build:

```bash
export TMPDIR=$HOME/tmp
export MAVEN_OPTS="-Djansi.tmpdir=$HOME/tmp -Djava.io.tmpdir=$HOME/tmp"
export _JAVA_OPTIONS="-Djava.io.tmpdir=$HOME/tmp"
```
