### PR TITLE
[codex] Exclude native debug symbols from fatjar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,8 @@
                           <exclude>META-INF/*.SF</exclude>
                           <exclude>META-INF/*.DSA</exclude>
                           <exclude>META-INF/*.RSA</exclude>
+                          <exclude>ai/onnxruntime/native/**/*.pdb</exclude>
+                          <exclude>ai/onnxruntime/native/**/*.dSYM/**</exclude>
                       </excludes>
                   </filter>
               </filters>


### PR DESCRIPTION
## Summary

Excludes ONNX Runtime native debug symbol artifacts from the shaded fatjar.

The runtime native libraries remain packaged, but large `.pdb` and `.dSYM` debug symbol files are omitted. This keeps the cross-platform fatjar behavior while reducing the generated artifact size substantially.

## Validation

- Ran `bin/qbuild.sh` successfully.
- Verified `target/anserini-2.0.1-SNAPSHOT-fatjar.jar` is `105M`, down from the previous `163M` local build.
- Verified no `.pdb` or `.dSYM` entries remain in the rebuilt fatjar.
- Ran `java -cp target/anserini-2.0.1-SNAPSHOT-fatjar.jar io.anserini.search.SearchCollection -options` successfully.