### PR TITLE
Add new entries to the reproduction logs for the onboarding guide

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -635,5 +635,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@izzat5233](https://github.com/izzat5233) on 2026-01-17 (commit [`5bda670`](https://github.com/castorini/anserini/commit/5bda6701ebe8cc217ffc66a600d3583671fe299d))
 + Results reproduced by [@aaryanshroff](https://github.com/aaryanshroff) on 2026-01-24 (commit [`952ac5e`](https://github.com/castorini/anserini/commit/952ac5e4573486a255778828b8f26fd892cda854))
 + Results reproduced by [@HusamIsied](https://github.com/HusamIsied) on 2026-01-25 (commit [`952ac5e4`](https://github.com/castorini/anserini/commit/952ac5e4573486a255778828b8f26fd892cda854))
-
-
++ Results reproduced by [@maherapp](https://github.com/maherapp) on 2026-02-01 (commit [`f0ecf565`](https://github.com/castorini/anserini/commit/f0ecf5655430b3fdccb802cde31e7f8ef821d0de))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -183,3 +183,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@izzat5233](https://github.com/izzat5233) on 2026-01-17 (commit [`5bda670`](https://github.com/castorini/anserini/commit/5bda6701ebe8cc217ffc66a600d3583671fe299d))
 + Results reproduced by [@HusamIsied](https://github.com/HusamIsied) on 2026-01-25 (commit [`952ac5e4`](https://github.com/castorini/anserini/commit/952ac5e4573486a255778828b8f26fd892cda854))
 + Results reproduced by [@aaryanshroff](https://github.com/aaryanshroff) on 2026-01-26 (commit [`952ac5e`](https://github.com/castorini/anserini/commit/952ac5e4573486a255778828b8f26fd892cda854))
++ Results reproduced by [@maherapp](https://github.com/maherapp) on 2026-02-01 (commit [`f0ecf565`](https://github.com/castorini/anserini/commit/f0ecf5655430b3fdccb802cde31e7f8ef821d0de))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -542,3 +542,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@izzat5233](https://github.com/izzat5233) on 2026-01-17 (commit [`5bda670`](https://github.com/castorini/anserini/commit/5bda6701ebe8cc217ffc66a600d3583671fe299d))
 + Results reproduced by [@aaryanshroff](https://github.com/aaryanshroff) on 2026-01-24 (commit [`952ac5e`](https://github.com/castorini/anserini/commit/952ac5e4573486a255778828b8f26fd892cda854))
 + Results reproduced by [@HusamIsied](https://github.com/HusamIsied) on 2026-01-25 (commit [`952ac5e4`](https://github.com/castorini/anserini/commit/952ac5e4573486a255778828b8f26fd892cda854))
++ Results reproduced by [@maherapp](https://github.com/maherapp) on 2026-02-01 (commit [`f0ecf565`](https://github.com/castorini/anserini/commit/f0ecf5655430b3fdccb802cde31e7f8ef821d0de))


### PR DESCRIPTION
I was able to reproduce the same results for the experiments listed in the onboarding guide on Hetzner's CPX62, a high-end shared-vCPU cloud server with the following core specifications:

- OS Ubuntu 24.04.3 LTS (GNU/Linux 6.8.0-90-generic x86_64)
- 16 vCPUs
- 32 GB RAM
- 640 + 1000 GB NVMe SSD storage

However, I encountered some secondary issues that were not related to the results themselves. I can summarize them as follows:

- When building Anserini, the test `FusionTest.testInvalidRuns` failed because it expected a different error message. This issue appears to be OS-dependent.
- Running the Pyserini unit tests took over six hours to complete, with around fifty tests failing, and consumed more than  500GB of disk space.
- In Pyserini’s detailed installation guide, `faiss-cpu` is listed as an optional dependency, but in practice it was required to complete the experiments.
- Logging in to Hugging Face is only mentioned in the last experiment, although it was already required in earlier experiments to download indexes and run unit tests. In practice, failing to log in sometimes led to 401 Unauthorized errors, which may be related to rate limiting or missing credentials.
- In [experiments-nfcorpus.md](https://github.com/castorini/pyserini/blob/e9b559c32c10893ae61c12a0c1e9ee2b264a2e41/docs/experiments-nfcorpus.md?plain=1#L103) and [conceptual-framework2.md](https://github.com/castorini/pyserini/blob/e9b559c32c10893ae61c12a0c1e9ee2b264a2e41/docs/conceptual-framework2.md?plain=1#L69), the index directory name is misspelled as `faiss.nfcorpus.contriever-msmacro`; it should be `faiss.nfcorpus.contriever-msmarco` for consistency with other files and the underlying model name. The same misspelling appears in [usage-fetch.md](https://github.com/castorini/pyserini/blob/e9b559c32c10893ae61c12a0c1e9ee2b264a2e41/docs/usage-fetch.md?plain=1#L30), [utils.py](https://github.com/castorini/pyserini/blob/e9b559c32c10893ae61c12a0c1e9ee2b264a2e41/integrations/utils.py#L58) and [test_nfcorpus_faiss.py](https://github.com/castorini/pyserini/blob/e9b559c32c10893ae61c12a0c1e9ee2b264a2e41/tests/optional/test_nfcorpus_faiss.py#L41), although correcting it in the last file may break existing tests that rely on the current name.