### PR TITLE
[codex] Fix reproduction command stdio handling

### DIFF
--- a/src/main/java/io/anserini/reproduce/RunJavaReproductionCommands.java
+++ b/src/main/java/io/anserini/reproduce/RunJavaReproductionCommands.java
@@ -287,8 +287,12 @@ public class RunJavaReproductionCommands {
   }
 
   private static Process launch(String command) throws IOException {
-    return new ProcessBuilder("bash", "-lc", command)
-        .inheritIO()
+    Process process = new ProcessBuilder("bash", "-lc", command)
+        .redirectInput(ProcessBuilder.Redirect.PIPE)
+        .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+        .redirectError(ProcessBuilder.Redirect.DISCARD)
         .start();
+    process.getOutputStream().close();
+    return process;
   }
 }


### PR DESCRIPTION
## Summary

- Stop reproduction command subprocesses from inheriting the Maven Surefire fork JVM's stdio streams.
- Explicitly disconnect subprocess stdin, stdout, and stderr in `RunJavaReproductionCommands.launch`.
- Close the subprocess stdin pipe immediately after launch so accidental stdin reads receive EOF instead of holding an open pipe.
- Preserve existing reproduction log behavior: generated command strings still redirect command output to `logs/log.*.txt`.

## Problem

`RunJavaReproductionCommands` launched reproduction commands through `.inheritIO()`:

```java
new ProcessBuilder("bash", "-lc", command)
    .inheritIO()
    .start();
```

This is risky inside Maven Surefire. Surefire runs tests in a forked JVM and uses the fork's stdio streams as part of its communication and reporting machinery. If a child process inherits those raw streams, output or stream behavior from that child can interfere with Surefire's protocol and surface as:

```text
[SUREFIRE] std/in stream corrupted
```

The failure was observed while running `io.anserini.reproduce.RunJavaReproductionCommandsTest`. This is not a normal test assertion failure; it indicates the forked test process encountered a Surefire stream/protocol problem.

## Root Cause

The reproduction command launcher gave child shell processes direct access to the Surefire fork's inherited stdio via `.inheritIO()`.

That inheritance is unnecessary here because `loadCommands()` already appends shell redirection to each generated command:

```text
> <log-file> 2>&1
```

So the useful command output is already captured in the reproduction log files. Inheriting the parent JVM streams only adds coupling to the test runner and creates the stream corruption risk.

## What Changed

The launcher now creates the subprocess with explicit stdio handling:

```java
Process process = new ProcessBuilder("bash", "-lc", command)
    .redirectInput(ProcessBuilder.Redirect.PIPE)
    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
    .redirectError(ProcessBuilder.Redirect.DISCARD)
    .start();
process.getOutputStream().close();
return process;
```

This means:

- The child process no longer inherits Surefire's stdin/stdout/stderr.
- Wrapper shell output cannot write to the Surefire fork streams.
- Wrapper shell stderr cannot write to the Surefire fork streams.
- Child stdin is closed promptly, so accidental interactive reads receive EOF.
- Reproduction command logs still go to the configured `logs/` files because the command string itself keeps its existing redirection.

## Rationale For Selected Solution

This is the smallest behavior-preserving fix for the observed Surefire corruption.

The reproduction runner already treats command logs as files, not as inherited console output. Therefore, disconnecting the wrapper process from the parent test JVM's stdio removes the problematic coupling without changing the documented output path for reproduction commands.

This also follows normal Java subprocess practice for non-interactive test and batch code: subprocess stdio should be explicitly managed instead of implicitly inheriting the test runner's process streams.

## Alternatives Considered

### Keep `.inheritIO()` and tune Surefire

One possible workaround is to change Maven Surefire configuration, for example by adjusting fork behavior or output handling.

Rejected because this addresses the symptom at the build layer while leaving the reproduction launcher coupled to Surefire internals. It may work in one environment and still fail in another, especially across Maven, Surefire, and JDK versions.

### Disable Surefire forking

Running tests without a forked JVM can avoid this specific Surefire protocol failure.

Rejected because it weakens test isolation and changes the behavior of the entire test suite. It is too broad for a problem localized to one subprocess launcher.

### Skip or isolate `RunJavaReproductionCommandsTest`

The failing test could be skipped, moved, or configured specially.

Rejected because the test is catching a real integration hazard. Skipping it would hide the problem rather than fix the launcher.

### Replace shell redirection with `ProcessBuilder.redirectOutput(logFile)`

A more structured design would parse commands into command metadata and configure stdout/stderr log files through `ProcessBuilder` directly.

This is cleaner long term, but it is a broader refactor. `loadCommands()` currently returns fully formed shell command strings, and existing reproduction command files may rely on shell semantics. Moving log handling into `ProcessBuilder` would require changing that contract.

This PR avoids that larger behavioral surface.

### Replace `bash -lc` with tokenized `ProcessBuilder(List<String>)`

This would avoid shell parsing and be more robust for simple commands.

Rejected for this fix because reproduction command files likely rely on shell-compatible command strings. Tokenizing them safely is a separate migration and could break current workflows.

### Redirect wrapper output to the same log file

The launcher could parse the generated command and redirect the wrapper process output to the same log file.

Rejected because the command already redirects its own output to the log file. Adding another layer of log handling would duplicate responsibility and increase parsing complexity without improving the fix.

## User/Developer Impact

For normal reproduction runs, command output should continue to appear in the same configured log files.

For tests and CI, subprocesses launched by `RunJavaReproductionCommands` no longer get direct access to the Surefire fork's stdio streams, reducing the chance of intermittent `[SUREFIRE] std/in stream corrupted` failures.

## Validation

- `mvn -Dtest=RunJavaReproductionCommandsTest test`
- `mvn -Dtest=RunJavaReproductionCommandsTest,ReproduceFromDocumentCollectionTest,ReproduceFromPrebuiltIndexesTest test`

Validation result:

- `RunJavaReproductionCommandsTest`: `9` tests run, `0` failures, `0` errors, `0` skipped.
- Reproduction test group: `25` tests run, `0` failures, `0` errors, `1` skipped.
