### PR TITLE
Add reproduction log entry for msmarco-passage BM25 baseline

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -654,3 +654,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@TahseenSust](https://github.com/TahseenSust) on 2026-04-28 (commit [`912d7c3`](https://github.com/castorini/anserini/commit/912d7c308559d6a86b9e57a80204a2d4598efc32))
 + Results reproduced by [@xiandadu](https://github.com/xiandadu) on 2026-04-30 (commit [`67e9fc4`](https://github.com/castorini/anserini/commit/67e9fc4356f84b2852dee2c0170aca194028c806))
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-01 (commit [`fb2fd258`](https://github.com/castorini/anserini/commit/fb2fd258024cc87133e8c07c5316ad3e9a82407f))
++ Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`a74898d`](https://github.com/castorini/anserini/commit/a74898de))


### PR DESCRIPTION
## Reproduction Log Entry: MS MARCO Passage BM25 Baseline

**Environment:**
- OS: macOS 26.4, Apple Silicon (ARM64)
- Java: 21.0.11 (OpenJDK, Homebrew)
- Maven: 3.9.15
- Anserini commit: `a74898de`

**Results reproduced:**
| Metric | Expected | Actual |
|--------|----------|--------|
| MRR@10 | 0.1874 | 0.18741227770955546 ✅ |
| MAP | 0.1957 | 0.1957 ✅ |
| recall@1000 | 0.8573 | 0.8573 ✅ |
| Documents indexed | 8,841,823 | 8,841,823 ✅ |
| Queries | 6,980 | 6,980 ✅ |

**Notes:**
- Initial indexing attempt with default `-Xmx192G` in `bin/run.sh` was killed by the OS (OOM/SIGKILL).
- Succeeded by running Java directly with `-Xmx16G -threads 4`.