### PR TITLE
Add reproduction logs for 'Start Here' and 'MS MARCO BM25 baseline'

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -636,3 +636,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@aaryanshroff](https://github.com/aaryanshroff) on 2026-01-24 (commit [`952ac5e`](https://github.com/castorini/anserini/commit/952ac5e4573486a255778828b8f26fd892cda854))
 + Results reproduced by [@HusamIsied](https://github.com/HusamIsied) on 2026-01-25 (commit [`952ac5e4`](https://github.com/castorini/anserini/commit/952ac5e4573486a255778828b8f26fd892cda854))
 + Results reproduced by [@maherapp](https://github.com/maherapp) on 2026-02-01 (commit [`f0ecf565`](https://github.com/castorini/anserini/commit/f0ecf5655430b3fdccb802cde31e7f8ef821d0de))
++ Results reproduced by [@Sina-rokna](https://github.com/Sina-rokna) on 2026-02-22 (commit [`792d9cb`](https://github.com/castorini/anserini/commit/792d9cbccf23507d164d63bc1a2a39b065777122))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -543,3 +543,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@aaryanshroff](https://github.com/aaryanshroff) on 2026-01-24 (commit [`952ac5e`](https://github.com/castorini/anserini/commit/952ac5e4573486a255778828b8f26fd892cda854))
 + Results reproduced by [@HusamIsied](https://github.com/HusamIsied) on 2026-01-25 (commit [`952ac5e4`](https://github.com/castorini/anserini/commit/952ac5e4573486a255778828b8f26fd892cda854))
 + Results reproduced by [@maherapp](https://github.com/maherapp) on 2026-02-01 (commit [`f0ecf565`](https://github.com/castorini/anserini/commit/f0ecf5655430b3fdccb802cde31e7f8ef821d0de))
++ Results reproduced by [@Sina-rokna](https://github.com/Sina-rokna) on 2026-02-22 (commit [`792d9cb`](https://github.com/castorini/anserini/commit/792d9cbccf23507d164d63bc1a2a39b065777122))


### PR DESCRIPTION
Successfully reproduced:

1. Start Here
2. Anserini: BM25 Baselines for MS MARCO Passage Ranking

Environment:
- OS: WSL2 Ubuntu 22.04
- RAM: 8GB
- Java: 21
- Maven: 3.x
- Storage: SSD (NTFS mounted via WSL)

Results:
MRR@10: 0.1874  
MAP: 0.1957  
Recall@1000: 0.8573  

Observations and issues encountered:

1. Line ending issues:
   `bin/run.sh` and `bin/trec_eval` initially failed due to CRLF line endings when working inside WSL. This was resolved using `dos2unix`.

2. Memory constraints:
   Indexing with higher thread counts ( 9 threads) resulted in the process being killed by the system. Reducing the number of threads (to 2) resolved the issue.

3. Index size difference:
   The documented index size is approximately 4.3G (as you reported), whereas the my produced index in this environment was ~4.1G.
   Potential reasons:
   - Differences in Lucene minor version or codec implementation
   - Filesystem differences 
   - OS-level compression and block allocation behavior

   However Retrieval results were identical despite the size difference.

All evaluation metrics matched the documented baseline values.