### PR TITLE
Add MS MARCO BM25 reproduction log entry

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -636,3 +636,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@aaryanshroff](https://github.com/aaryanshroff) on 2026-01-24 (commit [`952ac5e`](https://github.com/castorini/anserini/commit/952ac5e4573486a255778828b8f26fd892cda854))
 + Results reproduced by [@HusamIsied](https://github.com/HusamIsied) on 2026-01-25 (commit [`952ac5e4`](https://github.com/castorini/anserini/commit/952ac5e4573486a255778828b8f26fd892cda854))
 + Results reproduced by [@maherapp](https://github.com/maherapp) on 2026-02-01 (commit [`f0ecf565`](https://github.com/castorini/anserini/commit/f0ecf5655430b3fdccb802cde31e7f8ef821d0de))
++ Results reproduced by [@kwamearhinPORTFL](https://github.com/kwamearhinPORTFL) on 2026-02-17 (commit [`ed1b9e8`](https://github.com/castorini/anserini/commit/ed1b9e8)).


### PR DESCRIPTION
Successfully reproduced the BM25 baseline setup for MS MARCO Passage Ranking.

Environment:
- Windows 11 with WSL2 (Ubuntu 22.04)
- OpenJDK 21.0.10
- Maven installed via apt
- Python 3 used for scripts

All steps executed successfully. Minor issue encountered with `python` alias (resolved by using `python3`).

No other issues observed.
