### PR TITLE
[codex] Refactor Anserini agent skills

### DIFF
--- a/.agents/skills/install-anserini-dev-env/SKILL.md
+++ b/.agents/skills/install-anserini-dev-env/SKILL.md
@@ -67,6 +67,8 @@ Use separate shell commands when executing this workflow in Codex so failures ar
 
 After setup, run the check script again and then run `bin/qbuild.sh`, `bin/build.sh`, or a targeted test requested by the user. If dependency downloads fail because network access is sandboxed, rerun the build command with escalation instead of changing project files.
 
+For search, prebuilt-index catalog, topics catalog, or REST server examples after setup, use `$use-anserini-cli`.
+
 ## Troubleshooting
 
 - If `java -version` and `mvn -v` disagree about Java versions, fix `JAVA_HOME` and `PATH` so Maven uses JDK 21.

--- a/.agents/skills/install-anserini-dev-env/agents/openai.yaml
+++ b/.agents/skills/install-anserini-dev-env/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Install Anserini Dev Env"
   short_description: "Set up and verify Anserini dev environments"
-  default_prompt: "Use $install-anserini-dev-env to set up and verify an Anserini development environment."
+  default_prompt: "Use $install-anserini-dev-env to set up and verify an Anserini development environment. Use $use-anserini-cli for search, catalog, topics, or REST commands after setup."

--- a/.agents/skills/install-anserini-fatjar/SKILL.md
+++ b/.agents/skills/install-anserini-fatjar/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: install-anserini-fatjar
-description: Install and run Anserini quickly using a locally built `target/anserini-*-fatjar.jar` instead of running a full source workflow. Use when users want fast setup, smoke tests, or command execution without repeated Maven project compilation.
+description: Install and verify Anserini quickly using a locally built `target/anserini-*-fatjar.jar` instead of running a full source workflow. Use when users want fast setup or smoke tests without repeated Maven project compilation.
 ---
 
 # Install Anserini Fatjar
 
 ## Overview
 
-Use this skill to install and run Anserini quickly from a locally built fatjar in an Anserini checkout. Resolve the jar filename dynamically from `target/anserini-*-fatjar.jar`; do not hardcode a developer-specific path or Anserini version.
+Use this skill to install and verify Anserini quickly from a locally built fatjar in an Anserini checkout. Resolve the jar filename dynamically from `target/anserini-*-fatjar.jar`; do not hardcode a developer-specific path or Anserini version.
 
 ## Workflow
 
 1. Verify runtime tools.
 2. Resolve the latest local `target/anserini-*-fatjar.jar`.
 3. Run smoke test/help command.
-4. Execute target commands.
+4. Hand off to `$use-anserini-cli` for search, catalog, topics, or REST commands.
 
 ## 1. Verify Runtime Tools
 
@@ -65,117 +65,7 @@ java -cp "$ANSERINI_JAR" <main-class> <args>
 
 Keep all commands pinned to the same jar version unless the user asks to change versions.
 
-## 5. Prebuilt Index Catalog
-
-To inspect the prebuilt indexes exposed by `io.anserini.cli.PrebuiltIndexCatalog`, run:
-
-```bash
-java -cp "$ANSERINI_JAR" io.anserini.cli.PrebuiltIndexCatalog --list
-```
-
-`--list` emits JSON in the current jar, so prefer pairing it with `--filter` and `jq` instead of
-grepping raw output when you need to identify a specific index.
-
-`msmarco-v1-passage` is a particularly common choice and should be called out when users ask about available prebuilt indexes or MS MARCO passage retrieval setup.
-
-Recommended lookup for the standard MS MARCO V1 passage inverted index:
-
-```bash
-java -cp "$ANSERINI_JAR" \
-  io.anserini.cli.PrebuiltIndexCatalog \
-  --list --filter '^msmarco-v1-passage$' \
-| jq '.[0] | {name, type, description, filename}'
-```
-
-Useful variants:
-
-```bash
-java -cp "$ANSERINI_JAR" io.anserini.cli.PrebuiltIndexCatalog --help
-java -cp "$ANSERINI_JAR" io.anserini.cli.PrebuiltIndexCatalog --list --filter 'msmarco.*passage' | jq '.[].name'
-java -cp "$ANSERINI_JAR" io.anserini.cli.PrebuiltIndexCatalog --type flat --list
-java -cp "$ANSERINI_JAR" io.anserini.cli.PrebuiltIndexCatalog --type inverted --list
-java -cp "$ANSERINI_JAR" io.anserini.cli.PrebuiltIndexCatalog --type impact --list
-java -cp "$ANSERINI_JAR" io.anserini.cli.PrebuiltIndexCatalog --type hnsw --list
-```
-
-## 6. Topics Catalog
-
-To inspect the topics exposed by `io.anserini.cli.TopicsCatalog`, run:
-
-```bash
-java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsCatalog --list
-```
-
-`--list` emits JSON in the current jar, so prefer pairing it with `--filter` and `jq` to locate
-the exact symbol you need.
-
-To print all topics for a specific set, run:
-
-```bash
-java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsCatalog --get <set>
-```
-
-For the standard MS MARCO V1 passage queries that pair with the `msmarco-v1-passage` prebuilt
-index, use `msmarco-v1-passage.dev`.
-
-Recommended lookup:
-
-```bash
-java -cp "$ANSERINI_JAR" \
-  io.anserini.cli.TopicsCatalog \
-  --list --filter '^msmarco(-v1)?-passage(\\.dev|-dev)$' \
-| jq '.'
-```
-
-Use `--list` first to discover the exact set name, then `--get` to inspect its contents.
-
-## 7. Search CLI
-
-Use `io.anserini.cli.Search` for ad hoc retrieval against either a local Lucene index path or a prebuilt index name.
-
-Example using the popular `msmarco-v1-passage` prebuilt index:
-
-```bash
-java -cp "$ANSERINI_JAR" io.anserini.cli.Search --index msmarco-v1-passage --query "what is a lobster roll" --hits 10
-```
-
-Interactive mode:
-
-```bash
-java -cp "$ANSERINI_JAR" io.anserini.cli.Search --index msmarco-v1-passage --interactive
-```
-
-Useful output variants:
-
-```bash
-java -cp "$ANSERINI_JAR" io.anserini.cli.Search --index msmarco-v1-passage --query "what is a lobster roll" --json
-java -cp "$ANSERINI_JAR" io.anserini.cli.Search --index msmarco-v1-passage --query "what is a lobster roll" --trec
-```
-
-## 8. REST API Server
-
-Use `io.anserini.api.RestServer` to expose search and document lookup over HTTP.
-
-Fatjar invocation:
-
-```bash
-java -cp "$ANSERINI_JAR" io.anserini.api.RestServer --port 8081
-```
-
-If working inside an Anserini checkout, the equivalent helper script is:
-
-```bash
-bin/run.sh io.anserini.api.RestServer --port 8081
-```
-
-Sample requests against the popular `msmarco-v1-passage` index:
-
-```bash
-curl "http://localhost:8081/v1/msmarco-v1-passage/search?query=what%20is%20anserini&hits=5"
-curl "http://localhost:8081/v1/msmarco-v1-passage/documents/2161721"
-```
-
-This REST workflow is most useful when users want to query the same prebuilt indexes exposed by the CLI, especially `msmarco-v1-passage`.
+For search, prebuilt-index catalog, topics catalog, or REST server examples, use `$use-anserini-cli`.
 
 ## Troubleshooting
 

--- a/.agents/skills/install-anserini-fatjar/agents/openai.yaml
+++ b/.agents/skills/install-anserini-fatjar/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Install Anserini Fatjar"
-  short_description: "Install and run Anserini from a locally built fatjar"
-  default_prompt: "Set up Anserini quickly from the current checkout by resolving target/anserini-*-fatjar.jar dynamically, verify Java runtime, and run smoke test/help commands."
+  short_description: "Install and verify Anserini from a locally built fatjar"
+  default_prompt: "Set up Anserini quickly from the current checkout by resolving target/anserini-*-fatjar.jar dynamically, verify Java runtime, and run smoke test/help commands. Use $use-anserini-cli for search, catalog, topics, or REST commands after setup."

--- a/.agents/skills/use-anserini-cli/SKILL.md
+++ b/.agents/skills/use-anserini-cli/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: use-anserini-cli
+description: Run Anserini command-line and REST workflows from either a built fatjar or an Anserini source checkout. Use for PrebuiltIndexCatalog, TopicsCatalog, ad hoc search, interactive search, output formats, and RestServer examples.
+---
+
+# Use Anserini CLI
+
+## Overview
+
+Use this skill when Anserini is already available through either a resolved fatjar or a source checkout. It covers command usage, not environment setup. If setup is missing, use `$install-anserini-fatjar` or `$install-anserini-dev-env` first.
+
+Prefer the invocation form that matches the user's environment:
+
+```bash
+java -cp "$ANSERINI_JAR" <main-class> <args>
+```
+
+or, from an Anserini checkout:
+
+```bash
+bin/run.sh <main-class> <args>
+```
+
+Keep commands pinned to the same jar or checkout unless the user asks to change versions.
+
+## Runtime Check
+
+For a fatjar workflow, confirm `ANSERINI_JAR` is set and points to an existing jar:
+
+```bash
+test -n "$ANSERINI_JAR"
+test -f "$ANSERINI_JAR"
+```
+
+For a checkout workflow, confirm `bin/run.sh` is available:
+
+```bash
+test -x bin/run.sh
+```
+
+A useful smoke test is:
+
+```bash
+java -cp "$ANSERINI_JAR" io.anserini.search.SearchCollection -options
+```
+
+or:
+
+```bash
+bin/run.sh io.anserini.search.SearchCollection -options
+```
+
+Current jars reject `-help` for `SearchCollection`; use `-options`.
+
+## Prebuilt Index Catalog
+
+To inspect prebuilt indexes exposed by `io.anserini.cli.PrebuiltIndexCatalog`, run:
+
+```bash
+java -cp "$ANSERINI_JAR" io.anserini.cli.PrebuiltIndexCatalog --list
+```
+
+or:
+
+```bash
+bin/run.sh io.anserini.cli.PrebuiltIndexCatalog --list
+```
+
+`--list` emits JSON in current jars, so prefer `--filter` and `jq` instead of grepping raw output.
+
+`msmarco-v1-passage` is a common choice and should be called out when users ask about available prebuilt indexes or MS MARCO passage retrieval setup.
+
+Recommended lookup for the standard MS MARCO V1 passage inverted index:
+
+```bash
+java -cp "$ANSERINI_JAR" \
+  io.anserini.cli.PrebuiltIndexCatalog \
+  --list --filter '^msmarco-v1-passage$' \
+| jq '.[0] | {name, type, description, filename}'
+```
+
+Useful variants:
+
+```bash
+java -cp "$ANSERINI_JAR" io.anserini.cli.PrebuiltIndexCatalog --help
+java -cp "$ANSERINI_JAR" io.anserini.cli.PrebuiltIndexCatalog --list --filter 'msmarco.*passage' | jq '.[].name'
+java -cp "$ANSERINI_JAR" io.anserini.cli.PrebuiltIndexCatalog --type flat --list
+java -cp "$ANSERINI_JAR" io.anserini.cli.PrebuiltIndexCatalog --type inverted --list
+java -cp "$ANSERINI_JAR" io.anserini.cli.PrebuiltIndexCatalog --type impact --list
+java -cp "$ANSERINI_JAR" io.anserini.cli.PrebuiltIndexCatalog --type hnsw --list
+```
+
+Translate the examples to `bin/run.sh io.anserini.cli.PrebuiltIndexCatalog ...` when working from a checkout without `ANSERINI_JAR`.
+
+## Topics Catalog
+
+To inspect topics exposed by `io.anserini.cli.TopicsCatalog`, run:
+
+```bash
+java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsCatalog --list
+```
+
+or:
+
+```bash
+bin/run.sh io.anserini.cli.TopicsCatalog --list
+```
+
+`--list` emits JSON in current jars, so prefer `--filter` and `jq` to locate the exact symbol.
+
+To print all topics for a specific set, run:
+
+```bash
+java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsCatalog --get <set>
+```
+
+For the standard MS MARCO V1 passage queries that pair with the `msmarco-v1-passage` prebuilt index, use `msmarco-v1-passage.dev`.
+
+Recommended lookup:
+
+```bash
+java -cp "$ANSERINI_JAR" \
+  io.anserini.cli.TopicsCatalog \
+  --list --filter '^msmarco(-v1)?-passage(\\.dev|-dev)$' \
+| jq '.'
+```
+
+Use `--list` first to discover the exact set name, then `--get` to inspect its contents.
+
+## Search CLI
+
+Use `io.anserini.cli.Search` for ad hoc retrieval against either a local Lucene index path or a prebuilt index name.
+
+Example using the popular `msmarco-v1-passage` prebuilt index:
+
+```bash
+java -cp "$ANSERINI_JAR" io.anserini.cli.Search --index msmarco-v1-passage --query "what is a lobster roll" --hits 10
+```
+
+Checkout equivalent:
+
+```bash
+bin/run.sh io.anserini.cli.Search --index msmarco-v1-passage --query "what is a lobster roll" --hits 10
+```
+
+Interactive mode:
+
+```bash
+java -cp "$ANSERINI_JAR" io.anserini.cli.Search --index msmarco-v1-passage --interactive
+```
+
+Useful output variants:
+
+```bash
+java -cp "$ANSERINI_JAR" io.anserini.cli.Search --index msmarco-v1-passage --query "what is a lobster roll" --json
+java -cp "$ANSERINI_JAR" io.anserini.cli.Search --index msmarco-v1-passage --query "what is a lobster roll" --trec
+```
+
+## REST API Server
+
+Use `io.anserini.api.RestServer` to expose search and document lookup over HTTP.
+
+Fatjar invocation:
+
+```bash
+java -cp "$ANSERINI_JAR" io.anserini.api.RestServer --port 8081
+```
+
+Checkout invocation:
+
+```bash
+bin/run.sh io.anserini.api.RestServer --port 8081
+```
+
+Sample requests against the popular `msmarco-v1-passage` index:
+
+```bash
+curl "http://localhost:8081/v1/msmarco-v1-passage/search?query=what%20is%20anserini&hits=5"
+curl "http://localhost:8081/v1/msmarco-v1-passage/documents/2161721"
+```
+
+This REST workflow is most useful when users want to query the same prebuilt indexes exposed by the CLI, especially `msmarco-v1-passage`.
+
+## Troubleshooting
+
+- No fatjar found: use `$install-anserini-fatjar` to resolve or build `target/anserini-*-fatjar.jar`.
+- Missing `bin/run.sh`: use `$install-anserini-dev-env` from an Anserini checkout.
+- `ClassNotFoundException`: confirm the jar or checkout was built from the expected Anserini version.
+- Large downloads: prebuilt indexes can download on demand; avoid commands that trigger large retrieval assets unless the user explicitly asks.

--- a/.agents/skills/use-anserini-cli/agents/openai.yaml
+++ b/.agents/skills/use-anserini-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Use Anserini CLI"
+  short_description: "Run Anserini CLI and REST workflows"
+  default_prompt: "Use $use-anserini-cli to run Anserini commands from either a resolved fatjar or a source checkout, including PrebuiltIndexCatalog, TopicsCatalog, Search, and RestServer workflows."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,11 @@
 - Build system: Maven (`pom.xml`), artifact includes both thin jar and shaded `-fatjar`.
 - Required runtime/build versions: **Java 21** and Maven **3.9+**.
 
+## Task-Specific Skills
+- Use `$install-anserini-dev-env` for setting up or verifying a source-development environment, including Java/Maven requirements, submodules, builds, and eval tools.
+- Use `$install-anserini-fatjar` for resolving or building `target/anserini-*-fatjar.jar` and smoke-testing fatjar execution.
+- Use `$use-anserini-cli` for Anserini CLI, catalog, topics, search, and REST server workflows.
+
 ## Repository Layout
 - `src/main/java`: core indexing/search/eval/reranking implementations.
 - `src/test/java`: JUnit/Lucene test framework tests, including end-to-end integration tests.
@@ -22,8 +27,9 @@
   - `mvn clean package`
 - Fast local build (skip tests/javadocs):
   - `bin/qbuild.sh`
-- Run a main class from fatjar:
+- Run a main class from the source checkout:
   - `bin/run.sh io.anserini.search.SearchCollection [args...]`
+- For fatjar execution and CLI recipes, use `$install-anserini-fatjar` and `$use-anserini-cli`.
 - CI workflow (`.github/workflows/maven.yml`) runs:
   - `mvn -B package --file pom.xml`
 
@@ -39,7 +45,7 @@
 ## Submodules and External Tools
 - `tools/` is a required git submodule. After clone:
   - `git submodule update --init --recursive`
-- If evaluation binaries are needed locally, build as documented in README (`tools/eval` and `tools/eval/ndeval`).
+- If evaluation binaries are needed locally, use `$install-anserini-dev-env`; it contains the exact checked setup steps for `tools/eval`.
 
 ## Editing and Contribution Guardrails
 - Prefer minimal, behavior-preserving changes unless behavior change is explicitly intended.
@@ -54,7 +60,7 @@
 - Coverage is collected with JaCoCo and uploaded in CI.
 
 ## Practical Workflow for Changes
-1. Confirm Java 21 + submodule state.
+1. Confirm Java 21, Maven 3.9+, and submodule state; use `$install-anserini-dev-env` for detailed setup checks.
 2. Implement focused code/doc/template updates.
 3. Run targeted Maven tests for impacted classes/packages.
 4. Run broader `mvn test`/`mvn package` if change scope warrants.


### PR DESCRIPTION
## Summary

- Add a new `$use-anserini-cli` skill for shared Anserini CLI, catalog, topics, search, and REST workflows.
- Narrow `$install-anserini-fatjar` to fatjar setup and smoke-test verification, with a handoff to the CLI skill.
- Add handoffs from `$install-anserini-dev-env` to `$use-anserini-cli` for post-setup command usage.
- Update `AGENTS.md` to route task-specific setup and CLI workflows to skills while keeping repo-wide guidance centralized.

## Validation

- Documentation/agent-skill refactor only; no Java build or tests run.