### PR TITLE
Add dl20-doc to dl20 aliases

### DIFF
--- a/src/main/java/io/anserini/search/topicreader/Topics.java
+++ b/src/main/java/io/anserini/search/topicreader/Topics.java
@@ -769,6 +769,8 @@ public enum Topics {
     m.put("dl20-passage.cosdpr-distil", TREC2020_DL_COSDPR_DISTIL);
     m.put("dl20-passage.bge-base-en-v1.5", TREC2020_DL_BGE_BASE_EN_15);
     m.put("dl20-passage.cohere-embed-english-v3.0", TREC2020_DL_COHERE_EMBED_ENGLISH_30);
+    m.put("dl20-passage.unicoil.0shot", TREC2020_DL_UNICOIL);
+    m.put("dl20-passage.unicoil-noexp.0shot", TREC2020_DL_UNICOIL_NOEXP);
 
     m.put("dl20-doc.splade-pp-ed", TREC2020_DL_SPLADE_PP_ED);
     m.put("dl20-doc.splade-pp-sd", TREC2020_DL_SPLADE_PP_SD);
@@ -776,6 +778,8 @@ public enum Topics {
     m.put("dl20-doc.cosdpr-distil", TREC2020_DL_COSDPR_DISTIL);
     m.put("dl20-doc.bge-base-en-v1.5", TREC2020_DL_BGE_BASE_EN_15);
     m.put("dl20-doc.cohere-embed-english-v3.0", TREC2020_DL_COHERE_EMBED_ENGLISH_30);
+    m.put("dl20-doc.unicoil.0shot", TREC2020_DL_UNICOIL);
+    m.put("dl20-doc.unicoil-noexp.0shot", TREC2020_DL_UNICOIL_NOEXP);
 
     m.put("dl21-passage", TREC2021_DL);
     m.put("dl21-doc", TREC2021_DL);

--- a/src/main/java/io/anserini/search/topicreader/Topics.java
+++ b/src/main/java/io/anserini/search/topicreader/Topics.java
@@ -770,6 +770,13 @@ public enum Topics {
     m.put("dl20-passage.bge-base-en-v1.5", TREC2020_DL_BGE_BASE_EN_15);
     m.put("dl20-passage.cohere-embed-english-v3.0", TREC2020_DL_COHERE_EMBED_ENGLISH_30);
 
+    m.put("dl20-doc.splade-pp-ed", TREC2020_DL_SPLADE_PP_ED);
+    m.put("dl20-doc.splade-pp-sd", TREC2020_DL_SPLADE_PP_SD);
+    m.put("dl20-doc.splade-v3", TREC2020_DL_SPLADE_V3);
+    m.put("dl20-doc.cosdpr-distil", TREC2020_DL_COSDPR_DISTIL);
+    m.put("dl20-doc.bge-base-en-v1.5", TREC2020_DL_BGE_BASE_EN_15);
+    m.put("dl20-doc.cohere-embed-english-v3.0", TREC2020_DL_COHERE_EMBED_ENGLISH_30);
+
     m.put("dl21-passage", TREC2021_DL);
     m.put("dl21-doc", TREC2021_DL);
     m.put("dl22-passage", TREC2022_DL);

--- a/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-passage.optional.yaml
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-passage.optional.yaml
@@ -270,7 +270,7 @@ conditions:
       - topic_key: dl19-passage
         eval_key: dl19-passage
         expected_scores:
-          MAP: 0.4664
+          MAP: 0.4663
           nDCG@10: 0.7247
           R@1K: 0.8218
         metric_definitions:

--- a/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.core.yaml
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.core.yaml
@@ -247,8 +247,8 @@ conditions:
         eval_key: rag25.test-umbrela2
         expected_scores:
           nDCG@30: 0.2609
-          nDCG@100: 0.1747
-          R@100: 0.0555
+          nDCG@100: 0.1751
+          R@100: 0.0556
         metric_definitions:
           nDCG@30: "-c -m ndcg_cut.30"
           nDCG@100: "-c -m ndcg_cut.100"
@@ -257,8 +257,8 @@ conditions:
         eval_key: rag25.test
         expected_scores:
           nDCG@30: 0.2874
-          nDCG@100: 0.1848
-          R@100: 0.0564
+          nDCG@100: 0.1850
+          R@100: 0.0565
         metric_definitions:
           nDCG@30: "-c -m ndcg_cut.30"
           nDCG@100: "-c -m ndcg_cut.100"


### PR DESCRIPTION
DL20 topics were shared between doc and passage tasks. We have existing dl20-passage to dl20 aliases, but not for dl20-doc to dl20 aliases. Without these, `SearchCollection` can't find the topics.
