### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -623,5 +623,5 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@Hasebul21](https://github.com/Hasebul21) on 2025-11-24 (commit [`9aea5f3`](https://github.com/castorini/anserini/commit/9aea5f357c4d1ff50bd8cdf4594c035631ca73a5))
 + Results reproduced by [@RudraMantri123](https://github.com/RudraMantri123) on 2025-11-28 (commit [`9aea5f3`](https://github.com/castorini/anserini/commit/9aea5f357c4d1ff50bd8cdf4594c035631ca73a5))
 + Results reproduced by [@imishrr](https://www.github.com/imishrr) on 2025-12-01 (commit [`79e7777`](https://www.github.com/castorini/anserini/commit/79e77779dcf02c7e69b6e9869fc3c92005e5f2a4))
++ Results reproduced by [@MehdiJmlkh](https://github.com/MehdiJmlkh) on 2025-12-08 (commit [`259d483`](https://github.com/castorini/anserini/commit/259d483628a7ae97995be05ee23d168b308238b5))
 + Results reproduced by [@Kushion32](https://github.com/Kushion32) on 2025-12-09 (commit [`3e65fbd`](https://github.com/castorini/anserini/commit/3e65fbd9227d32bbb343ec1ff0ccaba43915dd4f))
-+ Results reproduced by [@MehdiJmlkh](https://github.com/MehdiJmlkh) on 2025-12-8 (commit [`259d483`](https://github.com/castorini/anserini/commit/259d483628a7ae97995be05ee23d168b308238b5))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -171,5 +171,5 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@Hasebul21](https://github.com/Hasebul21) on 2025-11-27 (commit [`9aea5f3`](https://github.com/castorini/anserini/commit/9aea5f357c4d1ff50bd8cdf4594c035631ca73a5))
 + Results reproduced by [@RudraMantri123](https://github.com/RudraMantri123) on 2025-11-28 (commit [`9aea5f3`](https://github.com/castorini/anserini/commit/9aea5f357c4d1ff50bd8cdf4594c035631ca73a5))
 + Results reproduced by [@imishrr](https://www.github.com/imishrr) on 2025-12-01 (commit [`79e7777`](https://www.github.com/castorini/anserini/commit/79e77779dcf02c7e69b6e9869fc3c92005e5f2a4))
++ Results reproduced by [@MehdiJmlkh](https://github.com/MehdiJmlkh) on 2025-12-08 (commit [`259d483`](https://github.com/castorini/anserini/commit/259d483628a7ae97995be05ee23d168b308238b5))
 + Results reproduced by [@Kushion32](https://github.com/Kushion32) on 2025-12-09 (commit [`3e65fbd`](https://github.com/castorini/anserini/commit/3e65fbd9227d32bbb343ec1ff0ccaba43915dd4f))
-+ Results reproduced by [@MehdiJmlkh](https://github.com/MehdiJmlkh) on 2025-12-8 (commit [`259d483`](https://github.com/castorini/anserini/commit/259d483628a7ae97995be05ee23d168b308238b5))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -530,5 +530,5 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@Hasebul21](https://github.com/Hasebul21) on 2025-11-23 (commit [`9aea5f3`](https://github.com/castorini/anserini/commit/9aea5f357c4d1ff50bd8cdf4594c035631ca73a5))
 + Results reproduced by [@imishrr](https://www.github.com/imishrr) on 2025-11-24 (commit [`79e7777`](https://www.github.com/castorini/anserini/commit/79e77779dcf02c7e69b6e9869fc3c92005e5f2a4))
 + Results reproduced by [@RudraMantri123](https://github.com/RudraMantri123) on 2025-11-28 (commit [`9aea5f3`](https://github.com/castorini/anserini/commit/9aea5f357c4d1ff50bd8cdf4594c035631ca73a5))
++ Results reproduced by [@MehdiJmlkh](https://github.com/MehdiJmlkh) on 2025-12-05 (commit [`259d483`](https://github.com/castorini/anserini/commit/259d483628a7ae97995be05ee23d168b308238b5))
 + Results reproduced by [@Kushion32](https://github.com/Kushion32) on 2025-12-09 (commit [`3e65fbd`](https://github.com/castorini/anserini/commit/3e65fbd9227d32bbb343ec1ff0ccaba43915dd4f))
-+ Results reproduced by [@MehdiJmlkh](https://github.com/MehdiJmlkh) on 2025-12-5 (commit [`259d483`](https://github.com/castorini/anserini/commit/259d483628a7ae97995be05ee23d168b308238b5))


### PR DESCRIPTION
Environment Details:
OS: Ubuntu 22.04.5 LTS
Machine: ASUS TUF Gaming F15 FX506LU
Processor: Intel Core i7-10870H CPU @ 2.20GHz × 16
RAM: 16GB
Java: 21.0.9
Python: 3.10.12
Maven: 3.9.11

Everything worked fine, with just a few minor issues:

1. In this section: [experiments-msmarco-passage.md#indexing](https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-passage.md#indexing), the memory usage of the inverted index is reported as:

    ```bash
    % du -h indexes
    4.3G	indexes/msmarco-passage/lucene-index-msmarco
    4.3G	indexes/msmarco-passage
    4.3G	indexes
    ```

    However, I got:

    ```bash
    $ du -h indexes
    4.1G	indexes/msmarco-passage/lucene-index-msmarco
    4.1G	indexes/msmarco-passage
    4.1G	indexes
    ```


2. In this section [experiments-msmarco-passage2.md#retrieval-with-dense-indexes](https://github.com/castorini/anserini/blob/master/docs/experiments-msmarco-passage2.md#retrieval-with-dense-indexes), it mentions that the HNSW index is 26 GB, but it's actually 25 GB (more precisely, 24.79 GB). Additionally, due to my limited internet speed, the download took 40 hours and was extremely difficult to complete. Is it possible to split the file into smaller segments?



