### PR TITLE
[codex] Avoid inherited subprocess stdio in tests

### DIFF
--- a/src/main/java/io/anserini/eval/TrecEval.java
+++ b/src/main/java/io/anserini/eval/TrecEval.java
@@ -178,10 +178,12 @@ public class TrecEval {
    */
   public int run(String[] args) {
     try {
-      ProcessBuilder pb = getBuilder(args);
-      pb.inheritIO();
-
+      ProcessBuilder pb = getBuilder(args)
+          .redirectInput(ProcessBuilder.Redirect.PIPE)
+          .redirectErrorStream(true);
       Process p = pb.start();
+      p.getOutputStream().close();
+      p.getInputStream().transferTo(System.out);
       exit = p.waitFor();
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/main/java/io/anserini/reproduce/ReproduceFromDocumentCollection.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromDocumentCollection.java
@@ -723,9 +723,12 @@ public class ReproduceFromDocumentCollection {
       return;
     }
 
-    ProcessBuilder pb = new ProcessBuilder("bash", "-lc", command);
-    pb.inheritIO();
-    Process p = pb.start();
+    Process p = new ProcessBuilder("bash", "-lc", command)
+        .redirectInput(ProcessBuilder.Redirect.PIPE)
+        .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+        .redirectError(ProcessBuilder.Redirect.DISCARD)
+        .start();
+    p.getOutputStream().close();
     int code = p.waitFor();
     if (code != 0) {
       throw new RuntimeException("Command failed: " + command);


### PR DESCRIPTION
## Summary

- Remove `ProcessBuilder.inheritIO()` from the fallback shell execution path in `ReproduceFromDocumentCollection`.
- Keep subprocesses away from Surefire-controlled fork stdio by giving them an explicit stdin pipe, discarding reproduction command stdout/stderr in that non-interactive path, and closing stdin after launch.
- Update `TrecEval.run()` to avoid inherited child stdio while preserving CLI output by streaming the child process output through the parent JVM's `System.out`.

## Root Cause

The failing GitHub Actions job reported `[SUREFIRE] std/in stream corrupted` even though Maven's test summary showed all tests passing. The corruption was logged while `PrebuiltIndexHandlerTest` was running, but that test class itself completed with `Failures: 0, Errors: 0`. That points to Surefire detecting corrupted fork communication, not a failed assertion in `PrebuiltIndexHandlerTest`.

The likely source was test-exercised subprocess code using `ProcessBuilder.inheritIO()`. Under Maven Surefire, inherited child-process stdio can interfere with the forked JVM protocol streams. This PR removes the remaining `inheritIO()` calls under `src/main/java` and `src/test/java`.

## Behavior Notes

- `ReproduceFromDocumentCollection` fallback shell commands are internal/non-interactive, so their child output is discarded instead of being attached to Surefire's stdio.
- `TrecEval.run()` is documented as displaying output to stdout, so it now captures child stdout/stderr and forwards it through `System.out` rather than inheriting the raw child stream.
- `PrebuiltIndexHandler` is intentionally unchanged because it does not use `inheritIO()`; its subprocesses already avoid the specific inherited-stdio pattern that likely triggered the Surefire error.

## Validation

- `mvn -Dtest=ReproduceFromDocumentCollectionTest,TrecEvalTest test`

Validation result: `Tests run: 14, Failures: 0, Errors: 0, Skipped: 1`.

The skipped test was an environment-gated network test in `ReproduceFromDocumentCollectionTest`; no test was explicitly excluded beyond selecting the two relevant test classes.