### PR TITLE
[codex] Upgrade GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -22,6 +22,6 @@ jobs:
     - name: Build with Maven
       run: mvn -B package --file pom.xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.5.5</version>
         <configuration>
           <!-- Need to add @{argLine} for JaCoCo to work; see
           https://stackoverflow.com/questions/71568474/getting-skipping-jacoco-execution-due-to-missing-execution-data-file-with-jaco -->


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` from `v4` to `v6`
- Upgrade `actions/setup-java` from `v4` to `v5`
- Upgrade `codecov/codecov-action` from `v3` to `v6`
- Upgrade `maven-surefire-plugin` from `3.1.0` to `3.5.5` to avoid the forked JVM stream corruption seen in CI

## Validation

- `git diff -- .github/workflows/maven.yml`
- `mvn -DskipTests test`
- `bin/build.sh` - `BUILD SUCCESS`; `Tests run: 1032, Failures: 0, Errors: 0, Skipped: 0`