### PR TITLE
Add NanoKnow v1.0 regressions

### DIFF
--- a/docs/reproduce/from-document-collection/nanoknow-v1.0-nq.md
+++ b/docs/reproduce/from-document-collection/nanoknow-v1.0-nq.md
@@ -1,0 +1,77 @@
+# Anserini Regressions: NanoKnow v1.0 &mdash; NQ-Open
+
+**Models**: BM25
+
+This page documents BM25 retrieval over the NanoKnow v1.0 corpus ([karpathy/fineweb-edu-100b-shuffle](https://huggingface.co/datasets/karpathy/fineweb-edu-100b-shuffle), ~97M documents) with NQ-Open validation queries, integrated into Anserini's regression testing framework.
+The corpus and qrels come from [NanoKnow](https://github.com/castorini/NanoKnow), a project that uses BM25 over this corpus to study the parametric knowledge of nanochat language models.
+Future versions (v2, v3, ...) of the NanoKnow regression are expected to project these query sets onto different corpora (e.g., ClimbMix), keeping the task format fixed and varying the index.
+
+The exact configurations for these regressions are stored in [this YAML file](../../../src/main/resources/reproduce/from-document-collection/configs/nanoknow-v1.0-nq.yaml).
+Note that this page is automatically generated from [this template](../../../src/main/resources/reproduce/from-document-collection/docgen/nanoknow-v1.0-nq.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config nanoknow-v1.0-nq
+```
+
+> :warning: Building the index from scratch reads ~325 GB of Parquet data and takes many hours; the resulting index is also ~325 GB.
+> If the index already exists at `indexes/lucene-inverted.nanoknow-v1.0/`, omit `--index` and just run `--verify --search`.
+> A pre-built index is also available for download from [LingweiGu/NanoKnow-Fineweb-Edu-Index](https://huggingface.co/datasets/LingweiGu/NanoKnow-Fineweb-Edu-Index).
+
+## Indexing
+
+Typical indexing command:
+
+```bash
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 32 \
+  -collection FineWebCollection \
+  -input /path/to/nanoknow-v1.0 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.nanoknow-v1.0/ \
+  -storeRaw \
+  >& logs/log.nanoknow-v1.0 &
+```
+
+The directory `/path/to/nanoknow-v1.0/` should contain the Parquet shards from the [karpathy/fineweb-edu-100b-shuffle](https://huggingface.co/datasets/karpathy/fineweb-edu-100b-shuffle) dataset (~97M documents, ~100B tokens).
+
+For additional details, see explanation of [common indexing options](../../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule:
+
++ [`topics.nanoknow-v1.0-nq.supported.tsv`](https://github.com/castorini/anserini-tools/blob/master/topics-and-qrels/topics.nanoknow-v1.0-nq.supported.tsv): 2,389 NQ-Open validation questions in `qid\tquery` TSV format.
++ [`qrels.nanoknow-v1.0-nq.supported.txt`](https://github.com/castorini/anserini-tools/blob/master/topics-and-qrels/qrels.nanoknow-v1.0-nq.supported.txt): NanoKnow v1.0 supported-document qrels in TREC format.
+
+The qrels are derived from the [NanoKnow](https://github.com/castorini/NanoKnow) pipeline: for each question, BM25 over this index returns the top-100 documents; documents that contain a normalized form of any official answer string are passed to a Qwen3-8B verifier; documents that the verifier judges as actually answering the question are recorded as relevant.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```bash
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.nanoknow-v1.0/ \
+  -topics tools/topics-and-qrels/topics.nanoknow-v1.0-nq.supported.tsv \
+  -topicReader TsvInt \
+  -output runs/run.nanoknow-v1.0.bm25.topics.nanoknow-v1.0-nq.supported.txt \
+  -bm25 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```bash
+bin/trec_eval -c -m recall.20 tools/topics-and-qrels/qrels.nanoknow-v1.0-nq.supported.txt runs/run.nanoknow-v1.0.bm25.topics.nanoknow-v1.0-nq.supported.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **R@20**                                                                                                     | **BM25 (default)**|
+|:-------------------------------------------------------------------------------------------------------------|-------------------|
+| [NanoKnow v1.0: NQ-Open Validation](https://github.com/castorini/NanoKnow)                                   | 0.3282            |
+
+The reported metric is **R@20** (Recall at 20). Because NanoKnow v1.0 qrels are themselves drawn from the BM25 top-100 over this exact index, R@100 is ~1.0 by construction and is not an interesting signal. R@20 instead measures what fraction of the verified answer-bearing documents BM25 ranks in the top-20; this number is sensitive to changes in the BM25 implementation, the index, or the topics, and so serves as a meaningful regression signal for the retrieval pipeline.
+
+This is intended to be a fully reproducible release regression: with the same Anserini code, the same `indexes/lucene-inverted.nanoknow-v1.0/` index, and the same NanoKnow v1.0 topics and qrels from `anserini-tools`, the reported R@20 value should remain unchanged across repeated runs.

--- a/docs/reproduce/from-document-collection/nanoknow-v1.0-squad.md
+++ b/docs/reproduce/from-document-collection/nanoknow-v1.0-squad.md
@@ -1,0 +1,77 @@
+# Anserini Regressions: NanoKnow v1.0 &mdash; SQuAD
+
+**Models**: BM25
+
+This page documents BM25 retrieval over the NanoKnow v1.0 corpus ([karpathy/fineweb-edu-100b-shuffle](https://huggingface.co/datasets/karpathy/fineweb-edu-100b-shuffle), ~97M documents) with SQuAD validation queries, integrated into Anserini's regression testing framework.
+The corpus and qrels come from [NanoKnow](https://github.com/castorini/NanoKnow), a project that uses BM25 over this corpus to study the parametric knowledge of nanochat language models.
+Future versions (v2, v3, ...) of the NanoKnow regression are expected to project these query sets onto different corpora (e.g., ClimbMix), keeping the task format fixed and varying the index.
+
+The exact configurations for these regressions are stored in [this YAML file](../../../src/main/resources/reproduce/from-document-collection/configs/nanoknow-v1.0-squad.yaml).
+Note that this page is automatically generated from [this template](../../../src/main/resources/reproduce/from-document-collection/docgen/nanoknow-v1.0-squad.template) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config nanoknow-v1.0-squad
+```
+
+> :warning: Building the index from scratch reads ~325 GB of Parquet data and takes many hours; the resulting index is also ~325 GB.
+> If the index already exists at `indexes/lucene-inverted.nanoknow-v1.0/`, omit `--index` and just run `--verify --search`.
+> A pre-built index is also available for download from [LingweiGu/NanoKnow-Fineweb-Edu-Index](https://huggingface.co/datasets/LingweiGu/NanoKnow-Fineweb-Edu-Index).
+
+## Indexing
+
+Typical indexing command:
+
+```bash
+bin/run.sh io.anserini.index.IndexCollection \
+  -threads 32 \
+  -collection FineWebCollection \
+  -input /path/to/nanoknow-v1.0 \
+  -generator DefaultLuceneDocumentGenerator \
+  -index indexes/lucene-inverted.nanoknow-v1.0/ \
+  -storeRaw \
+  >& logs/log.nanoknow-v1.0 &
+```
+
+The directory `/path/to/nanoknow-v1.0/` should contain the Parquet shards from the [karpathy/fineweb-edu-100b-shuffle](https://huggingface.co/datasets/karpathy/fineweb-edu-100b-shuffle) dataset (~97M documents, ~100B tokens).
+
+For additional details, see explanation of [common indexing options](../../../docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule:
+
++ [`topics.nanoknow-v1.0-squad.supported.tsv`](https://github.com/castorini/anserini-tools/blob/master/topics-and-qrels/topics.nanoknow-v1.0-squad.supported.tsv): 7,490 SQuAD validation questions in `qid\tquery` TSV format.
++ [`qrels.nanoknow-v1.0-squad.supported.txt`](https://github.com/castorini/anserini-tools/blob/master/topics-and-qrels/qrels.nanoknow-v1.0-squad.supported.txt): NanoKnow v1.0 supported-document qrels in TREC format.
+
+The qrels are derived from the [NanoKnow](https://github.com/castorini/NanoKnow) pipeline: for each question, BM25 over this index returns the top-100 documents; documents that contain a normalized form of any official answer string are passed to a Qwen3-8B verifier; documents that the verifier judges as actually answering the question are recorded as relevant.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```bash
+bin/run.sh io.anserini.search.SearchCollection \
+  -index indexes/lucene-inverted.nanoknow-v1.0/ \
+  -topics tools/topics-and-qrels/topics.nanoknow-v1.0-squad.supported.tsv \
+  -topicReader TsvInt \
+  -output runs/run.nanoknow-v1.0.bm25.topics.nanoknow-v1.0-squad.supported.txt \
+  -bm25 &
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```bash
+bin/trec_eval -c -m recall.20 tools/topics-and-qrels/qrels.nanoknow-v1.0-squad.supported.txt runs/run.nanoknow-v1.0.bm25.topics.nanoknow-v1.0-squad.supported.txt
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+| **R@20**                                                                                                     | **BM25 (default)**|
+|:-------------------------------------------------------------------------------------------------------------|-------------------|
+| [NanoKnow v1.0: SQuAD Validation](https://github.com/castorini/NanoKnow)                                     | 0.3106            |
+
+The reported metric is **R@20** (Recall at 20). Because NanoKnow v1.0 qrels are themselves drawn from the BM25 top-100 over this exact index, R@100 is ~1.0 by construction and is not an interesting signal. R@20 instead measures what fraction of the verified answer-bearing documents BM25 ranks in the top-20; this number is sensitive to changes in the BM25 implementation, the index, or the topics, and so serves as a meaningful regression signal for the retrieval pipeline.
+
+This is intended to be a fully reproducible release regression: with the same Anserini code, the same `indexes/lucene-inverted.nanoknow-v1.0/` index, and the same NanoKnow v1.0 topics and qrels from `anserini-tools`, the reported R@20 value should remain unchanged across repeated runs.

--- a/src/main/resources/reproduce/from-document-collection/configs/nanoknow-v1.0-nq.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/nanoknow-v1.0-nq.yaml
@@ -1,0 +1,37 @@
+---
+corpus: nanoknow-v1.0
+corpus_path: collections/nanoknow-v1.0/
+
+index_path: indexes/lucene-inverted.nanoknow-v1.0/
+collection_class: FineWebCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 32
+index_options: -storeRaw
+index_stats:
+  documents: 97230848
+  documents (non-empty): 97230848
+  total terms: 51464444242
+
+metrics:
+  - metric: R@20
+    command: bin/trec_eval
+    params: -c -m recall.20
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topics:
+  - name: "[NanoKnow v1.0: NQ-Open Validation](https://github.com/castorini/NanoKnow)"
+    id: nq
+    path: topics.nanoknow-v1.0-nq.supported.tsv
+    qrel: qrels.nanoknow-v1.0-nq.supported.txt
+
+models:
+  - name: bm25
+    display: BM25 (default)
+    params: -bm25
+    results:
+      R@20:
+        - 0.3282

--- a/src/main/resources/reproduce/from-document-collection/configs/nanoknow-v1.0-squad.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/nanoknow-v1.0-squad.yaml
@@ -1,0 +1,37 @@
+---
+corpus: nanoknow-v1.0
+corpus_path: collections/nanoknow-v1.0/
+
+index_path: indexes/lucene-inverted.nanoknow-v1.0/
+collection_class: FineWebCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 32
+index_options: -storeRaw
+index_stats:
+  documents: 97230848
+  documents (non-empty): 97230848
+  total terms: 51464444242
+
+metrics:
+  - metric: R@20
+    command: bin/trec_eval
+    params: -c -m recall.20
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topics:
+  - name: "[NanoKnow v1.0: SQuAD Validation](https://github.com/castorini/NanoKnow)"
+    id: squad
+    path: topics.nanoknow-v1.0-squad.supported.tsv
+    qrel: qrels.nanoknow-v1.0-squad.supported.txt
+
+models:
+  - name: bm25
+    display: BM25 (default)
+    params: -bm25
+    results:
+      R@20:
+        - 0.3106

--- a/src/main/resources/reproduce/from-document-collection/docgen/nanoknow-v1.0-nq.template
+++ b/src/main/resources/reproduce/from-document-collection/docgen/nanoknow-v1.0-nq.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: NanoKnow v1.0 &mdash; NQ-Open
+
+**Models**: BM25
+
+This page documents BM25 retrieval over the NanoKnow v1.0 corpus ([karpathy/fineweb-edu-100b-shuffle](https://huggingface.co/datasets/karpathy/fineweb-edu-100b-shuffle), ~97M documents) with NQ-Open validation queries, integrated into Anserini's regression testing framework.
+The corpus and qrels come from [NanoKnow](https://github.com/castorini/NanoKnow), a project that uses BM25 over this corpus to study the parametric knowledge of nanochat language models.
+Future versions (v2, v3, ...) of the NanoKnow regression are expected to project these query sets onto different corpora (e.g., ClimbMix), keeping the task format fixed and varying the index.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config ${test_name}
+```
+
+> :warning: Building the index from scratch reads ~325 GB of Parquet data and takes many hours; the resulting index is also ~325 GB.
+> If the index already exists at `indexes/lucene-inverted.nanoknow-v1.0/`, omit `--index` and just run `--verify --search`.
+> A pre-built index is also available for download from [LingweiGu/NanoKnow-Fineweb-Edu-Index](https://huggingface.co/datasets/LingweiGu/NanoKnow-Fineweb-Edu-Index).
+
+## Indexing
+
+Typical indexing command:
+
+```bash
+${index_cmds}
+```
+
+The directory `/path/to/nanoknow-v1.0/` should contain the Parquet shards from the [karpathy/fineweb-edu-100b-shuffle](https://huggingface.co/datasets/karpathy/fineweb-edu-100b-shuffle) dataset (~97M documents, ~100B tokens).
+
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule:
+
++ [`topics.nanoknow-v1.0-nq.supported.tsv`](https://github.com/castorini/anserini-tools/blob/master/topics-and-qrels/topics.nanoknow-v1.0-nq.supported.tsv): 2,389 NQ-Open validation questions in `qid\tquery` TSV format.
++ [`qrels.nanoknow-v1.0-nq.supported.txt`](https://github.com/castorini/anserini-tools/blob/master/topics-and-qrels/qrels.nanoknow-v1.0-nq.supported.txt): NanoKnow v1.0 supported-document qrels in TREC format.
+
+The qrels are derived from the [NanoKnow](https://github.com/castorini/NanoKnow) pipeline: for each question, BM25 over this index returns the top-100 documents; documents that contain a normalized form of any official answer string are passed to a Qwen3-8B verifier; documents that the verifier judges as actually answering the question are recorded as relevant.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```bash
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```bash
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}
+
+The reported metric is **R@20** (Recall at 20). Because NanoKnow v1.0 qrels are themselves drawn from the BM25 top-100 over this exact index, R@100 is ~1.0 by construction and is not an interesting signal. R@20 instead measures what fraction of the verified answer-bearing documents BM25 ranks in the top-20; this number is sensitive to changes in the BM25 implementation, the index, or the topics, and so serves as a meaningful regression signal for the retrieval pipeline.
+
+This is intended to be a fully reproducible release regression: with the same Anserini code, the same `indexes/lucene-inverted.nanoknow-v1.0/` index, and the same NanoKnow v1.0 topics and qrels from `anserini-tools`, the reported R@20 value should remain unchanged across repeated runs.

--- a/src/main/resources/reproduce/from-document-collection/docgen/nanoknow-v1.0-squad.template
+++ b/src/main/resources/reproduce/from-document-collection/docgen/nanoknow-v1.0-squad.template
@@ -1,0 +1,63 @@
+# Anserini Regressions: NanoKnow v1.0 &mdash; SQuAD
+
+**Models**: BM25
+
+This page documents BM25 retrieval over the NanoKnow v1.0 corpus ([karpathy/fineweb-edu-100b-shuffle](https://huggingface.co/datasets/karpathy/fineweb-edu-100b-shuffle), ~97M documents) with SQuAD validation queries, integrated into Anserini's regression testing framework.
+The corpus and qrels come from [NanoKnow](https://github.com/castorini/NanoKnow), a project that uses BM25 over this corpus to study the parametric knowledge of nanochat language models.
+Future versions (v2, v3, ...) of the NanoKnow regression are expected to project these query sets onto different corpora (e.g., ClimbMix), keeping the task format fixed and varying the index.
+
+The exact configurations for these regressions are stored in [this YAML file](${yaml}).
+Note that this page is automatically generated from [this template](${template}) as part of Anserini's regression pipeline, so do not modify this page directly; modify the template instead.
+
+From one of our Waterloo servers (e.g., `orca`), the following command will perform the complete regression, end to end:
+
+```bash
+bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --index --verify --search --config ${test_name}
+```
+
+> :warning: Building the index from scratch reads ~325 GB of Parquet data and takes many hours; the resulting index is also ~325 GB.
+> If the index already exists at `indexes/lucene-inverted.nanoknow-v1.0/`, omit `--index` and just run `--verify --search`.
+> A pre-built index is also available for download from [LingweiGu/NanoKnow-Fineweb-Edu-Index](https://huggingface.co/datasets/LingweiGu/NanoKnow-Fineweb-Edu-Index).
+
+## Indexing
+
+Typical indexing command:
+
+```bash
+${index_cmds}
+```
+
+The directory `/path/to/nanoknow-v1.0/` should contain the Parquet shards from the [karpathy/fineweb-edu-100b-shuffle](https://huggingface.co/datasets/karpathy/fineweb-edu-100b-shuffle) dataset (~97M documents, ~100B tokens).
+
+For additional details, see explanation of [common indexing options](${root_path}/docs/common-indexing-options.md).
+
+## Retrieval
+
+Topics and qrels are stored [here](https://github.com/castorini/anserini-tools/tree/master/topics-and-qrels), which is linked to the Anserini repo as a submodule:
+
++ [`topics.nanoknow-v1.0-squad.supported.tsv`](https://github.com/castorini/anserini-tools/blob/master/topics-and-qrels/topics.nanoknow-v1.0-squad.supported.tsv): 7,490 SQuAD validation questions in `qid\tquery` TSV format.
++ [`qrels.nanoknow-v1.0-squad.supported.txt`](https://github.com/castorini/anserini-tools/blob/master/topics-and-qrels/qrels.nanoknow-v1.0-squad.supported.txt): NanoKnow v1.0 supported-document qrels in TREC format.
+
+The qrels are derived from the [NanoKnow](https://github.com/castorini/NanoKnow) pipeline: for each question, BM25 over this index returns the top-100 documents; documents that contain a normalized form of any official answer string are passed to a Qwen3-8B verifier; documents that the verifier judges as actually answering the question are recorded as relevant.
+
+After indexing has completed, you should be able to perform retrieval as follows:
+
+```bash
+${ranking_cmds}
+```
+
+Evaluation can be performed using `trec_eval`:
+
+```bash
+${eval_cmds}
+```
+
+## Effectiveness
+
+With the above commands, you should be able to reproduce the following results:
+
+${effectiveness}
+
+The reported metric is **R@20** (Recall at 20). Because NanoKnow v1.0 qrels are themselves drawn from the BM25 top-100 over this exact index, R@100 is ~1.0 by construction and is not an interesting signal. R@20 instead measures what fraction of the verified answer-bearing documents BM25 ranks in the top-20; this number is sensitive to changes in the BM25 implementation, the index, or the topics, and so serves as a meaningful regression signal for the retrieval pipeline.
+
+This is intended to be a fully reproducible release regression: with the same Anserini code, the same `indexes/lucene-inverted.nanoknow-v1.0/` index, and the same NanoKnow v1.0 topics and qrels from `anserini-tools`, the reported R@20 value should remain unchanged across repeated runs.


### PR DESCRIPTION
Add BM25 release regressions for NanoKnow v1.0 over the Karpathy FineWeb-Edu 100B index, using the official supported topics and qrels merged in anserini-tools.

The regressions track R@20 for NQ-Open and SQuAD. Since the qrels are derived from BM25 top-100 over this same index, R@100 is effectively fixed by construction; R@20 provides a stable but non-trivial signal for ranking regressions across Anserini releases.