### PR TITLE
Add reproduction log entry for msmarco-passage dense retrieval

### DIFF
--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -202,3 +202,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@TahseenSust](https://github.com/TahseenSust) on 2026-04-28 (commit [`912d7c3`](https://github.com/castorini/anserini/commit/912d7c308559d6a86b9e57a80204a2d4598efc32))
 + Results reproduced by [@xiandadu](https://github.com/xiandadu) on 2026-05-01 (commit [`67e9fc4`](https://github.com/castorini/anserini/commit/67e9fc4356f84b2852dee2c0170aca194028c806))
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-01 (commit [`fb2fd258`](https://github.com/castorini/anserini/commit/fb2fd258024cc87133e8c07c5316ad3e9a82407f))
++ Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`a74898d`](https://github.com/castorini/anserini/commit/a74898de))


### PR DESCRIPTION
## Reproduction Log Entry: MS MARCO Passage Dense Retrieval

**Environment:**
- OS: Ubuntu 22.04 (remote server)
- Java: 21.0.10 (OpenJDK)
- Maven: 3.9.6
- Anserini commit: `a74898de`

**Results reproduced:**
### BM25 with prebuilt index
| Metric | Expected | Actual |
|--------|----------|--------|
| MRR@10 | 0.1875 | 0.1875 ✅ |
### Dense retrieval (BGE-base HNSW)
| Metric | Expected | Actual |
|--------|----------|--------|
| MRR@10 | 0.3521 | 0.3521 ✅ |

**Notes:**
- Prebuilt indexes downloaded and cached successfully.
- BM25 index: 2.0 GB, HNSW index: 24.2 GB.
- Dense retrieval (0.3521) significantly outperforms BM25 (0.1875) — +88% improvement.
- Both retrieval runs completed without issues.
