### PR TITLE
[codex] Capture trec_eval stderr in wrapper

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-java -cp `ls target/*-fatjar.jar` -Xms512M -Xmx192G -Dslf4j.internal.verbosity=WARN --add-modules jdk.incubator.vector "$@"
+java -cp `ls target/*-fatjar.jar` -Xms512M -Xmx192G -Dslf4j.internal.verbosity=WARN --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED "$@"
 # 2>&1 | grep -v "WARNING: Using incubator modules"
 
 # Notes:
 # - "WARNING: Using incubator modules: jdk.incubator.vector" cannot be suppressed, so just grep -v it.
-#   - the issue with the grep solution is that it interferes with downloading progress bars
+#   - the issue with the grep solution is that it interferes with some progress messages
 # - "SLF4J(I): Connected with provider of type [org.apache.logging.slf4j.SLF4JServiceProvider]": suppress using -Dslf4j
 # - "WARNING: A restricted method in java.lang.foreign.Linker has been called" fixed by --enable-native-access=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <configuration>
           <!-- Need to add @{argLine} for JaCoCo to work; see
           https://stackoverflow.com/questions/71568474/getting-skipping-jacoco-execution-due-to-missing-execution-data-file-with-jaco -->
-          <argLine>@{argLine} -Xmx8192m</argLine>
+          <argLine>@{argLine} -Xmx8192m --enable-native-access=ALL-UNNAMED</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/io/anserini/eval/TrecEval.java
+++ b/src/main/java/io/anserini/eval/TrecEval.java
@@ -167,8 +167,7 @@ public class TrecEval {
     if (exit != 0) {
       String stderrMessage = stderr.toString(StandardCharsets.UTF_8).trim();
       if (!stderrMessage.isEmpty()) {
-        throw new RuntimeException(String.format("trec_eval ended with non-zero exit code (%d): %s",
-            exit, stderrMessage));
+        throw new RuntimeException(String.format("trec_eval ended with non-zero exit code (%d): %s", exit, stderrMessage));
       }
       throw new RuntimeException(String.format("trec_eval ended with non-zero exit code (%d)", exit));
     }

--- a/src/main/java/io/anserini/eval/TrecEval.java
+++ b/src/main/java/io/anserini/eval/TrecEval.java
@@ -17,13 +17,14 @@
 package io.anserini.eval;
 
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.lang.ProcessBuilder.Redirect;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -137,10 +138,18 @@ public class TrecEval {
    */
   public String[][] runAndGetOutput(String[] args) {
     List<String[]> output = new ArrayList<String[]>();
+    ByteArrayOutputStream stderr = new ByteArrayOutputStream();
     try {
       ProcessBuilder pb = getBuilder(args);
-      pb.redirectError(Redirect.INHERIT);
       Process p = pb.start();
+      Thread stderrReader = new Thread(() -> {
+        try (InputStream err = p.getErrorStream()) {
+          err.transferTo(stderr);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      });
+      stderrReader.start();
       try (InputStream in = p.getInputStream();
            InputStreamReader reader = new InputStreamReader(in);
            LineIterator it = IOUtils.lineIterator(reader)) {
@@ -149,12 +158,18 @@ public class TrecEval {
         }
       }
       p.waitFor();
+      stderrReader.join();
       exit = p.exitValue();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
 
     if (exit != 0) {
+      String stderrMessage = stderr.toString(StandardCharsets.UTF_8).trim();
+      if (!stderrMessage.isEmpty()) {
+        throw new RuntimeException(String.format("trec_eval ended with non-zero exit code (%d): %s", exit,
+            stderrMessage));
+      }
       throw new RuntimeException(String.format("trec_eval ended with non-zero exit code (%d)", exit));
     }
 

--- a/src/main/java/io/anserini/eval/TrecEval.java
+++ b/src/main/java/io/anserini/eval/TrecEval.java
@@ -167,8 +167,8 @@ public class TrecEval {
     if (exit != 0) {
       String stderrMessage = stderr.toString(StandardCharsets.UTF_8).trim();
       if (!stderrMessage.isEmpty()) {
-        throw new RuntimeException(String.format("trec_eval ended with non-zero exit code (%d): %s", exit,
-            stderrMessage));
+        throw new RuntimeException(String.format("trec_eval ended with non-zero exit code (%d): %s",
+            exit, stderrMessage));
       }
       throw new RuntimeException(String.format("trec_eval ended with non-zero exit code (%d)", exit));
     }

--- a/src/test/java/io/anserini/StdOutStdErrRedirectableLuceneTestCase.java
+++ b/src/test/java/io/anserini/StdOutStdErrRedirectableLuceneTestCase.java
@@ -17,11 +17,13 @@
 package io.anserini;
 
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.io.PrintStream;
 
 public abstract class StdOutStdErrRedirectableLuceneTestCase extends SuppresedLoggingLuceneTestCase {
   protected final ByteArrayOutputStream out = new ByteArrayOutputStream();
   protected final ByteArrayOutputStream err = new ByteArrayOutputStream();
+  protected InputStream saveIn;
   protected PrintStream saveOut;
   protected PrintStream saveErr;
 
@@ -43,5 +45,17 @@ public abstract class StdOutStdErrRedirectableLuceneTestCase extends SuppresedLo
 
   protected void restoreStdOut() {
     System.setOut(saveOut);
+  }
+
+  protected void redirectStdIn(InputStream input) {
+    saveIn = System.in;
+    System.setIn(input);
+  }
+
+  protected void restoreStdIn() {
+    if (saveIn != null) {
+      System.setIn(saveIn);
+      saveIn = null;
+    }
   }
 }

--- a/src/test/java/io/anserini/cli/GetDocumentTest.java
+++ b/src/test/java/io/anserini/cli/GetDocumentTest.java
@@ -84,6 +84,7 @@ public class GetDocumentTest extends StdOutStdErrRedirectableLuceneTestCase {
 
   @After
   public void tearDown() throws Exception {
+    restoreStdIn();
     restoreStdOut();
     restoreStdErr();
     super.tearDown();
@@ -140,7 +141,7 @@ public class GetDocumentTest extends StdOutStdErrRedirectableLuceneTestCase {
   @Test
   public void testInteractiveGetDocumentWithCacm() {
     String stdin = "CACM-0001\n\nCACM-0002\n";
-    System.setIn(new ByteArrayInputStream(stdin.getBytes(StandardCharsets.UTF_8)));
+    redirectStdIn(new ByteArrayInputStream(stdin.getBytes(StandardCharsets.UTF_8)));
 
     GetDocument.main(new String[] {"--index", cacmIndexPath.toString(), "--interactive"});
 
@@ -153,6 +154,8 @@ public class GetDocumentTest extends StdOutStdErrRedirectableLuceneTestCase {
   @Test
   public void testInteractiveInvalidIndex() {
     Path missingIndexPath = cacmIndexPath.resolveSibling("anserini-get-document-test-missing-index");
+    redirectStdIn(new ByteArrayInputStream(new byte[0]));
+
     GetDocument.main(new String[] {"--index", missingIndexPath.toString(), "--interactive"});
 
     assertTrue(out.toString().isEmpty());

--- a/src/test/java/io/anserini/cli/SearchTest.java
+++ b/src/test/java/io/anserini/cli/SearchTest.java
@@ -74,6 +74,7 @@ public class SearchTest extends StdOutStdErrRedirectableLuceneTestCase {
 
   @After
   public void tearDown() throws Exception {
+    restoreStdIn();
     restoreStdOut();
     restoreStdErr();
     super.tearDown();
@@ -150,7 +151,7 @@ public class SearchTest extends StdOutStdErrRedirectableLuceneTestCase {
   @Test
   public void testInteractiveSearchTrecOutpuWithCacm() {
     String stdin = "information retrieval\n";
-    System.setIn(new ByteArrayInputStream(stdin.getBytes(StandardCharsets.UTF_8)));
+    redirectStdIn(new ByteArrayInputStream(stdin.getBytes(StandardCharsets.UTF_8)));
 
     Search.main(new String[] {"--index", cacmIndexPath.toString(), "--interactive", "--trec", "--hits", "1"});
 
@@ -163,7 +164,7 @@ public class SearchTest extends StdOutStdErrRedirectableLuceneTestCase {
   public void testInteractiveSearchJsonOutputWithCacm() throws Exception {
     String query = "information retrieval";
     String stdin = query + "\n";
-    System.setIn(new ByteArrayInputStream(stdin.getBytes(StandardCharsets.UTF_8)));
+    redirectStdIn(new ByteArrayInputStream(stdin.getBytes(StandardCharsets.UTF_8)));
 
     Search.main(new String[] {"--index", cacmIndexPath.toString(), "--interactive", "--json", "--hits", "1"});
 


### PR DESCRIPTION
## Summary

- Capture the native `trec_eval` process stderr in `TrecEval.runAndGetOutput()` instead of letting it inherit the forked test JVM stderr stream.
- Preserve the existing stdout parsing behavior for successful metric extraction while preventing native stderr bytes from bypassing Surefire's framed fork protocol.
- Include captured stderr in the thrown exception when `trec_eval` exits nonzero, so failure diagnostics are still available without writing directly to the inherited stream.
- Enable native access for Surefire and `bin/run.sh` JVM launches to suppress Java FFM native-access warnings that can be emitted outside normal Java stream redirection.
- Add shared stdin redirect/restore helpers for tests, and update `GetDocumentTest` and `SearchTest` so interactive CLI cases do not leave `System.in` replaced or accidentally read Surefire's control stream.

## Context

`ReproduceFromDocumentCollectionTest` calls `TrecEval.runAndGetOutput()` as part of CACM regression verification. Under Surefire's forked JVM protocol, native subprocess output or direct reads/writes on inherited stdio can corrupt the control stream and surface as:

```text
[SUREFIRE] std/in stream corrupted
```

The wrapper already reads `trec_eval` stdout through a pipe. This change applies the same containment to stderr by draining it from Java and reporting it only through the Java exception path when needed.

Follow-up CI runs showed the same Surefire corruption later in the CLI tests. The interactive `GetDocumentTest` and `SearchTest` cases were replacing or reading from `System.in`; the tests now use explicit byte-array stdin fixtures and restore the original stream in teardown.

## Validation

- `mvn -Dtest=TrecEvalTest,ReproduceFromDocumentCollectionTest test`
- `mvn '-Dtest=io.anserini.reproduce.*Test' test`
- `mvn -Dtest=GetDocumentTest,ExtractQueriesAndDocumentsFromTrecRunTest,SearchTest,TrecEvalTest,ReproduceFromDocumentCollectionTest test`
- GitHub Actions `Java CI with Maven / build` passed on commit `61638596` after the stdin restoration fix.