### PR TITLE
Upgrade to Lucene 10.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </developers>
 
   <properties>
-    <lucene.version>10.3.2</lucene.version>
+    <lucene.version>10.4.0</lucene.version>
     <java.version>21</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/src/main/java/io/anserini/index/IndexCollection.java
+++ b/src/main/java/io/anserini/index/IndexCollection.java
@@ -180,6 +180,7 @@ public final class IndexCollection extends AbstractIndexer {
     } else {
       config.setSimilarity(new BM25Similarity());
     }
+
     config.setOpenMode(IndexWriterConfig.OpenMode.CREATE);
     config.setRAMBufferSizeMB(args.memoryBuffer);
     config.setUseCompoundFile(false);

--- a/src/main/java/io/anserini/index/IndexFlatDenseVectors.java
+++ b/src/main/java/io/anserini/index/IndexFlatDenseVectors.java
@@ -23,8 +23,7 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.codecs.KnnVectorsFormat;
-import org.apache.lucene.codecs.lucene102.Lucene102BinaryQuantizedVectorsFormat;
-import org.apache.lucene.codecs.lucene103.Lucene103Codec;
+import org.apache.lucene.codecs.lucene104.Lucene104Codec;
 import org.apache.lucene.index.ConcurrentMergeScheduler;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -51,11 +50,8 @@ public final class IndexFlatDenseVectors extends AbstractIndexer {
     @Option(name = "-generator", metaVar = "[class]", usage = "Document generator class in io.anserini.index.generator.")
     public String generatorClass = DenseVectorDocumentGenerator.class.getSimpleName();
 
-    @Option(name = "-quantize.sqv", usage = "Quantize vectors using ScalarQuantizedVectors (mutually exclusive with -quantize.bqv).", forbids = "-quantize.bqv")
+    @Option(name = "-quantize.sqv", usage = "Quantize vectors using ScalarQuantizedVectors.")
     public boolean quantizeSQV = false;
-
-    @Option(name = "-quantize.bqv", usage = "Quantize vectors using BinaryQuantizedVectors (mutually exclusive with -quantize.sqv).", forbids = "-quantize.sqv")
-    public boolean quantizeBQV = false;
 
     @Option(name = "-docidField", metaVar = "[name]", usage = "Name of the document ID field in Parquet files.")
     public String docidField = "docid";
@@ -87,23 +83,15 @@ public final class IndexFlatDenseVectors extends AbstractIndexer {
 
       if (args.quantizeSQV) {
         config = new IndexWriterConfig().setCodec(
-            new Lucene103Codec() {
+            new Lucene104Codec() {
               @Override
               public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
                 return new Anserini20FlatScalarQuantizedVectorsFormat();
               }
             });
-      } else if (args.quantizeBQV) {
-        config = new IndexWriterConfig().setCodec(
-            new Lucene103Codec() {
-              @Override
-              public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
-                return new DelegatingKnnVectorsFormat(new Lucene102BinaryQuantizedVectorsFormat(), 4096);
-              }
-            });
       } else {
         config = new IndexWriterConfig().setCodec(
-            new Lucene103Codec() {
+            new Lucene104Codec() {
               @Override
               public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
                 return new Anserini20FlatVectorsFormat();
@@ -124,7 +112,6 @@ public final class IndexFlatDenseVectors extends AbstractIndexer {
     LOG.info("IndexFlatDenseVectors settings:");
     LOG.info(" + Generator: " + args.generatorClass);
     LOG.info(" + ScalarQuantizedVectors? " + args.quantizeSQV);
-    LOG.info(" + BinaryQuantizedVectors? " + args.quantizeBQV);
     LOG.info(" + Document ID field: " + args.docidField);
     LOG.info(" + Vector field: " + args.vectorField);
     LOG.info(" + Normalize vectors? " + args.normalizeVectors);

--- a/src/main/java/io/anserini/index/IndexFlatDenseVectors.java
+++ b/src/main/java/io/anserini/index/IndexFlatDenseVectors.java
@@ -38,7 +38,6 @@ import io.anserini.collection.ParquetDenseVectorCollection;
 import io.anserini.collection.SourceDocument;
 import io.anserini.index.codecs.Anserini20FlatScalarQuantizedVectorsFormat;
 import io.anserini.index.codecs.Anserini20FlatVectorsFormat;
-import io.anserini.index.codecs.DelegatingKnnVectorsFormat;
 import io.anserini.index.generator.DenseVectorDocumentGenerator;
 import io.anserini.index.generator.LuceneDocumentGenerator;
 import io.anserini.util.LoggingBootstrap;

--- a/src/main/java/io/anserini/index/IndexHnswDenseVectors.java
+++ b/src/main/java/io/anserini/index/IndexHnswDenseVectors.java
@@ -23,9 +23,8 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.codecs.KnnVectorsFormat;
-import org.apache.lucene.codecs.lucene102.Lucene102HnswBinaryQuantizedVectorsFormat;
-import org.apache.lucene.codecs.lucene103.Lucene103Codec;
-import org.apache.lucene.codecs.lucene99.Lucene99HnswScalarQuantizedVectorsFormat;
+import org.apache.lucene.codecs.lucene104.Lucene104Codec;
+import org.apache.lucene.codecs.lucene104.Lucene104HnswScalarQuantizedVectorsFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -55,11 +54,8 @@ public final class IndexHnswDenseVectors extends AbstractIndexer {
     @Option(name = "-efC", metaVar = "[num]", usage = "HNSW parameters ef Construction.")
     public int efC = 500;
 
-    @Option(name = "-quantize.sqv", usage = "Quantize vectors using ScalarQuantizedVectors (mutually exclusive with -quantize.bqv).", forbids = "-quantize.bqv")
+    @Option(name = "-quantize.sqv", usage = "Quantize vectors using ScalarQuantizedVectors.")
     public boolean quantizeSQV = false;
-
-    @Option(name = "-quantize.bqv", usage = "Quantize vectors using BinaryQuantizedVectors (mutually exclusive with -quantize.sqv).", forbids = "-quantize.sqv")
-    public boolean quantizeBQV = false;
   }
 
   @SuppressWarnings("unchecked")
@@ -79,23 +75,15 @@ public final class IndexHnswDenseVectors extends AbstractIndexer {
 
       if (args.quantizeSQV) {
         config = new IndexWriterConfig().setCodec(
-            new Lucene103Codec() {
+            new Lucene104Codec() {
               @Override
               public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
-                return new DelegatingKnnVectorsFormat(new Lucene99HnswScalarQuantizedVectorsFormat(args.M, args.efC), 4096);
-              }
-            });
-      } else if (args.quantizeBQV) {
-        config = new IndexWriterConfig().setCodec(
-            new Lucene103Codec() {
-              @Override
-              public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
-                return new DelegatingKnnVectorsFormat(new Lucene102HnswBinaryQuantizedVectorsFormat(args.M, args.efC), 4096);
+                return new DelegatingKnnVectorsFormat(new Lucene104HnswScalarQuantizedVectorsFormat(args.M, args.efC), 4096);
               }
             });
       } else {
         config = new IndexWriterConfig().setCodec(
-            new Lucene103Codec() {
+            new Lucene104Codec() {
               @Override
               public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
                 return new DelegatingKnnVectorsFormat(new Lucene99HnswVectorsFormat(args.M, args.efC), 4096);
@@ -113,7 +101,6 @@ public final class IndexHnswDenseVectors extends AbstractIndexer {
     LOG.info(" + M: " + args.M);
     LOG.info(" + efC: " + args.efC);
     LOG.info(" + ScalarQuantizedVectors? " + args.quantizeSQV);
-    LOG.info(" + BinaryQuantizedVectors? " + args.quantizeBQV);
   }
 
   public static void main(String[] args) throws Exception {

--- a/src/main/java/io/anserini/index/codecs/Anserini20FlatScalarQuantizedVectorsFormat.java
+++ b/src/main/java/io/anserini/index/codecs/Anserini20FlatScalarQuantizedVectorsFormat.java
@@ -20,7 +20,7 @@ import org.apache.lucene.codecs.KnnFieldVectorsWriter;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
-import org.apache.lucene.codecs.lucene99.Lucene99ScalarQuantizedVectorsFormat;
+import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
@@ -41,7 +41,7 @@ public class Anserini20FlatScalarQuantizedVectorsFormat extends KnnVectorsFormat
 
   static final String NAME = "Anserini20FlatScalarQuantizedVectorsFormat";
 
-  private final KnnVectorsFormat format = new Lucene99ScalarQuantizedVectorsFormat();
+  private final KnnVectorsFormat format = new Lucene104ScalarQuantizedVectorsFormat();
 
   /**
    * Sole constructor

--- a/src/main/java/io/anserini/index/codecs/Anserini20FlatScalarQuantizedVectorsFormat.java
+++ b/src/main/java/io/anserini/index/codecs/Anserini20FlatScalarQuantizedVectorsFormat.java
@@ -16,6 +16,8 @@
 
 package io.anserini.index.codecs;
 
+import java.io.IOException;
+
 import org.apache.lucene.codecs.KnnFieldVectorsWriter;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
@@ -34,8 +36,6 @@ import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.util.Bits;
-
-import java.io.IOException;
 
 public class Anserini20FlatScalarQuantizedVectorsFormat extends KnnVectorsFormat {
 

--- a/src/main/java/io/anserini/index/codecs/Anserini20FlatVectorsFormat.java
+++ b/src/main/java/io/anserini/index/codecs/Anserini20FlatVectorsFormat.java
@@ -31,10 +31,10 @@ import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.Sorter;
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.VectorScorer;
-import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.util.Bits;
 
 public class Anserini20FlatVectorsFormat extends KnnVectorsFormat {

--- a/src/main/java/io/anserini/index/codecs/AnseriniLucene99FlatVectorFormat.java
+++ b/src/main/java/io/anserini/index/codecs/AnseriniLucene99FlatVectorFormat.java
@@ -31,10 +31,10 @@ import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.Sorter;
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.VectorScorer;
-import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.util.Bits;
 
 public class AnseriniLucene99FlatVectorFormat extends KnnVectorsFormat {

--- a/src/main/java/io/anserini/index/codecs/AnseriniLucene99ScalarQuantizedVectorsFormat.java
+++ b/src/main/java/io/anserini/index/codecs/AnseriniLucene99ScalarQuantizedVectorsFormat.java
@@ -20,7 +20,7 @@ import org.apache.lucene.codecs.KnnFieldVectorsWriter;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
-import org.apache.lucene.codecs.lucene99.Lucene99ScalarQuantizedVectorsFormat;
+import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
@@ -41,7 +41,7 @@ public class AnseriniLucene99ScalarQuantizedVectorsFormat extends KnnVectorsForm
 
   static final String NAME = "AnseriniLucene99ScalarQuantizedVectorsFormat";
 
-  private final KnnVectorsFormat format = new Lucene99ScalarQuantizedVectorsFormat();
+  private final KnnVectorsFormat format = new Lucene104ScalarQuantizedVectorsFormat();
 
   /**
    * Sole constructor

--- a/src/main/java/io/anserini/index/codecs/AnseriniLucene99ScalarQuantizedVectorsFormat.java
+++ b/src/main/java/io/anserini/index/codecs/AnseriniLucene99ScalarQuantizedVectorsFormat.java
@@ -16,11 +16,13 @@
 
 package io.anserini.index.codecs;
 
+import java.io.IOException;
+
+import org.apache.lucene.backward_codecs.lucene99.Lucene99ScalarQuantizedVectorsFormat;
 import org.apache.lucene.codecs.KnnFieldVectorsWriter;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
-import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
@@ -35,14 +37,11 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.util.Bits;
 
-import java.io.IOException;
-
 public class AnseriniLucene99ScalarQuantizedVectorsFormat extends KnnVectorsFormat {
 
   static final String NAME = "AnseriniLucene99ScalarQuantizedVectorsFormat";
 
-  // Keep the legacy SPI name, but delegate to the Lucene 10.4 implementation.
-  private final KnnVectorsFormat format = new Lucene104ScalarQuantizedVectorsFormat();
+  private final KnnVectorsFormat format = new Lucene99ScalarQuantizedVectorsFormat();
 
   /**
    * Sole constructor

--- a/src/main/java/io/anserini/index/codecs/AnseriniLucene99ScalarQuantizedVectorsFormat.java
+++ b/src/main/java/io/anserini/index/codecs/AnseriniLucene99ScalarQuantizedVectorsFormat.java
@@ -41,6 +41,7 @@ public class AnseriniLucene99ScalarQuantizedVectorsFormat extends KnnVectorsForm
 
   static final String NAME = "AnseriniLucene99ScalarQuantizedVectorsFormat";
 
+  // Keep the legacy SPI name, but delegate to the Lucene 10.4 implementation.
   private final KnnVectorsFormat format = new Lucene104ScalarQuantizedVectorsFormat();
 
   /**

--- a/src/main/java/io/anserini/index/codecs/DelegatingKnnVectorsFormat.java
+++ b/src/main/java/io/anserini/index/codecs/DelegatingKnnVectorsFormat.java
@@ -17,6 +17,7 @@
 package io.anserini.index.codecs;
 
 import java.io.IOException;
+
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;

--- a/src/test/java/io/anserini/search/SearchHnswDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchHnswDenseVectorsTest.java
@@ -370,16 +370,16 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
     SearchHnswDenseVectors.main(searchArgs);
 
     TestUtils.checkRunFileApproximate(runfile, new String[] {
-        "2 Q0 224 1 0.581529 Anserini",
-        "2 Q0 208 2 0.580095 Anserini",
-        "2 Q0 136 3 0.575039 Anserini",
-        "2 Q0 384 4 0.573756 Anserini",
-        "2 Q0 720 5 0.572269 Anserini",
-        "1048585 Q0 624 1 0.569809 Anserini",
-        "1048585 Q0 120 2 0.564281 Anserini",
-        "1048585 Q0 320 3 0.558037 Anserini",
-        "1048585 Q0 232 4 0.553515 Anserini",
-        "1048585 Q0 328 5 0.550803 Anserini"
+        "2 Q0 208 1 0.578708 Anserini",
+        "2 Q0 224 2 0.578514 Anserini",
+        "2 Q0 384 3 0.573822 Anserini",
+        "2 Q0 136 4 0.572750 Anserini",
+        "2 Q0 720 5 0.571215 Anserini",
+        "1048585 Q0 624 1 0.568440 Anserini",
+        "1048585 Q0 120 2 0.563625 Anserini",
+        "1048585 Q0 320 3 0.558964 Anserini",
+        "1048585 Q0 232 4 0.551182 Anserini",
+        "1048585 Q0 328 5 0.551052 Anserini"
     });
 
     new File(runfile).delete();
@@ -544,7 +544,7 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
         "45 Q0 44 1 0.861596 Anserini",
         "45 Q0 40 2 0.858651 Anserini",
         "45 Q0 48 3 0.858514 Anserini",
-        "45 Q0 41 4 0.856264 Anserini",
+        "45 Q0 41 4 0.856265 Anserini"
     });
 
     new File(runfile).delete();
@@ -583,12 +583,12 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
         "160885 Q0 44 1 0.863064 Anserini",
         "160885 Q0 40 2 0.858651 Anserini",
         "160885 Q0 48 3 0.858514 Anserini",
-        "160885 Q0 a 4 0.856264 Anserini",
+        "160885 Q0 a 4 0.856265 Anserini",
         "160885 Q0 46 5 0.849332 Anserini",
-        "867490 Q0 10 1 0.850332 Anserini",
+        "867490 Q0 10 1 0.850331 Anserini",
         "867490 Q0 44 2 0.846281 Anserini",
         "867490 Q0 b 3 0.845013 Anserini",
-        "867490 Q0 40 4 0.837815 Anserini",
+        "867490 Q0 40 4 0.837814 Anserini",
         "867490 Q0 46 5 0.837050 Anserini"
     });
 


### PR DESCRIPTION
Upgrade to using the following:

```
org.apache.lucene.codecs.lucene104.Lucene104Codec;
org.apache.lucene.codecs.lucene104.Lucene104HnswScalarQuantizedVectorsFormat
org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat
```

Removed options to use `BinaryQuantizedVectors` since it's not being used.
