### PR TITLE
[codex] Add GetDocument CLI

### DIFF
--- a/src/main/java/io/anserini/cli/GetDocument.java
+++ b/src/main/java/io/anserini/cli/GetDocument.java
@@ -108,7 +108,7 @@ public final class GetDocument {
           continue;
         }
 
-        printDocument(searcher, docid);
+        printRawDocument(searcher, docid);
       }
     } catch (IOException e) {
       System.err.printf("Error: %s%n", e.getMessage());
@@ -117,25 +117,31 @@ public final class GetDocument {
 
   private static void runSingleDocid(Args parsed) {
     try (SimpleSearcher searcher = new SimpleSearcher(IndexReaderUtils.getIndex(parsed.index).toString())) {
-      printDocument(searcher, parsed.docid);
+      printRawDocument(searcher, parsed.docid);
     } catch (IOException e) {
       System.err.printf("Error: %s%n", e.getMessage());
     }
   }
 
-  private static void printDocument(SimpleSearcher searcher, String docid) {
+  private static void printRawDocument(SimpleSearcher searcher, String docid) {
+    try {
+      System.out.println(getRawDocument(searcher, docid));
+    } catch (IllegalArgumentException e) {
+      System.err.printf("Error: %s%n", e.getMessage());
+    }
+  }
+
+  private static String getRawDocument(SimpleSearcher searcher, String docid) {
     Document document = searcher.doc(docid);
     if (document == null) {
-      System.err.printf("Error: Document not found: %s%n", docid);
-      return;
+      throw new IllegalArgumentException("Document not found: " + docid);
     }
 
     String raw = document.get(Constants.RAW);
     if (raw == null) {
-      System.err.printf("Error: Document does not have stored raw field: %s%n", docid);
-      return;
+      throw new IllegalArgumentException("Document does not have stored raw field: " + docid);
     }
 
-    System.out.println(raw);
+    return raw;
   }
 }

--- a/src/main/java/io/anserini/cli/GetDocument.java
+++ b/src/main/java/io/anserini/cli/GetDocument.java
@@ -1,0 +1,141 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.cli;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.lucene.document.Document;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.ParserProperties;
+
+import io.anserini.index.Constants;
+import io.anserini.index.IndexReaderUtils;
+import io.anserini.search.SimpleSearcher;
+import io.anserini.util.LoggingBootstrap;
+
+public final class GetDocument {
+  public static class Args {
+    @Option(name = "--index", metaVar = "[path|name]", required = true, usage = "Path to Lucene index or prebuilt index name")
+    public String index;
+
+    @Option(name = "--docid", metaVar = "[docid]", usage = "Collection document id")
+    public String docid;
+
+    @Option(name = "--interactive", usage = "Read docids from stdin until user quits.")
+    public Boolean interactive = false;
+
+    @Option(name = "--help", help = true, usage = "Print this help message and exit.")
+    public boolean help = false;
+  }
+
+  private static final String[] argsOrdering = new String[] {
+      "--index", "--docid", "--interactive", "--help"};
+
+  public static void main(String[] args) {
+    LoggingBootstrap.installJulToSlf4jBridge();
+
+    Args parsedArgs = new Args();
+    CmdLineParser parser = new CmdLineParser(parsedArgs, ParserProperties.defaults().withUsageWidth(120));
+
+    try {
+      parser.parseArgument(args);
+    } catch (CmdLineException e) {
+      System.err.println(String.format("Error: %s", e.getMessage()));
+      CliUtils.printUsage(parser, GetDocument.class, argsOrdering);
+      return;
+    }
+
+    if (parsedArgs.help) {
+      CliUtils.printUsage(parser, GetDocument.class, argsOrdering);
+      return;
+    }
+
+    if (parsedArgs.interactive && parsedArgs.docid != null) {
+      System.err.println("Error: --interactive and --docid are mutually exclusive");
+      return;
+    }
+
+    if (!parsedArgs.interactive && parsedArgs.docid == null) {
+      System.err.println("Error: --docid is required when not running in interactive mode");
+      return;
+    }
+
+    Configurator.setRootLevel(Level.OFF);
+    run(parsedArgs);
+  }
+
+  private static void run(Args args) {
+    if (args.interactive) {
+      runInteractive(args);
+    } else {
+      runSingleDocid(args);
+    }
+  }
+
+  private static void runInteractive(Args args) {
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+         SimpleSearcher searcher = new SimpleSearcher(IndexReaderUtils.getIndex(args.index).toString())) {
+      String docid;
+      while (true) {
+        docid = reader.readLine();
+        if (docid == null) {
+          return;
+        }
+
+        docid = docid.trim();
+
+        if (docid.isBlank()) {
+          continue;
+        }
+
+        printDocument(searcher, docid);
+      }
+    } catch (IOException e) {
+      System.err.printf("Error: %s%n", e.getMessage());
+    }
+  }
+
+  private static void runSingleDocid(Args parsed) {
+    try (SimpleSearcher searcher = new SimpleSearcher(IndexReaderUtils.getIndex(parsed.index).toString())) {
+      printDocument(searcher, parsed.docid);
+    } catch (IOException e) {
+      System.err.printf("Error: %s%n", e.getMessage());
+    }
+  }
+
+  private static void printDocument(SimpleSearcher searcher, String docid) {
+    Document document = searcher.doc(docid);
+    if (document == null) {
+      System.err.printf("Error: Document not found: %s%n", docid);
+      return;
+    }
+
+    String raw = document.get(Constants.RAW);
+    if (raw == null) {
+      System.err.printf("Error: Document does not have stored raw field: %s%n", docid);
+      return;
+    }
+
+    System.out.println(raw);
+  }
+}

--- a/src/main/java/io/anserini/cli/GetDocument.java
+++ b/src/main/java/io/anserini/cli/GetDocument.java
@@ -88,7 +88,7 @@ public final class GetDocument {
     if (args.interactive) {
       runInteractive(args);
     } else {
-      runSingleDocid(args);
+      runSingleDocument(args);
     }
   }
 
@@ -119,7 +119,7 @@ public final class GetDocument {
     }
   }
 
-  private static void runSingleDocid(Args parsed) {
+  private static void runSingleDocument(Args parsed) {
     try (SimpleSearcher searcher = new SimpleSearcher(IndexReaderUtils.getIndex(parsed.index).toString())) {
       System.out.println(getRawDocument(searcher, parsed.docid));
     } catch (IllegalArgumentException | IOException e) {

--- a/src/main/java/io/anserini/cli/GetDocument.java
+++ b/src/main/java/io/anserini/cli/GetDocument.java
@@ -108,7 +108,11 @@ public final class GetDocument {
           continue;
         }
 
-        printRawDocument(searcher, docid);
+        try {
+          System.out.println(getRawDocument(searcher, docid));
+        } catch (IllegalArgumentException e) {
+          System.err.printf("Error: %s%n", e.getMessage());
+        }
       }
     } catch (IOException e) {
       System.err.printf("Error: %s%n", e.getMessage());
@@ -117,16 +121,8 @@ public final class GetDocument {
 
   private static void runSingleDocid(Args parsed) {
     try (SimpleSearcher searcher = new SimpleSearcher(IndexReaderUtils.getIndex(parsed.index).toString())) {
-      printRawDocument(searcher, parsed.docid);
-    } catch (IOException e) {
-      System.err.printf("Error: %s%n", e.getMessage());
-    }
-  }
-
-  private static void printRawDocument(SimpleSearcher searcher, String docid) {
-    try {
-      System.out.println(getRawDocument(searcher, docid));
-    } catch (IllegalArgumentException e) {
+      System.out.println(getRawDocument(searcher, parsed.docid));
+    } catch (IllegalArgumentException | IOException e) {
       System.err.printf("Error: %s%n", e.getMessage());
     }
   }

--- a/src/main/java/io/anserini/cli/GetDocument.java
+++ b/src/main/java/io/anserini/cli/GetDocument.java
@@ -114,7 +114,7 @@ public final class GetDocument {
           System.err.printf("Error: %s%n", e.getMessage());
         }
       }
-    } catch (IOException e) {
+    } catch (IllegalArgumentException | IOException e) {
       System.err.printf("Error: %s%n", e.getMessage());
     }
   }

--- a/src/test/java/io/anserini/cli/GetDocumentTest.java
+++ b/src/test/java/io/anserini/cli/GetDocumentTest.java
@@ -33,6 +33,7 @@ import io.anserini.index.IndexCollection;
 
 public class GetDocumentTest extends StdOutStdErrRedirectableLuceneTestCase {
   private static Path cacmIndexPath;
+  private static Path cacmIndexWithoutRawPath;
 
   @BeforeClass
   public static void setupClass() throws Exception {
@@ -49,12 +50,28 @@ public class GetDocumentTest extends StdOutStdErrRedirectableLuceneTestCase {
         "-storeRaw",
         "-quiet"
     });
+
+    cacmIndexWithoutRawPath = Files.createTempDirectory("anserini-get-document-test-cacm-no-raw");
+    IndexCollection.main(new String[] {
+        "-collection", "HtmlCollection",
+        "-generator", "DefaultLuceneDocumentGenerator",
+        "-threads", "1",
+        "-input", "src/main/resources/cacm",
+        "-index", cacmIndexWithoutRawPath.toString(),
+        "-storePositions",
+        "-storeDocvectors",
+        "-storeContents",
+        "-quiet"
+    });
   }
 
   @AfterClass
   public static void tearDownClass() throws Exception {
     if (cacmIndexPath != null) {
       FileUtils.deleteDirectory(cacmIndexPath.toFile());
+    }
+    if (cacmIndexWithoutRawPath != null) {
+      FileUtils.deleteDirectory(cacmIndexWithoutRawPath.toFile());
     }
   }
 
@@ -127,5 +144,12 @@ public class GetDocumentTest extends StdOutStdErrRedirectableLuceneTestCase {
     GetDocument.main(new String[] {"--index", cacmIndexPath.toString(), "--docid", "CACM-9999"});
     assertTrue(out.toString().isEmpty());
     assertTrue(err.toString().contains("Error: Document not found: CACM-9999"));
+  }
+
+  @Test
+  public void testDocumentWithoutRawField() {
+    GetDocument.main(new String[] {"--index", cacmIndexWithoutRawPath.toString(), "--docid", "CACM-0001"});
+    assertTrue(out.toString().isEmpty());
+    assertTrue(err.toString().contains("Error: Document does not have stored raw field: CACM-0001"));
   }
 }

--- a/src/test/java/io/anserini/cli/GetDocumentTest.java
+++ b/src/test/java/io/anserini/cli/GetDocumentTest.java
@@ -1,0 +1,131 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.cli;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
+import io.anserini.index.IndexCollection;
+
+public class GetDocumentTest extends StdOutStdErrRedirectableLuceneTestCase {
+  private static Path cacmIndexPath;
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    cacmIndexPath = Files.createTempDirectory("anserini-get-document-test-cacm");
+    IndexCollection.main(new String[] {
+        "-collection", "HtmlCollection",
+        "-generator", "DefaultLuceneDocumentGenerator",
+        "-threads", "1",
+        "-input", "src/main/resources/cacm",
+        "-index", cacmIndexPath.toString(),
+        "-storePositions",
+        "-storeDocvectors",
+        "-storeContents",
+        "-storeRaw",
+        "-quiet"
+    });
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws Exception {
+    if (cacmIndexPath != null) {
+      FileUtils.deleteDirectory(cacmIndexPath.toFile());
+    }
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    redirectStdOut();
+    redirectStdErr();
+    super.setUp();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    restoreStdOut();
+    restoreStdErr();
+    super.tearDown();
+  }
+
+  @Test
+  public void testHelpOption() {
+    GetDocument.main(new String[] {"--help"});
+    assertTrue(err.toString().contains("Options for GetDocument:"));
+    assertTrue(err.toString().contains("--help"));
+    assertFalse(err.toString().contains("Option \"--index\" is required"));
+  }
+
+  @Test
+  public void testMissingRequiredIndexOption() {
+    GetDocument.main(new String[] {});
+    assertTrue(err.toString().contains("Option \"--index\" is required"));
+  }
+
+  @Test
+  public void testMissingDocidInNonInteractiveMode() {
+    GetDocument.main(new String[] {"--index", cacmIndexPath.toString()});
+    assertTrue(err.toString().contains("Error: --docid is required when not running in interactive mode"));
+  }
+
+  @Test
+  public void testMutuallyExclusiveInteractiveAndDocid() {
+    GetDocument.main(new String[] {"--index", cacmIndexPath.toString(), "--docid", "CACM-0001", "--interactive"});
+    assertTrue(err.toString().contains("Error: --interactive and --docid are mutually exclusive"));
+  }
+
+  @Test
+  public void testGetDocumentWithCacm() {
+    GetDocument.main(new String[] {"--index", cacmIndexPath.toString(), "--docid", "CACM-0001"});
+
+    String output = out.toString();
+    assertTrue(output.contains("<html>"));
+    assertTrue(output.contains("Preliminary Report-International Algebraic Language"));
+    assertTrue(output.contains("CACM December, 1958"));
+    assertTrue(err.toString().isEmpty());
+  }
+
+  @Test
+  public void testInteractiveGetDocumentWithCacm() {
+    String stdin = "CACM-0001\n\nCACM-0002\n";
+    System.setIn(new ByteArrayInputStream(stdin.getBytes(StandardCharsets.UTF_8)));
+
+    GetDocument.main(new String[] {"--index", cacmIndexPath.toString(), "--interactive"});
+
+    String output = out.toString();
+    assertTrue(output.contains("Preliminary Report-International Algebraic Language"));
+    assertTrue(output.contains("Extraction of Roots by Repeated Subtractions"));
+    assertTrue(err.toString().isEmpty());
+  }
+
+  @Test
+  public void testDocumentNotFound() {
+    GetDocument.main(new String[] {"--index", cacmIndexPath.toString(), "--docid", "CACM-9999"});
+    assertTrue(out.toString().isEmpty());
+    assertTrue(err.toString().contains("Error: Document not found: CACM-9999"));
+  }
+}

--- a/src/test/java/io/anserini/cli/GetDocumentTest.java
+++ b/src/test/java/io/anserini/cli/GetDocumentTest.java
@@ -127,6 +127,17 @@ public class GetDocumentTest extends StdOutStdErrRedirectableLuceneTestCase {
   }
 
   @Test
+  public void testGetDocumentWithPrebuiltCacm() {
+    GetDocument.main(new String[] {"--index", "cacm", "--docid", "CACM-0001"});
+
+    String output = out.toString();
+    assertTrue(output.contains("<html>"));
+    assertTrue(output.contains("Preliminary Report-International Algebraic Language"));
+    assertTrue(output.contains("CACM December, 1958"));
+    assertTrue(err.toString().isEmpty());
+  }
+
+  @Test
   public void testInteractiveGetDocumentWithCacm() {
     String stdin = "CACM-0001\n\nCACM-0002\n";
     System.setIn(new ByteArrayInputStream(stdin.getBytes(StandardCharsets.UTF_8)));

--- a/src/test/java/io/anserini/cli/GetDocumentTest.java
+++ b/src/test/java/io/anserini/cli/GetDocumentTest.java
@@ -151,6 +151,15 @@ public class GetDocumentTest extends StdOutStdErrRedirectableLuceneTestCase {
   }
 
   @Test
+  public void testInteractiveInvalidIndex() {
+    Path missingIndexPath = cacmIndexPath.resolveSibling("anserini-get-document-test-missing-index");
+    GetDocument.main(new String[] {"--index", missingIndexPath.toString(), "--interactive"});
+
+    assertTrue(out.toString().isEmpty());
+    assertTrue(err.toString().contains("Error:"));
+  }
+
+  @Test
   public void testDocumentNotFound() {
     GetDocument.main(new String[] {"--index", cacmIndexPath.toString(), "--docid", "CACM-9999"});
     assertTrue(out.toString().isEmpty());


### PR DESCRIPTION
## Summary

- Add `io.anserini.cli.GetDocument` for fetching stored raw documents by docid from Lucene or prebuilt indexes
- Support command-line and interactive stdin modes, modeled after the existing `Search` CLI
- Keep raw document lookup separate from CLI printing/error handling so interactive mode can report per-docid errors and continue
- Add CACM-based tests for validation, local and prebuilt-index fetches, interactive fetch, missing-doc errors, and indexes without stored raw fields

## Validation

- `mvn -Dtest=GetDocumentTest test` (9 tests)