### PR TITLE
Add test case for getting index with raw documents from JSON metatdata

### DIFF
--- a/src/main/java/io/anserini/rerank/GenerateRerankerRequests.java
+++ b/src/main/java/io/anserini/rerank/GenerateRerankerRequests.java
@@ -222,8 +222,7 @@ public class GenerateRerankerRequests<K extends Comparable<K>> implements Closea
       PrebuiltInvertedIndex.Entry entry = PrebuiltInvertedIndex.get(index);
       if (entry != null) {
         resolvedIndex = IndexReaderUtils.getIndex(entry.invertedIndex).toString();
-      }
-      else {
+      } else {
         IndexInfo currentIndex = IndexInfo.get(index);
         resolvedIndex = IndexReaderUtils.getIndex(currentIndex.invertedIndex).toString();
       }


### PR DESCRIPTION
After some digging, I found that `GenerateRerankerRequests` uses `IndexInfo` directly to get the metadata field that specifies the inverted index with the raw documents. This means that if we want, #3102 can be **merged without a problem right now** since it does not affect the direct access of `IndexInfo`. 

However, if we want to slightly refactor `GenerateRerankerRequests` to use the pattern introduced in #3102 to  "use new metadata if available, but default to IndexInfo for everything else", then we have a problem since we don't have a field to access the raw inverted index from the JSON metadata entries. This PR is what the slight refactor to `GenerateRerankerRequests` could look like, where it currently errors because I try to access a field on PrebuiltInvertedIndex.Entry that doesn't exist. To test this further, you can use `GenerateRerankerRequestsTest#testPrebuilt`. 

#3104