### PR TITLE
[codex] Update fatjar skill for Maven Central downloads

### DIFF
--- a/.agents/skills/install-anserini-fatjar/SKILL.md
+++ b/.agents/skills/install-anserini-fatjar/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: install-anserini-fatjar
-description: Install and verify Anserini quickly using a locally built `target/anserini-*-fatjar.jar` instead of running a full source workflow. Use when users want fast setup or smoke tests without repeated Maven project compilation.
+description: Install and verify Anserini quickly by downloading the published fatjar from Maven Central instead of cloning or building the source repository. Use when users want fast setup, smoke tests, or CLI examples from a released Anserini jar.
 ---
 
 # Install Anserini Fatjar
 
 ## Overview
 
-Use this skill to install and verify Anserini quickly from a locally built fatjar in an Anserini checkout. Resolve the jar filename dynamically from `target/anserini-*-fatjar.jar`; do not hardcode a developer-specific path or Anserini version.
+Use this skill to install and verify Anserini quickly from a published fatjar. Do not clone the repository and do not build from source in this workflow. Fatjar regression workflows are designed to run directly from the Maven Central fatjar, so a source checkout is not required. Download the released `anserini-*-fatjar.jar` from Maven Central, set `ANSERINI_JAR` to the downloaded file, and smoke test it.
+
+If the user needs source development, local code changes, or a snapshot jar built from the current checkout, use `$install-anserini-dev-env` instead.
 
 ## Workflow
 
 1. Verify runtime tools.
-2. Resolve the latest local `target/anserini-*-fatjar.jar`.
+2. Download the released fatjar from Maven Central.
 3. Run smoke test/help command.
 4. Hand off to `$use-anserini-cli` for search, catalog, topics, or REST commands.
 
@@ -29,23 +31,40 @@ Require:
 - Java available on PATH
 - Java major version `21`, matching Anserini's current runtime/build requirement
 
-## 2. Resolve Fatjar
+## 2. Download Fatjar
 
-From the Anserini repository root, run:
+Choose the requested Anserini release. If the user does not specify a version, verify the latest Maven Central release before choosing `ANSERINI_VERSION`. Check:
 
-```bash
-ANSERINI_JAR="$(ls -t target/anserini-*-fatjar.jar 2>/dev/null | head -n 1)"
-test -n "$ANSERINI_JAR"
+```text
+https://repo1.maven.org/maven2/io/anserini/anserini/maven-metadata.xml
 ```
 
-All subsequent commands assume `ANSERINI_JAR` points to the resolved fatjar. If no jar is found, build one first:
+A quick command-line check is:
 
 ```bash
-bin/qbuild.sh
-ANSERINI_JAR="$(ls -t target/anserini-*-fatjar.jar | head -n 1)"
+curl -sS https://repo1.maven.org/maven2/io/anserini/anserini/maven-metadata.xml \
+  | sed -n 's:.*<release>\(.*\)</release>.*:\1:p'
 ```
 
-If `bin/qbuild.sh` fails because Java, Maven, submodules, or dependency setup is missing, switch to `$install-anserini-dev-env` instead of debugging the fatjar workflow here.
+Then download that release:
+
+```bash
+ANSERINI_VERSION=2.0.0
+wget "https://repo1.maven.org/maven2/io/anserini/anserini/${ANSERINI_VERSION}/anserini-${ANSERINI_VERSION}-fatjar.jar"
+ANSERINI_JAR="anserini-${ANSERINI_VERSION}-fatjar.jar"
+test -f "$ANSERINI_JAR"
+```
+
+If `wget` is unavailable, use `curl`:
+
+```bash
+curl -fL -o "anserini-${ANSERINI_VERSION}-fatjar.jar" \
+  "https://repo1.maven.org/maven2/io/anserini/anserini/${ANSERINI_VERSION}/anserini-${ANSERINI_VERSION}-fatjar.jar"
+ANSERINI_JAR="anserini-${ANSERINI_VERSION}-fatjar.jar"
+test -f "$ANSERINI_JAR"
+```
+
+All subsequent commands assume `ANSERINI_JAR` points to the downloaded fatjar. Keep commands pinned to this jar unless the user asks to change versions.
 
 ## 3. Smoke Test
 
@@ -60,7 +79,7 @@ Treat options output as proof the runtime is ready. Note that current jars rejec
 
 ## 4. Command Execution
 
-Run Anserini commands against the resolved jar:
+Run Anserini commands against the downloaded jar:
 
 ```bash
 java -cp "$ANSERINI_JAR" <main-class> <args>
@@ -72,14 +91,15 @@ For search, prebuilt-index catalog, topics catalog, or REST server examples, use
 
 ## Troubleshooting
 
-- No fatjar found: run `bin/qbuild.sh` from the Anserini repository root and resolve `ANSERINI_JAR` again.
-- `ClassNotFoundException`: confirm `ANSERINI_JAR` points to an existing fatjar built from the current checkout.
+- No fatjar found: download the release fatjar from Maven Central and set `ANSERINI_JAR` to that path.
+- Download returns 404: confirm the requested Anserini version exists on Maven Central.
+- `ClassNotFoundException`: confirm `ANSERINI_JAR` points to the downloaded `anserini-*-fatjar.jar`, not the thin jar.
 - Java errors: use a supported Java version and re-run.
 
 ## Completion Criteria
 
 Treat setup as complete when all are true:
 
-- `ANSERINI_JAR` points to an existing `target/anserini-*-fatjar.jar`.
+- `ANSERINI_JAR` points to an existing downloaded `anserini-*-fatjar.jar`.
 - `SearchCollection -options` executes successfully.
 - The user can run target commands via `java -cp ...`.

--- a/.agents/skills/install-anserini-fatjar/agents/openai.yaml
+++ b/.agents/skills/install-anserini-fatjar/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Install Anserini Fatjar"
-  short_description: "Install and verify Anserini from a locally built fatjar"
-  default_prompt: "Set up Anserini quickly from the current checkout by resolving target/anserini-*-fatjar.jar dynamically, verify Java runtime, and run smoke test/help commands. Use $use-anserini-cli for search, catalog, topics, or REST commands after setup."
+  short_description: "Install and verify Anserini from a Maven Central fatjar"
+  default_prompt: "Set up Anserini quickly by downloading the published fatjar from Maven Central, verify Java runtime, and run smoke test/help commands. Do not clone or build the source repository for this workflow. Use $use-anserini-cli for search, catalog, topics, or REST commands after setup."

--- a/.agents/skills/use-anserini-cli/SKILL.md
+++ b/.agents/skills/use-anserini-cli/SKILL.md
@@ -183,7 +183,7 @@ This REST workflow is most useful when users want to query the same prebuilt ind
 
 ## Troubleshooting
 
-- No fatjar found: use `$install-anserini-fatjar` to resolve or build `target/anserini-*-fatjar.jar`.
+- No fatjar found: use `$install-anserini-fatjar` to download a released Maven Central fatjar, or `$install-anserini-dev-env` if the user needs a jar built from the source checkout.
 - Missing `bin/run.sh`: use `$install-anserini-dev-env` from an Anserini checkout.
 - `ClassNotFoundException`: confirm the jar or checkout was built from the expected Anserini version.
 - `RestServer` reports `Port already in use` for unused ports in a sandboxed Codex session: local socket binding may be blocked by sandbox permissions. Rerun the server command with escalation, and use an available high local port if the documented port is occupied.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 
 ## Task-Specific Skills
 - Use `$install-anserini-dev-env` when the user needs source checkout setup, Java/Maven verification, submodules, full or quick builds, Maven troubleshooting, or eval tool setup.
-- Use `$install-anserini-fatjar` when the user only needs to resolve or build a local `target/anserini-*-fatjar.jar` and run fatjar smoke tests.
+- Use `$install-anserini-fatjar` when the user only needs to download a released Maven Central fatjar and run fatjar smoke tests, without cloning or building the source repository.
 - Use `$use-anserini-cli` only after Anserini is available, for catalog, topics, search, run output, and REST server commands.
 - If a task spans setup and CLI usage, use the relevant setup skill first, then `$use-anserini-cli`.
 


### PR DESCRIPTION
## Summary

- Reframe `$install-anserini-fatjar` around downloading a released fatjar from Maven Central instead of cloning or building the source repository.
- Emphasize that fatjar regression workflows do not require a source checkout.
- Add Maven metadata guidance for checking the current released Anserini version before setting `ANSERINI_VERSION`.
- Update related AGENTS and CLI troubleshooting references to preserve the split between Maven Central fatjars and source-built jars.

## Validation

- Verified Maven metadata at `https://repo1.maven.org/maven2/io/anserini/anserini/maven-metadata.xml` currently reports release `2.0.0`.
- No Maven tests run; changes are Markdown/YAML instruction updates only.