### PR TITLE
[codex] Clean up test-generated artifacts

### DIFF
--- a/src/test/java/io/anserini/eval/TrecEvalTest.java
+++ b/src/test/java/io/anserini/eval/TrecEvalTest.java
@@ -64,6 +64,15 @@ public class TrecEvalTest {
   }
 
   @Test
+  public void testRunWithMainInvalidQrels() {
+    TrecEval.main(new String[] {
+        "-m", "P.30",
+        "fake",
+        "src/test/resources/sample_runs/cacm/cacm-bm25.txt"
+    });
+  }
+
+  @Test
   public void testRunAndGetOutputCacm() {
     assertNotNull(TrecEval.getExecutableName());
 

--- a/src/test/java/io/anserini/eval/TrecEvalTest.java
+++ b/src/test/java/io/anserini/eval/TrecEvalTest.java
@@ -18,16 +18,21 @@ package io.anserini.eval;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
 public class TrecEvalTest {
   @Test
-  public void testRunWithMainCacmBm25() {
+  public void testRunWithMainCacmBm25() throws Exception {
     assertNotNull(TrecEval.getExecutableName());
 
     String[] args = new String[] {
@@ -36,7 +41,26 @@ public class TrecEvalTest {
         "src/test/resources/sample_runs/cacm/cacm-bm25.txt"
     };
 
-    TrecEval.main(args);
+    ArrayList<String> command = new ArrayList<>();
+    command.add(Paths.get(System.getProperty("java.home"), "bin", "java").toString());
+    command.add("-cp");
+    command.add(System.getProperty("java.class.path"));
+    command.add(TrecEval.class.getName());
+    for (String arg : args) {
+      command.add(arg);
+    }
+
+    ProcessBuilder builder = new ProcessBuilder(command);
+    builder.redirectErrorStream(true);
+
+    Process process = builder.start();
+    assertTrue("trec_eval command timed out", process.waitFor(30, TimeUnit.SECONDS));
+
+    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    assertEquals(output, 0, process.exitValue());
+    assertTrue(output.contains("P_30"));
+    assertTrue(output.contains("all"));
+    assertTrue(output.contains("0.1942"));
   }
 
   @Test

--- a/src/test/java/io/anserini/index/IndexCollectionInovcationsTest.java
+++ b/src/test/java/io/anserini/index/IndexCollectionInovcationsTest.java
@@ -16,6 +16,11 @@
 
 package io.anserini.index;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.lucene.tests.util.TestRuleLimitSysouts;
@@ -28,6 +33,7 @@ import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
 
 @TestRuleLimitSysouts.Limit(bytes = 64 * 1024L)
 public class IndexCollectionInovcationsTest extends StdOutStdErrRedirectableLuceneTestCase {
+  private final List<String> indexPaths = new ArrayList<>();
 
   @BeforeClass
   public static void setupClass() {
@@ -45,7 +51,17 @@ public class IndexCollectionInovcationsTest extends StdOutStdErrRedirectableLuce
   public void tearDown() throws Exception {
     restoreStdOut();
     restoreStdErr();
+    for (String indexPath : indexPaths) {
+      FileUtils.deleteDirectory(new File(indexPath));
+    }
+    indexPaths.clear();
     super.tearDown();
+  }
+
+  private String newIndexPath(String prefix) {
+    String indexPath = prefix + System.currentTimeMillis();
+    indexPaths.add(indexPath);
+    return indexPath;
   }
 
   @Test
@@ -68,7 +84,7 @@ public class IndexCollectionInovcationsTest extends StdOutStdErrRedirectableLuce
     String[] indexArgs = new String[] {
         "-collection", "FakeTrecCollection",
         "-input", "src/test/resources/sample_docs/trec/collection2",
-        "-index", "target/idx-sample-trec-index" + System.currentTimeMillis(),
+        "-index", newIndexPath("target/idx-sample-trec-index"),
         "-generator", "DefaultLuceneDocumentGenerator",
     };
 
@@ -80,7 +96,7 @@ public class IndexCollectionInovcationsTest extends StdOutStdErrRedirectableLuce
     String[] indexArgs = new String[] {
         "-collection", "TrecCollection",
         "-input", "src/test/resources/sample_docs/trec/collection2_fake_path",
-        "-index", "target/idx-sample-trec-index" + System.currentTimeMillis(),
+        "-index", newIndexPath("target/idx-sample-trec-index"),
         "-generator", "DefaultLuceneDocumentGenerator",
     };
 
@@ -92,7 +108,7 @@ public class IndexCollectionInovcationsTest extends StdOutStdErrRedirectableLuce
     String[] indexArgs = new String[] {
         "-collection", "TrecCollection",
         "-input", "src/test/resources/sample_docs/trec/collection2",
-        "-index", "target/idx-sample-trec-index" + System.currentTimeMillis(),
+        "-index", newIndexPath("target/idx-sample-trec-index"),
         "-generator", "FakeDefaultLuceneDocumentGenerator",
     };
 
@@ -104,7 +120,7 @@ public class IndexCollectionInovcationsTest extends StdOutStdErrRedirectableLuce
     String[] indexArgs = new String[] {
         "-collection", "TrecCollection",
         "-input", "src/test/resources/sample_docs/trec/collection2",
-        "-index", "target/idx-sample-trec-index" + System.currentTimeMillis()
+        "-index", newIndexPath("target/idx-sample-trec-index")
     };
 
     IndexCollection.main(indexArgs);

--- a/src/test/java/io/anserini/index/IndexFlatDenseVectorsTest.java
+++ b/src/test/java/io/anserini/index/IndexFlatDenseVectorsTest.java
@@ -16,8 +16,12 @@
 
 package io.anserini.index;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.lucene.index.IndexReader;
@@ -32,6 +36,8 @@ import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
  * Tests for {@link IndexFlatDenseVectors}
  */
 public class IndexFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTestCase {
+  private final List<String> indexPaths = new ArrayList<>();
+
   @BeforeClass
   public static void setupClass() {
     suppressJvmLogging();
@@ -51,7 +57,17 @@ public class IndexFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
   public void tearDown() throws Exception {
     restoreStdOut();
     restoreStdErr();
+    for (String indexPath : indexPaths) {
+      FileUtils.deleteDirectory(new File(indexPath));
+    }
+    indexPaths.clear();
     super.tearDown();
+  }
+
+  private String newIndexPath(String prefix) {
+    String indexPath = prefix + System.currentTimeMillis();
+    indexPaths.add(indexPath);
+    return indexPath;
   }
 
   @Test
@@ -71,7 +87,7 @@ public class IndexFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidCollection() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "FakeJsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -85,7 +101,7 @@ public class IndexFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test(expected = IllegalArgumentException.class)
   public void testCollectionPath() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector_fake_path",
@@ -99,7 +115,7 @@ public class IndexFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidGenerator() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -113,7 +129,7 @@ public class IndexFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void testDefaultGenerator() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -127,7 +143,7 @@ public class IndexFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void testJsonDenseVectorCollection() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -148,7 +164,7 @@ public class IndexFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void testParquetFloat() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "ParquetDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/parquet/msmarco-passage-bge-base-en-v1.5.parquet-float/",
@@ -169,7 +185,7 @@ public class IndexFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void testParquetDouble() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "ParquetDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/parquet/msmarco-passage-bge-base-en-v1.5.parquet-double/",
@@ -190,7 +206,7 @@ public class IndexFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void testQuantizedInt8() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",

--- a/src/test/java/io/anserini/index/IndexHnswDenseVectorsTest.java
+++ b/src/test/java/io/anserini/index/IndexHnswDenseVectorsTest.java
@@ -16,8 +16,12 @@
 
 package io.anserini.index;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.lucene.index.IndexReader;
@@ -33,6 +37,8 @@ import io.anserini.index.generator.DenseVectorDocumentGenerator;
  * Tests for {@link IndexHnswDenseVectors}
  */
 public class IndexHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTestCase {
+  private final List<String> indexPaths = new ArrayList<>();
+
   @BeforeClass
   public static void setupClass() {
     suppressJvmLogging();
@@ -53,7 +59,17 @@ public class IndexHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
   public void tearDown() throws Exception {
     restoreStdOut();
     restoreStdErr();
+    for (String indexPath : indexPaths) {
+      FileUtils.deleteDirectory(new File(indexPath));
+    }
+    indexPaths.clear();
     super.tearDown();
+  }
+
+  private String newIndexPath(String prefix) {
+    String indexPath = prefix + System.currentTimeMillis();
+    indexPaths.add(indexPath);
+    return indexPath;
   }
 
   @Test
@@ -73,7 +89,7 @@ public class IndexHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidCollection() throws Exception {
-    String indexPath = "target/lucene-test-index.hnsw." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.hnsw.");
     String[] indexArgs = new String[] {
         "-collection", "FakeJsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -88,7 +104,7 @@ public class IndexHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test(expected = IllegalArgumentException.class)
   public void testCollectionPath() throws Exception {
-    String indexPath = "target/lucene-test-index.hnsw." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.hnsw.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector_fake_path",
@@ -103,7 +119,7 @@ public class IndexHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidGenerator() throws Exception {
-    String indexPath = "target/lucene-test-index.hnsw." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.hnsw.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -118,7 +134,7 @@ public class IndexHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void testDefaultGenerator() throws Exception {
-    String indexPath = "target/lucene-test-index.hnsw." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.hnsw.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -133,7 +149,7 @@ public class IndexHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void testJsonDenseVectorCollection() throws Exception {
-    String indexPath = "target/lucene-test-index.hnsw." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.hnsw.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -155,7 +171,7 @@ public class IndexHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void testParquetFloat() throws Exception {
-    String indexPath = "target/lucene-test-index.hnsw." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.hnsw.");
     String[] indexArgs = new String[] {
         "-collection", "ParquetDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/parquet/msmarco-passage-bge-base-en-v1.5.parquet-float/",
@@ -177,7 +193,7 @@ public class IndexHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void testParquetDouble() throws Exception {
-    String indexPath = "target/lucene-test-index.hnsw." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.hnsw.");
     String[] indexArgs = new String[] {
         "-collection", "ParquetDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/parquet/msmarco-passage-bge-base-en-v1.5.parquet-double/",
@@ -199,7 +215,7 @@ public class IndexHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void testNullVectorDense() throws Exception {
-    String indexPath = "target/lucene-test-index.hnsw." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.hnsw.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector_null",
@@ -223,7 +239,7 @@ public class IndexHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void testNullVectorInverted() throws Exception {
-    String indexPath = "target/lucene-test-index.hnsw." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.hnsw.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector_null",
@@ -242,7 +258,7 @@ public class IndexHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void testQuantizedSQV() throws Exception {
-    String indexPath = "target/lucene-test-index.hnsw." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.hnsw.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",

--- a/src/test/java/io/anserini/index/IndexInvertedDenseVectorsTest.java
+++ b/src/test/java/io/anserini/index/IndexInvertedDenseVectorsTest.java
@@ -16,8 +16,12 @@
 
 package io.anserini.index;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.lucene.index.IndexReader;
@@ -32,6 +36,8 @@ import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
  * Tests for {@link IndexInvertedDenseVectors}
  */
 public class IndexInvertedDenseVectorsTest extends StdOutStdErrRedirectableLuceneTestCase {
+  private final List<String> indexPaths = new ArrayList<>();
+
   @BeforeClass
   public static void setupClass() {
     Configurator.setLevel(AbstractIndexer.class.getName(), Level.ERROR);
@@ -49,7 +55,17 @@ public class IndexInvertedDenseVectorsTest extends StdOutStdErrRedirectableLucen
   public void tearDown() throws Exception {
     restoreStdOut();
     restoreStdErr();
+    for (String indexPath : indexPaths) {
+      FileUtils.deleteDirectory(new File(indexPath));
+    }
+    indexPaths.clear();
     super.tearDown();
+  }
+
+  private String newIndexPath(String prefix) {
+    String indexPath = prefix + System.currentTimeMillis();
+    indexPaths.add(indexPath);
+    return indexPath;
   }
 
   @Test
@@ -73,7 +89,7 @@ public class IndexInvertedDenseVectorsTest extends StdOutStdErrRedirectableLucen
         "-collection", "FakeCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
         "-generator", "InvertedDenseVectorDocumentGenerator",
-        "-index", "target/idx-sample-ll-vector" + System.currentTimeMillis(),
+        "-index", newIndexPath("target/idx-sample-ll-vector"),
         "-encoding", "lexlsh"
     };
 
@@ -86,7 +102,7 @@ public class IndexInvertedDenseVectorsTest extends StdOutStdErrRedirectableLucen
         "-collection", "JsonDenseVectorCollection",
         "-input", "invalid/path",
         "-generator", "InvertedDenseVectorDocumentGenerator",
-        "-index", "target/idx-sample-ll-vector" + System.currentTimeMillis(),
+        "-index", newIndexPath("target/idx-sample-ll-vector"),
         "-encoding", "lexlsh"
     };
 
@@ -99,7 +115,7 @@ public class IndexInvertedDenseVectorsTest extends StdOutStdErrRedirectableLucen
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
         "-generator", "FakeGenerator",
-        "-index", "target/idx-sample-ll-vector" + System.currentTimeMillis(),
+        "-index", newIndexPath("target/idx-sample-ll-vector"),
         "-encoding", "lexlsh"
     };
 
@@ -111,7 +127,7 @@ public class IndexInvertedDenseVectorsTest extends StdOutStdErrRedirectableLucen
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
-        "-index", "target/idx-sample-ll-vector" + System.currentTimeMillis(),
+        "-index", newIndexPath("target/idx-sample-ll-vector"),
         "-encoding", "lexlsh"
     };
 
@@ -125,7 +141,7 @@ public class IndexInvertedDenseVectorsTest extends StdOutStdErrRedirectableLucen
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
         "-generator", "InvertedDenseVectorDocumentGenerator",
-        "-index", "target/idx-sample-ll-vector" + System.currentTimeMillis(),
+        "-index", newIndexPath("target/idx-sample-ll-vector"),
         "-encoding", "xxx"
     };
 
@@ -134,7 +150,7 @@ public class IndexInvertedDenseVectorsTest extends StdOutStdErrRedirectableLucen
 
   @Test
   public void testLLCollection() throws Exception {
-    String indexPath = "target/idx-sample-ll-vector" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-ll-vector");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -158,7 +174,7 @@ public class IndexInvertedDenseVectorsTest extends StdOutStdErrRedirectableLucen
 
   @Test
   public void testFWCollection() throws Exception {
-    String indexPath = "target/idx-sample-fw-vector" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-fw-vector");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",

--- a/src/test/java/io/anserini/reproduce/ReproduceFromDocumentCollectionTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromDocumentCollectionTest.java
@@ -50,6 +50,8 @@ import io.anserini.search.topicreader.TopicReader;
 import io.anserini.search.topicreader.Topics;
 
 public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectableLuceneTestCase {
+  private static final Path CACM_FATJAR_LOG = Paths.get("target", "run-cacm-fatjar.log");
+
   private static final String[] CACM_COLLECTION_IN_REPO_EXPECTED_RUNS = {
     "runs/run.inverted.cacm.cacm.bm25.txt",
     "runs/run.inverted.cacm.cacm.bm25+rm3.txt",
@@ -91,6 +93,7 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
   public void tearDown() throws Exception {
     restoreStdOut();
     restoreStdErr();
+    Files.deleteIfExists(CACM_FATJAR_LOG);
     super.tearDown();
   }
 
@@ -212,9 +215,8 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
 
     ProcessBuilder builder = new ProcessBuilder(command);
     builder.redirectErrorStream(true);
-    Path processLog = Paths.get("target", "run-cacm-fatjar.log");
-    Files.createDirectories(processLog.getParent());
-    builder.redirectOutput(processLog.toFile());
+    Files.createDirectories(CACM_FATJAR_LOG.getParent());
+    builder.redirectOutput(CACM_FATJAR_LOG.toFile());
 
     Process process = builder.start();
     assertTrue("Reproduction command timed out", process.waitFor(10, TimeUnit.MINUTES));

--- a/src/test/java/io/anserini/search/FlatDenseSearcherTest.java
+++ b/src/test/java/io/anserini/search/FlatDenseSearcherTest.java
@@ -16,6 +16,7 @@
 
 package io.anserini.search;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -23,8 +24,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -36,6 +39,8 @@ import io.anserini.search.topicreader.TopicReader;
 import io.anserini.search.topicreader.TsvIntTopicReader;
 
 public class FlatDenseSearcherTest extends SuppresedLoggingLuceneTestCase {
+  private final List<String> indexPaths = new ArrayList<>();
+
   @BeforeClass
   public static void setupClass() {
     suppressJvmLogging();
@@ -45,9 +50,24 @@ public class FlatDenseSearcherTest extends SuppresedLoggingLuceneTestCase {
     Configurator.setLevel(FlatDenseSearcher.class.getName(), Level.ERROR);
   }
 
+  @After
+  public void tearDown() throws Exception {
+    for (String indexPath : indexPaths) {
+      FileUtils.deleteDirectory(new File(indexPath));
+    }
+    indexPaths.clear();
+    super.tearDown();
+  }
+
+  private String newIndexPath(String prefix) {
+    String indexPath = prefix + System.currentTimeMillis();
+    indexPaths.add(indexPath);
+    return indexPath;
+  }
+
   @Test
   public void testAda2() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -136,7 +156,7 @@ public class FlatDenseSearcherTest extends SuppresedLoggingLuceneTestCase {
 
   @Test
   public void testAda2Batch() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -200,7 +220,7 @@ public class FlatDenseSearcherTest extends SuppresedLoggingLuceneTestCase {
 
   @Test
   public void testCosDpr() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cosdpr-distil/json_vector/",
@@ -289,7 +309,7 @@ public class FlatDenseSearcherTest extends SuppresedLoggingLuceneTestCase {
 
   @Test
   public void testCosDprWithOnnx() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cosdpr-distil/json_vector/",
@@ -379,7 +399,7 @@ public class FlatDenseSearcherTest extends SuppresedLoggingLuceneTestCase {
 
   @Test
   public void testCosDprBatchWithOnnx() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cosdpr-distil/json_vector/",

--- a/src/test/java/io/anserini/search/HnswDenseSearcherTest.java
+++ b/src/test/java/io/anserini/search/HnswDenseSearcherTest.java
@@ -16,6 +16,7 @@
 
 package io.anserini.search;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -23,8 +24,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -36,6 +39,8 @@ import io.anserini.search.topicreader.TopicReader;
 import io.anserini.search.topicreader.TsvIntTopicReader;
 
 public class HnswDenseSearcherTest extends SuppresedLoggingLuceneTestCase {
+  private final List<String> indexPaths = new ArrayList<>();
+
   @BeforeClass
   public static void setupClass() {
     suppressJvmLogging();
@@ -45,9 +50,24 @@ public class HnswDenseSearcherTest extends SuppresedLoggingLuceneTestCase {
     Configurator.setLevel(HnswDenseSearcher.class.getName(), Level.ERROR);
   }
 
+  @After
+  public void tearDown() throws Exception {
+    for (String indexPath : indexPaths) {
+      FileUtils.deleteDirectory(new File(indexPath));
+    }
+    indexPaths.clear();
+    super.tearDown();
+  }
+
+  private String newIndexPath(String prefix) {
+    String indexPath = prefix + System.currentTimeMillis();
+    indexPaths.add(indexPath);
+    return indexPath;
+  }
+
   @Test
   public void testAda2() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -137,7 +157,7 @@ public class HnswDenseSearcherTest extends SuppresedLoggingLuceneTestCase {
 
   @Test
   public void testAda2Batch() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -202,7 +222,7 @@ public class HnswDenseSearcherTest extends SuppresedLoggingLuceneTestCase {
 
   @Test
   public void testCosDpr() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cosdpr-distil/json_vector/",
@@ -292,7 +312,7 @@ public class HnswDenseSearcherTest extends SuppresedLoggingLuceneTestCase {
 
   @Test
   public void testCosDprWithOnnx() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cosdpr-distil/json_vector/",
@@ -383,7 +403,7 @@ public class HnswDenseSearcherTest extends SuppresedLoggingLuceneTestCase {
 
   @Test
   public void testCosDprBatchWithOnnx() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cosdpr-distil/json_vector/",

--- a/src/test/java/io/anserini/search/InvertedDenseSearcherTest.java
+++ b/src/test/java/io/anserini/search/InvertedDenseSearcherTest.java
@@ -16,6 +16,7 @@
 
 package io.anserini.search;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -23,8 +24,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -35,6 +38,8 @@ import io.anserini.search.topicreader.JsonIntVectorTopicReader;
 import io.anserini.search.topicreader.TopicReader;
 
 public class InvertedDenseSearcherTest extends StdOutStdErrRedirectableLuceneTestCase {
+  private final List<String> indexPaths = new ArrayList<>();
+
   @BeforeClass
   public static void setupClass() {
     Configurator.setLevel(AbstractIndexer.class.getName(), Level.ERROR);
@@ -42,9 +47,24 @@ public class InvertedDenseSearcherTest extends StdOutStdErrRedirectableLuceneTes
     Configurator.setLevel(InvertedDenseSearcher.class.getName(), Level.ERROR);
   }
 
+  @After
+  public void tearDown() throws Exception {
+    for (String indexPath : indexPaths) {
+      FileUtils.deleteDirectory(new File(indexPath));
+    }
+    indexPaths.clear();
+    super.tearDown();
+  }
+
+  private String newIndexPath(String prefix) {
+    String indexPath = prefix + System.currentTimeMillis();
+    indexPaths.add(indexPath);
+    return indexPath;
+  }
+
   @Test
   public void searchAda2FWTest() throws Exception {
-    String indexPath = "target/idx-sample-fw-vector-" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-fw-vector-");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -132,7 +152,7 @@ public class InvertedDenseSearcherTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void searchAda2FWBatchTest() throws Exception {
-    String indexPath = "target/idx-sample-fw-vector-" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-fw-vector-");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -196,7 +216,7 @@ public class InvertedDenseSearcherTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void searchAda2LLTest() throws Exception {
-    String indexPath = "target/idx-sample-fw-vector-" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-fw-vector-");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -284,7 +304,7 @@ public class InvertedDenseSearcherTest extends StdOutStdErrRedirectableLuceneTes
 
   @Test
   public void searchAda2LLBatchTest() throws Exception {
-    String indexPath = "target/idx-sample-fw-vector-" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-fw-vector-");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",

--- a/src/test/java/io/anserini/search/SearchCollectionTest.java
+++ b/src/test/java/io/anserini/search/SearchCollectionTest.java
@@ -30,6 +30,8 @@ import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
 import io.anserini.TestUtils;
 
 public class SearchCollectionTest extends StdOutStdErrRedirectableLuceneTestCase {
+  private static final String RUN_TEST = "target/run-search-collection-test";
+
   @BeforeClass
   public static void setupClass() {
     Configurator.setLevel(SearchCollection.class.getName(), Level.ERROR);
@@ -46,6 +48,7 @@ public class SearchCollectionTest extends StdOutStdErrRedirectableLuceneTestCase
   public void tearDown() throws Exception {
     restoreStdOut();
     restoreStdErr();
+    new File(RUN_TEST).delete();
     super.tearDown();
   }
 
@@ -114,7 +117,7 @@ public class SearchCollectionTest extends StdOutStdErrRedirectableLuceneTestCase
         "-index", "src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_trec_collection2/",
         "-topics", "src/test/resources/sample_topics/Trec",
         "-topicReader", "FakeTrec",
-        "-output", "run.test", "-bm25"});
+        "-output", RUN_TEST, "-bm25"});
     assertTrue(err.toString().contains("Unable to load topic reader"));
   }
 
@@ -125,7 +128,7 @@ public class SearchCollectionTest extends StdOutStdErrRedirectableLuceneTestCase
         "-topics", "src/test/resources/sample_topics/Trec",
         "-topicReader", "Trec",
         "-fields", "field1=a",
-        "-output", "run.test", "-bm25"});
+        "-output", RUN_TEST, "-bm25"});
     assertTrue(err.toString().contains("Error parsing -fields"));
   }
 
@@ -135,24 +138,24 @@ public class SearchCollectionTest extends StdOutStdErrRedirectableLuceneTestCase
         "-index", "src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_trec_collection2/",
         "-topics", "src/test/resources/sample_topics/Trec",
         "-topicReader", "Trec",
-        "-output", "run.test", "-bm25"});
+        "-output", RUN_TEST, "-bm25"});
 
-    TestUtils.checkFile("run.test", new String[]{
+    TestUtils.checkFile(RUN_TEST, new String[]{
         "1 Q0 DOC222 1 0.343200 Anserini",
         "1 Q0 TREC_DOC_1 2 0.333400 Anserini",
         "1 Q0 WSJ_1 3 0.068700 Anserini"});
-    assertTrue(new File("run.test").delete());
+    assertTrue(new File(RUN_TEST).delete());
 
     SearchCollection.main(new String[] {
         "-index", "src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_json_collection_tokenized/",
         "-topics", "src/test/resources/sample_topics/json_topics1.tsv",
         "-topicReader", "TsvInt",
-        "-output", "run.test",
+        "-output", RUN_TEST,
         "-pretokenized", "-impact"});
 
-    TestUtils.checkFile("run.test", new String[]{
+    TestUtils.checkFile(RUN_TEST, new String[]{
         "1 Q0 2000001 1 4.000000 Anserini",});
-    assertTrue(new File("run.test").delete());
+    assertTrue(new File(RUN_TEST).delete());
   }
 
   @Test
@@ -160,10 +163,10 @@ public class SearchCollectionTest extends StdOutStdErrRedirectableLuceneTestCase
     SearchCollection.main(new String[] {
         "-index", "src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_trec_collection2/",
         "-topics", "TREC2019_DL_PASSAGE",
-        "-output", "run.test", "-bm25"});
+        "-output", RUN_TEST, "-bm25"});
 
     // Not checking content, just checking if the topics were loaded successfully.
-    File f = new File("run.test");
+    File f = new File(RUN_TEST);
     assertTrue(f.exists());
     f.delete();
   }
@@ -174,7 +177,7 @@ public class SearchCollectionTest extends StdOutStdErrRedirectableLuceneTestCase
         "-index", "src/test/resources/prebuilt_indexes/lucene-inverted.sample-wapo.no-raw_no-docvectors/",
         "-topics", "src/test/resources/sample_topics/bglinking.txt",
         "-topicReader", "BackgroundLinking",
-        "-output", "run.test", "-bm25",
+        "-output", RUN_TEST, "-bm25",
         "-backgroundLinking", "-backgroundLinking.k", "100"});
 
     // Running on index with no raw, no docvectors - should get an error.
@@ -187,7 +190,7 @@ public class SearchCollectionTest extends StdOutStdErrRedirectableLuceneTestCase
         "-index", "src/test/resources/prebuilt_indexes/lucene-inverted.sample-wapo.no-raw_with-docvectors/",
         "-topics", "src/test/resources/sample_topics/bglinking.txt",
         "-topicReader", "BackgroundLinking",
-        "-output", "run.test", "-bm25",
+        "-output", RUN_TEST, "-bm25",
         "-backgroundLinking", "-backgroundLinking.k", "100"});
 
     // Running on index with no raw, no docvectors - should get an error.
@@ -200,14 +203,14 @@ public class SearchCollectionTest extends StdOutStdErrRedirectableLuceneTestCase
         "-index", "src/test/resources/prebuilt_indexes/lucene-inverted.sample-wapo.with-raw_with-docvectors/",
         "-topics", "src/test/resources/sample_topics/bglinking.txt",
         "-topicReader", "BackgroundLinking",
-        "-output", "run.test", "-bm25",
+        "-output", RUN_TEST, "-bm25",
         "-backgroundLinking", "-backgroundLinking.k", "100"});
 
     // Running on index with raw, with docvectors - should run fine.
-    TestUtils.checkFile("run.test", new String[]{
+    TestUtils.checkFile(RUN_TEST, new String[]{
         "321 Q0 eacd327b20aa77a2aa909596ae336497 1 7.792500 Anserini",
         "321 Q0 dafe3110-4a9e-11e6-acbc-4d4870a079da 2 5.247200 Anserini"});
-    assertTrue(new File("run.test").delete());
+    assertTrue(new File(RUN_TEST).delete());
   }
 
   @Test
@@ -216,15 +219,15 @@ public class SearchCollectionTest extends StdOutStdErrRedirectableLuceneTestCase
         "-index", "src/test/resources/prebuilt_indexes/lucene-inverted.sample-wapo.with-raw_no-docvectors/",
         "-topics", "src/test/resources/sample_topics/bglinking.txt",
         "-topicReader", "BackgroundLinking",
-        "-output", "run.test", "-bm25",
+        "-output", RUN_TEST, "-bm25",
         "-backgroundLinking", "-backgroundLinking.k", "100",
         "-collection", "WashingtonPostCollection"});
 
     // Running on index with raw, no docvectors - needs -collection WashingtonPostCollection
-    TestUtils.checkFile("run.test", new String[]{
+    TestUtils.checkFile(RUN_TEST, new String[]{
         "321 Q0 eacd327b20aa77a2aa909596ae336497 1 7.792500 Anserini",
         "321 Q0 dafe3110-4a9e-11e6-acbc-4d4870a079da 2 5.247200 Anserini"});
-    assertTrue(new File("run.test").delete());
+    assertTrue(new File(RUN_TEST).delete());
   }
 
   @Test
@@ -233,7 +236,7 @@ public class SearchCollectionTest extends StdOutStdErrRedirectableLuceneTestCase
         "-index", "src/test/resources/prebuilt_indexes/lucene-inverted.sample-wapo.no-raw_no-docvectors/",
         "-topics", "src/test/resources/sample_topics/bglinking.txt",
         "-topicReader", "BackgroundLinking",
-        "-output", "run.test", "-bm25", "-rm3",
+        "-output", RUN_TEST, "-bm25", "-rm3",
         "-backgroundLinking", "-backgroundLinking.k", "100"});
 
     // Running on index with no raw, no docvectors - should get an error.
@@ -246,7 +249,7 @@ public class SearchCollectionTest extends StdOutStdErrRedirectableLuceneTestCase
         "-index", "src/test/resources/prebuilt_indexes/lucene-inverted.sample-wapo.no-raw_with-docvectors/",
         "-topics", "src/test/resources/sample_topics/bglinking.txt",
         "-topicReader", "BackgroundLinking",
-        "-output", "run.test", "-bm25", "-rm3",
+        "-output", RUN_TEST, "-bm25", "-rm3",
         "-backgroundLinking", "-backgroundLinking.k", "100"});
 
     // Running on index with no raw, no docvectors - should get an error.
@@ -259,15 +262,15 @@ public class SearchCollectionTest extends StdOutStdErrRedirectableLuceneTestCase
         "-index", "src/test/resources/prebuilt_indexes/lucene-inverted.sample-wapo.with-raw_with-docvectors/",
         "-topics", "src/test/resources/sample_topics/bglinking.txt",
         "-topicReader", "BackgroundLinking",
-        "-output", "run.test", "-bm25", "-rm3",
+        "-output", RUN_TEST, "-bm25", "-rm3",
         "-backgroundLinking", "-backgroundLinking.k", "100"});
 
     // Running on index with raw, with docvectors - should run fine.
-    TestUtils.checkFile("run.test", new String[]{
+    TestUtils.checkFile(RUN_TEST, new String[]{
         "321 Q0 eacd327b20aa77a2aa909596ae336497 1 0.039000 Anserini",
         "321 Q0 dafe3110-4a9e-11e6-acbc-4d4870a079da 2 0.026200 Anserini",
         "321 Q0 03049850-58e3-11e6-8b48-0cb344221131 3 0.011300 Anserini"});
-    assertTrue(new File("run.test").delete());
+    assertTrue(new File(RUN_TEST).delete());
   }
 
   @Test
@@ -276,15 +279,15 @@ public class SearchCollectionTest extends StdOutStdErrRedirectableLuceneTestCase
         "-index", "src/test/resources/prebuilt_indexes/lucene-inverted.sample-wapo.with-raw_no-docvectors/",
         "-topics", "src/test/resources/sample_topics/bglinking.txt",
         "-topicReader", "BackgroundLinking",
-        "-output", "run.test", "-bm25", "-rm3",
+        "-output", RUN_TEST, "-bm25", "-rm3",
         "-backgroundLinking", "-backgroundLinking.k", "100",
         "-collection", "WashingtonPostCollection"});
 
     // Running on index with raw, no docvectors - needs -collection WashingtonPostCollection
-    TestUtils.checkFile("run.test", new String[]{
+    TestUtils.checkFile(RUN_TEST, new String[]{
         "321 Q0 eacd327b20aa77a2aa909596ae336497 1 0.039000 Anserini",
         "321 Q0 dafe3110-4a9e-11e6-acbc-4d4870a079da 2 0.026200 Anserini",
         "321 Q0 03049850-58e3-11e6-8b48-0cb344221131 3 0.011300 Anserini"});
-    assertTrue(new File("run.test").delete());
+    assertTrue(new File(RUN_TEST).delete());
   }
 }

--- a/src/test/java/io/anserini/search/SearchFlatDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchFlatDenseVectorsTest.java
@@ -17,7 +17,10 @@
 package io.anserini.search;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
@@ -36,6 +39,8 @@ import static org.junit.Assert.assertTrue;
  * Tests for {@link SearchFlatDenseVectors}
  */
 public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTestCase {
+  private final List<String> indexPaths = new ArrayList<>();
+
   @BeforeClass
   public static void setupClass() {
     suppressJvmLogging();
@@ -57,7 +62,17 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
   public void tearDown() throws Exception {
     restoreStdOut();
     restoreStdErr();
+    for (String indexPath : indexPaths) {
+      FileUtils.deleteDirectory(new File(indexPath));
+    }
+    indexPaths.clear();
     super.tearDown();
+  }
+
+  private String newIndexPath(String prefix) {
+    String indexPath = prefix + System.currentTimeMillis();
+    indexPaths.add(indexPath);
+    return indexPath;
   }
 
   @Test
@@ -107,7 +122,7 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
 
   @Test
   public void searchInvalidTopics() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -135,7 +150,7 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
 
   @Test
   public void searchInvalidReader() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -163,7 +178,7 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
 
   @Test
   public void searchInvalidTopicField() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -191,7 +206,7 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
 
   @Test
   public void searchInvalidGenerator() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -219,7 +234,7 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
 
   @Test
   public void searchInvalidEncoder() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -249,7 +264,7 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void testBasicAda2() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -290,7 +305,7 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void testBasicCosDpr() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cosdpr-distil/json_vector/",
@@ -331,7 +346,7 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void testBasicCosDprQuantized() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cosdpr-distil/json_vector/",
@@ -372,7 +387,7 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void testBasicCosDprSpecifyTopicsAsSymbol() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cosdpr-distil/json_vector/",
@@ -414,7 +429,7 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void testBasicWithOnnx() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cosdpr-distil/json_vector/",
@@ -489,7 +504,7 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void testRemoveQuery() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector/",
@@ -529,7 +544,7 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void testPassage() throws Exception {
-    String indexPath = "target/lucene-test-index.flat." + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/lucene-test-index.flat.");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector2",

--- a/src/test/java/io/anserini/search/SearchHnswDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchHnswDenseVectorsTest.java
@@ -17,7 +17,10 @@
 package io.anserini.search;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
@@ -34,6 +37,8 @@ import io.anserini.index.IndexHnswDenseVectors;
  * Tests for {@link SearchHnswDenseVectors}
  */
 public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTestCase {
+  private final List<String> indexPaths = new ArrayList<>();
+
   @BeforeClass
   public static void setupClass() {
     suppressJvmLogging();
@@ -55,7 +60,17 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
   public void tearDown() throws Exception {
     restoreStdOut();
     restoreStdErr();
+    for (String indexPath : indexPaths) {
+      FileUtils.deleteDirectory(new File(indexPath));
+    }
+    indexPaths.clear();
     super.tearDown();
+  }
+
+  private String newIndexPath(String prefix) {
+    String indexPath = prefix + System.currentTimeMillis();
+    indexPaths.add(indexPath);
+    return indexPath;
   }
 
   @Test
@@ -107,7 +122,7 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
 
   @Test
   public void searchInvalidTopics() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -137,7 +152,7 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
 
   @Test
   public void searchInvalidReader() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -167,7 +182,7 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
 
   @Test
   public void searchInvalidTopicField() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -197,7 +212,7 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
 
   @Test
   public void searchInvalidGenerator() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -227,7 +242,7 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
 
   @Test
   public void searchInvalidEncoder() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -259,7 +274,7 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void testBasicAda2() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -302,7 +317,7 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void testBasicCosDpr() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cosdpr-distil/json_vector/",
@@ -345,7 +360,7 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void testBasicCosDprQuantized() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cosdpr-distil/json_vector/",
@@ -388,7 +403,7 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void testBasicCosDprSpecifyTopicsAsSymbol() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cosdpr-distil/json_vector/",
@@ -433,7 +448,7 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void testBasicWithOnnx() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/cosdpr-distil/json_vector/",
@@ -511,7 +526,7 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void testRemoveQuery() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -553,7 +568,7 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void testPassage() throws Exception {
-    String indexPath = "target/idx-sample-hnsw" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-hnsw");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector2",

--- a/src/test/java/io/anserini/search/SearchInvertedDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchInvertedDenseVectorsTest.java
@@ -17,7 +17,10 @@
 package io.anserini.search;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
@@ -34,6 +37,8 @@ import io.anserini.index.IndexInvertedDenseVectors;
  * Tests for {@link SearchInvertedDenseVectors}
  */
 public class SearchInvertedDenseVectorsTest extends StdOutStdErrRedirectableLuceneTestCase {
+  private final List<String> indexPaths = new ArrayList<>();
+
   @BeforeClass
   public static void setupClass() {
     suppressJvmLogging();
@@ -55,7 +60,17 @@ public class SearchInvertedDenseVectorsTest extends StdOutStdErrRedirectableLuce
   public void tearDown() throws Exception {
     restoreStdOut();
     restoreStdErr();
+    for (String indexPath : indexPaths) {
+      FileUtils.deleteDirectory(new File(indexPath));
+    }
+    indexPaths.clear();
     super.tearDown();
+  }
+
+  private String newIndexPath(String prefix) {
+    String indexPath = prefix + System.currentTimeMillis();
+    indexPaths.add(indexPath);
+    return indexPath;
   }
 
   @Test
@@ -106,7 +121,7 @@ public class SearchInvertedDenseVectorsTest extends StdOutStdErrRedirectableLuce
 
   @Test
   public void searchInvalidTopics() throws Exception {
-    String indexPath = "target/idx-sample-fw-vector-" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-fw-vector-");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -134,7 +149,7 @@ public class SearchInvertedDenseVectorsTest extends StdOutStdErrRedirectableLuce
 
   @Test
   public void searchInvalidReader() throws Exception {
-    String indexPath = "target/idx-sample-fw-vector-" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-fw-vector-");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -162,7 +177,7 @@ public class SearchInvertedDenseVectorsTest extends StdOutStdErrRedirectableLuce
 
   @Test
   public void searchInvalidTopicField() throws Exception {
-    String indexPath = "target/idx-sample-fw-vector-" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-fw-vector-");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -190,7 +205,7 @@ public class SearchInvertedDenseVectorsTest extends StdOutStdErrRedirectableLuce
 
   @Test
   public void searchInvalidEncoding() throws Exception {
-    String indexPath = "target/idx-sample-fw-vector-" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-fw-vector-");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -219,7 +234,7 @@ public class SearchInvertedDenseVectorsTest extends StdOutStdErrRedirectableLuce
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void searchFWTest() throws Exception {
-    String indexPath = "target/idx-sample-fw-vector-" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-fw-vector-");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",
@@ -259,7 +274,7 @@ public class SearchInvertedDenseVectorsTest extends StdOutStdErrRedirectableLuce
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
   public void searchLLTest() throws Exception {
-    String indexPath = "target/idx-sample-fw-vector-" + System.currentTimeMillis();
+    String indexPath = newIndexPath("target/idx-sample-fw-vector-");
     String[] indexArgs = new String[] {
         "-collection", "JsonDenseVectorCollection",
         "-input", "src/test/resources/sample_docs/openai_ada2/json_vector",

--- a/src/test/java/io/anserini/search/SearchShardedHnswDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchShardedHnswDenseVectorsTest.java
@@ -71,6 +71,7 @@ public class SearchShardedHnswDenseVectorsTest {
     assertTrue("Topic file doesn't exist: " + topicFile, Files.exists(Paths.get(topicFile)));
 
     String runfile = SHARDED_RUN;
+    deleteRunFiles(runfile);
 
     // Create parent directory for output if it doesn't exist
     Files.createDirectories(Paths.get(runfile).getParent());
@@ -88,6 +89,7 @@ public class SearchShardedHnswDenseVectorsTest {
 
     SearchShardedHnswDenseVectors.main(searchArgs);
 
+    assertRunFileExistsAndNonEmpty(runfile);
     assertRunFileExistsAndNonEmpty(runfile + ".shard00");
     assertRunFileExistsAndNonEmpty(runfile + ".shard01");
   }
@@ -106,6 +108,7 @@ public class SearchShardedHnswDenseVectorsTest {
     assertTrue("Topic file doesn't exist: " + topicFile, Files.exists(Paths.get(topicFile)));
 
     String runfile = SHARDED_VECTORS_RUN;
+    deleteRunFiles(runfile);
 
     // Create parent directory for output if it doesn't exist
     Files.createDirectories(Paths.get(runfile).getParent());
@@ -123,6 +126,7 @@ public class SearchShardedHnswDenseVectorsTest {
 
     SearchShardedHnswDenseVectors.main(searchArgs);
 
+    assertRunFileExistsAndNonEmpty(runfile);
     assertRunFileExistsAndNonEmpty(runfile + ".shard00");
     assertRunFileExistsAndNonEmpty(runfile + ".shard01");
   }

--- a/src/test/java/io/anserini/search/SearchShardedHnswDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchShardedHnswDenseVectorsTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Paths;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -33,6 +34,8 @@ import org.junit.Test;
 public class SearchShardedHnswDenseVectorsTest {
   // Note, cannot extend StdOutStdErrRedirectableLuceneTestCase due to concurrency issues.
   // As a result, we cannot just call suppressJvmLogging() - must duplicate code below.
+  private static final String SHARDED_RUN = "target/run-sharded-test";
+  private static final String SHARDED_VECTORS_RUN = "target/run-sharded-vectors-test";
 
   @BeforeClass
   public static void setupClass() {
@@ -48,6 +51,12 @@ public class SearchShardedHnswDenseVectorsTest {
     Configurator.setLevel(HnswDenseSearcher.class.getName(), Level.ERROR);
   }
 
+  @After
+  public void tearDown() {
+    deleteRunFiles(SHARDED_RUN);
+    deleteRunFiles(SHARDED_VECTORS_RUN);
+  }
+
   @Test
   public void testBasicShardedSearch() throws Exception {
     // Verify the paths exist before running test
@@ -61,8 +70,7 @@ public class SearchShardedHnswDenseVectorsTest {
     String topicFile = "src/test/resources/sample_topics/arctic.tsv";
     assertTrue("Topic file doesn't exist: " + topicFile, Files.exists(Paths.get(topicFile)));
 
-    String timestamp = String.valueOf(System.currentTimeMillis());
-    String runfile = "target/run-sharded-" + timestamp;
+    String runfile = SHARDED_RUN;
 
     // Create parent directory for output if it doesn't exist
     Files.createDirectories(Paths.get(runfile).getParent());
@@ -80,11 +88,8 @@ public class SearchShardedHnswDenseVectorsTest {
 
     SearchShardedHnswDenseVectors.main(searchArgs);
 
-    File f = new File(runfile);
-    assertTrue("Output file doesn't exist: " + runfile, f.exists());
-    assertTrue("Output file is empty: " + runfile, f.length() > 0);
-
-    f.delete();
+    assertRunFileExistsAndNonEmpty(runfile + ".shard00");
+    assertRunFileExistsAndNonEmpty(runfile + ".shard01");
   }
 
   @Test
@@ -100,8 +105,7 @@ public class SearchShardedHnswDenseVectorsTest {
     String topicFile = "src/test/resources/sample_topics/arctic.jsonl";
     assertTrue("Topic file doesn't exist: " + topicFile, Files.exists(Paths.get(topicFile)));
 
-    String timestamp = String.valueOf(System.currentTimeMillis());
-    String runfile = "target/run-sharded-vectors-" + timestamp;
+    String runfile = SHARDED_VECTORS_RUN;
 
     // Create parent directory for output if it doesn't exist
     Files.createDirectories(Paths.get(runfile).getParent());
@@ -119,10 +123,19 @@ public class SearchShardedHnswDenseVectorsTest {
 
     SearchShardedHnswDenseVectors.main(searchArgs);
 
+    assertRunFileExistsAndNonEmpty(runfile + ".shard00");
+    assertRunFileExistsAndNonEmpty(runfile + ".shard01");
+  }
+
+  private static void assertRunFileExistsAndNonEmpty(String runfile) {
     File f = new File(runfile);
     assertTrue("Output file doesn't exist: " + runfile, f.exists());
     assertTrue("Output file is empty: " + runfile, f.length() > 0);
+  }
 
-    f.delete();
+  private static void deleteRunFiles(String runfile) {
+    new File(runfile).delete();
+    new File(runfile + ".shard00").delete();
+    new File(runfile + ".shard01").delete();
   }
 }


### PR DESCRIPTION
## Summary

- Move test run outputs under `target/` and clean generated run files in teardown.
- Track and delete generated test index directories, including `target/idx-sample-*` and `target/lucene-test-index*`.
- Isolate `TrecEval.main` coverage in a test subprocess to avoid Surefire corrupted-channel output without changing `TrecEval`.

## Validation

- `mvn -Dtest=TrecEvalTest test`
- `mvn -Dtest=SearchCollectionTest test`
- `mvn -Dtest=SearchShardedHnswDenseVectorsTest,ReproduceFromDocumentCollectionTest test`
- `mvn -Dtest=IndexCollectionInovcationsTest,IndexInvertedDenseVectorsTest,InvertedDenseSearcherTest,SearchInvertedDenseVectorsTest,HnswDenseSearcherTest,SearchHnswDenseVectorsTest,FlatDenseSearcherTest test`
- `mvn -Dtest=IndexFlatDenseVectorsTest,IndexHnswDenseVectorsTest,SearchFlatDenseVectorsTest test`
- `bin/build.sh`

Clean full build passed with `Tests run: 1005, Failures: 0, Errors: 0, Skipped: 0`. Post-build checks found no `target/run-*`, no `target/idx-sample-*`, no `target/lucene-test-index*`, and no Surefire `*.dumpstream` files.