### PR TITLE
Add reproduction log entries for mhmmdmostafavi (MS MARCO passage + document)

### DIFF
--- a/docs/experiments-msmarco-doc.md
+++ b/docs/experiments-msmarco-doc.md
@@ -292,3 +292,4 @@ That's it!
 + Results reproduced by [@ErrenYeager](https://github.com/ErrenYeager) on 2023-09-02 (commit [`4ae518b`](https://github.com/castorini/anserini/commit/4ae518bb284ebcba0b273a473bc8774735cb7d19))
 + Results reproduced by [@Minhajul99](https://github.com/Minhajul99) on 2023-12-09 (commit [`f1d6320`](https://github.com/Minhajul99/anserini/commit/f1d6320a0002faeec28f3262cc5bf982c992503b))
 + Results reproduced by [@MariaPonomarenko38](https://github.com/MehrnazSadeghieh) on 2024-07-19 (commit [`1f750c6`](https://github.com/castorini/anserini/commit/1f750c67f42f02820b0a75237579e34a8c676248))
++ Results reproduced by [@mhmmdmostafavi](https://github.com/mhmmdmostafavi) on 2025-12-31 (commit [`943ca3f`](https://github.com/castorini/anserini/commit/943ca3fc0426b56817b12d70d3500eed4c64c64e))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -178,3 +178,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@anjanpa](https://github.com/anjanpa) on 2025-12-17 (commit [`1d062ef`](https://github.com/castorini/anserini/commit/1d062ef7461b0da9dd861b5385aa4bbcf61bb272))
 + Results reproduced by [@nli33](https://github.com/nli33) on 2025-12-22 (commit [`1c5cd32`](https://github.com/castorini/anserini/commit/1c5cd32b48f03f63eb5752834600ad7c17e5fe7d))
 + Results reproduced by [@VarnitOS](https://github.com/VarnitOS) on 2025-12-26 (commit [⁠ 1c5cd32 ⁠](https://github.com/castorini/anserini/commit/1c5cd32b48f03f63eb5752834600ad7c17e5fe7d))
++ Results reproduced by [@mhmmdmostafavi](https://github.com/mhmmdmostafavi) on 2025-12-31 (commit [`943ca3f`](https://github.com/castorini/anserini/commit/943ca3fc0426b56817b12d70d3500eed4c64c64e))


### PR DESCRIPTION
## Setup Details
- **Operating System:** macOS (Apple M4 Pro)
- **Java Version:** 21.0.9
- **Date:** 2025-12-31

## MS MARCO Passage Ranking Results

### BM25 (Sparse Retrieval)
- MAP: 0.1926
- MRR@10: 0.1960

### BGE-base-en-v1.5 (Dense Retrieval)
- MAP: 0.3573
- MRR@10: 0.3633

## MS MARCO Document Ranking Results

### BM25 (Sparse Retrieval)
- MAP: 0.2305
- MRR: 0.2305

### Dense Retrieval
- Note: Prebuilt HNSW index not available for MS MARCO documents

## Status
✅ All available experiments completed successfully
✅ Results match expected baselines
✅ Both sparse and dense retrieval completed for passages
✅ Reproduction log entries added for both passage and document ranking