### PR TITLE
[codex] Add REST index alias config support

### DIFF
--- a/src/main/java/io/anserini/api/RestServer.java
+++ b/src/main/java/io/anserini/api/RestServer.java
@@ -17,11 +17,16 @@
 package io.anserini.api;
 
 import java.io.Closeable;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +43,7 @@ import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.ParserProperties;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import io.anserini.cli.CliUtils;
 import io.anserini.index.IndexReaderUtils;
@@ -56,17 +62,21 @@ public final class RestServer implements Closeable {
     @Option(name = "--port", metaVar = "[number]", usage = "Port to bind server to")
     public int port = 8080;
 
+    @Option(name = "--index-config", metaVar = "[path]", usage = "Path to YAML config containing REST index aliases")
+    public String indexConfig;
+
     @Option(name = "--help", help = true, usage = "Print this help message and exit.")
     public boolean help = false;
   }
 
   private static final String[] argsOrdering = new String[] {
-      "--host", "--port", "--help"};
+      "--host", "--port", "--index-config", "--help"};
 
   private static final int DEFAULT_HITS = 10;
   private static final String OPENAPI_PATH = "/openapi.yaml";
   private static final String DOCS_PATH = "/docs";
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+  private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
   private static final byte[] OPENAPI_SPEC = loadOpenApiSpec();
   private static final byte[] DOCS_PAGE = loadResource("/rest/docs.html");
   private static final String ROUTE_ERROR = "Expected route /v1/{index}/search or /v1/{index}/doc/{docid}";
@@ -75,11 +85,17 @@ public final class RestServer implements Closeable {
   private final Javalin app;
   private final String host;
   private final int port;
+  private final Map<String, String> configuredIndexes;
   private final ConcurrentHashMap<String, SimpleSearcher> searchers = new ConcurrentHashMap<>();
+
+  private static class IndexConfig {
+    public Map<String, String> indexes = Collections.emptyMap();
+  }
 
   RestServer(Args args) throws IOException {
     this.host = args.host;
     this.port = args.port;
+    this.configuredIndexes = loadConfiguredIndexes(args.indexConfig);
     JavalinLogger.enabled = false;
     Configurator.setLevel("io.javalin", Level.ERROR);
     Configurator.setLevel("org.eclipse.jetty", Level.ERROR);
@@ -95,6 +111,9 @@ public final class RestServer implements Closeable {
     app.start(host, port);
     System.out.printf("Anserini REST server listening on %s:%d%n", host, getPort());
     System.out.printf("v1 endpoint: GET /v1/{index}/search?query=...&hits=%d%n", DEFAULT_HITS);
+    if (!configuredIndexes.isEmpty()) {
+      System.out.printf("Configured index aliases: %s%n", String.join(", ", configuredIndexes.keySet()));
+    }
   }
 
   int getPort() {
@@ -199,9 +218,57 @@ public final class RestServer implements Closeable {
 
   private SimpleSearcher createSearcher(String index) {
     try {
-      return new SimpleSearcher(IndexReaderUtils.getIndex(index).toString());
+      return new SimpleSearcher(resolveIndex(index).toString());
     } catch (Exception e) {
       return null;
+    }
+  }
+
+  private Path resolveIndex(String index) throws IOException {
+    String configuredIndex = configuredIndexes.get(index);
+    if (configuredIndex != null) {
+      return Paths.get(configuredIndex);
+    }
+
+    return IndexReaderUtils.getIndex(index);
+  }
+
+  private static Map<String, String> loadConfiguredIndexes(String configPath) throws IOException {
+    if (configPath == null || configPath.isBlank()) {
+      return Map.of();
+    }
+
+    try (InputStream inputStream = new FileInputStream(configPath)) {
+      IndexConfig config = YAML_MAPPER.readValue(inputStream, IndexConfig.class);
+      if (config == null || config.indexes == null || config.indexes.isEmpty()) {
+        return Map.of();
+      }
+
+      LinkedHashMap<String, String> indexes = new LinkedHashMap<>();
+      for (Map.Entry<String, String> entry : config.indexes.entrySet()) {
+        String alias = entry.getKey();
+        String configuredPath = entry.getValue();
+        if (alias == null || alias.isBlank()) {
+          throw new IllegalArgumentException("Index aliases in --index-config must be non-empty");
+        }
+        if (configuredPath == null || configuredPath.isBlank()) {
+          throw new IllegalArgumentException("Index alias \"" + alias + "\" must map to a non-empty path");
+        }
+
+        Path resolvedPath = Paths.get(configuredPath);
+        if (!resolvedPath.isAbsolute()) {
+          Path configParent = Paths.get(configPath).toAbsolutePath().getParent();
+          resolvedPath = (configParent == null ? resolvedPath.toAbsolutePath() : configParent.resolve(resolvedPath)).normalize();
+        }
+        if (!Files.exists(resolvedPath)) {
+          throw new IllegalArgumentException(
+              "Index alias \"" + alias + "\" points to missing path: " + resolvedPath);
+        }
+
+        indexes.put(alias, resolvedPath.toString());
+      }
+
+      return Collections.unmodifiableMap(indexes);
     }
   }
 

--- a/src/main/java/io/anserini/api/RestServer.java
+++ b/src/main/java/io/anserini/api/RestServer.java
@@ -433,7 +433,7 @@ public final class RestServer implements Closeable {
         }
       }));
       server.start();
-    } catch (IOException e) {
+    } catch (Exception e) {
       System.err.printf("Error: %s%n", e.getMessage());
     }
   }

--- a/src/main/java/io/anserini/api/RestServer.java
+++ b/src/main/java/io/anserini/api/RestServer.java
@@ -95,7 +95,7 @@ public final class RestServer implements Closeable {
   RestServer(Args args) throws IOException {
     this.host = args.host;
     this.port = args.port;
-    this.configuredIndexes = loadConfiguredIndexes(args.indexConfig);
+    this.configuredIndexes = loadConfig(args.indexConfig);
     JavalinLogger.enabled = false;
     Configurator.setLevel("io.javalin", Level.ERROR);
     Configurator.setLevel("org.eclipse.jetty", Level.ERROR);
@@ -233,7 +233,7 @@ public final class RestServer implements Closeable {
     return IndexReaderUtils.getIndex(index);
   }
 
-  private static Map<String, String> loadConfiguredIndexes(String configPath) throws IOException {
+  private static Map<String, String> loadConfig(String configPath) throws IOException {
     if (configPath == null || configPath.isBlank()) {
       return Map.of();
     }
@@ -260,9 +260,9 @@ public final class RestServer implements Closeable {
           Path configParent = Paths.get(configPath).toAbsolutePath().getParent();
           resolvedPath = (configParent == null ? resolvedPath.toAbsolutePath() : configParent.resolve(resolvedPath)).normalize();
         }
+
         if (!Files.exists(resolvedPath)) {
-          throw new IllegalArgumentException(
-              "Index alias \"" + alias + "\" points to missing path: " + resolvedPath);
+          throw new IllegalArgumentException("Index alias \"" + alias + "\" points to missing path: " + resolvedPath);
         }
 
         indexes.put(alias, resolvedPath.toString());

--- a/src/main/java/io/anserini/api/RestServer.java
+++ b/src/main/java/io/anserini/api/RestServer.java
@@ -56,16 +56,16 @@ import io.javalin.util.JavalinLogger;
 
 public final class RestServer implements Closeable {
   public static class Args {
-    @Option(name = "--host", metaVar = "[address]", usage = "Address to bind server to")
+    @Option(name = "--host", metaVar = "[address]", usage = "address to bind server to")
     public String host = "0.0.0.0";
 
-    @Option(name = "--port", metaVar = "[number]", usage = "Port to bind server to")
+    @Option(name = "--port", metaVar = "[number]", usage = "port to bind server to")
     public int port = 8080;
 
-    @Option(name = "--index-config", metaVar = "[path]", usage = "Path to YAML config containing REST index aliases")
+    @Option(name = "--index-config", metaVar = "[path]", usage = "path to YAML config containing index aliases")
     public String indexConfig;
 
-    @Option(name = "--help", help = true, usage = "Print this help message and exit.")
+    @Option(name = "--help", help = true, usage = "print this help message and exit")
     public boolean help = false;
   }
 

--- a/src/test/java/io/anserini/api/RestServerTest.java
+++ b/src/test/java/io/anserini/api/RestServerTest.java
@@ -47,9 +47,9 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     args.port = 0;
 
     server = new RestServer(args);
-    server.start();
+    startServerQuietly(server);
 
-    baseUrl = "http://127.0.0.1:" + server.getPort();
+    baseUrl = String.format("http://127.0.0.1:%d", server.getPort());
   }
 
   @Override
@@ -70,7 +70,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     String output;
     try {
       RestServer.main(new String[] {"--invalid"});
-      output = out.toString(StandardCharsets.UTF_8) + err.toString(StandardCharsets.UTF_8);
+      output = String.format("%s%s", out.toString(StandardCharsets.UTF_8), err.toString(StandardCharsets.UTF_8));
     } finally {
       restoreStdOut();
       restoreStdErr();
@@ -89,7 +89,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     String output;
     try {
       RestServer.main(new String[] {"--port", "0"});
-      output = out.toString(StandardCharsets.UTF_8) + err.toString(StandardCharsets.UTF_8);
+      output = String.format("%s%s", out.toString(StandardCharsets.UTF_8), err.toString(StandardCharsets.UTF_8));
     } finally {
       restoreStdOut();
       restoreStdErr();
@@ -102,14 +102,14 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
   @Test
   public void testInvalidIndexConfigStartupOptions() throws Exception {
     Path config = Files.createTempFile("rest-server-indexes-invalid-main", ".yaml");
-    Files.writeString(config, "indexes:\n" + "  missing: /path/that/does/not/exist\n", StandardCharsets.UTF_8);
+    Files.writeString(config, String.format("indexes:\n  missing: /path/that/does/not/exist\n"), StandardCharsets.UTF_8);
 
     redirectStdOut();
     redirectStdErr();
     String output;
     try {
       RestServer.main(new String[] {"--index-config", config.toString()});
-      output = out.toString(StandardCharsets.UTF_8) + err.toString(StandardCharsets.UTF_8);
+      output = String.format("%s%s", out.toString(StandardCharsets.UTF_8), err.toString(StandardCharsets.UTF_8));
     } finally {
       restoreStdOut();
       restoreStdErr();
@@ -128,7 +128,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     String output;
     try {
       RestServer.main(new String[] {"--help"});
-      output = out.toString(StandardCharsets.UTF_8) + err.toString(StandardCharsets.UTF_8);
+      output = String.format("%s%s", out.toString(StandardCharsets.UTF_8), err.toString(StandardCharsets.UTF_8));
     } finally {
       restoreStdOut();
       restoreStdErr();
@@ -148,7 +148,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     Path indexPath = Path.of("src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_trec_collection2")
         .toAbsolutePath()
         .normalize();
-    Files.writeString(config, "indexes:\n" + "  sample: " + indexPath + "\n", StandardCharsets.UTF_8);
+    Files.writeString(config, String.format("indexes:\n  sample: %s\n", indexPath), StandardCharsets.UTF_8);
 
     RestServer aliasServer = null;
     try {
@@ -158,9 +158,9 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
       args.indexConfig = config.toString();
 
       aliasServer = new RestServer(args);
-      aliasServer.start();
+      startServerQuietly(aliasServer);
 
-      TestResponse response = sendGet("http://127.0.0.1:" + aliasServer.getPort() + "/v1/sample/search?query=text&hits=1");
+      TestResponse response = sendGet(String.format("http://127.0.0.1:%d/v1/sample/search?query=text&hits=1", aliasServer.getPort()));
       assertEquals(200, response.statusCode);
 
       JsonNode body = JSON_MAPPER.readTree(response.body);
@@ -177,7 +177,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
   @Test
   public void testInvalidIndexConfigFailsFast() throws Exception {
     Path config = Files.createTempFile("rest-server-indexes-invalid", ".yaml");
-    Files.writeString(config, "indexes:\n" + "  missing: /path/that/does/not/exist\n", StandardCharsets.UTF_8);
+    Files.writeString(config, String.format("indexes:\n  missing: /path/that/does/not/exist\n"), StandardCharsets.UTF_8);
 
     try {
       RestServer.Args args = new RestServer.Args();
@@ -191,8 +191,43 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
   }
 
   @Test
+  public void testInvalidIndexConfigWithBlankAliasFailsFast() throws Exception {
+    Path config = Files.createTempFile("rest-server-indexes-invalid-alias", ".yaml");
+    Path indexPath = Path.of("src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_trec_collection2")
+        .toAbsolutePath()
+        .normalize();
+    Files.writeString(config, String.format("indexes:\n  '': %s\n", indexPath), StandardCharsets.UTF_8);
+
+    try {
+      RestServer.Args args = new RestServer.Args();
+      args.indexConfig = config.toString();
+
+      IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> new RestServer(args));
+      assertTrue(exception.getMessage().contains("must be non-empty"));
+    } finally {
+      Files.deleteIfExists(config);
+    }
+  }
+
+  @Test
+  public void testInvalidIndexConfigWithBlankPathFailsFast() throws Exception {
+    Path config = Files.createTempFile("rest-server-indexes-invalid-path", ".yaml");
+    Files.writeString(config, String.format("indexes:\n  sample: ''\n"), StandardCharsets.UTF_8);
+
+    try {
+      RestServer.Args args = new RestServer.Args();
+      args.indexConfig = config.toString();
+
+      IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> new RestServer(args));
+      assertTrue(exception.getMessage().contains("must map to a non-empty path"));
+    } finally {
+      Files.deleteIfExists(config);
+    }
+  }
+
+  @Test
   public void testRouteValidation() throws Exception {
-    TestResponse response = sendGet(baseUrl + "/v1/bad/route");
+    TestResponse response = sendGet(String.format("%s/v1/bad/route", baseUrl));
 
     assertEquals(404, response.statusCode);
     JsonNode body = JSON_MAPPER.readTree(response.body);
@@ -201,7 +236,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
 
   @Test
   public void testMissingQueryValidation() throws Exception {
-    TestResponse response = sendGet(baseUrl + "/v1/any-index/search");
+    TestResponse response = sendGet(String.format("%s/v1/any-index/search", baseUrl));
 
     assertEquals(400, response.statusCode);
     JsonNode body = JSON_MAPPER.readTree(response.body);
@@ -210,7 +245,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
 
   @Test
   public void testInvalidHitsValidation() throws Exception {
-    TestResponse response = sendGet(baseUrl + "/v1/any-index/search?query=text&hits=0");
+    TestResponse response = sendGet(String.format("%s/v1/any-index/search?query=text&hits=0", baseUrl));
 
     assertEquals(400, response.statusCode);
     JsonNode body = JSON_MAPPER.readTree(response.body);
@@ -219,7 +254,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
 
   @Test
   public void testInvalidParseValidation() throws Exception {
-    TestResponse response = sendGet(baseUrl + "/v1/any-index/search?query=text&parse=maybe");
+    TestResponse response = sendGet(String.format("%s/v1/any-index/search?query=text&parse=maybe", baseUrl));
 
     assertEquals(400, response.statusCode);
     JsonNode body = JSON_MAPPER.readTree(response.body);
@@ -229,7 +264,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
   @Test
   public void testSearchEndpoint() throws Exception {
     String index = URLEncoder.encode("src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_trec_collection2", StandardCharsets.UTF_8);
-    TestResponse response = sendGet(baseUrl + "/v1/" + index + "/search?query=text&hits=2");
+    TestResponse response = sendGet(String.format("%s/v1/%s/search?query=text&hits=2", baseUrl, index));
 
     assertEquals(200, response.statusCode);
     JsonNode body = JSON_MAPPER.readTree(response.body);
@@ -246,13 +281,14 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     String rawIndex = "src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_trec_collection2";
     String index = URLEncoder.encode(rawIndex, StandardCharsets.UTF_8);
 
-    TestResponse searchResponse = sendGet(baseUrl + "/v1/" + index + "/search?query=text&hits=1");
+    TestResponse searchResponse = sendGet(String.format("%s/v1/%s/search?query=text&hits=1", baseUrl, index));
     assertEquals(200, searchResponse.statusCode);
     JsonNode searchBody = JSON_MAPPER.readTree(searchResponse.body);
     JsonNode candidate = searchBody.get("candidates").get(0);
     String docid = candidate.get("docid").asText();
 
-    TestResponse documentResponse = sendGet(baseUrl + "/v1/" + index + "/doc/" + URLEncoder.encode(docid, StandardCharsets.UTF_8));
+    TestResponse documentResponse =
+        sendGet(String.format("%s/v1/%s/doc/%s", baseUrl, index, URLEncoder.encode(docid, StandardCharsets.UTF_8)));
     assertEquals(200, documentResponse.statusCode);
     JsonNode documentBody = JSON_MAPPER.readTree(documentResponse.body);
 
@@ -266,7 +302,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     String rawIndex = "src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_trec_collection2";
     String index = URLEncoder.encode(rawIndex, StandardCharsets.UTF_8);
 
-    TestResponse searchResponse = sendGet(baseUrl + "/v1/" + index + "/search?query=text&hits=1&parse=false");
+    TestResponse searchResponse = sendGet(String.format("%s/v1/%s/search?query=text&hits=1&parse=false", baseUrl, index));
     assertEquals(200, searchResponse.statusCode);
     JsonNode searchBody = JSON_MAPPER.readTree(searchResponse.body);
     JsonNode candidate = searchBody.get("candidates").get(0);
@@ -279,7 +315,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
   public void testDocumentEndpoint() throws Exception {
     String index = URLEncoder.encode("src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_trec_collection2", StandardCharsets.UTF_8);
     String docid = URLEncoder.encode("DOC222", StandardCharsets.UTF_8);
-    TestResponse response = sendGet(baseUrl + "/v1/" + index + "/doc/" + docid);
+    TestResponse response = sendGet(String.format("%s/v1/%s/doc/%s", baseUrl, index, docid));
 
     assertEquals(200, response.statusCode);
     JsonNode body = JSON_MAPPER.readTree(response.body);
@@ -293,13 +329,13 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
   public void testDocumentEndpointUsesNormalizedDocumentShape() throws Exception {
     String rawIndex = "src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_trec_collection2";
     String index = URLEncoder.encode(rawIndex, StandardCharsets.UTF_8);
-    TestResponse searchResponse = sendGet(baseUrl + "/v1/" + index + "/search?query=text&hits=1");
+    TestResponse searchResponse = sendGet(String.format("%s/v1/%s/search?query=text&hits=1", baseUrl, index));
     assertEquals(200, searchResponse.statusCode);
     JsonNode searchBody = JSON_MAPPER.readTree(searchResponse.body);
     JsonNode candidate = searchBody.get("candidates").get(0);
     String docid = candidate.get("docid").asText();
 
-    TestResponse response = sendGet(baseUrl + "/v1/" + index + "/doc/" + URLEncoder.encode(docid, StandardCharsets.UTF_8));
+    TestResponse response = sendGet(String.format("%s/v1/%s/doc/%s", baseUrl, index, URLEncoder.encode(docid, StandardCharsets.UTF_8)));
     assertEquals(200, response.statusCode);
     JsonNode body = JSON_MAPPER.readTree(response.body);
 
@@ -311,7 +347,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     String rawIndex = "src/test/resources/prebuilt_indexes/lucene-inverted.sample_cacm.store_raw";
     String index = URLEncoder.encode(rawIndex, StandardCharsets.UTF_8);
 
-    TestResponse searchResponse = sendGet(baseUrl + "/v1/" + index + "/search?query=preliminary&hits=1");
+    TestResponse searchResponse = sendGet(String.format("%s/v1/%s/search?query=preliminary&hits=1", baseUrl, index));
     assertEquals(200, searchResponse.statusCode);
     JsonNode searchBody = JSON_MAPPER.readTree(searchResponse.body);
     JsonNode candidate = searchBody.get("candidates").get(0);
@@ -320,7 +356,8 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     assertTrue(candidate.get("doc").isTextual());
     assertTrue(candidate.get("doc").asText().contains("Preliminary Report"));
 
-    TestResponse documentResponse = sendGet(baseUrl + "/v1/" + index + "/doc/" + URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8));
+    TestResponse documentResponse = sendGet(String.format("%s/v1/%s/doc/%s",
+        baseUrl, index, URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8)));
     assertEquals(200, documentResponse.statusCode);
     JsonNode documentBody = JSON_MAPPER.readTree(documentResponse.body);
 
@@ -333,7 +370,8 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     String rawIndex = "src/test/resources/prebuilt_indexes/lucene-inverted.sample_cacm.store_raw";
     String index = URLEncoder.encode(rawIndex, StandardCharsets.UTF_8);
 
-    TestResponse searchResponse = sendGet(baseUrl + "/v1/" + index + "/search?query=preliminary&hits=1&parse=false");
+    TestResponse searchResponse =
+        sendGet(String.format("%s/v1/%s/search?query=preliminary&hits=1&parse=false", baseUrl, index));
     assertEquals(200, searchResponse.statusCode);
     JsonNode searchBody = JSON_MAPPER.readTree(searchResponse.body);
     JsonNode candidate = searchBody.get("candidates").get(0);
@@ -342,8 +380,8 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     assertTrue(candidate.get("doc").isTextual());
     assertTrue(candidate.get("doc").asText().contains("Preliminary Report"));
 
-    TestResponse documentResponse = sendGet(baseUrl + "/v1/" + index + "/doc/" +
-        URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8) + "?parse=false");
+    TestResponse documentResponse = sendGet(String.format("%s/v1/%s/doc/%s?parse=false", baseUrl, index,
+        URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8)));
     assertEquals(200, documentResponse.statusCode);
     JsonNode documentBody = JSON_MAPPER.readTree(documentResponse.body);
 
@@ -356,7 +394,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     String rawIndex = "src/test/resources/prebuilt_indexes/lucene-inverted.sample_msmarco-v1-passage.store_raw";
     String index = URLEncoder.encode(rawIndex, StandardCharsets.UTF_8);
 
-    TestResponse searchResponse = sendGet(baseUrl + "/v1/" + index + "/search?query=obliterated&hits=1");
+    TestResponse searchResponse = sendGet(String.format("%s/v1/%s/search?query=obliterated&hits=1", baseUrl, index));
     assertEquals(200, searchResponse.statusCode);
     JsonNode searchBody = JSON_MAPPER.readTree(searchResponse.body);
     JsonNode candidate = searchBody.get("candidates").get(0);
@@ -365,8 +403,8 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     assertTrue(candidate.get("doc").isTextual());
     assertTrue(candidate.get("doc").asText().contains("hundreds of thousands of innocent lives obliterated"));
 
-    TestResponse documentResponse = sendGet(baseUrl + "/v1/" + index + "/doc/" +
-        URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8));
+    TestResponse documentResponse = sendGet(String.format("%s/v1/%s/doc/%s", baseUrl, index,
+        URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8)));
     assertEquals(200, documentResponse.statusCode);
     JsonNode documentBody = JSON_MAPPER.readTree(documentResponse.body);
 
@@ -379,7 +417,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     String rawIndex = "src/test/resources/prebuilt_indexes/lucene-inverted.sample_msmarco-v1-passage.store_raw";
     String index = URLEncoder.encode(rawIndex, StandardCharsets.UTF_8);
 
-    TestResponse searchResponse = sendGet(baseUrl + "/v1/" + index + "/search?query=obliterated&hits=1&parse=false");
+    TestResponse searchResponse = sendGet(String.format("%s/v1/%s/search?query=obliterated&hits=1&parse=false", baseUrl, index));
     assertEquals(200, searchResponse.statusCode);
     JsonNode searchBody = JSON_MAPPER.readTree(searchResponse.body);
     JsonNode candidate = searchBody.get("candidates").get(0);
@@ -390,8 +428,8 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     assertTrue(candidate.get("doc").asText().contains("\"contents\""));
     assertTrue(candidate.get("doc").asText().contains("hundreds of thousands of innocent lives obliterated"));
 
-    TestResponse documentResponse = sendGet(baseUrl + "/v1/" + index + "/doc/" +
-        URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8) + "?parse=false");
+    TestResponse documentResponse = sendGet(String.format("%s/v1/%s/doc/%s?parse=false", baseUrl, index,
+        URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8)));
     assertEquals(200, documentResponse.statusCode);
     JsonNode documentBody = JSON_MAPPER.readTree(documentResponse.body);
 
@@ -404,7 +442,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     String rawIndex = "src/test/resources/prebuilt_indexes/lucene-inverted.sample_msmarco-v2.1-doc-segmented.store_raw";
     String index = URLEncoder.encode(rawIndex, StandardCharsets.UTF_8);
 
-    TestResponse searchResponse = sendGet(baseUrl + "/v1/" + index + "/search?query=demerara&hits=1");
+    TestResponse searchResponse = sendGet(String.format("%s/v1/%s/search?query=demerara&hits=1", baseUrl, index));
     assertEquals(200, searchResponse.statusCode);
     JsonNode searchBody = JSON_MAPPER.readTree(searchResponse.body);
     JsonNode candidate = searchBody.get("candidates").get(0);
@@ -415,8 +453,8 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
         candidate.get("doc").get("title").asText());
     assertTrue(candidate.get("doc").get("segment").asText().contains("Not all brown sugars are the same"));
 
-    TestResponse documentResponse = sendGet(baseUrl + "/v1/" + index + "/doc/" +
-        URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8));
+    TestResponse documentResponse = sendGet(String.format("%s/v1/%s/doc/%s", baseUrl, index,
+        URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8)));
     assertEquals(200, documentResponse.statusCode);
     JsonNode documentBody = JSON_MAPPER.readTree(documentResponse.body);
 
@@ -429,7 +467,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     String rawIndex = "src/test/resources/prebuilt_indexes/lucene-inverted.sample_msmarco-v2.1-doc-segmented.store_raw";
     String index = URLEncoder.encode(rawIndex, StandardCharsets.UTF_8);
 
-    TestResponse searchResponse = sendGet(baseUrl + "/v1/" + index + "/search?query=demerara&hits=1&parse=false");
+    TestResponse searchResponse = sendGet(String.format("%s/v1/%s/search?query=demerara&hits=1&parse=false", baseUrl, index));
     assertEquals(200, searchResponse.statusCode);
     JsonNode searchBody = JSON_MAPPER.readTree(searchResponse.body);
     JsonNode candidate = searchBody.get("candidates").get(0);
@@ -440,8 +478,8 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     assertTrue(candidate.get("doc").asText().contains("\"segment\""));
     assertTrue(candidate.get("doc").asText().contains("Not all brown sugars are the same"));
 
-    TestResponse documentResponse = sendGet(baseUrl + "/v1/" + index + "/doc/" +
-        URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8) + "?parse=false");
+    TestResponse documentResponse = sendGet(String.format("%s/v1/%s/doc/%s?parse=false", baseUrl, index,
+        URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8)));
     assertEquals(200, documentResponse.statusCode);
     JsonNode documentBody = JSON_MAPPER.readTree(documentResponse.body);
 
@@ -454,7 +492,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     String rawIndex = "src/test/resources/prebuilt_indexes/lucene-inverted.sample_beir-nfcorpus.flat.store_raw";
     String index = URLEncoder.encode(rawIndex, StandardCharsets.UTF_8);
 
-    TestResponse searchResponse = sendGet(baseUrl + "/v1/" + index + "/search?query=statin&hits=1");
+    TestResponse searchResponse = sendGet(String.format("%s/v1/%s/search?query=statin&hits=1", baseUrl, index));
     assertEquals(200, searchResponse.statusCode);
     JsonNode searchBody = JSON_MAPPER.readTree(searchResponse.body);
     JsonNode candidate = searchBody.get("candidates").get(0);
@@ -465,8 +503,8 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
         candidate.get("doc").get("title").asText());
     assertTrue(candidate.get("doc").get("text").asText().contains("Recent studies have suggested"));
 
-    TestResponse documentResponse = sendGet(baseUrl + "/v1/" + index + "/doc/" +
-        URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8));
+    TestResponse documentResponse = sendGet(String.format("%s/v1/%s/doc/%s", baseUrl, index,
+        URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8)));
     assertEquals(200, documentResponse.statusCode);
     JsonNode documentBody = JSON_MAPPER.readTree(documentResponse.body);
 
@@ -479,7 +517,8 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     String rawIndex = "src/test/resources/prebuilt_indexes/lucene-inverted.sample_beir-nfcorpus.flat.store_raw";
     String index = URLEncoder.encode(rawIndex, StandardCharsets.UTF_8);
 
-    TestResponse searchResponse = sendGet(baseUrl + "/v1/" + index + "/search?query=statin&hits=1&parse=false");
+    TestResponse searchResponse =
+        sendGet(String.format("%s/v1/%s/search?query=statin&hits=1&parse=false", baseUrl, index));
     assertEquals(200, searchResponse.statusCode);
     JsonNode searchBody = JSON_MAPPER.readTree(searchResponse.body);
     JsonNode candidate = searchBody.get("candidates").get(0);
@@ -491,8 +530,8 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     assertTrue(candidate.get("doc").asText().contains("\"text\""));
     assertTrue(candidate.get("doc").asText().contains("Statin Use and Breast Cancer Survival"));
 
-    TestResponse documentResponse = sendGet(baseUrl + "/v1/" + index + "/doc/" +
-        URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8) + "?parse=false");
+    TestResponse documentResponse = sendGet(String.format("%s/v1/%s/doc/%s?parse=false",
+        baseUrl, index, URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8)));
     assertEquals(200, documentResponse.statusCode);
     JsonNode documentBody = JSON_MAPPER.readTree(documentResponse.body);
 
@@ -505,7 +544,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     String rawIndex = "src/test/resources/prebuilt_indexes/lucene-inverted.sample_cacm.store_raw";
     String index = URLEncoder.encode(rawIndex, StandardCharsets.UTF_8);
     String docid = URLEncoder.encode("NOT_A_REAL_DOC", StandardCharsets.UTF_8);
-    TestResponse response = sendGet(baseUrl + "/v1/" + index + "/doc/" + docid);
+    TestResponse response = sendGet(String.format("%s/v1/%s/doc/%s", baseUrl, index, docid));
 
     assertEquals(404, response.statusCode);
     JsonNode body = JSON_MAPPER.readTree(response.body);
@@ -514,7 +553,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
 
   @Test
   public void testOpenApiEndpoint() throws Exception {
-    TestResponse response = sendGet(baseUrl + "/openapi.yaml");
+    TestResponse response = sendGet(String.format("%s/openapi.yaml", baseUrl));
 
     assertEquals(200, response.statusCode);
     assertTrue(response.body.contains("openapi: 3.0.3"));
@@ -525,7 +564,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
 
   @Test
   public void testDocsEndpoint() throws Exception {
-    TestResponse response = sendGet(baseUrl + "/docs");
+    TestResponse response = sendGet(String.format("%s/docs", baseUrl));
 
     assertEquals(200, response.statusCode);
     assertTrue(response.body.contains("SwaggerUIBundle"));
@@ -547,6 +586,15 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     }
 
     return new TestResponse(statusCode, body);
+  }
+
+  private void startServerQuietly(RestServer server) {
+    redirectStdOut();
+    try {
+      server.start();
+    } finally {
+      restoreStdOut();
+    }
   }
 
   private static JsonNode expectedParsedDocument(JsonNode document) throws Exception {

--- a/src/test/java/io/anserini/api/RestServerTest.java
+++ b/src/test/java/io/anserini/api/RestServerTest.java
@@ -100,6 +100,28 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
   }
 
   @Test
+  public void testInvalidIndexConfigStartupOptions() throws Exception {
+    Path config = Files.createTempFile("rest-server-indexes-invalid-main", ".yaml");
+    Files.writeString(config, "indexes:\n" + "  missing: /path/that/does/not/exist\n", StandardCharsets.UTF_8);
+
+    redirectStdOut();
+    redirectStdErr();
+    String output;
+    try {
+      RestServer.main(new String[] {"--index-config", config.toString()});
+      output = out.toString(StandardCharsets.UTF_8) + err.toString(StandardCharsets.UTF_8);
+    } finally {
+      restoreStdOut();
+      restoreStdErr();
+      Files.deleteIfExists(config);
+    }
+
+    assertTrue(output.contains("Error:"));
+    assertTrue(output.contains("missing path"));
+    assertFalse(output.contains("Anserini REST server listening on"));
+  }
+
+  @Test
   public void testHelp() throws Exception {
     redirectStdOut();
     redirectStdErr();
@@ -230,8 +252,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     JsonNode candidate = searchBody.get("candidates").get(0);
     String docid = candidate.get("docid").asText();
 
-    TestResponse documentResponse = sendGet(baseUrl + "/v1/" + index + "/doc/" +
-        URLEncoder.encode(docid, StandardCharsets.UTF_8));
+    TestResponse documentResponse = sendGet(baseUrl + "/v1/" + index + "/doc/" + URLEncoder.encode(docid, StandardCharsets.UTF_8));
     assertEquals(200, documentResponse.statusCode);
     JsonNode documentBody = JSON_MAPPER.readTree(documentResponse.body);
 
@@ -278,8 +299,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     JsonNode candidate = searchBody.get("candidates").get(0);
     String docid = candidate.get("docid").asText();
 
-    TestResponse response = sendGet(baseUrl + "/v1/" + index + "/doc/" +
-        URLEncoder.encode(docid, StandardCharsets.UTF_8));
+    TestResponse response = sendGet(baseUrl + "/v1/" + index + "/doc/" + URLEncoder.encode(docid, StandardCharsets.UTF_8));
     assertEquals(200, response.statusCode);
     JsonNode body = JSON_MAPPER.readTree(response.body);
 
@@ -300,8 +320,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     assertTrue(candidate.get("doc").isTextual());
     assertTrue(candidate.get("doc").asText().contains("Preliminary Report"));
 
-    TestResponse documentResponse = sendGet(baseUrl + "/v1/" + index + "/doc/" +
-        URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8));
+    TestResponse documentResponse = sendGet(baseUrl + "/v1/" + index + "/doc/" + URLEncoder.encode(candidate.get("docid").asText(), StandardCharsets.UTF_8));
     assertEquals(200, documentResponse.statusCode);
     JsonNode documentBody = JSON_MAPPER.readTree(documentResponse.body);
 

--- a/src/test/java/io/anserini/api/RestServerTest.java
+++ b/src/test/java/io/anserini/api/RestServerTest.java
@@ -20,6 +20,8 @@ import java.net.URI;
 import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Scanner;
@@ -113,8 +115,57 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     assertTrue(output.contains("Options for RestServer:"));
     assertTrue(output.contains("--host [address]"));
     assertTrue(output.contains("--port [number]"));
+    assertTrue(output.contains("--index-config [path]"));
     assertTrue(output.contains("--help"));
     assertFalse(output.contains("Anserini REST server listening on"));
+  }
+
+  @Test
+  public void testIndexAliasFromConfig() throws Exception {
+    Path config = Files.createTempFile("rest-server-indexes", ".yaml");
+    Path indexPath = Path.of("src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_trec_collection2")
+        .toAbsolutePath()
+        .normalize();
+    Files.writeString(config, "indexes:\n" + "  sample: " + indexPath + "\n", StandardCharsets.UTF_8);
+
+    RestServer aliasServer = null;
+    try {
+      RestServer.Args args = new RestServer.Args();
+      args.host = "127.0.0.1";
+      args.port = 0;
+      args.indexConfig = config.toString();
+
+      aliasServer = new RestServer(args);
+      aliasServer.start();
+
+      TestResponse response = sendGet("http://127.0.0.1:" + aliasServer.getPort() + "/v1/sample/search?query=text&hits=1");
+      assertEquals(200, response.statusCode);
+
+      JsonNode body = JSON_MAPPER.readTree(response.body);
+      assertEquals("sample", body.get("index").asText());
+      assertEquals("DOC222", body.get("candidates").get(0).get("docid").asText());
+    } finally {
+      if (aliasServer != null) {
+        aliasServer.close();
+      }
+      Files.deleteIfExists(config);
+    }
+  }
+
+  @Test
+  public void testInvalidIndexConfigFailsFast() throws Exception {
+    Path config = Files.createTempFile("rest-server-indexes-invalid", ".yaml");
+    Files.writeString(config, "indexes:\n" + "  missing: /path/that/does/not/exist\n", StandardCharsets.UTF_8);
+
+    try {
+      RestServer.Args args = new RestServer.Args();
+      args.indexConfig = config.toString();
+
+      IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> new RestServer(args));
+      assertTrue(exception.getMessage().contains("missing"));
+    } finally {
+      Files.deleteIfExists(config);
+    }
   }
 
   @Test
@@ -155,9 +206,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
 
   @Test
   public void testSearchEndpoint() throws Exception {
-    String index = URLEncoder.encode(
-        "src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_trec_collection2",
-        StandardCharsets.UTF_8);
+    String index = URLEncoder.encode("src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_trec_collection2", StandardCharsets.UTF_8);
     TestResponse response = sendGet(baseUrl + "/v1/" + index + "/search?query=text&hits=2");
 
     assertEquals(200, response.statusCode);
@@ -207,9 +256,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
 
   @Test
   public void testDocumentEndpoint() throws Exception {
-    String index = URLEncoder.encode(
-        "src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_trec_collection2",
-        StandardCharsets.UTF_8);
+    String index = URLEncoder.encode("src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_trec_collection2", StandardCharsets.UTF_8);
     String docid = URLEncoder.encode("DOC222", StandardCharsets.UTF_8);
     TestResponse response = sendGet(baseUrl + "/v1/" + index + "/doc/" + docid);
 

--- a/src/test/java/io/anserini/api/RestServerTest.java
+++ b/src/test/java/io/anserini/api/RestServerTest.java
@@ -287,8 +287,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     JsonNode candidate = searchBody.get("candidates").get(0);
     String docid = candidate.get("docid").asText();
 
-    TestResponse documentResponse =
-        sendGet(String.format("%s/v1/%s/doc/%s", baseUrl, index, URLEncoder.encode(docid, StandardCharsets.UTF_8)));
+    TestResponse documentResponse = sendGet(String.format("%s/v1/%s/doc/%s", baseUrl, index, URLEncoder.encode(docid, StandardCharsets.UTF_8)));
     assertEquals(200, documentResponse.statusCode);
     JsonNode documentBody = JSON_MAPPER.readTree(documentResponse.body);
 
@@ -370,8 +369,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     String rawIndex = "src/test/resources/prebuilt_indexes/lucene-inverted.sample_cacm.store_raw";
     String index = URLEncoder.encode(rawIndex, StandardCharsets.UTF_8);
 
-    TestResponse searchResponse =
-        sendGet(String.format("%s/v1/%s/search?query=preliminary&hits=1&parse=false", baseUrl, index));
+    TestResponse searchResponse = sendGet(String.format("%s/v1/%s/search?query=preliminary&hits=1&parse=false", baseUrl, index));
     assertEquals(200, searchResponse.statusCode);
     JsonNode searchBody = JSON_MAPPER.readTree(searchResponse.body);
     JsonNode candidate = searchBody.get("candidates").get(0);
@@ -517,8 +515,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     String rawIndex = "src/test/resources/prebuilt_indexes/lucene-inverted.sample_beir-nfcorpus.flat.store_raw";
     String index = URLEncoder.encode(rawIndex, StandardCharsets.UTF_8);
 
-    TestResponse searchResponse =
-        sendGet(String.format("%s/v1/%s/search?query=statin&hits=1&parse=false", baseUrl, index));
+    TestResponse searchResponse = sendGet(String.format("%s/v1/%s/search?query=statin&hits=1&parse=false", baseUrl, index));
     assertEquals(200, searchResponse.statusCode);
     JsonNode searchBody = JSON_MAPPER.readTree(searchResponse.body);
     JsonNode candidate = searchBody.get("candidates").get(0);


### PR DESCRIPTION
## Summary
- add `--index-config` to `RestServer` to load YAML aliases for REST index names
- resolve configured aliases before falling back to existing index path and prebuilt index resolution
- validate configured aliases at startup and add tests for config-based lookup and fail-fast invalid paths

## Why
The REST API currently expects the `{index}` path segment to be either a local filesystem path or a built-in prebuilt index name. That makes deployment awkward when the server should expose stable public aliases for externally managed index locations.

This change lets operators provide an explicit startup config that maps API-visible index names to real index paths without changing the request format.

## Validation
- `mvn -Dtest=RestServerTest test`

## Notes
- relative paths inside the YAML config are resolved relative to the config file location
- existing direct path and prebuilt index behavior remains available as a fallback when an alias is not configured