### PR TITLE
[codex] Refactor prebuilt-index summary table output

### DIFF
--- a/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -426,7 +427,7 @@ public class ReproduceFromPrebuiltIndexes {
               condition.name,
               topic.topic_key,
               entry.getKey(),
-              String.format("%.4f", entry.getValue())
+              String.format(Locale.ROOT, "%.4f", entry.getValue())
           };
           rows.add(row);
           conditionWidth = Math.max(conditionWidth, row[0].length());

--- a/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
@@ -438,13 +438,12 @@ public class ReproduceFromPrebuiltIndexes {
       }
     }
 
-    String summaryFormat = "%-" + conditionWidth + "s  %-" + topicWidth + "s  %-" + metricWidth + "s  %"
-        + expectedWidth + "s%n";
+    String summaryFormat = "%-" + conditionWidth + "s  %-" + topicWidth + "s  %-" + metricWidth + "s  %" + expectedWidth + "s%n";
     StringBuilder summary = new StringBuilder();
     summary.append("Summary").append(System.lineSeparator());
     summary.append(String.format(summaryFormat, "condition", "topic", "metric", "expected"));
-    summary.append(String.format(summaryFormat, repeat('-', conditionWidth), repeat('-', topicWidth), repeat('-', metricWidth),
-        repeat('-', expectedWidth)));
+    summary.append(String.format(summaryFormat,
+      repeat('-', conditionWidth), repeat('-', topicWidth), repeat('-', metricWidth), repeat('-', expectedWidth)));
 
     String previousCondition = null;
     for (String[] row : rows) {

--- a/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -332,6 +333,10 @@ public class ReproduceFromPrebuiltIndexes {
     final Instant endTime = Instant.now();
     final long durationMillis = endTime.toEpochMilli() - startTime.toEpochMilli();
 
+    if (!config.conditions.isEmpty()) {
+      System.out.print(renderSummaryTable(config));
+    }
+
     System.out.println("Start time: " + ReproductionUtils.formatStartTime(startTime));
     System.out.println("End time:   " + ReproductionUtils.formatEndTime(endTime));
     System.out.println("Duration:   " + ReproductionUtils.formatDuration(durationMillis));
@@ -405,6 +410,51 @@ public class ReproduceFromPrebuiltIndexes {
     StringBuilder sb = new StringBuilder(n);
     for (int i = 0; i < n; i++) sb.append(c);
     return sb.toString();
+  }
+
+  static String renderSummaryTable(Config config) {
+    int conditionWidth = "condition".length();
+    int topicWidth = "topic".length();
+    int metricWidth = "metric".length();
+    int expectedWidth = "expected".length();
+
+    List<String[]> rows = new ArrayList<>();
+    for (Condition condition : config.conditions) {
+      for (Topic topic : condition.topics) {
+        for (Map.Entry<String, Double> entry : topic.expected_scores.entrySet()) {
+          String[] row = new String[] {
+              condition.name,
+              topic.topic_key,
+              entry.getKey(),
+              String.format("%.4f", entry.getValue())
+          };
+          rows.add(row);
+          conditionWidth = Math.max(conditionWidth, row[0].length());
+          topicWidth = Math.max(topicWidth, row[1].length());
+          metricWidth = Math.max(metricWidth, row[2].length());
+          expectedWidth = Math.max(expectedWidth, row[3].length());
+        }
+      }
+    }
+
+    String summaryFormat = "%-" + conditionWidth + "s  %-" + topicWidth + "s  %-" + metricWidth + "s  %"
+        + expectedWidth + "s%n";
+    StringBuilder summary = new StringBuilder();
+    summary.append("Summary").append(System.lineSeparator());
+    summary.append(String.format(summaryFormat, "condition", "topic", "metric", "expected"));
+    summary.append(String.format(summaryFormat, repeat('-', conditionWidth), repeat('-', topicWidth), repeat('-', metricWidth),
+        repeat('-', expectedWidth)));
+
+    String previousCondition = null;
+    for (String[] row : rows) {
+      if (previousCondition != null && !row[0].equals(previousCondition)) {
+        summary.append(System.lineSeparator());
+      }
+      summary.append(String.format(summaryFormat, row[0], row[1], row[2], row[3]));
+      previousCondition = row[0];
+    }
+    summary.append(System.lineSeparator());
+    return summary.toString();
   }
 
   public static class Config {

--- a/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
@@ -19,6 +19,7 @@ package io.anserini.reproduce;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -136,7 +137,21 @@ public class ReproduceFromPrebuiltIndexesTest extends StdOutStdErrRedirectableLu
     assertTrue(summary.contains("0.1234"));
     assertTrue(summary.contains("R@1K"));
     assertTrue(summary.contains("0.5678"));
-    assertTrue(summary.contains(System.lineSeparator() + System.lineSeparator() + "cond-b"));
+    List<String> lines = summary.lines().collect(Collectors.toList());
+    int firstConditionLastRow = -1;
+    int secondConditionFirstRow = -1;
+    for (int i = 0; i < lines.size(); i++) {
+      String line = lines.get(i);
+      if (line.startsWith("cond-a")) {
+        firstConditionLastRow = i;
+      } else if (line.startsWith("cond-b")) {
+        secondConditionFirstRow = i;
+        break;
+      }
+    }
+    assertTrue(firstConditionLastRow >= 0);
+    assertTrue(secondConditionFirstRow > firstConditionLastRow + 1);
+    assertEquals("", lines.get(secondConditionFirstRow - 1));
     assertTrue(summary.contains("MAP"));
     assertTrue(summary.contains("0.9876"));
   }

--- a/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
@@ -16,6 +16,8 @@
 
 package io.anserini.reproduce;
 
+import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
@@ -97,5 +99,45 @@ public class ReproduceFromPrebuiltIndexesTest extends StdOutStdErrRedirectableLu
     String s = out.toString();
     assertTrue(s.contains("Indexes referenced by this run"));
     assertTrue(s.contains("Total size across"));
+  }
+
+  @Test
+  public void testRenderSummaryTable() {
+    ReproduceFromPrebuiltIndexes.Config config = new ReproduceFromPrebuiltIndexes.Config();
+
+    ReproduceFromPrebuiltIndexes.Condition firstCondition = new ReproduceFromPrebuiltIndexes.Condition();
+    firstCondition.name = "cond-a";
+    ReproduceFromPrebuiltIndexes.Topic firstTopic = new ReproduceFromPrebuiltIndexes.Topic();
+    firstTopic.topic_key = "topic-a";
+    firstTopic.expected_scores = new LinkedHashMap<>();
+    firstTopic.expected_scores.put("MRR@10", 0.1234);
+    firstTopic.expected_scores.put("R@1K", 0.5678);
+    firstCondition.topics = Arrays.asList(firstTopic);
+
+    ReproduceFromPrebuiltIndexes.Condition secondCondition = new ReproduceFromPrebuiltIndexes.Condition();
+    secondCondition.name = "cond-b";
+    ReproduceFromPrebuiltIndexes.Topic secondTopic = new ReproduceFromPrebuiltIndexes.Topic();
+    secondTopic.topic_key = "topic-b";
+    secondTopic.expected_scores = new LinkedHashMap<>();
+    secondTopic.expected_scores.put("MAP", 0.9876);
+    secondCondition.topics = Arrays.asList(secondTopic);
+
+    config.conditions = Arrays.asList(firstCondition, secondCondition);
+
+    String summary = ReproduceFromPrebuiltIndexes.renderSummaryTable(config);
+    assertTrue(summary.startsWith("Summary"));
+    assertTrue(summary.contains("condition"));
+    assertTrue(summary.contains("topic"));
+    assertTrue(summary.contains("metric"));
+    assertTrue(summary.contains("expected"));
+    assertTrue(summary.contains("cond-a"));
+    assertTrue(summary.contains("topic-a"));
+    assertTrue(summary.contains("MRR@10"));
+    assertTrue(summary.contains("0.1234"));
+    assertTrue(summary.contains("R@1K"));
+    assertTrue(summary.contains("0.5678"));
+    assertTrue(summary.contains(System.lineSeparator() + System.lineSeparator() + "cond-b"));
+    assertTrue(summary.contains("MAP"));
+    assertTrue(summary.contains("0.9876"));
   }
 }


### PR DESCRIPTION
## Summary
- refactor `ReproduceFromPrebuiltIndexes` summary-table rendering into its own method
- print one expected score per row and insert a blank line between condition groups
- add a focused unit test for summary-table rendering

## Testing
- `mvn -Dtest=ReproduceFromPrebuiltIndexesTest test`