### PR TITLE
Add reproduction log entry for MS MARCO passage (start-here)

### DIFF
--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -555,5 +555,6 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@ShanaxWorld](https://github.com/ShanaxWorld) on 2026-04-05 (commit [`a6f3d474`](https://github.com/castorini/anserini/commit/a6f3d474837f337dfa19f037e1f727dc8f8fd9cc))
 + Results reproduced by [@h79yan](https://github.com/h79yan) on 2026-04-09 (commit [`e441bc83`](https://github.com/castorini/anserini/commit/e441bc83cc29e4fc1c94491220fa09728be4e6c3))
 + Results reproduced by [@kwamearhinPORTFL](https://github.com/kwamearhinPORTFL) on 2026-04-15 (commit [`5c51ee5`](https://github.com/castorini/anserini/commit/5c51ee567f5039f97e5de8de17b4052fd34a0498))
++ Results reproduced by [@zatchbell1311-wq](https://github.com/zatchbell1311-wq) on 2026-04-17 (commit [`c6eed686`](https://github.com/castorini/anserini/commit/c6eed686d26d6f39bd75cb44a1fc9385dbbd1b15))
 + Results reproduced by [@Zixi-Sam-Tang](https://github.com/Zixi-Sam-Tang) on 2026-04-20 (commit [`1e7b470`](https://github.com/castorini/anserini/commit/1e7b4702f0d2fd00752867577c88d8db819d71aa))
 + Results reproduced by [@Seun-Ajayi](https://github.com/Seun-Ajayi) on 2026-04-24 (commit [`2896644`](https://github.com/castorini/anserini/commit/28966448532d560267be1f45f9f2d2ec3eb96ef4))


### PR DESCRIPTION
Reproduced the MS MARCO passage ranking setup as described in start-here.md.

Setup:
- OS: Ubuntu 24.04 (WSL2 on Windows 11, Hyper-V)
- Java: OpenJDK 21.0.10
- Hardware: Lenovo, 6GB RAM allocated to WSL2

Everything worked as expected. Followed the guide to download and explore the MS MARCO passage ranking test collection, including examining the collection, queries, and qrels files.