### PR TITLE
Adds configs and template for rag25 with Spladev3

### DIFF
--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.splade-v3.cached.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.splade-v3.cached.md
@@ -50,7 +50,7 @@ To confirm, `msmarco-v2.1-doc-segmented-splade-v3.tar` is 125 GB and has MD5 che
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression rag25-doc-segmented-test-nist.splade-v3.cached \
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config rag25-doc-segmented-test-nist.splade-v3.cached \
   --corpus-path collections/msmarco_v2.1_doc_segmented_splade-v3
 ```
 

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.splade-v3.cached.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.splade-v3.cached.md
@@ -54,6 +54,19 @@ bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verif
   --corpus-path collections/msmarco_v2.1_doc_segmented_splade-v3
 ```
 
+## Pre-encoding Topics
+
+Following command can be used to pre-encode topics (optional here):
+
+```bash
+bin/run.sh io.anserini.encoder.QueryEncoder \
+  -encoder SpladeV3 \
+  -queries tools/topics-and-qrels/topics.rag25.test.jsonl \
+  -topicReader JsonString \
+  -output encoded-queries/topics.rag25.test.splade-v3.jsonl.gz \
+  -compress
+```
+
 ## Indexing
 
 Typical indexing command:

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.splade-v3.cached.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.splade-v3.cached.md
@@ -1,0 +1,111 @@
+# Anserini Regressions: TREC 2025 RAG Track Test Topics
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments for ranking _on the segmented version_ of the MS MARCO V2.1 document corpus using the test topics (= queries in TREC parlance), which is integrated into Anserini's regression testing framework.
+This corpus was derived from the MS MARCO V2 _segmented_ document corpus and prepared for the TREC 2024 RAG Track.
+
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+Evaluation uses qrels over 22 topics from the TREC 2025 RAG Track test set.
+These qrels represent manual relevance judgments from NIST assessors, contrasted with automatically generated UMBRELA judgments.
+More details can be found in the following paper:
+
+> Shivani Upadhyay, Nandan Thakur, Ronak Pradeep, Nick Craswell, Daniel Campos and Jimmy Lin. [Overview of the TREC 2025 Retrieval Augmented Generation (RAG) Track.](https://arxiv.org/abs/2603.09891) _arXiv:2603.09891_, March 2026.
+
+The exact configurations for these regressions are stored in [this YAML file](../../../src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../../src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-nist.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config rag25-doc-segmented-test-nist.splade-v3.cached
+```
+
+We make available a version of the MS MARCO V2.1 segmented document corpus that has already been encoded with SPLADE-v3.
+
+From any machine, the following command will download the corpus and perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --download --index --verify --search --config rag25-doc-segmented-test-nist.splade-v3.cached
+```
+
+The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
+
+## Corpus Download
+
+Download the corpus and unpack into `collections/`:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco_v2.1_doc_segmented_splade-v3.tar -P collections/
+tar xvf collections/msmarco_v2.1_doc_segmented_splade-v3.tar -C collections/
+```
+
+To confirm, `msmarco-v2.1-doc-segmented-splade-v3.tar` is 125 GB and has MD5 checksum `c62490569364a1eb0101da1ca4a894d9`.
+With the corpus downloaded, the following command will perform the remaining steps below:
+
+```bash
+python src/main/python/run_regression.py --index --verify --search --regression rag25-doc-segmented-test-nist.splade-v3.cached \
+  --corpus-path collections/msmarco_v2.1_doc_segmented_splade-v3
+```
+
+## Indexing
+
+Typical indexing command:
+
+```bash
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 24 \
+  -collection JsonVectorCollection \
+  -input /path/to/msmarco-v2.1-doc-segmented-splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.msmarco-v2.1-doc-segmented-splade-v3 &
+```
+
+The setting of `-input` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Here, we are using 22 test topics from the TREC 2025 RAG Track with manual relevance judgments from NIST assessors.
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```bash
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.rag25.test.jsonl \
+  -topicReader JsonString \
+  -output runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.jsonl.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```bash
+bin/trec_eval -c -m ndcg_cut.30 tools/topics-and-qrels/qrels.rag25.test.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.100 tools/topics-and-qrels/qrels.rag25.test.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.rag25.test.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.jsonl.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@30**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|--------------|
+| RAG 25: Test queries                                                                                         | 0.0150       |
+| **nDCG@100**                                                                                                 | **SPLADE-v3**|
+| RAG 25: Test queries                                                                                         | 0.0209       |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| RAG 25: Test queries                                                                                         | 0.0096       |

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.splade-v3.cached.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.splade-v3.cached.md
@@ -84,18 +84,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented.splade-v3/ \
-  -topics tools/topics-and-qrels/topics.rag25.test.jsonl \
+  -topics tools/topics-and-qrels/topics.rag25.test.splade-v3.jsonl.gz \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.splade-v3.jsonl.txt \
   -impact -pretokenized -removeQuery -hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 tools/topics-and-qrels/qrels.rag25.test.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 tools/topics-and-qrels/qrels.rag25.test.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.rag25.test.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 tools/topics-and-qrels/qrels.rag25.test.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.splade-v3.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.100 tools/topics-and-qrels/qrels.rag25.test.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.splade-v3.jsonl.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.rag25.test.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.splade-v3.jsonl.txt
 ```
 
 ## Effectiveness
@@ -104,8 +104,8 @@ With the above commands, you should be able to reproduce the following results:
 
 | **nDCG@30**                                                                                                  | **SPLADE-v3**|
 |:-------------------------------------------------------------------------------------------------------------|--------------|
-| RAG 25: Test queries                                                                                         | 0.0150       |
+| RAG 25: Test queries                                                                                         | 0.5957       |
 | **nDCG@100**                                                                                                 | **SPLADE-v3**|
-| RAG 25: Test queries                                                                                         | 0.0209       |
+| RAG 25: Test queries                                                                                         | 0.5387       |
 | **R@100**                                                                                                    | **SPLADE-v3**|
-| RAG 25: Test queries                                                                                         | 0.0096       |
+| RAG 25: Test queries                                                                                         | 0.2103       |

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.splade-v3.cached.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.splade-v3.cached.md
@@ -59,7 +59,7 @@ bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verif
 Following command can be used to pre-encode topics (optional here):
 
 ```bash
-bin/run.sh io.anserini.encoder.QueryEncoder \
+bin/run.sh io.anserini.encoder.EncodeQuery \
   -encoder SpladeV3 \
   -queries tools/topics-and-qrels/topics.rag25.test.jsonl \
   -topicReader JsonString \

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.splade-v3.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.splade-v3.onnx.md
@@ -1,0 +1,110 @@
+# Anserini Regressions: TREC 2025 RAG Track Test Topics
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments for ranking _on the segmented version_ of the MS MARCO V2.1 document corpus using the test topics (= queries in TREC parlance), which is integrated into Anserini's regression testing framework.
+This corpus was derived from the MS MARCO V2 _segmented_ document corpus and prepared for the TREC 2024 RAG Track.
+
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+Evaluation uses qrels over 22 topics from the TREC 2025 RAG Track test set.
+These qrels represent manual relevance judgments from NIST assessors, contrasted with automatically generated UMBRELA judgments.
+More details can be found in the following paper:
+
+> Shivani Upadhyay, Nandan Thakur, Ronak Pradeep, Nick Craswell, Daniel Campos and Jimmy Lin. [Overview of the TREC 2025 Retrieval Augmented Generation (RAG) Track.](https://arxiv.org/abs/2603.09891) _arXiv:2603.09891_, March 2026.
+The exact configurations for these regressions are stored in [this YAML file](../../../src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../../src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-nist.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config rag25-doc-segmented-test-nist.splade-v3.onnx
+```
+
+We make available a version of the MS MARCO V2.1 segmented document corpus that has already been encoded with SPLADE-v3.
+
+From any machine, the following command will download the corpus and perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --download --index --verify --search --config rag25-doc-segmented-test-nist.splade-v3.onnx
+```
+
+The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
+
+## Corpus Download
+
+Download the corpus and unpack into `collections/`:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco_v2.1_doc_segmented_splade-v3.tar -P collections/
+tar xvf collections/msmarco_v2.1_doc_segmented_splade-v3.tar -C collections/
+```
+
+To confirm, `msmarco-v2.1-doc-segmented-splade-v3.tar` is 125 GB and has MD5 checksum `c62490569364a1eb0101da1ca4a894d9`.
+With the corpus downloaded, the following command will perform the remaining steps below:
+
+```bash
+python src/main/python/run_regression.py --index --verify --search --regression rag25-doc-segmented-test-nist.splade-v3.onnx \
+  --corpus-path collections/msmarco_v2.1_doc_segmented_splade-v3
+```
+
+## Indexing
+
+Typical indexing command:
+
+```bash
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 24 \
+  -collection JsonVectorCollection \
+  -input /path/to/msmarco-v2.1-doc-segmented-splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.msmarco-v2.1-doc-segmented-splade-v3 &
+```
+
+The setting of `-input` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Here, we are using 22 test topics from the TREC 2025 RAG Track with manual relevance judgments from NIST assessors.
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```bash
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.rag25.test.jsonl \
+  -topicReader JsonString \
+  -output runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.jsonl.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```bash
+bin/trec_eval -c -m ndcg_cut.30 tools/topics-and-qrels/qrels.rag25.test.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.100 tools/topics-and-qrels/qrels.rag25.test.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.rag25.test.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.jsonl.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@30**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|--------------|
+| RAG 25: Test queries                                                                                         | 0.5957       |
+| **nDCG@100**                                                                                                 | **SPLADE-v3**|
+| RAG 25: Test queries                                                                                         | 0.5387       |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| RAG 25: Test queries                                                                                         | 0.2103       |

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.splade-v3.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.splade-v3.onnx.md
@@ -49,7 +49,7 @@ To confirm, `msmarco-v2.1-doc-segmented-splade-v3.tar` is 125 GB and has MD5 che
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression rag25-doc-segmented-test-nist.splade-v3.onnx \
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config rag25-doc-segmented-test-nist.splade-v3.onnx \
   --corpus-path collections/msmarco_v2.1_doc_segmented_splade-v3
 ```
 

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.splade-v3.cached.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.splade-v3.cached.md
@@ -1,0 +1,110 @@
+# Anserini Regressions: TREC 2025 RAG Track Test Topics
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments for ranking _on the segmented version_ of the MS MARCO V2.1 document corpus using the test topics (= queries in TREC parlance), which is integrated into Anserini's regression testing framework.
+This corpus was derived from the MS MARCO V2 _segmented_ document corpus and prepared for the TREC 2024 RAG Track.
+
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+Evaluation uses qrels over 22 topics from the TREC 2025 RAG Track test set.
+More details can be found in the following paper:
+
+> Shivani Upadhyay, Nandan Thakur, Ronak Pradeep, Nick Craswell, Daniel Campos and Jimmy Lin. [Overview of the TREC 2025 Retrieval Augmented Generation (RAG) Track.](https://arxiv.org/abs/2603.09891) _arXiv:2603.09891_, March 2026.
+
+The exact configurations for these regressions are stored in [this YAML file](../../../src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.splade-v3.cached.yaml).
+Note that this page is automatically generated from [this template](../../../src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-umbrela2.splade-v3.cached.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config rag25-doc-segmented-test-umbrela2.splade-v3.cached
+```
+
+We make available a version of the MS MARCO V2.1 segmented document corpus that has already been encoded with SPLADE-v3.
+
+From any machine, the following command will download the corpus and perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --download --index --verify --search --config rag25-doc-segmented-test-umbrela2.splade-v3.cached
+```
+
+The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
+
+## Corpus Download
+
+Download the corpus and unpack into `collections/`:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco_v2.1_doc_segmented_splade-v3.tar -P collections/
+tar xvf collections/msmarco_v2.1_doc_segmented_splade-v3.tar -C collections/
+```
+
+To confirm, `msmarco-v2.1-doc-segmented-splade-v3.tar` is 125 GB and has MD5 checksum `c62490569364a1eb0101da1ca4a894d9`.
+With the corpus downloaded, the following command will perform the remaining steps below:
+
+```bash
+python src/main/python/run_regression.py --index --verify --search --regression rag25-doc-segmented-test-umbrela2.splade-v3.cached \
+  --corpus-path collections/msmarco_v2.1_doc_segmented_splade-v3
+```
+
+## Indexing
+
+Typical indexing command:
+
+```bash
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 24 \
+  -collection JsonVectorCollection \
+  -input /path/to/msmarco-v2.1-doc-segmented-splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.msmarco-v2.1-doc-segmented-splade-v3 &
+```
+
+The setting of `-input` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Here, we are using 22 test topics from the TREC 2025 RAG Track with manual relevance judgments from NIST assessors.
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```bash
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.rag25.test.jsonl \
+  -topicReader JsonString \
+  -output runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.jsonl.txt \
+  -impact -pretokenized -removeQuery -hits 1000 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```bash
+bin/trec_eval -c -m ndcg_cut.30 tools/topics-and-qrels/qrels.rag25.test-umbrela2.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.100 tools/topics-and-qrels/qrels.rag25.test-umbrela2.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.rag25.test-umbrela2.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.jsonl.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@30**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|--------------|
+| RAG 25: Test queries                                                                                         | 0.0219       |
+| **nDCG@100**                                                                                                 | **SPLADE-v3**|
+| RAG 25: Test queries                                                                                         | 0.0259       |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| RAG 25: Test queries                                                                                         | 0.0113       |

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.splade-v3.cached.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.splade-v3.cached.md
@@ -53,6 +53,19 @@ bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verif
   --corpus-path collections/msmarco_v2.1_doc_segmented_splade-v3
 ```
 
+## Pre-encoding Topics
+
+Following command can be used to pre-encode topics (optional here):
+
+```bash
+bin/run.sh io.anserini.encoder.QueryEncoder \
+  -encoder SpladeV3 \
+  -queries tools/topics-and-qrels/topics.rag25.test.jsonl \
+  -topicReader JsonString \
+  -output encoded-queries/topics.rag25.test.splade-v3.jsonl.gz \
+  -compress
+```
+
 ## Indexing
 
 Typical indexing command:

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.splade-v3.cached.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.splade-v3.cached.md
@@ -83,18 +83,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented.splade-v3/ \
-  -topics tools/topics-and-qrels/topics.rag25.test.jsonl \
+  -topics tools/topics-and-qrels/topics.rag25.test.splade-v3.jsonl.gz \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.splade-v3.jsonl.txt \
   -impact -pretokenized -removeQuery -hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 tools/topics-and-qrels/qrels.rag25.test-umbrela2.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 tools/topics-and-qrels/qrels.rag25.test-umbrela2.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.rag25.test-umbrela2.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 tools/topics-and-qrels/qrels.rag25.test-umbrela2.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.splade-v3.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.100 tools/topics-and-qrels/qrels.rag25.test-umbrela2.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.splade-v3.jsonl.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.rag25.test-umbrela2.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-cached.topics.rag25.test.splade-v3.jsonl.txt
 ```
 
 ## Effectiveness
@@ -103,8 +103,8 @@ With the above commands, you should be able to reproduce the following results:
 
 | **nDCG@30**                                                                                                  | **SPLADE-v3**|
 |:-------------------------------------------------------------------------------------------------------------|--------------|
-| RAG 25: Test queries                                                                                         | 0.0219       |
+| RAG 25: Test queries                                                                                         | 0.5838       |
 | **nDCG@100**                                                                                                 | **SPLADE-v3**|
-| RAG 25: Test queries                                                                                         | 0.0259       |
+| RAG 25: Test queries                                                                                         | 0.5372       |
 | **R@100**                                                                                                    | **SPLADE-v3**|
-| RAG 25: Test queries                                                                                         | 0.0113       |
+| RAG 25: Test queries                                                                                         | 0.1992       |

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.splade-v3.cached.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.splade-v3.cached.md
@@ -58,7 +58,7 @@ bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verif
 Following command can be used to pre-encode topics (optional here):
 
 ```bash
-bin/run.sh io.anserini.encoder.QueryEncoder \
+bin/run.sh io.anserini.encoder.EncodeQuery \
   -encoder SpladeV3 \
   -queries tools/topics-and-qrels/topics.rag25.test.jsonl \
   -topicReader JsonString \

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.splade-v3.cached.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.splade-v3.cached.md
@@ -49,7 +49,7 @@ To confirm, `msmarco-v2.1-doc-segmented-splade-v3.tar` is 125 GB and has MD5 che
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression rag25-doc-segmented-test-umbrela2.splade-v3.cached \
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config rag25-doc-segmented-test-umbrela2.splade-v3.cached \
   --corpus-path collections/msmarco_v2.1_doc_segmented_splade-v3
 ```
 

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.splade-v3.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.splade-v3.onnx.md
@@ -1,0 +1,110 @@
+# Anserini Regressions: TREC 2025 RAG Track Test Topics
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments for ranking _on the segmented version_ of the MS MARCO V2.1 document corpus using the test topics (= queries in TREC parlance), which is integrated into Anserini's regression testing framework.
+This corpus was derived from the MS MARCO V2 _segmented_ document corpus and prepared for the TREC 2024 RAG Track.
+
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+Evaluation uses qrels over 22 topics from the TREC 2025 RAG Track test set.
+More details can be found in the following paper:
+
+> Shivani Upadhyay, Nandan Thakur, Ronak Pradeep, Nick Craswell, Daniel Campos and Jimmy Lin. [Overview of the TREC 2025 Retrieval Augmented Generation (RAG) Track.](https://arxiv.org/abs/2603.09891) _arXiv:2603.09891_, March 2026.
+
+The exact configurations for these regressions are stored in [this YAML file](../../../src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.splade-v3.onnx.yaml).
+Note that this page is automatically generated from [this template](../../../src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-umbrela2.splade-v3.onnx.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config rag25-doc-segmented-test-umbrela2.splade-v3.onnx
+```
+
+We make available a version of the MS MARCO V2.1 segmented document corpus that has already been encoded with SPLADE-v3.
+
+From any machine, the following command will download the corpus and perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --download --index --verify --search --config rag25-doc-segmented-test-umbrela2.splade-v3.onnx
+```
+
+The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
+
+## Corpus Download
+
+Download the corpus and unpack into `collections/`:
+
+```bash
+wget https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco_v2.1_doc_segmented_splade-v3.tar -P collections/
+tar xvf collections/msmarco_v2.1_doc_segmented_splade-v3.tar -C collections/
+```
+
+To confirm, `msmarco-v2.1-doc-segmented-splade-v3.tar` is 125 GB and has MD5 checksum `c62490569364a1eb0101da1ca4a894d9`.
+With the corpus downloaded, the following command will perform the remaining steps below:
+
+```bash
+python src/main/python/run_regression.py --index --verify --search --regression rag25-doc-segmented-test-umbrela2.splade-v3.onnx \
+  --corpus-path collections/msmarco_v2.1_doc_segmented_splade-v3
+```
+
+## Indexing
+
+Typical indexing command:
+
+```bash
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 24 \
+  -collection JsonVectorCollection \
+  -input /path/to/msmarco-v2.1-doc-segmented-splade-v3 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented.splade-v3/ \
+  -impact -pretokenized \
+  >& logs/log.msmarco-v2.1-doc-segmented-splade-v3 &
+```
+
+The setting of `-input` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](../../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Here, we are using 22 test topics from the TREC 2025 RAG Track with manual relevance judgments from NIST assessors.
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```bash
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented.splade-v3/ \
+  -topics tools/topics-and-qrels/topics.rag25.test.jsonl \
+  -topicReader JsonString \
+  -output runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.jsonl.txt \
+  -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```bash
+bin/trec_eval -c -m ndcg_cut.30 tools/topics-and-qrels/qrels.rag25.test-umbrela2.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.100 tools/topics-and-qrels/qrels.rag25.test-umbrela2.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.rag25.test-umbrela2.txt runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.jsonl.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **nDCG@30**                                                                                                  | **SPLADE-v3**|
+|:-------------------------------------------------------------------------------------------------------------|--------------|
+| RAG 25: Test queries                                                                                         | 0.5838       |
+| **nDCG@100**                                                                                                 | **SPLADE-v3**|
+| RAG 25: Test queries                                                                                         | 0.5372       |
+| **R@100**                                                                                                    | **SPLADE-v3**|
+| RAG 25: Test queries                                                                                         | 0.1992       |

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.splade-v3.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.splade-v3.onnx.md
@@ -49,7 +49,7 @@ To confirm, `msmarco-v2.1-doc-segmented-splade-v3.tar` is 125 GB and has MD5 che
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression rag25-doc-segmented-test-umbrela2.splade-v3.onnx \
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config rag25-doc-segmented-test-umbrela2.splade-v3.onnx \
   --corpus-path collections/msmarco_v2.1_doc_segmented_splade-v3
 ```
 

--- a/src/main/java/io/anserini/encoder/EncodeQuery.java
+++ b/src/main/java/io/anserini/encoder/EncodeQuery.java
@@ -201,12 +201,11 @@ public class EncodeQuery {
       Files.createDirectories(outputPath.getParent());
     }
 
-    BufferedWriter writer = args.compress
-        ? new BufferedWriter(new OutputStreamWriter(
-              new GZIPOutputStream(Files.newOutputStream(outputPath)), StandardCharsets.UTF_8))
-        : Files.newBufferedWriter(outputPath);
-
-    try (OnnxEncoder<?> encoder = buildEncoder(args.encoder); writer) {
+    try (OnnxEncoder<?> encoder = buildEncoder(args.encoder);
+         BufferedWriter writer = args.compress
+             ? new BufferedWriter(new OutputStreamWriter(
+                   new GZIPOutputStream(Files.newOutputStream(outputPath)), StandardCharsets.UTF_8))
+             : Files.newBufferedWriter(outputPath)) {
 
       for (Map.Entry<String, Map<String, String>> entry : topics.entrySet()) {
         String queryId   = entry.getKey();

--- a/src/main/java/io/anserini/encoder/EncodeQuery.java
+++ b/src/main/java/io/anserini/encoder/EncodeQuery.java
@@ -74,15 +74,15 @@ import java.util.Set;
  *
  * <p>Example invocation via fatjar:
  * <pre>
- * bin/run.sh io.anserini.encoder.QueryEncoder \
+ * bin/run.sh io.anserini.encoder.EncodeQuery \
  *   -encoder SpladeV3 \
  *   -queries tools/topics-and-qrels/topics.rag25.test.jsonl \
  *   -topicReader JsonString \
  *   -output encoded-queries/topics.rag25.test.splade-v3.jsonl
  * </pre>
  */
-public class QueryEncoder {
-  private static final Logger LOG = LogManager.getLogger(QueryEncoder.class);
+public class EncodeQuery {
+  private static final Logger LOG = LogManager.getLogger(EncodeQuery.class);
 
   private static final String TOPIC_READER_PACKAGE = "io.anserini.search.topicreader.";
 

--- a/src/main/java/io/anserini/encoder/QueryEncoder.java
+++ b/src/main/java/io/anserini/encoder/QueryEncoder.java
@@ -86,12 +86,10 @@ public class QueryEncoder {
 
   private static final String TOPIC_READER_PACKAGE = "io.anserini.search.topicreader.";
 
-  /** Dense encoder names supported by this tool. */
   public static final Set<String> DENSE_ENCODER_NAMES = Set.of(
       "ArcticEmbedL", "BgeBaseEn15", "BgeLargeEn15", "CosDprDistil"
   );
 
-  /** Sparse encoder names supported by this tool. */
   public static final Set<String> SPARSE_ENCODER_NAMES = Set.of(
       "SpladePlusPlusEnsembleDistil", "SpladePlusPlusSelfDistil",
       "SpladeV3", "UniCoil"
@@ -174,7 +172,7 @@ public class QueryEncoder {
       return;
     }
 
-    // Use the TopicReader infrastructure, identical to SearchCollection's convention.
+    // Use the TopicReader infrastructure.
     String readerClass = TOPIC_READER_PACKAGE + args.topicReader + "TopicReader";
     Map<String, Map<String, String>> topics =
         TopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass(readerClass, args.queriesPath);

--- a/src/main/java/io/anserini/encoder/QueryEncoder.java
+++ b/src/main/java/io/anserini/encoder/QueryEncoder.java
@@ -1,0 +1,279 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.encoder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.anserini.encoder.dense.ArcticEmbedLEncoder;
+import io.anserini.encoder.dense.BgeBaseEn15Encoder;
+import io.anserini.encoder.dense.BgeLargeEn15Encoder;
+import io.anserini.encoder.dense.CosDprDistilEncoder;
+import io.anserini.encoder.dense.DenseEncoder;
+import io.anserini.encoder.sparse.SpladePlusPlusEnsembleDistilEncoder;
+import io.anserini.encoder.sparse.SpladePlusPlusSelfDistilEncoder;
+import io.anserini.encoder.sparse.SpladeV3Encoder;
+import io.anserini.encoder.sparse.SparseEncoder;
+import io.anserini.encoder.sparse.UniCoilEncoder;
+import io.anserini.search.topicreader.TopicReader;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.ParserProperties;
+
+import java.io.BufferedWriter;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.zip.GZIPOutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Encodes a set of queries with any Anserini ONNX encoder and writes the
+ * results to a JSONL file (one JSON object per line).
+ *
+ * <p>Topics are read via the standard {@link TopicReader} infrastructure, using
+ * the same {@code -topicReader} and {@code -topicField} convention as
+ * {@code SearchCollection}.
+ *
+ * <p>Dense output — feed to SearchCollection with
+ * {@code -topicReader JsonStringVector -topicField vector}:
+ * <pre>{"qid":"301","vector":[0.021,-0.003,...]}</pre>
+ *
+ * <p>Sparse output — feed to SearchCollection with
+ * {@code -topicReader JsonString -impact -pretokenized}:
+ * <pre>{"id":"301","title":"retrieval retrieval information information ..."}</pre>
+ *
+ * <p>Supported encoders:
+ * <ul>
+ *   <li>Dense:  ArcticEmbedL, BgeBaseEn15, BgeLargeEn15, CosDprDistil</li>
+ *   <li>Sparse: SpladePlusPlusEnsembleDistil, SpladePlusPlusSelfDistil,
+ *               SpladeV3, UniCoil</li>
+ * </ul>
+ *
+ * <p>Example invocation via fatjar:
+ * <pre>
+ * bin/run.sh io.anserini.encoder.QueryEncoder \
+ *   -encoder SpladeV3 \
+ *   -queries tools/topics-and-qrels/topics.rag25.test.jsonl \
+ *   -topicReader JsonString \
+ *   -output encoded-queries/topics.rag25.test.splade-v3.jsonl
+ * </pre>
+ */
+public class QueryEncoder {
+  private static final Logger LOG = LogManager.getLogger(QueryEncoder.class);
+
+  private static final String TOPIC_READER_PACKAGE = "io.anserini.search.topicreader.";
+
+  /** Dense encoder names supported by this tool. */
+  public static final Set<String> DENSE_ENCODER_NAMES = Set.of(
+      "ArcticEmbedL", "BgeBaseEn15", "BgeLargeEn15", "CosDprDistil"
+  );
+
+  /** Sparse encoder names supported by this tool. */
+  public static final Set<String> SPARSE_ENCODER_NAMES = Set.of(
+      "SpladePlusPlusEnsembleDistil", "SpladePlusPlusSelfDistil",
+      "SpladeV3", "UniCoil"
+  );
+
+  public static class Args {
+    @Option(name = "-encoder", metaVar = "[name]", required = true,
+        usage = "Encoder name. Dense: ArcticEmbedL | BgeBaseEn15 | BgeLargeEn15 | CosDprDistil. " +
+                "Sparse: SpladePlusPlusEnsembleDistil | SpladePlusPlusSelfDistil | SpladeV3 | UniCoil.")
+    public String encoder;
+
+    @Option(name = "-queries", metaVar = "[path]", required = true,
+        usage = "Path to the queries file.")
+    public String queriesPath;
+
+    @Option(name = "-topicReader", metaVar = "[class]",
+        usage = "TopicReader class to use, e.g. JsonString, TsvString, TsvInt. " +
+                "Resolved to io.anserini.search.topicreader.{topicReader}TopicReader. " +
+                "Default: JsonString.")
+    public String topicReader = "JsonString";
+
+    @Option(name = "-topicField", metaVar = "[field]",
+        usage = "Topic field to use as query text. Default: title.")
+    public String topicField = "title";
+
+    @Option(name = "-output", metaVar = "[path]", required = true,
+        usage = "Output file path.")
+    public String outputPath;
+
+    @Option(name = "-outputFormat", metaVar = "[format]",
+        usage = "Output format: jsonl or tsv. " +
+                "Defaults to tsv when -topicReader is TsvString or TsvInt, otherwise jsonl. " +
+                "jsonl — Dense: {\"qid\":\"...\",\"vector\":[...]}; Sparse: {\"id\":\"...\",\"title\":\"tok tok ...\"}. " +
+                "tsv  — Dense: id<TAB>f1 f2 ...; Sparse: id<TAB>tok tok tok ...")
+    public String outputFormat = null;  // null = auto-detect from topicReader
+
+    @Option(name = "-compress", usage = "Gzip-compress the output file.")
+    public boolean compress = false;
+  }
+
+  /** Instantiates the named encoder. Models are downloaded and cached on first use. */
+  public static OnnxEncoder<?> buildEncoder(String name) throws Exception {
+    switch (name) {
+      case "ArcticEmbedL":                 return new ArcticEmbedLEncoder();
+      case "BgeBaseEn15":                  return new BgeBaseEn15Encoder();
+      case "BgeLargeEn15":                 return new BgeLargeEn15Encoder();
+      case "CosDprDistil":                 return new CosDprDistilEncoder();
+      case "SpladePlusPlusEnsembleDistil": return new SpladePlusPlusEnsembleDistilEncoder();
+      case "SpladePlusPlusSelfDistil":     return new SpladePlusPlusSelfDistilEncoder();
+      case "SpladeV3":                     return new SpladeV3Encoder();
+      case "UniCoil":                      return new UniCoilEncoder();
+      default:
+        throw new IllegalArgumentException(
+            "Unknown encoder '" + name + "'. Valid names: " + allEncoderNames());
+    }
+  }
+
+  /** Returns a sorted list of all supported encoder names. */
+  public static List<String> allEncoderNames() {
+    List<String> names = new ArrayList<>();
+    names.addAll(DENSE_ENCODER_NAMES);
+    names.addAll(SPARSE_ENCODER_NAMES);
+    Collections.sort(names);
+    return names;
+  }
+
+  public static void main(String[] argv) throws Exception {
+    Args args = new Args();
+    CmdLineParser parser = new CmdLineParser(args, ParserProperties.defaults().withUsageWidth(100));
+    try {
+      parser.parseArgument(argv);
+    } catch (CmdLineException e) {
+      System.err.println(e.getMessage());
+      parser.printUsage(System.err);
+      return;
+    }
+
+    if (!DENSE_ENCODER_NAMES.contains(args.encoder) && !SPARSE_ENCODER_NAMES.contains(args.encoder)) {
+      System.err.println("Unknown encoder '" + args.encoder + "'. Valid names: " + allEncoderNames());
+      return;
+    }
+
+    // Use the TopicReader infrastructure, identical to SearchCollection's convention.
+    String readerClass = TOPIC_READER_PACKAGE + args.topicReader + "TopicReader";
+    Map<String, Map<String, String>> topics =
+        TopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass(readerClass, args.queriesPath);
+
+    if (topics == null || topics.isEmpty()) {
+      System.err.println("No topics loaded. Check -queries path and -topicReader class.");
+      return;
+    }
+    LOG.info("Read {} topics from {} using {}", topics.size(), args.queriesPath, args.topicReader);
+
+    boolean isDense = DENSE_ENCODER_NAMES.contains(args.encoder);
+    // Auto-detect output format from topicReader when not explicitly set.
+    String outputFormat = args.outputFormat != null ? args.outputFormat.toLowerCase()
+        : (args.topicReader.startsWith("Tsv") ? "tsv" : "jsonl");
+    if (!outputFormat.equals("jsonl") && !outputFormat.equals("tsv")) {
+      System.err.println("Unknown -outputFormat '" + outputFormat + "'. Must be jsonl or tsv.");
+      return;
+    }
+    LOG.info("Output format: {}", outputFormat);
+
+    ObjectMapper mapper = new ObjectMapper();
+    int encoded = 0;
+
+    Path outputPath = Paths.get(args.outputPath);
+    if (outputPath.getParent() != null) {
+      Files.createDirectories(outputPath.getParent());
+    }
+
+    BufferedWriter writer = args.compress
+        ? new BufferedWriter(new OutputStreamWriter(
+              new GZIPOutputStream(Files.newOutputStream(outputPath)), StandardCharsets.UTF_8))
+        : Files.newBufferedWriter(outputPath);
+
+    try (OnnxEncoder<?> encoder = buildEncoder(args.encoder); writer) {
+
+      for (Map.Entry<String, Map<String, String>> entry : topics.entrySet()) {
+        String queryId   = entry.getKey();
+        String queryText = entry.getValue().get(args.topicField);
+
+        if (queryText == null) {
+          LOG.warn("Topic {} has no '{}' field — skipping.", queryId, args.topicField);
+          continue;
+        }
+
+        final String line;
+        if (isDense) {
+          float[] vector = ((DenseEncoder) encoder).encode(queryText);
+          if (outputFormat.equals("tsv")) {
+            // id <TAB> f1 f2 f3 ...  (space-separated floats)
+            StringBuilder sb = new StringBuilder(queryId).append('\t');
+            for (int i = 0; i < vector.length; i++) {
+              if (i > 0) sb.append(' ');
+              sb.append(vector[i]);
+            }
+            line = sb.toString();
+          } else {
+            // {"qid":"...","vector":[...]} — SearchCollection: -topicReader JsonStringVector -topicField vector
+            Map<String, Object> record = new LinkedHashMap<>();
+            record.put("qid", queryId);
+            record.put("vector", floatArrayToList(vector));
+            line = mapper.writeValueAsString(record);
+          }
+        } else {
+          Map<String, Integer> weights = ((SparseEncoder) encoder).encode(queryText);
+          String flat = SparseEncoder.flatten(weights);
+          if (outputFormat.equals("tsv")) {
+            // id <TAB> tok tok tok ...
+            line = queryId + '\t' + flat;
+          } else {
+            // {"id":"...","title":"tok tok ..."} — SearchCollection: -topicReader JsonString -impact -pretokenized
+            Map<String, Object> record = new LinkedHashMap<>();
+            record.put("id", queryId);
+            record.put("title", flat);
+            line = mapper.writeValueAsString(record);
+          }
+        }
+
+        writer.write(line);
+        writer.newLine();
+
+        encoded++;
+        if (encoded % 500 == 0) {
+          LOG.info("Encoded {}/{} queries", encoded, topics.size());
+        }
+      }
+    }
+
+    LOG.info("Done — encoded {} queries to {}", encoded, args.outputPath);
+  }
+
+  /**
+   * Converts a primitive float array to a List&lt;Float&gt; so that Jackson
+   * serialises it as a plain JSON number array rather than a base64 blob.
+   */
+  private static List<Float> floatArrayToList(float[] arr) {
+    List<Float> list = new ArrayList<>(arr.length);
+    for (float v : arr) {
+      list.add(v);
+    }
+    return list;
+  }
+}

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.splade-v3.cached.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.splade-v3.cached.yaml
@@ -1,0 +1,59 @@
+---
+corpus: msmarco-v2.1-doc-segmented-splade-v3
+corpus_path: collections/msmarco/msmarco_v2.1_doc_segmented_splade-v3
+
+download_url: https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco_v2.1_doc_segmented_splade-v3.tar
+download_checksum: c62490569364a1eb0101da1ca4a894d9
+download_corpus: msmarco_v2.1_doc_segmented_splade-v3
+
+index_path: indexes/lucene-inverted.msmarco-v2.1-doc-segmented.splade-v3/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 24
+index_options: -impact -pretokenized
+index_stats:
+  documents: 113520750
+  documents (non-empty): 113520750
+  total terms: 866904601378
+
+metrics:
+  - metric: nDCG@30
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.30
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@100
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonString
+topics:
+  - name: "RAG 25: Test queries"
+    id: rag25.test
+    path: topics.rag25.test.jsonl
+    qrel: qrels.rag25.test.txt
+
+models:
+  - name: splade-v3-cached
+    display: SPLADE-v3
+    params: -impact -pretokenized -removeQuery -hits 1000
+    results:
+      nDCG@30:
+        - 0.0150
+      nDCG@100:
+        - 0.0209
+      R@100:
+        - 0.0096

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.splade-v3.cached.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.splade-v3.cached.yaml
@@ -43,7 +43,7 @@ topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
     id: rag25.test
-    path: topics.rag25.test.jsonl
+    path: topics.rag25.test.splade-v3.jsonl.gz
     qrel: qrels.rag25.test.txt
 
 models:
@@ -52,8 +52,8 @@ models:
     params: -impact -pretokenized -removeQuery -hits 1000
     results:
       nDCG@30:
-        - 0.0150
+        - 0.5957
       nDCG@100:
-        - 0.0209
+        - 0.5387
       R@100:
-        - 0.0096
+        - 0.2103

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.splade-v3.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.splade-v3.onnx.yaml
@@ -1,0 +1,59 @@
+---
+corpus: msmarco-v2.1-doc-segmented-splade-v3
+corpus_path: collections/msmarco/msmarco_v2.1_doc_segmented_splade-v3
+
+download_url: https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco_v2.1_doc_segmented_splade-v3.tar
+download_checksum: c62490569364a1eb0101da1ca4a894d9
+download_corpus: msmarco_v2.1_doc_segmented_splade-v3
+
+index_path: indexes/lucene-inverted.msmarco-v2.1-doc-segmented.splade-v3/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 24
+index_options: -impact -pretokenized
+index_stats:
+  documents: 113520750
+  documents (non-empty): 113520750
+  total terms: 866904601378
+
+metrics:
+  - metric: nDCG@30
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.30
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@100
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonString
+topics:
+  - name: "RAG 25: Test queries"
+    id: rag25.test
+    path: topics.rag25.test.jsonl
+    qrel: qrels.rag25.test.txt
+
+models:
+  - name: splade-v3-onnx
+    display: SPLADE-v3
+    params: -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3
+    results:
+      nDCG@30:
+        - 0.5957
+      nDCG@100:
+        - 0.5387
+      R@100:
+        - 0.2103

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.splade-v3.cached.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.splade-v3.cached.yaml
@@ -43,7 +43,7 @@ topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
     id: rag25.test
-    path: topics.rag25.test.jsonl
+    path: topics.rag25.test.splade-v3.jsonl.gz
     qrel: qrels.rag25.test-umbrela2.txt
 
 models:
@@ -52,8 +52,8 @@ models:
     params: -impact -pretokenized -removeQuery -hits 1000
     results:
       nDCG@30:
-        - 0.0219
+        - 0.5838
       nDCG@100:
-        - 0.0259
+        - 0.5372
       R@100:
-        - 0.0113
+        - 0.1992

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.splade-v3.cached.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.splade-v3.cached.yaml
@@ -1,0 +1,59 @@
+---
+corpus: msmarco-v2.1-doc-segmented-splade-v3
+corpus_path: collections/msmarco/msmarco_v2.1_doc_segmented_splade-v3
+
+download_url: https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco_v2.1_doc_segmented_splade-v3.tar
+download_checksum: c62490569364a1eb0101da1ca4a894d9
+download_corpus: msmarco_v2.1_doc_segmented_splade-v3
+
+index_path: indexes/lucene-inverted.msmarco-v2.1-doc-segmented.splade-v3/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 24
+index_options: -impact -pretokenized
+index_stats:
+  documents: 113520750
+  documents (non-empty): 113520750
+  total terms: 866904601378
+
+metrics:
+  - metric: nDCG@30
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.30
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@100
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonString
+topics:
+  - name: "RAG 25: Test queries"
+    id: rag25.test
+    path: topics.rag25.test.jsonl
+    qrel: qrels.rag25.test-umbrela2.txt
+
+models:
+  - name: splade-v3-cached
+    display: SPLADE-v3
+    params: -impact -pretokenized -removeQuery -hits 1000
+    results:
+      nDCG@30:
+        - 0.0219
+      nDCG@100:
+        - 0.0259
+      R@100:
+        - 0.0113

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.splade-v3.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.splade-v3.onnx.yaml
@@ -1,0 +1,59 @@
+---
+corpus: msmarco-v2.1-doc-segmented-splade-v3
+corpus_path: collections/msmarco/msmarco_v2.1_doc_segmented_splade-v3
+
+download_url: https://rgw.cs.uwaterloo.ca/pyserini/data/msmarco_v2.1_doc_segmented_splade-v3.tar
+download_checksum: c62490569364a1eb0101da1ca4a894d9
+download_corpus: msmarco_v2.1_doc_segmented_splade-v3
+
+index_path: indexes/lucene-inverted.msmarco-v2.1-doc-segmented.splade-v3/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 24
+index_options: -impact -pretokenized
+index_stats:
+  documents: 113520750
+  documents (non-empty): 113520750
+  total terms: 866904601378
+
+metrics:
+  - metric: nDCG@30
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.30
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@100
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: JsonString
+topics:
+  - name: "RAG 25: Test queries"
+    id: rag25.test
+    path: topics.rag25.test.jsonl
+    qrel: qrels.rag25.test-umbrela2.txt
+
+models:
+  - name: splade-v3-onnx
+    display: SPLADE-v3
+    params: -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3
+    results:
+      nDCG@30:
+        - 0.5838
+      nDCG@100:
+        - 0.5372
+      R@100:
+        - 0.1992

--- a/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-nist.splade-v3.cached.template
+++ b/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-nist.splade-v3.cached.template
@@ -1,0 +1,91 @@
+# Anserini Regressions: TREC 2025 RAG Track Test Topics
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments for ranking _on the segmented version_ of the MS MARCO V2.1 document corpus using the test topics (= queries in TREC parlance), which is integrated into Anserini's regression testing framework.
+This corpus was derived from the MS MARCO V2 _segmented_ document corpus and prepared for the TREC 2024 RAG Track.
+
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+Evaluation uses qrels over 22 topics from the TREC 2025 RAG Track test set.
+These qrels represent manual relevance judgments from NIST assessors, contrasted with automatically generated UMBRELA judgments.
+More details can be found in the following paper:
+
+> Shivani Upadhyay, Nandan Thakur, Ronak Pradeep, Nick Craswell, Daniel Campos and Jimmy Lin. [Overview of the TREC 2025 Retrieval Augmented Generation (RAG) Track.](https://arxiv.org/abs/2603.09891) _arXiv:2603.09891_, March 2026.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config ${test_name}
+```
+
+We make available a version of the MS MARCO V2.1 segmented document corpus that has already been encoded with SPLADE-v3.
+
+From any machine, the following command will download the corpus and perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --download --index --verify --search --config ${test_name}
+```
+
+The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
+
+## Corpus Download
+
+Download the corpus and unpack into `collections/`:
+
+```bash
+wget ${download_url} -P collections/
+tar xvf collections/${download_corpus}.tar -C collections/
+```
+
+To confirm, `${corpus}.tar` is 125 GB and has MD5 checksum `${download_checksum}`.
+With the corpus downloaded, the following command will perform the remaining steps below:
+
+```bash
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
+  --corpus-path collections/${download_corpus}
+```
+
+## Indexing
+
+Typical indexing command:
+
+```bash
+${index_cmds}
+```
+
+The setting of `-input` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Here, we are using 22 test topics from the TREC 2025 RAG Track with manual relevance judgments from NIST assessors.
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```bash
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```bash
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-nist.splade-v3.cached.template
+++ b/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-nist.splade-v3.cached.template
@@ -59,7 +59,7 @@ bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verif
 Following command can be used to pre-encode topics (optional here):
 
 ```bash
-bin/run.sh io.anserini.encoder.QueryEncoder \
+bin/run.sh io.anserini.encoder.EncodeQuery \
   -encoder SpladeV3 \
   -queries tools/topics-and-qrels/topics.rag25.test.jsonl \
   -topicReader JsonString \

--- a/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-nist.splade-v3.cached.template
+++ b/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-nist.splade-v3.cached.template
@@ -50,7 +50,7 @@ To confirm, `${corpus}.tar` is 125 GB and has MD5 checksum `${download_checksum}
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config ${test_name} \
   --corpus-path collections/${download_corpus}
 ```
 

--- a/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-nist.splade-v3.cached.template
+++ b/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-nist.splade-v3.cached.template
@@ -54,6 +54,19 @@ bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verif
   --corpus-path collections/${download_corpus}
 ```
 
+## Pre-encoding Topics
+
+Following command can be used to pre-encode topics (optional here):
+
+```bash
+bin/run.sh io.anserini.encoder.QueryEncoder \
+  -encoder SpladeV3 \
+  -queries tools/topics-and-qrels/topics.rag25.test.jsonl \
+  -topicReader JsonString \
+  -output encoded-queries/topics.rag25.test.splade-v3.jsonl.gz \
+  -compress
+```
+
 ## Indexing
 
 Typical indexing command:

--- a/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-nist.splade-v3.onnx.template
+++ b/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-nist.splade-v3.onnx.template
@@ -49,7 +49,7 @@ To confirm, `${corpus}.tar` is 125 GB and has MD5 checksum `${download_checksum}
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config ${test_name} \
   --corpus-path collections/${download_corpus}
 ```
 

--- a/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-nist.splade-v3.onnx.template
+++ b/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-nist.splade-v3.onnx.template
@@ -1,0 +1,90 @@
+# Anserini Regressions: TREC 2025 RAG Track Test Topics
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments for ranking _on the segmented version_ of the MS MARCO V2.1 document corpus using the test topics (= queries in TREC parlance), which is integrated into Anserini's regression testing framework.
+This corpus was derived from the MS MARCO V2 _segmented_ document corpus and prepared for the TREC 2024 RAG Track.
+
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+Evaluation uses qrels over 22 topics from the TREC 2025 RAG Track test set.
+These qrels represent manual relevance judgments from NIST assessors, contrasted with automatically generated UMBRELA judgments.
+More details can be found in the following paper:
+
+> Shivani Upadhyay, Nandan Thakur, Ronak Pradeep, Nick Craswell, Daniel Campos and Jimmy Lin. [Overview of the TREC 2025 Retrieval Augmented Generation (RAG) Track.](https://arxiv.org/abs/2603.09891) _arXiv:2603.09891_, March 2026.
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config ${test_name}
+```
+
+We make available a version of the MS MARCO V2.1 segmented document corpus that has already been encoded with SPLADE-v3.
+
+From any machine, the following command will download the corpus and perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --download --index --verify --search --config ${test_name}
+```
+
+The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
+
+## Corpus Download
+
+Download the corpus and unpack into `collections/`:
+
+```bash
+wget ${download_url} -P collections/
+tar xvf collections/${download_corpus}.tar -C collections/
+```
+
+To confirm, `${corpus}.tar` is 125 GB and has MD5 checksum `${download_checksum}`.
+With the corpus downloaded, the following command will perform the remaining steps below:
+
+```bash
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
+  --corpus-path collections/${download_corpus}
+```
+
+## Indexing
+
+Typical indexing command:
+
+```bash
+${index_cmds}
+```
+
+The setting of `-input` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Here, we are using 22 test topics from the TREC 2025 RAG Track with manual relevance judgments from NIST assessors.
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```bash
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```bash
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-umbrela2.splade-v3.cached.template
+++ b/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-umbrela2.splade-v3.cached.template
@@ -49,7 +49,7 @@ To confirm, `${corpus}.tar` is 125 GB and has MD5 checksum `${download_checksum}
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config ${test_name} \
   --corpus-path collections/${download_corpus}
 ```
 

--- a/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-umbrela2.splade-v3.cached.template
+++ b/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-umbrela2.splade-v3.cached.template
@@ -53,6 +53,19 @@ bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verif
   --corpus-path collections/${download_corpus}
 ```
 
+## Pre-encoding Topics
+
+Following command can be used to pre-encode topics (optional here):
+
+```bash
+bin/run.sh io.anserini.encoder.QueryEncoder \
+  -encoder SpladeV3 \
+  -queries tools/topics-and-qrels/topics.rag25.test.jsonl \
+  -topicReader JsonString \
+  -output encoded-queries/topics.rag25.test.splade-v3.jsonl.gz \
+  -compress
+```
+
 ## Indexing
 
 Typical indexing command:

--- a/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-umbrela2.splade-v3.cached.template
+++ b/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-umbrela2.splade-v3.cached.template
@@ -58,7 +58,7 @@ bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verif
 Following command can be used to pre-encode topics (optional here):
 
 ```bash
-bin/run.sh io.anserini.encoder.QueryEncoder \
+bin/run.sh io.anserini.encoder.EncodeQuery \
   -encoder SpladeV3 \
   -queries tools/topics-and-qrels/topics.rag25.test.jsonl \
   -topicReader JsonString \

--- a/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-umbrela2.splade-v3.cached.template
+++ b/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-umbrela2.splade-v3.cached.template
@@ -1,0 +1,90 @@
+# Anserini Regressions: TREC 2025 RAG Track Test Topics
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using cached queries)
+
+This page describes regression experiments for ranking _on the segmented version_ of the MS MARCO V2.1 document corpus using the test topics (= queries in TREC parlance), which is integrated into Anserini's regression testing framework.
+This corpus was derived from the MS MARCO V2 _segmented_ document corpus and prepared for the TREC 2024 RAG Track.
+
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using cached queries (i.e., cached results of query encoding).
+
+Evaluation uses qrels over 22 topics from the TREC 2025 RAG Track test set.
+More details can be found in the following paper:
+
+> Shivani Upadhyay, Nandan Thakur, Ronak Pradeep, Nick Craswell, Daniel Campos and Jimmy Lin. [Overview of the TREC 2025 Retrieval Augmented Generation (RAG) Track.](https://arxiv.org/abs/2603.09891) _arXiv:2603.09891_, March 2026.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config ${test_name}
+```
+
+We make available a version of the MS MARCO V2.1 segmented document corpus that has already been encoded with SPLADE-v3.
+
+From any machine, the following command will download the corpus and perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --download --index --verify --search --config ${test_name}
+```
+
+The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
+
+## Corpus Download
+
+Download the corpus and unpack into `collections/`:
+
+```bash
+wget ${download_url} -P collections/
+tar xvf collections/${download_corpus}.tar -C collections/
+```
+
+To confirm, `${corpus}.tar` is 125 GB and has MD5 checksum `${download_checksum}`.
+With the corpus downloaded, the following command will perform the remaining steps below:
+
+```bash
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
+  --corpus-path collections/${download_corpus}
+```
+
+## Indexing
+
+Typical indexing command:
+
+```bash
+${index_cmds}
+```
+
+The setting of `-input` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Here, we are using 22 test topics from the TREC 2025 RAG Track with manual relevance judgments from NIST assessors.
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```bash
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```bash
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-umbrela2.splade-v3.onnx.template
+++ b/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-umbrela2.splade-v3.onnx.template
@@ -49,7 +49,7 @@ To confirm, `${corpus}.tar` is 125 GB and has MD5 checksum `${download_checksum}
 With the corpus downloaded, the following command will perform the remaining steps below:
 
 ```bash
-python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config ${test_name} \
   --corpus-path collections/${download_corpus}
 ```
 

--- a/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-umbrela2.splade-v3.onnx.template
+++ b/src/main/resources/reproduce/from-document-collection/docgen/rag25-doc-segmented-test-umbrela2.splade-v3.onnx.template
@@ -1,0 +1,90 @@
+# Anserini Regressions: TREC 2025 RAG Track Test Topics
+
+**Model**: [SPLADE-v3](https://arxiv.org/abs/2403.06789) (using ONNX for on-the-fly query encoding)
+
+This page describes regression experiments for ranking _on the segmented version_ of the MS MARCO V2.1 document corpus using the test topics (= queries in TREC parlance), which is integrated into Anserini's regression testing framework.
+This corpus was derived from the MS MARCO V2 _segmented_ document corpus and prepared for the TREC 2024 RAG Track.
+
+The model itself can be download [here](https://huggingface.co/naver/splade-v3).
+See the [official SPLADE repo](https://github.com/naver/splade) and the following paper for more details:
+
+> Carlos Lassance, Hervé Déjean, Thibault Formal, and Stéphane Clinchant. [SPLADE-v3: New baselines for SPLADE.](https://arxiv.org/abs/2403.06789) _arXiv:2403.06789_.
+
+In these experiments, we are using ONNX to perform query encoding on the fly.
+
+Evaluation uses qrels over 22 topics from the TREC 2025 RAG Track test set.
+More details can be found in the following paper:
+
+> Shivani Upadhyay, Nandan Thakur, Ronak Pradeep, Nick Craswell, Daniel Campos and Jimmy Lin. [Overview of the TREC 2025 Retrieval Augmented Generation (RAG) Track.](https://arxiv.org/abs/2603.09891) _arXiv:2603.09891_, March 2026.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead and then run `bin/build.sh` to rebuild the documentation.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config ${test_name}
+```
+
+We make available a version of the MS MARCO V2.1 segmented document corpus that has already been encoded with SPLADE-v3.
+
+From any machine, the following command will download the corpus and perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --download --index --verify --search --config ${test_name}
+```
+
+The `run_regression.py` script automates the following steps, but if you want to perform each step manually, simply copy/paste from the commands below and you'll obtain the same regression results.
+
+## Corpus Download
+
+Download the corpus and unpack into `collections/`:
+
+```bash
+wget ${download_url} -P collections/
+tar xvf collections/${download_corpus}.tar -C collections/
+```
+
+To confirm, `${corpus}.tar` is 125 GB and has MD5 checksum `${download_checksum}`.
+With the corpus downloaded, the following command will perform the remaining steps below:
+
+```bash
+python src/main/python/run_regression.py --index --verify --search --regression ${test_name} \
+  --corpus-path collections/${download_corpus}
+```
+
+## Indexing
+
+Typical indexing command:
+
+```bash
+${index_cmds}
+```
+
+The setting of `-input` should be a directory containing the compressed `jsonl` files that comprise the corpus.
+
+The important indexing options to note here are `-impact -pretokenized`: the first tells Anserini not to encode BM25 doclengths into Lucene's norms (which is the default) and the second option says not to apply any additional tokenization on the pre-encoded tokens.
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Here, we are using 22 test topics from the TREC 2025 RAG Track with manual relevance judgments from NIST assessors.
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```bash
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```bash
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}

--- a/src/test/java/io/anserini/encoder/EncodeQueryTest.java
+++ b/src/test/java/io/anserini/encoder/EncodeQueryTest.java
@@ -1,0 +1,209 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.encoder;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.GZIPInputStream;
+
+@LuceneTestCase.SuppressSysoutChecks(bugUrl = "output comes from args4j and EncodeQuery stderr")
+public class EncodeQueryTest extends StdOutStdErrRedirectableLuceneTestCase {
+
+  private static final String QUERIES = "src/test/resources/sample_topics/encode-query-test-queries.jsonl";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @BeforeClass
+  public static void setupClass() {
+    suppressJvmLogging();
+    Configurator.setLevel(EncodeQuery.class.getName(), Level.ERROR);
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    redirectStdErr();
+    super.setUp();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    restoreStdErr();
+    super.tearDown();
+  }
+
+  /** Finds the JSONL line whose "id" or "qid" field matches the given id. */
+  private static JsonNode findById(List<String> lines, String id) throws Exception {
+    for (String line : lines) {
+      JsonNode node = MAPPER.readTree(line);
+      JsonNode idNode = node.has("id") ? node.get("id") : node.get("qid");
+      if (idNode != null && idNode.asText().equals(id)) return node;
+    }
+    throw new AssertionError("No record with id=" + id + " in output");
+  }
+
+  /** Finds the TSV line whose first tab-separated field matches the given id. */
+  private static String[] findTsvById(List<String> lines, String id) {
+    for (String line : lines) {
+      String[] parts = line.split("\t", 2);
+      if (parts.length == 2 && parts[0].equals(id)) return parts;
+    }
+    throw new AssertionError("No TSV record with id=" + id + " in output");
+  }
+
+  // --- CLI argument validation ---
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuildEncoderUnknownThrows() throws Exception {
+    EncodeQuery.buildEncoder("UnknownEncoder");
+  }
+
+  @Test
+  public void testMissingEncoder() throws Exception {
+    EncodeQuery.main(new String[]{});
+    assertTrue(err.toString().contains("Option \"-encoder\" is required"));
+  }
+
+  @Test
+  public void testMissingQueries() throws Exception {
+    EncodeQuery.main(new String[]{"-encoder", "SpladeV3", "-output", "out.jsonl"});
+    assertTrue(err.toString().contains("Option \"-queries\" is required"));
+  }
+
+  @Test
+  public void testMissingOutput() throws Exception {
+    EncodeQuery.main(new String[]{"-encoder", "SpladeV3", "-queries", "topics.jsonl"});
+    assertTrue(err.toString().contains("Option \"-output\" is required"));
+  }
+
+  @Test
+  public void testUnknownEncoderPrintsError() throws Exception {
+    File output = File.createTempFile("encode-query-test", ".jsonl");
+    output.deleteOnExit();
+    EncodeQuery.main(new String[]{
+        "-encoder", "NoSuchEncoder",
+        "-queries", QUERIES,
+        "-output", output.getAbsolutePath()
+    });
+    assertTrue(err.toString().contains("Unknown encoder 'NoSuchEncoder'"));
+  }
+
+  @Test
+  public void testNonExistentTopicsFilePrintsError() throws Exception {
+    File output = File.createTempFile("encode-query-test", ".jsonl");
+    output.deleteOnExit();
+    EncodeQuery.main(new String[]{
+        "-encoder", "SpladeV3",
+        "-queries", "/nonexistent/path/to/topics.jsonl",
+        "-output", output.getAbsolutePath()
+    });
+    assertTrue(err.toString().contains("No topics loaded"));
+  }
+  // --- Sparse encoding ---
+
+  @Test
+  public void testSparseJsonlOutput() throws Exception {
+    File output = File.createTempFile("encode-query-test", ".jsonl");
+    output.deleteOnExit();
+    EncodeQuery.main(new String[]{
+        "-encoder", "SpladeV3",
+        "-queries", QUERIES,
+        "-output", output.getAbsolutePath()
+    });
+
+    List<String> lines = Files.readAllLines(output.toPath());
+    assertEquals(2, lines.size());
+    for (String line : lines) {
+      JsonNode node = MAPPER.readTree(line);
+      assertNotNull(node.get("id"));
+      assertFalse(node.get("title").asText().isEmpty());
+    }
+
+    // "what is paula deen's brother" → SpladeV3 expands to include "paula" and "brother"
+    JsonNode paulaNode = findById(lines, "1048585");
+    assertTrue(paulaNode.get("title").asText().contains("paula"));
+    assertTrue(paulaNode.get("title").asText().contains("brother"));
+
+    // "Androgen receptor define" → expands to include "receptor" and "hormone"
+    JsonNode androgenNode = findById(lines, "2");
+    assertTrue(androgenNode.get("title").asText().contains("receptor"));
+    assertTrue(androgenNode.get("title").asText().contains("hormone"));
+  }
+
+  @Test
+  public void testSparseCompressedOutput() throws Exception {
+    File output = File.createTempFile("encode-query-test", ".jsonl.gz");
+    output.deleteOnExit();
+    EncodeQuery.main(new String[]{
+        "-encoder", "SpladeV3",
+        "-queries", QUERIES,
+        "-compress",
+        "-output", output.getAbsolutePath()
+    });
+
+    List<String> lines = new ArrayList<>();
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+        new GZIPInputStream(new FileInputStream(output)), StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) lines.add(line);
+    }
+    assertEquals(2, lines.size());
+
+    JsonNode paulaNode = findById(lines, "1048585");
+    assertTrue(paulaNode.get("title").asText().contains("paula"));
+  }
+
+  // --- Dense encoding ---
+
+  @Test
+  public void testDenseTsvOutput() throws Exception {
+    File output = File.createTempFile("encode-query-test", ".tsv");
+    output.deleteOnExit();
+    EncodeQuery.main(new String[]{
+        "-encoder", "CosDprDistil",
+        "-queries", QUERIES,
+        "-outputFormat", "tsv",
+        "-output", output.getAbsolutePath()
+    });
+
+    List<String> lines = Files.readAllLines(output.toPath());
+    assertEquals(2, lines.size());
+    for (String line : lines) {
+      String[] parts = line.split("\t", 2);
+      assertEquals(2, parts.length);
+      assertEquals(768, parts[1].split(" ").length);
+    }
+
+    String[] paulaParts = findTsvById(lines, "1048585");
+    assertEquals(768, paulaParts[1].split(" ").length);
+  }
+}

--- a/src/test/resources/sample_topics/encode-query-test-queries.jsonl
+++ b/src/test/resources/sample_topics/encode-query-test-queries.jsonl
@@ -1,0 +1,2 @@
+{"id": "1048585", "title": "what is paula deen's brother"}
+{"id": "2", "title": "Androgen receptor define"}


### PR DESCRIPTION
Adds configs and template for rag25 with Splade v3.
Adds/updates configs and templates for rag25 qrels (manual: qrels.rag25.test.txt and automatic: qrels.rag25.test-umbrela2.txt) using Splade v3.

Includes EncodeQuery class that can be used for pre-encoding queries.