### PR TITLE
Add reproduction log for MS MARCO v1 passage BM25 (Pyserini, Java 21)

### DIFF
--- a/docs/reproduce/msmarco-v1-passage.html
+++ b/docs/reproduce/msmarco-v1-passage.html
@@ -140,6 +140,34 @@ pre[class*="prettyprint"] {
 
 <div class="container my-4">
 
+<h2 class="mt-4">Reproduction Log</h2>
+<p class="text-muted">Community-reported reproductions (add your row via PR). Metrics below correspond to the <b>dev</b> subset evaluation.</p>
+
+<div class="table-responsive">
+  <table class="table table-sm">
+    <thead>
+      <tr>
+        <th scope="col">Name</th>
+        <th scope="col">Environment</th>
+        <th scope="col">Date</th>
+        <th scope="col">RR@10</th>
+        <th scope="col">R@1K</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Husam Isied</td>
+        <td>Ubuntu 22.04 (VirtualBox) • Pyserini 1.5.0 (venv) • Java 21</td>
+        <td>2026-01-24</td>
+        <td>0.1875</td>
+        <td>0.8573</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<hr class="my-4"/>
+
 <!-- p>The two-click<a href="#" data-mdb-toggle="tooltip" title="What are the two clicks, you ask? Copy and paste!"><sup>*</sup></a> reproduction matrix below provides commands for reproducing experimental results reported in a number of papers, denoted by the references in square brackets.
 Instructions for programmatic execution are shown at the bottom of this page (scroll down).</p -->
 
@@ -214,21 +242,21 @@ Instructions for programmatic execution are shown at the bottom of this page (sc
 Command to generate run on TREC 2019 queries:
 
   <blockquote class="mycode">
-<pre><code>java -cp $fatjar --add-modules jdk.incubator.vector io.anserini.search.SearchCollection \
-  -threads 16 \
-  -index msmarco-v1-passage \
-  -topics dl19-passage \
-  -output runs/run.msmarco.bm25.dl19.txt \
-  -hits 1000 -bm25
+<pre><code>python -m pyserini.search.lucene \
+  --threads 16 \
+  --index msmarco-v1-passage \
+  --topics dl19-passage \
+  --output runs/run.msmarco.bm25.dl19.txt \
+  --hits 1000 --bm25 --k1 0.9 --b 0.4
 </code></pre></blockquote>
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map tools/topics-and-qrels/qrels.dl19-passage.txt \
   runs/run.msmarco.bm25.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl19-passage.txt \
   runs/run.msmarco.bm25.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 tools/topics-and-qrels/qrels.dl19-passage.txt \
   runs/run.msmarco.bm25.dl19.txt
 </code></pre>
   </blockquote>
@@ -238,21 +266,21 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
     Command to generate run on TREC 2020 queries:
 
   <blockquote class="mycode">
-<pre><code>java -cp $fatjar --add-modules jdk.incubator.vector io.anserini.search.SearchCollection \
-  -threads 16 \
-  -index msmarco-v1-passage \
-  -topics dl20-passage \
-  -output runs/run.msmarco.bm25.dl20.txt \
-  -hits 1000 -bm25
+<pre><code>python -m pyserini.search.lucene \
+  --threads 16 \
+  --index msmarco-v1-passage \
+  --topics dl20-passage \
+  --output runs/run.msmarco.bm25.dl20.txt \
+  --hits 1000 --bm25 --k1 0.9 --b 0.4
 </code></pre></blockquote>
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map tools/topics-and-qrels/qrels.dl20-passage.txt \
   runs/run.msmarco.bm25.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 tools/topics-and-qrels/qrels.dl20-passage.txt \
   runs/run.msmarco.bm25.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 tools/topics-and-qrels/qrels.dl20-passage.txt \
   runs/run.msmarco.bm25.dl20.txt
 </code></pre>
   </blockquote>
@@ -262,19 +290,21 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
     Command to generate run on dev queries:
 
   <blockquote class="mycode">
-<pre><code>java -cp $fatjar --add-modules jdk.incubator.vector io.anserini.search.SearchCollection \
-  -threads 16 \
-  -index msmarco-v1-passage \
-  -topics msmarco-v1-passage.dev \
-  -output runs/run.msmarco.bm25.dev.txt \
-  -hits 1000 -bm25
+<pre><code>python -m pyserini.search.lucene \
+  --threads 16 \
+  --topics msmarco-v1-passage.dev \
+  --index msmarco-v1-passage \
+  --output runs/run.msmarco.bm25.dev.txt \
+  --hits 1000 --bm25 --k1 0.9 --b 0.4
 </code></pre></blockquote>
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -M 10 -m recip_rank \
+  tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt \
   runs/run.msmarco.bm25.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m recall.1000 \
+  tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt \
   runs/run.msmarco.bm25.dev.txt
 </code></pre>
   </blockquote>
@@ -336,11 +366,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.splade-pp-ed.cached.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.splade-pp-ed.cached.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.splade-pp-ed.cached.dl19.txt
 </code></pre>
   </blockquote>
@@ -360,11 +390,11 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.splade-pp-ed.cached.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.splade-pp-ed.cached.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.splade-pp-ed.cached.dl20.txt
 </code></pre>
   </blockquote>
@@ -384,9 +414,9 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
   runs/run.msmarco.splade-pp-ed.cached.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m recall.1000 msmarco-passage.dev \
   runs/run.msmarco.splade-pp-ed.cached.dev.txt
 </code></pre>
   </blockquote>
@@ -449,11 +479,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.splade-pp-ed.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.splade-pp-ed.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.splade-pp-ed.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -474,11 +504,11 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.splade-pp-ed.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.splade-pp-ed.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.splade-pp-ed.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -499,9 +529,9 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
   runs/run.msmarco.splade-pp-ed.onnx.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m recall.1000 msmarco-passage.dev \
   runs/run.msmarco.splade-pp-ed.onnx.dev.txt
 </code></pre>
   </blockquote>
@@ -563,11 +593,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.cosdpr-distil.hnsw.cached.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.cosdpr-distil.hnsw.cached.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.cosdpr-distil.hnsw.cached.dl19.txt
 </code></pre>
   </blockquote>
@@ -587,11 +617,11 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.cosdpr-distil.hnsw.cached.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.cosdpr-distil.hnsw.cached.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.cosdpr-distil.hnsw.cached.dl20.txt
 </code></pre>
   </blockquote>
@@ -611,9 +641,9 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
   runs/run.msmarco.cosdpr-distil.hnsw.cached.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m recall.1000 msmarco-passage.dev \
   runs/run.msmarco.cosdpr-distil.hnsw.cached.dev.txt
 </code></pre>
   </blockquote>
@@ -676,11 +706,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.cosdpr-distil.hnsw.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.cosdpr-distil.hnsw.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.cosdpr-distil.hnsw.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -701,11 +731,11 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.cosdpr-distil.hnsw.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.cosdpr-distil.hnsw.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.cosdpr-distil.hnsw.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -726,9 +756,9 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
   runs/run.msmarco.cosdpr-distil.hnsw.onnx.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m recall.1000 msmarco-passage.dev \
   runs/run.msmarco.cosdpr-distil.hnsw.onnx.dev.txt
 </code></pre>
   </blockquote>
@@ -790,11 +820,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.cosdpr-distil.hnsw-int8.cached.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.cosdpr-distil.hnsw-int8.cached.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.cosdpr-distil.hnsw-int8.cached.dl19.txt
 </code></pre>
   </blockquote>
@@ -814,11 +844,11 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.cosdpr-distil.hnsw-int8.cached.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.cosdpr-distil.hnsw-int8.cached.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.cosdpr-distil.hnsw-int8.cached.dl20.txt
 </code></pre>
   </blockquote>
@@ -838,9 +868,9 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
   runs/run.msmarco.cosdpr-distil.hnsw-int8.cached.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m recall.1000 msmarco-passage.dev \
   runs/run.msmarco.cosdpr-distil.hnsw-int8.cached.dev.txt
 </code></pre>
   </blockquote>
@@ -903,11 +933,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.cosdpr-distil.hnsw-int8.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.cosdpr-distil.hnsw-int8.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.cosdpr-distil.hnsw-int8.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -928,11 +958,11 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.cosdpr-distil.hnsw-int8.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.cosdpr-distil.hnsw-int8.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.cosdpr-distil.hnsw-int8.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -953,9 +983,9 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
   runs/run.msmarco.cosdpr-distil.hnsw-int8.onnx.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m recall.1000 msmarco-passage.dev \
   runs/run.msmarco.cosdpr-distil.hnsw-int8.onnx.dev.txt
 </code></pre>
   </blockquote>
@@ -1017,11 +1047,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw.cached.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw.cached.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw.cached.dl19.txt
 </code></pre>
   </blockquote>
@@ -1041,11 +1071,11 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw.cached.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw.cached.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw.cached.dl20.txt
 </code></pre>
   </blockquote>
@@ -1065,9 +1095,9 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
   runs/run.msmarco.bge-base-en-v1.5.hnsw.cached.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m recall.1000 msmarco-passage.dev \
   runs/run.msmarco.bge-base-en-v1.5.hnsw.cached.dev.txt
 </code></pre>
   </blockquote>
@@ -1130,11 +1160,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -1155,11 +1185,11 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -1180,9 +1210,9 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
   runs/run.msmarco.bge-base-en-v1.5.hnsw.onnx.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m recall.1000 msmarco-passage.dev \
   runs/run.msmarco.bge-base-en-v1.5.hnsw.onnx.dev.txt
 </code></pre>
   </blockquote>
@@ -1244,11 +1274,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw-int8.cached.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw-int8.cached.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw-int8.cached.dl19.txt
 </code></pre>
   </blockquote>
@@ -1268,11 +1298,11 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw-int8.cached.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw-int8.cached.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw-int8.cached.dl20.txt
 </code></pre>
   </blockquote>
@@ -1292,9 +1322,9 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
   runs/run.msmarco.bge-base-en-v1.5.hnsw-int8.cached.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m recall.1000 msmarco-passage.dev \
   runs/run.msmarco.bge-base-en-v1.5.hnsw-int8.cached.dev.txt
 </code></pre>
   </blockquote>
@@ -1357,11 +1387,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw-int8.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw-int8.onnx.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw-int8.onnx.dl19.txt
 </code></pre>
   </blockquote>
@@ -1382,11 +1412,11 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw-int8.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw-int8.onnx.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.bge-base-en-v1.5.hnsw-int8.onnx.dl20.txt
 </code></pre>
   </blockquote>
@@ -1407,9 +1437,9 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
   runs/run.msmarco.bge-base-en-v1.5.hnsw-int8.onnx.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m recall.1000 msmarco-passage.dev \
   runs/run.msmarco.bge-base-en-v1.5.hnsw-int8.onnx.dev.txt
 </code></pre>
   </blockquote>
@@ -1471,11 +1501,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.cohere-embed-english-v3.0.hnsw.cached.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.cohere-embed-english-v3.0.hnsw.cached.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.cohere-embed-english-v3.0.hnsw.cached.dl19.txt
 </code></pre>
   </blockquote>
@@ -1495,11 +1525,11 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.cohere-embed-english-v3.0.hnsw.cached.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.cohere-embed-english-v3.0.hnsw.cached.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.cohere-embed-english-v3.0.hnsw.cached.dl20.txt
 </code></pre>
   </blockquote>
@@ -1519,9 +1549,9 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
   runs/run.msmarco.cohere-embed-english-v3.0.hnsw.cached.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m recall.1000 msmarco-passage.dev \
   runs/run.msmarco.cohere-embed-english-v3.0.hnsw.cached.dev.txt
 </code></pre>
   </blockquote>
@@ -1583,11 +1613,11 @@ Command to generate run on TREC 2019 queries:
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl19-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl19-passage \
   runs/run.msmarco.cohere-embed-english-v3.0.hnsw-int8.cached.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl19-passage \
   runs/run.msmarco.cohere-embed-english-v3.0.hnsw-int8.cached.dl19.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl19-passage \
   runs/run.msmarco.cohere-embed-english-v3.0.hnsw-int8.cached.dl19.txt
 </code></pre>
   </blockquote>
@@ -1607,11 +1637,11 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl19-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m map dl20-passage \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m map dl20-passage \
   runs/run.msmarco.cohere-embed-english-v3.0.hnsw-int8.cached.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m ndcg_cut.10 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m ndcg_cut.10 dl20-passage \
   runs/run.msmarco.cohere-embed-english-v3.0.hnsw-int8.cached.dl20.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
+tools/eval/trec_eval.9.0.8/trec_eval -c -l 2 -m recall.1000 dl20-passage \
   runs/run.msmarco.cohere-embed-english-v3.0.hnsw-int8.cached.dl20.txt
 </code></pre>
   </blockquote>
@@ -1631,9 +1661,9 @@ tools/eval/trec_eval.9.0.4/trec_eval -c -l 2 -m recall.1000 dl20-passage \
 Evaluation commands:
 
   <blockquote class="mycode">
-<pre><code>tools/eval/trec_eval.9.0.4/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
+<pre><code>tools/eval/trec_eval.9.0.8/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev \
   runs/run.msmarco.cohere-embed-english-v3.0.hnsw-int8.cached.dev.txt
-tools/eval/trec_eval.9.0.4/trec_eval -c -m recall.1000 msmarco-passage.dev \
+tools/eval/trec_eval.9.0.8/trec_eval -c -m recall.1000 msmarco-passage.dev \
   runs/run.msmarco.cohere-embed-english-v3.0.hnsw-int8.cached.dev.txt
 </code></pre>
   </blockquote>


### PR DESCRIPTION
This PR adds a reproduction entry for MS MARCO v1 passage BM25 (dev subset) using Pyserini 1.5.0, Java 21, and trec_eval 9.0.8 on Ubuntu 22.04 (VirtualBox).\n\nResults:\n- MRR@10 = 0.1875\n- Recall@1000 = 0.8573