### PR TITLE
[codex] Add cache directory resolver

### DIFF
--- a/docs/prebuilt-indexes.md
+++ b/docs/prebuilt-indexes.md
@@ -36,7 +36,9 @@ Nope, that's not a bug.
 
 Downloaded indexes are by default stored in `~/.cache/pyserini/indexes/`.
 (Yes, `pyserini`, that's not a bug &mdash; this is so prebuilt indexes can be shared between Pyserini and Anserini.)
-You can specify a custom cache directory by setting the environment variable `$ANSERINI_INDEX_CACHE` or the system property `anserini.index.cache`.
+If an `index/` directory exists in the current working directory, downloaded indexes are stored there.
+Otherwise, you can specify a custom base cache directory by setting the environment variable `$ANSERINI_CACHE` or the system property `anserini.cache`.
+If no custom base cache directory is specified and a `.cache/` directory exists in the current working directory, downloaded indexes are stored in `.cache/pyserini/indexes/` under the current working directory.
 
 Another helpful tip is to download and manage the indexes by hand.
 As an example, from the metadata in [`msmarco-v1-passage-inverted.json`](https://github.com/castorini/anserini/blob/master/src/main/resources/prebuilt-indexes/msmarco-v1-passage-inverted.json), you can see that `msmarco-v1-passage` can be downloaded from:

--- a/docs/prebuilt-indexes.md
+++ b/docs/prebuilt-indexes.md
@@ -34,11 +34,14 @@ Nope, that's not a bug.
 
 ## Managing Indexes
 
-Downloaded indexes are by default stored in `~/.cache/pyserini/indexes/`.
-(Yes, `pyserini`, that's not a bug &mdash; this is so prebuilt indexes can be shared between Pyserini and Anserini.)
-If an `index/` directory exists in the current working directory, downloaded indexes are stored there.
-Otherwise, you can specify a custom base cache directory by setting the environment variable `$ANSERINI_CACHE` or the system property `anserini.cache`.
-If no custom base cache directory is specified and a `.cache/` directory exists in the current working directory, downloaded indexes are stored in `.cache/pyserini/indexes/` under the current working directory.
+Downloaded indexes are stored in the first matching cache location:
+
+1. If the system property `pyserini.cache` is set, downloaded indexes are stored in `indexes/` under that base cache directory.
+2. Otherwise, if the environment variable `$PYSERINI_CACHE` is set, downloaded indexes are stored in `indexes/` under that base cache directory.
+3. Otherwise, if a `.cache/` directory exists in the current working directory, downloaded indexes are stored in `.cache/pyserini/indexes/` under the current working directory.
+4. Otherwise, downloaded indexes are stored in `~/.cache/pyserini/indexes/`.
+
+Yes, `pyserini`, that's not a bug &mdash; this is so prebuilt indexes can be shared between Pyserini and Anserini.
 
 Another helpful tip is to download and manage the indexes by hand.
 As an example, from the metadata in [`msmarco-v1-passage-inverted.json`](https://github.com/castorini/anserini/blob/master/src/main/resources/prebuilt-indexes/msmarco-v1-passage-inverted.json), you can see that `msmarco-v1-passage` can be downloaded from:

--- a/src/main/java/io/anserini/encoder/OnnxEncoder.java
+++ b/src/main/java/io/anserini/encoder/OnnxEncoder.java
@@ -80,7 +80,7 @@ public abstract class OnnxEncoder<T> implements AutoCloseable {
   }
 
   public Path getVocabPath() throws URISyntaxException, IOException {
-    File vocabFile = new File(getCacheDir(), vocabName);
+    File vocabFile = CacheDirectoryResolver.getEncodersCachePath().resolve(vocabName).toFile();
     if (!vocabFile.exists()) {
       FileUtils.copyURLToFile(new URI(vocabUrl).toURL(), vocabFile);
     }
@@ -88,22 +88,13 @@ public abstract class OnnxEncoder<T> implements AutoCloseable {
     return vocabFile.toPath();
   }
 
-  @SuppressWarnings("ResultOfMethodCallIgnored")
-  public String getCacheDir() {
-    File cacheDir = CacheDirectoryResolver.getEncodersCachePath().toFile();
-
-    if (!cacheDir.exists()) {
-      cacheDir.mkdirs();
-    }
-    return cacheDir.getPath();
-  }
-
   public Path getModelPath() throws IOException, URISyntaxException {
-    File modelFile = new File(getCacheDir(), modelName);
+    Path cachePath = CacheDirectoryResolver.getEncodersCachePath();
+    File modelFile = cachePath.resolve(modelName).toFile();
     if (!modelFile.exists()) {
       FileUtils.copyURLToFile(new URI(modelUrl).toURL(), modelFile);
       if (configUrl != null) {
-        File configFile = new File(getCacheDir(), this.getClass().getSimpleName() + '-' + BASE_CONFIG_NAME);
+        File configFile = cachePath.resolve(this.getClass().getSimpleName() + '-' + BASE_CONFIG_NAME).toFile();
         FileUtils.copyURLToFile(new URI(configUrl).toURL(), configFile);
       }
     }

--- a/src/main/java/io/anserini/encoder/OnnxEncoder.java
+++ b/src/main/java/io/anserini/encoder/OnnxEncoder.java
@@ -26,6 +26,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
+import io.anserini.util.CacheDirectoryResolver;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -35,8 +37,6 @@ import java.util.List;
 
 public abstract class OnnxEncoder<T> implements AutoCloseable {
   private static final Logger LOG = LogManager.getLogger(OnnxEncoder.class);
-
-  private static final String CACHE_DIR = Path.of(System.getProperty("user.home"), ".cache", "pyserini", "encoders").toString();
 
   private static final String BASE_CONFIG_NAME = "config.json";
 
@@ -90,10 +90,10 @@ public abstract class OnnxEncoder<T> implements AutoCloseable {
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public String getCacheDir() {
-    File cacheDir = new File(CACHE_DIR);
+    File cacheDir = CacheDirectoryResolver.getEncodersCachePath().toFile();
 
     if (!cacheDir.exists()) {
-      cacheDir.mkdir();
+      cacheDir.mkdirs();
     }
     return cacheDir.getPath();
   }

--- a/src/main/java/io/anserini/eval/ExcludeDocs.java
+++ b/src/main/java/io/anserini/eval/ExcludeDocs.java
@@ -23,13 +23,13 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
 
 import io.anserini.search.ScoredDoc;
+import io.anserini.util.CacheDirectoryResolver;
 
 public class ExcludeDocs {
   private static final String BRIGHT_AOPS = "bright-aops";
@@ -38,7 +38,6 @@ public class ExcludeDocs {
   private static final String PREFIX = "exclude.";
   private static final String SUFFIX = ".txt";
 
-  private static final String CACHE_DIR = Path.of(System.getProperty("user.home"), ".cache", "pyserini", "topics-and-qrels").toString();
   private static final String SERVER_PATH = "https://raw.githubusercontent.com/castorini/anserini-tools/master/topics-and-qrels/";
 
   private HashMap<String, Set<String>> excludeDocs = new HashMap<>();
@@ -60,7 +59,7 @@ public class ExcludeDocs {
     }
     file = PREFIX + file + SUFFIX;
 
-    Path local = Paths.get(CACHE_DIR, file);
+    Path local = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve(file);
     if (local == null || !Files.exists(local)) {
       String URL = SERVER_PATH + file;
       // TODO: Should probably change this to a log statement.
@@ -68,6 +67,7 @@ public class ExcludeDocs {
       if (local == null) {
         throw new IOException("Error downloading exclusion ids from " + URL);
       }
+      Files.createDirectories(local.getParent());
       File qrelsFile = new File(local.toString());  
       try {
         FileUtils.copyURLToFile(new URI(URL).toURL(), qrelsFile);

--- a/src/main/java/io/anserini/eval/ExcludeDocs.java
+++ b/src/main/java/io/anserini/eval/ExcludeDocs.java
@@ -60,14 +60,10 @@ public class ExcludeDocs {
     file = PREFIX + file + SUFFIX;
 
     Path local = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve(file);
-    if (local == null || !Files.exists(local)) {
+    if (!Files.exists(local)) {
       String URL = SERVER_PATH + file;
       // TODO: Should probably change this to a log statement.
       System.out.println("Downloading exclusion ids from " + URL);
-      if (local == null) {
-        throw new IOException("Error downloading exclusion ids from " + URL);
-      }
-      Files.createDirectories(local.getParent());
       File qrelsFile = new File(local.toString());  
       try {
         FileUtils.copyURLToFile(new URI(URL).toURL(), qrelsFile);

--- a/src/main/java/io/anserini/eval/RelevanceJudgments.java
+++ b/src/main/java/io/anserini/eval/RelevanceJudgments.java
@@ -17,14 +17,12 @@
 package io.anserini.eval;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -117,14 +115,6 @@ public class RelevanceJudgments {
     }
   }
 
-  private static String getCacheDir() {
-    File cacheDir = CacheDirectoryResolver.getTopicsAndQrelsCachePath().toFile();
-    if (!cacheDir.exists()) {
-      cacheDir.mkdirs();
-    }
-    return cacheDir.getPath();
-  }
-
   /**
    * Method will return the qrels file as a string
    * 
@@ -161,7 +151,7 @@ public class RelevanceJudgments {
     }
     if (!isContained && !isContainedSymbol) {
       // If the topic file is not in the list of known topics, we assume it is a local file.
-      Path tempPath = Paths.get(getCacheDir(), qrelsPath.getFileName().toString());
+      Path tempPath = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve(qrelsPath.getFileName());
       if (Files.exists(tempPath)) {
         // if it is a unregistred topic in the Topics Enum, but it is in the cache, we use it.
         return tempPath;
@@ -182,7 +172,7 @@ public class RelevanceJudgments {
   }
 
   public static Path getNewQrelAbsPath(Path qrelsPath) {
-    return Paths.get(getCacheDir(), qrelsPath.getFileName().toString());
+    return CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve(qrelsPath.getFileName());
   }
 
   /**
@@ -196,13 +186,13 @@ public class RelevanceJudgments {
   public static Path downloadQrels(Path qrelsPath) throws IOException {
     String qrelsURL = SERVER_PATH + qrelsPath.getFileName().toString();
     System.out.println("Downloading qrels from " + qrelsURL);
-    File qrelsFile = new File(getCacheDir(), qrelsPath.getFileName().toString());
+    Path localQrelsPath = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve(qrelsPath.getFileName());
 
     try {
-      FileUtils.copyURLToFile(new URI(qrelsURL).toURL(), qrelsFile);
+      FileUtils.copyURLToFile(new URI(qrelsURL).toURL(), localQrelsPath.toFile());
     } catch (Exception e) {
       throw new IOException("Error downloading topics from " + qrelsURL);
     }
-    return qrelsFile.toPath();
+    return localQrelsPath;
   }
 }

--- a/src/main/java/io/anserini/eval/RelevanceJudgments.java
+++ b/src/main/java/io/anserini/eval/RelevanceJudgments.java
@@ -31,9 +31,10 @@ import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
 
+import io.anserini.util.CacheDirectoryResolver;
+
 public class RelevanceJudgments {
   private final Map<String, Map<String, Integer>> qrels;
-  private static final String CACHE_DIR = Path.of(System.getProperty("user.home"), ".cache", "pyserini", "topics-and-qrels").toString();
   private static final String SERVER_PATH = "https://raw.githubusercontent.com/castorini/anserini-tools/master/topics-and-qrels/";
 
   public static RelevanceJudgments fromQrels(Qrels qrels) throws IOException {
@@ -117,9 +118,9 @@ public class RelevanceJudgments {
   }
 
   private static String getCacheDir() {
-    File cacheDir = new File(CACHE_DIR);
+    File cacheDir = CacheDirectoryResolver.getTopicsAndQrelsCachePath().toFile();
     if (!cacheDir.exists()) {
-      cacheDir.mkdir();
+      cacheDir.mkdirs();
     }
     return cacheDir.getPath();
   }

--- a/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
@@ -44,6 +44,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.anserini.cli.CliUtils;
 
 import io.anserini.index.IndexReaderUtils;
+import io.anserini.util.CacheDirectoryResolver;
 import io.anserini.util.LoggingBootstrap;
 import io.anserini.util.PrebuiltIndexHandler;
 
@@ -397,14 +398,7 @@ public class ReproduceFromPrebuiltIndexes {
   }
 
   private static String getCacheRoot() {
-    String cacheDir = System.getProperty("anserini.index.cache");
-    if (cacheDir == null || cacheDir.isEmpty()) {
-      cacheDir = System.getenv("ANSERINI_INDEX_CACHE");
-    }
-    if (cacheDir == null || cacheDir.isEmpty()) {
-      cacheDir = java.nio.file.Path.of(System.getProperty("user.home"), ".cache", "pyserini", "indexes").toString();
-    }
-    return cacheDir;
+    return CacheDirectoryResolver.getIndexCachePath().toString();
   }
 
   private static String repeat(char c, int n) {

--- a/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
@@ -358,7 +358,7 @@ public class ReproduceFromPrebuiltIndexes {
   private static Path expectedPrebuiltPath(String indexName) {
     try {
       PrebuiltIndexHandler handler = PrebuiltIndexHandler.get(indexName);
-      String cacheRoot = getCacheRoot();
+      String cacheRoot = CacheDirectoryResolver.getIndexCachePath().toString();
       String base = handler.getFilename();
       if (base.endsWith(".tar.gz")) {
         base = base.substring(0, base.length() - ".tar.gz".length());
@@ -395,10 +395,6 @@ public class ReproduceFromPrebuiltIndexes {
       }
     }
     return pathForSize;
-  }
-
-  private static String getCacheRoot() {
-    return CacheDirectoryResolver.getIndexCachePath().toString();
   }
 
   private static String repeat(char c, int n) {

--- a/src/main/java/io/anserini/search/topicreader/TopicReader.java
+++ b/src/main/java/io/anserini/search/topicreader/TopicReader.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.zip.GZIPInputStream;
 
+import io.anserini.util.CacheDirectoryResolver;
 import io.anserini.search.SearchCollection;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
@@ -46,7 +47,6 @@ import org.apache.logging.log4j.Logger;
  */
 public abstract class TopicReader<K> {
   private static final Logger LOG = LogManager.getLogger(SearchCollection.class);
-  private static final String CACHE_DIR = Path.of(System.getProperty("user.home"), ".cache", "pyserini", "topics-and-qrels").toString();
   private static final String SERVER_PATH = "https://raw.githubusercontent.com/castorini/anserini-tools/master/topics-and-qrels/";
   private static final Map<String, Class<? extends TopicReader<?>>> TOPIC_FILE_TO_TYPE = new HashMap<>();
 
@@ -211,9 +211,9 @@ public abstract class TopicReader<K> {
   }
 
   private static String getCacheDir() {
-    File cacheDir = new File(CACHE_DIR);
+    File cacheDir = CacheDirectoryResolver.getTopicsAndQrelsCachePath().toFile();
     if (!cacheDir.exists()) {
-      cacheDir.mkdir();
+      cacheDir.mkdirs();
     }
     return cacheDir.getPath();
   }

--- a/src/main/java/io/anserini/search/topicreader/TopicReader.java
+++ b/src/main/java/io/anserini/search/topicreader/TopicReader.java
@@ -17,7 +17,6 @@
 package io.anserini.search.topicreader;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -210,14 +209,6 @@ public abstract class TopicReader<K> {
     }
   }
 
-  private static String getCacheDir() {
-    File cacheDir = CacheDirectoryResolver.getTopicsAndQrelsCachePath().toFile();
-    if (!cacheDir.exists()) {
-      cacheDir.mkdirs();
-    }
-    return cacheDir.getPath();
-  }
-
   /**
    * Downloads the topics from the cloud and returns the path to the local copy
    * @param topicPath Path to the topics
@@ -227,17 +218,17 @@ public abstract class TopicReader<K> {
   public static Path downloadTopics(Path topicPath) throws IOException {
     String topicURL = SERVER_PATH + topicPath.getFileName().toString();
     LOG.info("Downloading topics from " + topicURL);
-    File topicFile = new File(getCacheDir(), topicPath.getFileName().toString());
+    Path localTopicPath = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve(topicPath.getFileName());
     try {
-      FileUtils.copyURLToFile(new URI(topicURL).toURL(), topicFile);
+      FileUtils.copyURLToFile(new URI(topicURL).toURL(), localTopicPath.toFile());
     } catch (Exception e){
       throw new IOException("Error downloading topics from " + topicURL);
     }
-    return topicFile.toPath();
+    return localTopicPath;
   }
 
   public static Path getNewTopicsAbsPath(Path topicPath){
-    return Paths.get(getCacheDir(), topicPath.getFileName().toString());
+    return CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve(topicPath.getFileName());
   }
 
   /**
@@ -252,7 +243,7 @@ public abstract class TopicReader<K> {
     } else {
       if (!TOPIC_FILE_TO_TYPE.containsKey(topicPath.getFileName().toString())) {
         // If the topic file is not in the list of known topics, we assume it is a local file.
-        Path tempPath = Paths.get(getCacheDir(), topicPath.getFileName().toString());
+        Path tempPath = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve(topicPath.getFileName());
         if (Files.exists(tempPath)) {
           // if it is an unregistred topic, but it is in the cache, we use it
           return tempPath;

--- a/src/main/java/io/anserini/util/CacheDirectoryResolver.java
+++ b/src/main/java/io/anserini/util/CacheDirectoryResolver.java
@@ -16,24 +16,26 @@
 
 package io.anserini.util;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
  * Resolves cache directories used by Anserini. The base cache path is {@code ~/.cache/pyserini} by default. The
- * {@code anserini.cache} system property and {@code ANSERINI_CACHE} environment variable override the base cache path.
+ * {@code pyserini.cache} system property and {@code PYSERINI_CACHE} environment variable override the base cache path.
  * If neither override is set and a {@code .cache} directory exists in the current working directory, the base cache path
- * is {@code <cwd>/.cache/pyserini}. If a {@code index} directory exists in the current working directory, indexes are
- * stored in {@code <cwd>/index}; otherwise, indexes are stored in {@code <base>/indexes}. Topics, qrels, and encoders
- * are stored under {@code <base>/topics-and-qrels} and {@code <base>/encoders}.
+ * is {@code <cwd>/.cache/pyserini}. Indexes are stored under {@code <base>/indexes}. Topics and qrels are stored
+ * together under {@code <base>/topics-and-qrels}. Encoders are stored under {@code <base>/encoders}. All public
+ * accessors create the resolved directory before returning it.
  */
 public final class CacheDirectoryResolver {
-  public static final String CACHE_PROPERTY = "anserini.cache";
-  public static final String CACHE_ENV = "ANSERINI_CACHE";
+  public static final String CACHE_PROPERTY = "pyserini.cache";
+  public static final String CACHE_ENV = "PYSERINI_CACHE";
 
   private static final String LOCAL_CACHE_DIR = ".cache";
   private static final String DEFAULT_CACHE_PARENT = ".cache";
   private static final String DEFAULT_CACHE_NAME = "pyserini";
-  private static final String LOCAL_INDEX_DIR = "index";
   private static final String INDEXES_DIR = "indexes";
   private static final String TOPICS_AND_QRELS_DIR = "topics-and-qrels";
   private static final String ENCODERS_DIR = "encoders";
@@ -42,6 +44,22 @@ public final class CacheDirectoryResolver {
   }
 
   public static Path getBasePath() {
+    return createDirectories(resolveBasePath());
+  }
+
+  public static Path getIndexCachePath() {
+    return createDirectories(resolveBasePath().resolve(INDEXES_DIR));
+  }
+
+  public static Path getTopicsAndQrelsCachePath() {
+    return createDirectories(resolveBasePath().resolve(TOPICS_AND_QRELS_DIR));
+  }
+
+  public static Path getEncodersCachePath() {
+    return createDirectories(resolveBasePath().resolve(ENCODERS_DIR));
+  }
+
+  private static Path resolveBasePath() {
     Path configuredBasePath = getConfiguredBasePath();
     if (configuredBasePath != null) {
       return configuredBasePath;
@@ -55,34 +73,9 @@ public final class CacheDirectoryResolver {
     return getDefaultBasePath();
   }
 
-  public static Path getIndexCachePath() {
-    if (getLocalIndexPath().toFile().isDirectory()) {
-      return getLocalIndexPath();
-    }
-
-    Path configuredBasePath = getConfiguredBasePath();
-    if (configuredBasePath != null) {
-      return configuredBasePath.resolve(INDEXES_DIR);
-    }
-
-    return getBasePath().resolve(INDEXES_DIR);
-  }
-
-  public static Path getTopicsAndQrelsCachePath() {
-    return getBasePath().resolve(TOPICS_AND_QRELS_DIR);
-  }
-
-  public static Path getEncodersCachePath() {
-    return getBasePath().resolve(ENCODERS_DIR);
-  }
-
-  private static Path getLocalIndexPath() {
-    return Path.of(System.getProperty("user.dir"), LOCAL_INDEX_DIR);
-  }
-
   private static Path getLocalBasePath() {
     Path localCachePath = Path.of(System.getProperty("user.dir"), LOCAL_CACHE_DIR);
-    if (localCachePath.toFile().isDirectory()) {
+    if (Files.isDirectory(localCachePath)) {
       return localCachePath.resolve(DEFAULT_CACHE_NAME);
     }
 
@@ -105,5 +98,13 @@ public final class CacheDirectoryResolver {
     }
 
     return null;
+  }
+
+  private static Path createDirectories(Path path) {
+    try {
+      return Files.createDirectories(path);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Unable to create cache directory: " + path, e);
+    }
   }
 }

--- a/src/main/java/io/anserini/util/CacheDirectoryResolver.java
+++ b/src/main/java/io/anserini/util/CacheDirectoryResolver.java
@@ -1,0 +1,109 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.util;
+
+import java.nio.file.Path;
+
+/**
+ * Resolves cache directories used by Anserini. The base cache path is {@code ~/.cache/pyserini} by default. The
+ * {@code anserini.cache} system property and {@code ANSERINI_CACHE} environment variable override the base cache path.
+ * If neither override is set and a {@code .cache} directory exists in the current working directory, the base cache path
+ * is {@code <cwd>/.cache/pyserini}. If a {@code index} directory exists in the current working directory, indexes are
+ * stored in {@code <cwd>/index}; otherwise, indexes are stored in {@code <base>/indexes}. Topics, qrels, and encoders
+ * are stored under {@code <base>/topics-and-qrels} and {@code <base>/encoders}.
+ */
+public final class CacheDirectoryResolver {
+  public static final String CACHE_PROPERTY = "anserini.cache";
+  public static final String CACHE_ENV = "ANSERINI_CACHE";
+
+  private static final String LOCAL_CACHE_DIR = ".cache";
+  private static final String DEFAULT_CACHE_PARENT = ".cache";
+  private static final String DEFAULT_CACHE_NAME = "pyserini";
+  private static final String LOCAL_INDEX_DIR = "index";
+  private static final String INDEXES_DIR = "indexes";
+  private static final String TOPICS_AND_QRELS_DIR = "topics-and-qrels";
+  private static final String ENCODERS_DIR = "encoders";
+
+  private CacheDirectoryResolver() {
+  }
+
+  public static Path getBasePath() {
+    Path configuredBasePath = getConfiguredBasePath();
+    if (configuredBasePath != null) {
+      return configuredBasePath;
+    }
+
+    Path localBasePath = getLocalBasePath();
+    if (localBasePath != null) {
+      return localBasePath;
+    }
+
+    return getDefaultBasePath();
+  }
+
+  public static Path getIndexCachePath() {
+    if (getLocalIndexPath().toFile().isDirectory()) {
+      return getLocalIndexPath();
+    }
+
+    Path configuredBasePath = getConfiguredBasePath();
+    if (configuredBasePath != null) {
+      return configuredBasePath.resolve(INDEXES_DIR);
+    }
+
+    return getBasePath().resolve(INDEXES_DIR);
+  }
+
+  public static Path getTopicsAndQrelsCachePath() {
+    return getBasePath().resolve(TOPICS_AND_QRELS_DIR);
+  }
+
+  public static Path getEncodersCachePath() {
+    return getBasePath().resolve(ENCODERS_DIR);
+  }
+
+  private static Path getLocalIndexPath() {
+    return Path.of(System.getProperty("user.dir"), LOCAL_INDEX_DIR);
+  }
+
+  private static Path getLocalBasePath() {
+    Path localCachePath = Path.of(System.getProperty("user.dir"), LOCAL_CACHE_DIR);
+    if (localCachePath.toFile().isDirectory()) {
+      return localCachePath.resolve(DEFAULT_CACHE_NAME);
+    }
+
+    return null;
+  }
+
+  private static Path getDefaultBasePath() {
+    return Path.of(System.getProperty("user.home"), DEFAULT_CACHE_PARENT, DEFAULT_CACHE_NAME);
+  }
+
+  private static Path getConfiguredBasePath() {
+    String cacheDirectory = System.getProperty(CACHE_PROPERTY);
+
+    if (cacheDirectory == null || cacheDirectory.isEmpty()) {
+      cacheDirectory = System.getenv(CACHE_ENV);
+    }
+
+    if (cacheDirectory != null && !cacheDirectory.isEmpty()) {
+      return Path.of(cacheDirectory);
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/io/anserini/util/PrebuiltIndexHandler.java
+++ b/src/main/java/io/anserini/util/PrebuiltIndexHandler.java
@@ -40,9 +40,6 @@ import java.nio.file.Path;
 public class PrebuiltIndexHandler {
   private static final Logger LOG = LogManager.getLogger(PrebuiltIndexHandler.class);
 
-  private static final String DEFAULT_CACHE_DIR = Path.of(System.getProperty("user.home"), ".cache", "pyserini", "indexes").toString();
-  private static final String CACHE_DIR_PROPERTY = "anserini.index.cache";
-  private static final String CACHE_DIR_ENV = "ANSERINI_INDEX_CACHE";
   private static final int MAX_DOWNLOAD_ATTEMPTS = 3;
   private static final int DOWNLOAD_BUFFER_SIZE = 1 << 16; // 64 KB
   private static final int CONNECT_TIMEOUT_MS = 60_000;
@@ -57,9 +54,11 @@ public class PrebuiltIndexHandler {
 
   /**
    * Returns a <tt>PrebuiltIndexHandler</tt> for a prebuilt index given its name, or <tt>null</tt> if it doesn't exist.
-   * The default cache directory is <tt>~/.cache/pyserini/indexes</tt>.
-   * Alternatively, a custom cache directory can be specified via the environment variable <tt>$ANSERINI_INDEX_CACHE</tt>
-   * or the system property <tt>anserini.index.cache</tt>.
+   * The default cache directory is <tt>~/.cache/pyserini/indexes</tt>, or <tt>index</tt> in the current working
+   * directory if it exists. If <tt>index</tt> does not exist, a custom base cache directory can be specified via the
+   * environment variable <tt>$ANSERINI_CACHE</tt> or the system property <tt>anserini.cache</tt>. If no custom base
+   * cache directory is specified and <tt>.cache</tt> exists in the current working directory, indexes are stored in
+   * <tt>.cache/pyserini/indexes</tt> under the current working directory.
    *
    * @param name the name of the prebuilt index
    * @return a <tt>PrebuiltIndexHandler</tt> for a prebuilt index given its name, or <tt>null</tt> if it doesn't exist.
@@ -90,20 +89,6 @@ public class PrebuiltIndexHandler {
     }
   }
 
-  private static String getCache() {
-    String cacheDirectory = System.getProperty(CACHE_DIR_PROPERTY);
-    
-    if (cacheDirectory == null || cacheDirectory.isEmpty()) {
-      cacheDirectory = System.getenv(CACHE_DIR_ENV);
-    }
-    
-    if (cacheDirectory == null || cacheDirectory.isEmpty()) {
-      cacheDirectory = DEFAULT_CACHE_DIR;
-    }
-    
-    return cacheDirectory;
-  }
-
   private static boolean verifyChecksum(Path path, String md5) throws IOException {
     try (InputStream is = Files.newInputStream(path)) {
       String generatedChecksum = DigestUtils.md5Hex(is);
@@ -112,7 +97,7 @@ public class PrebuiltIndexHandler {
   }
 
   public void fetch() throws IOException {
-    fetch(getCache());
+    fetch(CacheDirectoryResolver.getIndexCachePath().toString());
   }
 
   public void fetch(String cacheDirectory) throws IOException {

--- a/src/main/java/io/anserini/util/PrebuiltIndexHandler.java
+++ b/src/main/java/io/anserini/util/PrebuiltIndexHandler.java
@@ -54,11 +54,11 @@ public class PrebuiltIndexHandler {
 
   /**
    * Returns a <tt>PrebuiltIndexHandler</tt> for a prebuilt index given its name, or <tt>null</tt> if it doesn't exist.
-   * The default cache directory is <tt>~/.cache/pyserini/indexes</tt>, or <tt>index</tt> in the current working
-   * directory if it exists. If <tt>index</tt> does not exist, a custom base cache directory can be specified via the
-   * environment variable <tt>$ANSERINI_CACHE</tt> or the system property <tt>anserini.cache</tt>. If no custom base
-   * cache directory is specified and <tt>.cache</tt> exists in the current working directory, indexes are stored in
-   * <tt>.cache/pyserini/indexes</tt> under the current working directory.
+   * Downloaded indexes are stored in <tt>indexes</tt> under the base cache directory specified by the system property
+   * <tt>pyserini.cache</tt>. If the property is not set, the environment variable <tt>$PYSERINI_CACHE</tt> specifies
+   * the base cache directory. If neither is set and <tt>.cache</tt> exists in the current working directory, indexes are
+   * stored in <tt>.cache/pyserini/indexes</tt> under the current working directory. Otherwise, indexes are stored in
+   * <tt>~/.cache/pyserini/indexes</tt>.
    *
    * @param name the name of the prebuilt index
    * @return a <tt>PrebuiltIndexHandler</tt> for a prebuilt index given its name, or <tt>null</tt> if it doesn't exist.

--- a/src/test/java/io/anserini/doc/GeneratePrebuiltIndexesDocTest.java
+++ b/src/test/java/io/anserini/doc/GeneratePrebuiltIndexesDocTest.java
@@ -180,7 +180,9 @@ public class GeneratePrebuiltIndexesDocTest {
 
     Downloaded indexes are by default stored in `~/.cache/pyserini/indexes/`.
     (Yes, `pyserini`, that's not a bug &mdash; this is so prebuilt indexes can be shared between Pyserini and Anserini.)
-    You can specify a custom cache directory by setting the environment variable `$ANSERINI_INDEX_CACHE` or the system property `anserini.index.cache`.
+    If an `index/` directory exists in the current working directory, downloaded indexes are stored there.
+    Otherwise, you can specify a custom base cache directory by setting the environment variable `$ANSERINI_CACHE` or the system property `anserini.cache`.
+    If no custom base cache directory is specified and a `.cache/` directory exists in the current working directory, downloaded indexes are stored in `.cache/pyserini/indexes/` under the current working directory.
 
     Another helpful tip is to download and manage the indexes by hand.
     As an example, from the metadata in [`msmarco-v1-passage-inverted.json`](https://github.com/castorini/anserini/blob/master/src/main/resources/prebuilt-indexes/msmarco-v1-passage-inverted.json), you can see that `msmarco-v1-passage` can be downloaded from:

--- a/src/test/java/io/anserini/doc/GeneratePrebuiltIndexesDocTest.java
+++ b/src/test/java/io/anserini/doc/GeneratePrebuiltIndexesDocTest.java
@@ -178,11 +178,14 @@ public class GeneratePrebuiltIndexesDocTest {
 
     ## Managing Indexes
 
-    Downloaded indexes are by default stored in `~/.cache/pyserini/indexes/`.
-    (Yes, `pyserini`, that's not a bug &mdash; this is so prebuilt indexes can be shared between Pyserini and Anserini.)
-    If an `index/` directory exists in the current working directory, downloaded indexes are stored there.
-    Otherwise, you can specify a custom base cache directory by setting the environment variable `$ANSERINI_CACHE` or the system property `anserini.cache`.
-    If no custom base cache directory is specified and a `.cache/` directory exists in the current working directory, downloaded indexes are stored in `.cache/pyserini/indexes/` under the current working directory.
+    Downloaded indexes are stored in the first matching cache location:
+
+    1. If the system property `pyserini.cache` is set, downloaded indexes are stored in `indexes/` under that base cache directory.
+    2. Otherwise, if the environment variable `$PYSERINI_CACHE` is set, downloaded indexes are stored in `indexes/` under that base cache directory.
+    3. Otherwise, if a `.cache/` directory exists in the current working directory, downloaded indexes are stored in `.cache/pyserini/indexes/` under the current working directory.
+    4. Otherwise, downloaded indexes are stored in `~/.cache/pyserini/indexes/`.
+
+    Yes, `pyserini`, that's not a bug &mdash; this is so prebuilt indexes can be shared between Pyserini and Anserini.
 
     Another helpful tip is to download and manage the indexes by hand.
     As an example, from the metadata in [`msmarco-v1-passage-inverted.json`](https://github.com/castorini/anserini/blob/master/src/main/resources/prebuilt-indexes/msmarco-v1-passage-inverted.json), you can see that `msmarco-v1-passage` can be downloaded from:

--- a/src/test/java/io/anserini/eval/RelevanceJudgmentsTest.java
+++ b/src/test/java/io/anserini/eval/RelevanceJudgmentsTest.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import io.anserini.util.CacheDirectoryResolver;
+
 public class RelevanceJudgmentsTest{
 
   public int getQrelsCount(RelevanceJudgments qrels) throws IOException{
@@ -1928,45 +1930,45 @@ public class RelevanceJudgmentsTest{
     Path expected;
     Path produced;
 
-    expected = Path.of(System.getProperty("user.home"), ".cache", "pyserini", "topics-and-qrels", "qrels.cacm.txt");
+    expected = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve("qrels.cacm.txt");
     produced = RelevanceJudgments.getQrelsPath(Path.of("cacm"));
 
-    expected = Path.of(System.getProperty("user.home"), ".cache", "pyserini", "topics-and-qrels", "qrels.msmarco-passage.dev-subset.txt");
+    expected = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve("qrels.msmarco-passage.dev-subset.txt");
     produced = RelevanceJudgments.getQrelsPath(Path.of("msmarco-passage.dev-subset"));
     assertNotNull(produced);
     assertEquals(expected, produced);
 
-    expected = Path.of(System.getProperty("user.home"), ".cache", "pyserini", "topics-and-qrels", "qrels.msmarco-v2-passage.dev2.txt");
+    expected = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve("qrels.msmarco-v2-passage.dev2.txt");
     produced = RelevanceJudgments.getQrelsPath(Path.of("msmarco-v2-passage.dev2"));
     assertNotNull(produced);
     assertEquals(expected, produced);
 
-    expected = Path.of(System.getProperty("user.home"), ".cache", "pyserini", "topics-and-qrels", "qrels.miracl-v1.0-en-dev.tsv");
+    expected = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve("qrels.miracl-v1.0-en-dev.tsv");
     produced = RelevanceJudgments.getQrelsPath(Path.of("miracl-v1.0-en-dev"));
     assertNotNull(produced);
     assertEquals(expected, produced);
 
-    expected = Path.of(System.getProperty("user.home"), ".cache", "pyserini", "topics-and-qrels", "qrels.covid-round3.txt");
+    expected = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve("qrels.covid-round3.txt");
     produced = RelevanceJudgments.getQrelsPath(Path.of("covid-round3"));
     assertNotNull(produced);
     assertEquals(expected, produced);
     
-    expected = Path.of(System.getProperty("user.home"), ".cache", "pyserini", "topics-and-qrels", "qrels.ciral-v1.0-yo-test-a-pools.tsv");
+    expected = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve("qrels.ciral-v1.0-yo-test-a-pools.tsv");
     produced = RelevanceJudgments.getQrelsPath(Path.of("ciral-v1.0-yo-test-a-pools"));
     assertNotNull(produced);
     assertEquals(expected, produced);
 
-    expected = Path.of(System.getProperty("user.home"), ".cache", "pyserini", "topics-and-qrels", "qrels.adhoc.151-200.txt");
+    expected = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve("qrels.adhoc.151-200.txt");
     produced = RelevanceJudgments.getQrelsPath(Path.of("adhoc.151-200"));
     assertNotNull(produced);
     assertEquals(expected, produced);
 
-    expected = Path.of(System.getProperty("user.home"), ".cache", "pyserini", "topics-and-qrels", "qrels.microblog2012.txt");
+    expected = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve("qrels.microblog2012.txt");
     produced = RelevanceJudgments.getQrelsPath(Path.of("microblog2012"));
     assertNotNull(produced);
     assertEquals(expected, produced);
 
-    expected = Path.of(System.getProperty("user.home"), ".cache", "pyserini", "topics-and-qrels", "qrels.terabyte04.701-750.txt");
+    expected = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve("qrels.terabyte04.701-750.txt");
     produced = RelevanceJudgments.getQrelsPath(Path.of("terabyte04.701-750"));
     assertNotNull(produced);
     assertEquals(expected, produced);

--- a/src/test/java/io/anserini/util/CacheDirectoryResolverTest.java
+++ b/src/test/java/io/anserini/util/CacheDirectoryResolverTest.java
@@ -17,8 +17,10 @@
 package io.anserini.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -33,18 +35,22 @@ public class CacheDirectoryResolverTest {
   public TemporaryFolder tempFolder = new TemporaryFolder();
 
   private String userDir;
+  private String userHome;
   private String cacheProperty;
 
   @Before
-  public void setUp() {
+  public void setUp() throws IOException {
     userDir = System.getProperty("user.dir");
+    userHome = System.getProperty("user.home");
     cacheProperty = System.getProperty(CacheDirectoryResolver.CACHE_PROPERTY);
+    System.setProperty("user.home", tempFolder.newFolder("home").toString());
     System.clearProperty(CacheDirectoryResolver.CACHE_PROPERTY);
   }
 
   @After
   public void tearDown() {
     System.setProperty("user.dir", userDir);
+    System.setProperty("user.home", userHome);
     if (cacheProperty == null) {
       System.clearProperty(CacheDirectoryResolver.CACHE_PROPERTY);
     } else {
@@ -57,7 +63,9 @@ public class CacheDirectoryResolverTest {
     Path cwd = tempFolder.newFolder("no-local-cache").toPath();
     System.setProperty("user.dir", cwd.toString());
 
-    assertEquals(Path.of(System.getProperty("user.home"), ".cache", "pyserini"), CacheDirectoryResolver.getBasePath());
+    Path base = Path.of(System.getProperty("user.home"), ".cache", "pyserini");
+    assertEquals(base, CacheDirectoryResolver.getBasePath());
+    assertTrue(Files.isDirectory(base));
   }
 
   @Test
@@ -69,6 +77,9 @@ public class CacheDirectoryResolverTest {
     assertEquals(base.resolve("indexes"), CacheDirectoryResolver.getIndexCachePath());
     assertEquals(base.resolve("topics-and-qrels"), CacheDirectoryResolver.getTopicsAndQrelsCachePath());
     assertEquals(base.resolve("encoders"), CacheDirectoryResolver.getEncodersCachePath());
+    assertTrue(Files.isDirectory(base.resolve("indexes")));
+    assertTrue(Files.isDirectory(base.resolve("topics-and-qrels")));
+    assertTrue(Files.isDirectory(base.resolve("encoders")));
   }
 
   @Test
@@ -82,30 +93,10 @@ public class CacheDirectoryResolverTest {
     assertEquals(base.resolve("indexes"), CacheDirectoryResolver.getIndexCachePath());
     assertEquals(base.resolve("topics-and-qrels"), CacheDirectoryResolver.getTopicsAndQrelsCachePath());
     assertEquals(base.resolve("encoders"), CacheDirectoryResolver.getEncodersCachePath());
-  }
-
-  @Test
-  public void testLocalIndexDirectory() throws IOException {
-    Path cwd = tempFolder.newFolder("local-index").toPath();
-    Files.createDirectory(cwd.resolve("index"));
-    System.setProperty("user.dir", cwd.toString());
-
-    assertEquals(cwd.resolve("index"), CacheDirectoryResolver.getIndexCachePath());
-  }
-
-  @Test
-  public void testLocalIndexDirectoryOverridesCacheProperty() throws IOException {
-    Path cwd = tempFolder.newFolder("local-index-with-override").toPath();
-    Files.createDirectory(cwd.resolve("index"));
-    System.setProperty("user.dir", cwd.toString());
-
-    Path override = tempFolder.newFolder("cache").toPath();
-    System.setProperty(CacheDirectoryResolver.CACHE_PROPERTY, override.toString());
-
-    assertEquals(cwd.resolve("index"), CacheDirectoryResolver.getIndexCachePath());
-    assertEquals(override, CacheDirectoryResolver.getBasePath());
-    assertEquals(override.resolve("topics-and-qrels"), CacheDirectoryResolver.getTopicsAndQrelsCachePath());
-    assertEquals(override.resolve("encoders"), CacheDirectoryResolver.getEncodersCachePath());
+    assertTrue(Files.isDirectory(base));
+    assertTrue(Files.isDirectory(base.resolve("indexes")));
+    assertTrue(Files.isDirectory(base.resolve("topics-and-qrels")));
+    assertTrue(Files.isDirectory(base.resolve("encoders")));
   }
 
   @Test
@@ -121,5 +112,20 @@ public class CacheDirectoryResolverTest {
     assertEquals(override.resolve("indexes"), CacheDirectoryResolver.getIndexCachePath());
     assertEquals(override.resolve("topics-and-qrels"), CacheDirectoryResolver.getTopicsAndQrelsCachePath());
     assertEquals(override.resolve("encoders"), CacheDirectoryResolver.getEncodersCachePath());
+    assertTrue(Files.isDirectory(override));
+    assertTrue(Files.isDirectory(override.resolve("indexes")));
+    assertTrue(Files.isDirectory(override.resolve("topics-and-qrels")));
+    assertTrue(Files.isDirectory(override.resolve("encoders")));
+  }
+
+  @Test(expected = UncheckedIOException.class)
+  public void testDirectoryCreationFailure() throws IOException {
+    Path cwd = tempFolder.newFolder("creation-failure").toPath();
+    System.setProperty("user.dir", cwd.toString());
+
+    Path file = tempFolder.newFile("cache-file").toPath();
+    System.setProperty(CacheDirectoryResolver.CACHE_PROPERTY, file.toString());
+
+    CacheDirectoryResolver.getBasePath();
   }
 }

--- a/src/test/java/io/anserini/util/CacheDirectoryResolverTest.java
+++ b/src/test/java/io/anserini/util/CacheDirectoryResolverTest.java
@@ -1,0 +1,125 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class CacheDirectoryResolverTest {
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private String userDir;
+  private String cacheProperty;
+
+  @Before
+  public void setUp() {
+    userDir = System.getProperty("user.dir");
+    cacheProperty = System.getProperty(CacheDirectoryResolver.CACHE_PROPERTY);
+    System.clearProperty(CacheDirectoryResolver.CACHE_PROPERTY);
+  }
+
+  @After
+  public void tearDown() {
+    System.setProperty("user.dir", userDir);
+    if (cacheProperty == null) {
+      System.clearProperty(CacheDirectoryResolver.CACHE_PROPERTY);
+    } else {
+      System.setProperty(CacheDirectoryResolver.CACHE_PROPERTY, cacheProperty);
+    }
+  }
+
+  @Test
+  public void testDefaultBasePath() throws IOException {
+    Path cwd = tempFolder.newFolder("no-local-cache").toPath();
+    System.setProperty("user.dir", cwd.toString());
+
+    assertEquals(Path.of(System.getProperty("user.home"), ".cache", "pyserini"), CacheDirectoryResolver.getBasePath());
+  }
+
+  @Test
+  public void testDefaultCacheSubpaths() throws IOException {
+    Path cwd = tempFolder.newFolder("default-subpaths").toPath();
+    System.setProperty("user.dir", cwd.toString());
+
+    Path base = Path.of(System.getProperty("user.home"), ".cache", "pyserini");
+    assertEquals(base.resolve("indexes"), CacheDirectoryResolver.getIndexCachePath());
+    assertEquals(base.resolve("topics-and-qrels"), CacheDirectoryResolver.getTopicsAndQrelsCachePath());
+    assertEquals(base.resolve("encoders"), CacheDirectoryResolver.getEncodersCachePath());
+  }
+
+  @Test
+  public void testLocalCacheDirectoryBasePath() throws IOException {
+    Path cwd = tempFolder.newFolder("local-cache").toPath();
+    Files.createDirectory(cwd.resolve(".cache"));
+    System.setProperty("user.dir", cwd.toString());
+
+    Path base = cwd.resolve(".cache").resolve("pyserini");
+    assertEquals(base, CacheDirectoryResolver.getBasePath());
+    assertEquals(base.resolve("indexes"), CacheDirectoryResolver.getIndexCachePath());
+    assertEquals(base.resolve("topics-and-qrels"), CacheDirectoryResolver.getTopicsAndQrelsCachePath());
+    assertEquals(base.resolve("encoders"), CacheDirectoryResolver.getEncodersCachePath());
+  }
+
+  @Test
+  public void testLocalIndexDirectory() throws IOException {
+    Path cwd = tempFolder.newFolder("local-index").toPath();
+    Files.createDirectory(cwd.resolve("index"));
+    System.setProperty("user.dir", cwd.toString());
+
+    assertEquals(cwd.resolve("index"), CacheDirectoryResolver.getIndexCachePath());
+  }
+
+  @Test
+  public void testLocalIndexDirectoryOverridesCacheProperty() throws IOException {
+    Path cwd = tempFolder.newFolder("local-index-with-override").toPath();
+    Files.createDirectory(cwd.resolve("index"));
+    System.setProperty("user.dir", cwd.toString());
+
+    Path override = tempFolder.newFolder("cache").toPath();
+    System.setProperty(CacheDirectoryResolver.CACHE_PROPERTY, override.toString());
+
+    assertEquals(cwd.resolve("index"), CacheDirectoryResolver.getIndexCachePath());
+    assertEquals(override, CacheDirectoryResolver.getBasePath());
+    assertEquals(override.resolve("topics-and-qrels"), CacheDirectoryResolver.getTopicsAndQrelsCachePath());
+    assertEquals(override.resolve("encoders"), CacheDirectoryResolver.getEncodersCachePath());
+  }
+
+  @Test
+  public void testCachePropertyOverride() throws IOException {
+    Path cwd = tempFolder.newFolder("override").toPath();
+    Files.createDirectory(cwd.resolve(".cache"));
+    System.setProperty("user.dir", cwd.toString());
+
+    Path override = tempFolder.newFolder("cache").toPath();
+    System.setProperty(CacheDirectoryResolver.CACHE_PROPERTY, override.toString());
+
+    assertEquals(override, CacheDirectoryResolver.getBasePath());
+    assertEquals(override.resolve("indexes"), CacheDirectoryResolver.getIndexCachePath());
+    assertEquals(override.resolve("topics-and-qrels"), CacheDirectoryResolver.getTopicsAndQrelsCachePath());
+    assertEquals(override.resolve("encoders"), CacheDirectoryResolver.getEncodersCachePath());
+  }
+}


### PR DESCRIPTION
## Summary
- add `CacheDirectoryResolver` for shared cache path resolution
- route prebuilt indexes, topics/qrels, and encoder cache users through the resolver
- add resolver tests and update qrels path expectations

## Test Plan
- `mvn -Dtest=CacheDirectoryResolverTest test`
- `mvn -Dtest=PrebuiltIndexHandlerTest,RelevanceJudgmentsTest,TopicsRegistryTest test`
- `bin/build.sh` (fails in `PrebuiltInvertedIndexTest.testUrls` due timeout connecting to `https://rgw.cs.uwaterloo.ca/pyserini/indexes/lucene/lucene-inverted.msmarco-v2-doc-segmented.unicoil-0shot.20220808.4d6d2a.tar.gz`)