### PR TITLE
[codex] Normalize test import ordering

### DIFF
--- a/src/test/java/io/anserini/TestUtils.java
+++ b/src/test/java/io/anserini/TestUtils.java
@@ -16,11 +16,11 @@
 
 package io.anserini;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
-
-import static org.junit.Assert.assertEquals;
 
 public class TestUtils {
   public static void checkFile(String output, String[] ref) throws IOException {

--- a/src/test/java/io/anserini/analysis/AnalyzerUtilsTest.java
+++ b/src/test/java/io/anserini/analysis/AnalyzerUtilsTest.java
@@ -16,12 +16,9 @@
 
 package io.anserini.analysis;
 
-import io.anserini.collection.FileSegment;
-import io.anserini.collection.HtmlCollection;
-import io.anserini.collection.JsonCollection;
-import io.anserini.index.IndexCollection;
-import org.apache.lucene.analysis.Analyzer;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -30,9 +27,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.apache.lucene.analysis.Analyzer;
+import org.junit.Test;
+
+import io.anserini.collection.FileSegment;
+import io.anserini.collection.HtmlCollection;
+import io.anserini.collection.JsonCollection;
+import io.anserini.index.IndexCollection;
 
 public class AnalyzerUtilsTest {
   private String loadFirstCacmDocumentContents() throws IOException {

--- a/src/test/java/io/anserini/analysis/AutoCompositeAnalyzerTest.java
+++ b/src/test/java/io/anserini/analysis/AutoCompositeAnalyzerTest.java
@@ -16,7 +16,13 @@
 
 package io.anserini.analysis;
 
-import junit.framework.JUnit4TestAdapter;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.lucene.analysis.Analyzer;
@@ -29,13 +35,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
-
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import junit.framework.JUnit4TestAdapter;
 
 public class AutoCompositeAnalyzerTest extends StdOutStdErrRedirectableLuceneTestCase {
   @BeforeClass

--- a/src/test/java/io/anserini/analysis/DefaultEnglishAnalyzerTest.java
+++ b/src/test/java/io/anserini/analysis/DefaultEnglishAnalyzerTest.java
@@ -16,14 +16,14 @@
 
 package io.anserini.analysis;
 
-import org.apache.lucene.analysis.CharArraySet;
-import org.apache.lucene.analysis.en.EnglishAnalyzer;
-import org.junit.Test;
+import static io.anserini.analysis.DefaultEnglishAnalyzer.fromArguments;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 
-import static io.anserini.analysis.DefaultEnglishAnalyzer.fromArguments;
-import static org.junit.Assert.assertEquals;
+import org.apache.lucene.analysis.CharArraySet;
+import org.apache.lucene.analysis.en.EnglishAnalyzer;
+import org.junit.Test;
 
 public class DefaultEnglishAnalyzerTest {
 

--- a/src/test/java/io/anserini/analysis/EnglishStemmingAnalyzerTest.java
+++ b/src/test/java/io/anserini/analysis/EnglishStemmingAnalyzerTest.java
@@ -16,13 +16,13 @@
 
 package io.anserini.analysis;
 
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.CharArraySet;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.CharArraySet;
+import org.junit.Test;
 
 public class EnglishStemmingAnalyzerTest {
   private static final String INPUT = "City buses are running on schedule.";

--- a/src/test/java/io/anserini/analysis/FeatureVectorTokenizerTest.java
+++ b/src/test/java/io/anserini/analysis/FeatureVectorTokenizerTest.java
@@ -16,15 +16,15 @@
 
 package io.anserini.analysis;
 
-import org.apache.lucene.analysis.Tokenizer;
-import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.StringReader;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.Test;
 
 /**
  * Tests for {@link FeatureVectorsTokenizer}

--- a/src/test/java/io/anserini/analysis/TweetTokenizationTest.java
+++ b/src/test/java/io/anserini/analysis/TweetTokenizationTest.java
@@ -16,18 +16,19 @@
 
 package io.anserini.analysis;
 
-import junit.framework.JUnit4TestAdapter;
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.Test;
+
+import junit.framework.JUnit4TestAdapter;
 
 public class TweetTokenizationTest {
 

--- a/src/test/java/io/anserini/analysis/fw/FakeWordsEncodeAndQuantizeFilterTest.java
+++ b/src/test/java/io/anserini/analysis/fw/FakeWordsEncodeAndQuantizeFilterTest.java
@@ -16,16 +16,17 @@
 
 package io.anserini.analysis.fw;
 
-import io.anserini.analysis.FeatureVectorsTokenizer;
-import org.apache.lucene.analysis.Tokenizer;
-import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.StringReader;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.Test;
+
+import io.anserini.analysis.FeatureVectorsTokenizer;
 
 /**
  * Tests for {@link FakeWordsEncodeAndQuantizeFilter}

--- a/src/test/java/io/anserini/analysis/fw/FakeWordsEncoderAnalyzerTest.java
+++ b/src/test/java/io/anserini/analysis/fw/FakeWordsEncoderAnalyzerTest.java
@@ -16,6 +16,9 @@
 
 package io.anserini.analysis.fw;
 
+import static org.apache.lucene.search.BooleanClause.Occur.SHOULD;
+import static org.junit.Assert.assertEquals;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.LinkedList;
@@ -30,12 +33,10 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.CommonTermsQuery;
-import static org.apache.lucene.search.BooleanClause.Occur.SHOULD;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import io.anserini.analysis.AnalyzerUtils;

--- a/src/test/java/io/anserini/analysis/lexlsh/LexicalLshAnalyzerTest.java
+++ b/src/test/java/io/anserini/analysis/lexlsh/LexicalLshAnalyzerTest.java
@@ -16,6 +16,9 @@
 
 package io.anserini.analysis.lexlsh;
 
+import static org.apache.lucene.search.BooleanClause.Occur.SHOULD;
+import static org.junit.Assert.assertEquals;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.LinkedList;
@@ -29,12 +32,10 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.CommonTermsQuery;
-import static org.apache.lucene.search.BooleanClause.Occur.SHOULD;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import io.anserini.analysis.AnalyzerUtils;

--- a/src/test/java/io/anserini/analysis/lexlsh/LexicalLshFeaturePositionTokenFilterTest.java
+++ b/src/test/java/io/anserini/analysis/lexlsh/LexicalLshFeaturePositionTokenFilterTest.java
@@ -16,16 +16,17 @@
 
 package io.anserini.analysis.lexlsh;
 
-import io.anserini.analysis.FeatureVectorsTokenizer;
-import org.apache.lucene.analysis.Tokenizer;
-import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.StringReader;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.Test;
+
+import io.anserini.analysis.FeatureVectorsTokenizer;
 
 /**
  * Tests for {@link LexicalLshFeaturePositionTokenFilter}

--- a/src/test/java/io/anserini/analysis/lexlsh/LexicalLshTruncateTokenFilterTest.java
+++ b/src/test/java/io/anserini/analysis/lexlsh/LexicalLshTruncateTokenFilterTest.java
@@ -16,16 +16,16 @@
 
 package io.anserini.analysis.lexlsh;
 
-import org.apache.lucene.analysis.Tokenizer;
-import org.apache.lucene.analysis.core.WhitespaceTokenizer;
-import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.StringReader;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.core.WhitespaceTokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.Test;
 
 /**
  * Tests for {@link LexicalLshTruncateTokenFilter}

--- a/src/test/java/io/anserini/cli/ExtractQueriesAndDocumentsFromTrecRunTest.java
+++ b/src/test/java/io/anserini/cli/ExtractQueriesAndDocumentsFromTrecRunTest.java
@@ -16,9 +16,6 @@
 
 package io.anserini.cli;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;

--- a/src/test/java/io/anserini/collection/AclAnthologyTest.java
+++ b/src/test/java/io/anserini/collection/AclAnthologyTest.java
@@ -16,12 +16,12 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class AclAnthologyTest extends DocumentCollectionTest<AclAnthology.Document> {
   @Before

--- a/src/test/java/io/anserini/collection/AfribertaCollectionTest.java
+++ b/src/test/java/io/anserini/collection/AfribertaCollectionTest.java
@@ -16,12 +16,12 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class AfribertaCollectionTest extends DocumentCollectionTest<AfribertaCollection.Document> {
   

--- a/src/test/java/io/anserini/collection/BeirFlatCollectionCompressedTest.java
+++ b/src/test/java/io/anserini/collection/BeirFlatCollectionCompressedTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class BeirFlatCollectionCompressedTest extends DocumentCollectionTest<BeirFlatCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/BeirFlatCollectionTest.java
+++ b/src/test/java/io/anserini/collection/BeirFlatCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class BeirFlatCollectionTest extends DocumentCollectionTest<BeirFlatCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/BeirMultifieldCollectionCompressedTest.java
+++ b/src/test/java/io/anserini/collection/BeirMultifieldCollectionCompressedTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class BeirMultifieldCollectionCompressedTest extends DocumentCollectionTest<BeirMultifieldCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/BeirMultifieldCollectionTest.java
+++ b/src/test/java/io/anserini/collection/BeirMultifieldCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class BeirMultifieldCollectionTest extends DocumentCollectionTest<BeirMultifieldCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/BibtexCollectionTest.java
+++ b/src/test/java/io/anserini/collection/BibtexCollectionTest.java
@@ -16,14 +16,14 @@
 
 package io.anserini.collection;
 
-import org.jbibtex.Key;
-import org.jbibtex.Value;
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.jbibtex.Key;
+import org.jbibtex.Value;
+import org.junit.Before;
 
 public class BibtexCollectionTest extends DocumentCollectionTest<BibtexCollection.Document> {
   @Before

--- a/src/test/java/io/anserini/collection/C4CollectionTest.java
+++ b/src/test/java/io/anserini/collection/C4CollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class C4CollectionTest extends DocumentCollectionTest<C4Collection.Document> {
   @Before

--- a/src/test/java/io/anserini/collection/C4NoCleanCollectionTest.java
+++ b/src/test/java/io/anserini/collection/C4NoCleanCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class C4NoCleanCollectionTest extends DocumentCollectionTest<C4Collection.Document> {
   @Before

--- a/src/test/java/io/anserini/collection/C4NoCleanCollectionWithDocnoTest.java
+++ b/src/test/java/io/anserini/collection/C4NoCleanCollectionWithDocnoTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class C4NoCleanCollectionWithDocnoTest extends DocumentCollectionTest<C4Collection.Document> {
   @Before

--- a/src/test/java/io/anserini/collection/CleanTrecCollectionTest.java
+++ b/src/test/java/io/anserini/collection/CleanTrecCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class CleanTrecCollectionTest extends DocumentCollectionTest<CleanTrecCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/ClueWeb09CollectionTest.java
+++ b/src/test/java/io/anserini/collection/ClueWeb09CollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class ClueWeb09CollectionTest extends DocumentCollectionTest<ClueWeb09Collection.Document> {
 

--- a/src/test/java/io/anserini/collection/ClueWeb12CollectionTest.java
+++ b/src/test/java/io/anserini/collection/ClueWeb12CollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class ClueWeb12CollectionTest extends DocumentCollectionTest<ClueWeb12Collection.Document> {
 

--- a/src/test/java/io/anserini/collection/CommonCrawlNewsEnWarcCollectionTest.java
+++ b/src/test/java/io/anserini/collection/CommonCrawlNewsEnWarcCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class CommonCrawlNewsEnWarcCollectionTest extends DocumentCollectionTest<CommonCrawlNewsEnWarcCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/CommonCrawlWarcCollectionTest.java
+++ b/src/test/java/io/anserini/collection/CommonCrawlWarcCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class CommonCrawlWarcCollectionTest extends DocumentCollectionTest<CommonCrawlWarcCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/CommonCrawlWetCollectionTest.java
+++ b/src/test/java/io/anserini/collection/CommonCrawlWetCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class CommonCrawlWetCollectionTest extends DocumentCollectionTest<CommonCrawlWetCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/Cord19AbstractCollectionTest.java
+++ b/src/test/java/io/anserini/collection/Cord19AbstractCollectionTest.java
@@ -16,14 +16,15 @@
 
 package io.anserini.collection;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.Before;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class Cord19AbstractCollectionTest extends DocumentCollectionTest<Cord19AbstractCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/Cord19FullTextCollectionTest.java
+++ b/src/test/java/io/anserini/collection/Cord19FullTextCollectionTest.java
@@ -16,14 +16,15 @@
 
 package io.anserini.collection;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.Before;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class Cord19FullTextCollectionTest extends DocumentCollectionTest<Cord19FullTextCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/Cord19ParagraphCollectionTest.java
+++ b/src/test/java/io/anserini/collection/Cord19ParagraphCollectionTest.java
@@ -16,12 +16,12 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class Cord19ParagraphCollectionTest extends DocumentCollectionTest<Cord19ParagraphCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/CoreCollectionTest.java
+++ b/src/test/java/io/anserini/collection/CoreCollectionTest.java
@@ -16,14 +16,15 @@
 
 package io.anserini.collection;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.junit.Before;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class CoreCollectionTest extends DocumentCollectionTest<CoreCollection.Document> {
   List<Map<String, JsonNode>> expectedJsonFields;

--- a/src/test/java/io/anserini/collection/DocumentCollectionTest.java
+++ b/src/test/java/io/anserini/collection/DocumentCollectionTest.java
@@ -16,12 +16,6 @@
 
 package io.anserini.collection;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
@@ -34,6 +28,12 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
 
 public abstract class DocumentCollectionTest<T extends SourceDocument> extends StdOutStdErrRedirectableLuceneTestCase {
   Path collectionPath;

--- a/src/test/java/io/anserini/collection/EpidemicQACollectionTest.java
+++ b/src/test/java/io/anserini/collection/EpidemicQACollectionTest.java
@@ -16,14 +16,15 @@
 
 package io.anserini.collection;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.Before;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class EpidemicQACollectionTest  extends DocumentCollectionTest<EpidemicQACollection.Document> {
 

--- a/src/test/java/io/anserini/collection/FeverParagraphCollectionTest.java
+++ b/src/test/java/io/anserini/collection/FeverParagraphCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class FeverParagraphCollectionTest extends DocumentCollectionTest<FeverParagraphCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/FeverSentenceCollectionTest.java
+++ b/src/test/java/io/anserini/collection/FeverSentenceCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class FeverSentenceCollectionTest extends DocumentCollectionTest<FeverSentenceCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/FineWebCollectionTest.java
+++ b/src/test/java/io/anserini/collection/FineWebCollectionTest.java
@@ -16,14 +16,7 @@
 
 package io.anserini.collection;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
-import org.apache.parquet.example.data.Group;
-import org.apache.parquet.example.data.simple.SimpleGroup;
-import org.apache.parquet.schema.LogicalTypeAnnotation;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
-import org.apache.parquet.schema.Types;
-import org.junit.Test;
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -35,7 +28,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroup;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Types;
+import org.junit.Test;
 
 /**
  * Unit tests and integration tests for {@link FineWebCollection}.

--- a/src/test/java/io/anserini/collection/HtmlCollectionTest.java
+++ b/src/test/java/io/anserini/collection/HtmlCollectionTest.java
@@ -16,7 +16,8 @@
 
 package io.anserini.collection;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -25,8 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import org.junit.Test;
 
 // Since the CACM collection is checked into our repo, we can directly test against it.
 public class HtmlCollectionTest {

--- a/src/test/java/io/anserini/collection/Iso19115CollectionTest.java
+++ b/src/test/java/io/anserini/collection/Iso19115CollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class Iso19115CollectionTest extends DocumentCollectionTest<Iso19115Collection.Document> {
   @Before

--- a/src/test/java/io/anserini/collection/JsonCollectionDocumentArrayCompressedTest.java
+++ b/src/test/java/io/anserini/collection/JsonCollectionDocumentArrayCompressedTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 // A file in a JsonCollection can either be:
 // (1) A single JSON object (i.e., a single document)

--- a/src/test/java/io/anserini/collection/JsonCollectionDocumentArrayTest.java
+++ b/src/test/java/io/anserini/collection/JsonCollectionDocumentArrayTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 // A file in a JsonCollection can either be:
 // (1) A single JSON object (i.e., a single document)

--- a/src/test/java/io/anserini/collection/JsonCollectionDocumentObjectCompressedTest.java
+++ b/src/test/java/io/anserini/collection/JsonCollectionDocumentObjectCompressedTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 // A file in a JsonCollection can either be:
 // (1) A single JSON object (i.e., a single document)

--- a/src/test/java/io/anserini/collection/JsonCollectionDocumentObjectTest.java
+++ b/src/test/java/io/anserini/collection/JsonCollectionDocumentObjectTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 // A file in a JsonCollection can either be:
 // (1) A single JSON object (i.e., a single document)

--- a/src/test/java/io/anserini/collection/JsonCollectionErrorCheckingTest.java
+++ b/src/test/java/io/anserini/collection/JsonCollectionErrorCheckingTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.nio.file.Paths;
+
+import org.junit.Before;
+import org.junit.Test;
 
 // A file in a JsonCollection might not have the required fields that
 // we expect. This tests whether the appropriate error is thrown.

--- a/src/test/java/io/anserini/collection/JsonCollectionGeoRiverTest.java
+++ b/src/test/java/io/anserini/collection/JsonCollectionGeoRiverTest.java
@@ -1,10 +1,10 @@
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class JsonCollectionGeoRiverTest extends JsonCollectionTest {
   @Before

--- a/src/test/java/io/anserini/collection/JsonCollectionLineObjectCompressedTest.java
+++ b/src/test/java/io/anserini/collection/JsonCollectionLineObjectCompressedTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 // A file in a JsonCollection can either be:
 // (1) A single JSON object (i.e., a single document)

--- a/src/test/java/io/anserini/collection/JsonCollectionLineObjectTest.java
+++ b/src/test/java/io/anserini/collection/JsonCollectionLineObjectTest.java
@@ -16,13 +16,13 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
 
 // A file in a JsonCollection can either be:
 // (1) A single JSON object (i.e., a single document)

--- a/src/test/java/io/anserini/collection/JsonVectorCollectionDocumentArrayCompressedTest.java
+++ b/src/test/java/io/anserini/collection/JsonVectorCollectionDocumentArrayCompressedTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 // A file in a JsonVectorCollection can either be:
 // (1) A single JSON object (i.e., a single document)

--- a/src/test/java/io/anserini/collection/JsonVectorCollectionDocumentArrayTest.java
+++ b/src/test/java/io/anserini/collection/JsonVectorCollectionDocumentArrayTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 // A file in a JsonVectorCollection can either be:
 // (1) A single JSON object (i.e., a single document)

--- a/src/test/java/io/anserini/collection/JsonVectorCollectionDocumentObjectCompressedTest.java
+++ b/src/test/java/io/anserini/collection/JsonVectorCollectionDocumentObjectCompressedTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 // A file in a JsonVectorCollection can either be:
 // (1) A single JSON object (i.e., a single document)

--- a/src/test/java/io/anserini/collection/JsonVectorCollectionDocumentObjectTest.java
+++ b/src/test/java/io/anserini/collection/JsonVectorCollectionDocumentObjectTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 // A file in a JsonVectorCollection can either be:
 // (1) A single JSON object (i.e., a single document)

--- a/src/test/java/io/anserini/collection/JsonVectorCollectionLineObjectCompressedTest.java
+++ b/src/test/java/io/anserini/collection/JsonVectorCollectionLineObjectCompressedTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 // A file in a JsonVectorCollection can either be:
 // (1) A single JSON object (i.e., a single document)

--- a/src/test/java/io/anserini/collection/JsonVectorCollectionLineObjectTest.java
+++ b/src/test/java/io/anserini/collection/JsonVectorCollectionLineObjectTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 // A file in a JsonVectorCollection can either be:
 // (1) A single JSON object (i.e., a single document)

--- a/src/test/java/io/anserini/collection/JsonVectorCollectionTest.java
+++ b/src/test/java/io/anserini/collection/JsonVectorCollectionTest.java
@@ -17,6 +17,7 @@
 package io.anserini.collection;
 
 import java.util.Map;
+
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/io/anserini/collection/MrTyDiCollectionArTest.java
+++ b/src/test/java/io/anserini/collection/MrTyDiCollectionArTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MrTyDiCollectionArTest extends DocumentCollectionTest<MrTyDiCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/MrTyDiCollectionBnTest.java
+++ b/src/test/java/io/anserini/collection/MrTyDiCollectionBnTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MrTyDiCollectionBnTest extends DocumentCollectionTest<MrTyDiCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/MrTyDiCollectionEnTest.java
+++ b/src/test/java/io/anserini/collection/MrTyDiCollectionEnTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MrTyDiCollectionEnTest extends DocumentCollectionTest<MrTyDiCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/MrTyDiCollectionFiTest.java
+++ b/src/test/java/io/anserini/collection/MrTyDiCollectionFiTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MrTyDiCollectionFiTest extends DocumentCollectionTest<MrTyDiCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/MrTyDiCollectionIdTest.java
+++ b/src/test/java/io/anserini/collection/MrTyDiCollectionIdTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MrTyDiCollectionIdTest extends DocumentCollectionTest<MrTyDiCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/MrTyDiCollectionJaTest.java
+++ b/src/test/java/io/anserini/collection/MrTyDiCollectionJaTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MrTyDiCollectionJaTest extends DocumentCollectionTest<MrTyDiCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/MrTyDiCollectionKoTest.java
+++ b/src/test/java/io/anserini/collection/MrTyDiCollectionKoTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MrTyDiCollectionKoTest extends DocumentCollectionTest<MrTyDiCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/MrTyDiCollectionRuTest.java
+++ b/src/test/java/io/anserini/collection/MrTyDiCollectionRuTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MrTyDiCollectionRuTest extends DocumentCollectionTest<MrTyDiCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/MrTyDiCollectionSwTest.java
+++ b/src/test/java/io/anserini/collection/MrTyDiCollectionSwTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MrTyDiCollectionSwTest extends DocumentCollectionTest<MrTyDiCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/MrTyDiCollectionTeTest.java
+++ b/src/test/java/io/anserini/collection/MrTyDiCollectionTeTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MrTyDiCollectionTeTest extends DocumentCollectionTest<MrTyDiCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/MrTyDiCollectionThTest.java
+++ b/src/test/java/io/anserini/collection/MrTyDiCollectionThTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MrTyDiCollectionThTest extends DocumentCollectionTest<MrTyDiCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/MsMarcoV2DocCollectionCompressedTest.java
+++ b/src/test/java/io/anserini/collection/MsMarcoV2DocCollectionCompressedTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MsMarcoV2DocCollectionCompressedTest extends DocumentCollectionTest<MsMarcoV2DocCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/MsMarcoV2DocCollectionTest.java
+++ b/src/test/java/io/anserini/collection/MsMarcoV2DocCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MsMarcoV2DocCollectionTest extends DocumentCollectionTest<MsMarcoV2DocCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/MsMarcoV2DocSegmentedCollectionTest.java
+++ b/src/test/java/io/anserini/collection/MsMarcoV2DocSegmentedCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MsMarcoV2DocSegmentedCollectionTest extends DocumentCollectionTest<MsMarcoV2DocCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/MsMarcoV2PassageAugmentedCollectionTest.java
+++ b/src/test/java/io/anserini/collection/MsMarcoV2PassageAugmentedCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MsMarcoV2PassageAugmentedCollectionTest extends DocumentCollectionTest<MsMarcoV2PassageCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/MsMarcoV2PassageCollectionCompressedTest.java
+++ b/src/test/java/io/anserini/collection/MsMarcoV2PassageCollectionCompressedTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MsMarcoV2PassageCollectionCompressedTest extends DocumentCollectionTest<MsMarcoV2PassageCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/MsMarcoV2PassageCollectionTest.java
+++ b/src/test/java/io/anserini/collection/MsMarcoV2PassageCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class MsMarcoV2PassageCollectionTest extends DocumentCollectionTest<MsMarcoV2PassageCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/NeuClirCollectionTest.java
+++ b/src/test/java/io/anserini/collection/NeuClirCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class NeuClirCollectionTest extends DocumentCollectionTest<NeuClirCollection.Document> {
   

--- a/src/test/java/io/anserini/collection/NewYorkTimesCollectionTest.java
+++ b/src/test/java/io/anserini/collection/NewYorkTimesCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class NewYorkTimesCollectionTest extends DocumentCollectionTest<NewYorkTimesCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/SmolTalkCollectionTest.java
+++ b/src/test/java/io/anserini/collection/SmolTalkCollectionTest.java
@@ -16,9 +16,6 @@
 
 package io.anserini.collection;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -26,6 +23,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.junit.Test;
 
 /**
  * Tests for {@link SmolTalkCollection}.

--- a/src/test/java/io/anserini/collection/TrecCollectionTest.java
+++ b/src/test/java/io/anserini/collection/TrecCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class TrecCollectionTest extends DocumentCollectionTest<TrecCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/TrecwebCollectionTest.java
+++ b/src/test/java/io/anserini/collection/TrecwebCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class TrecwebCollectionTest extends DocumentCollectionTest<TrecwebCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/TweetCollectionCompressedTest.java
+++ b/src/test/java/io/anserini/collection/TweetCollectionCompressedTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class TweetCollectionCompressedTest extends DocumentCollectionTest<TweetCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/TweetCollectionTest.java
+++ b/src/test/java/io/anserini/collection/TweetCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class TweetCollectionTest extends DocumentCollectionTest<TweetCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/TwentyNewsgroupsCollectionTest.java
+++ b/src/test/java/io/anserini/collection/TwentyNewsgroupsCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class TwentyNewsgroupsCollectionTest extends DocumentCollectionTest<TwentyNewsgroupsCollection.Document> {
   @Before

--- a/src/test/java/io/anserini/collection/WashingtonPostCollectionTest.java
+++ b/src/test/java/io/anserini/collection/WashingtonPostCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class WashingtonPostCollectionTest extends DocumentCollectionTest<WashingtonPostCollection.Document> {
 

--- a/src/test/java/io/anserini/collection/WikipediaCollectionTest.java
+++ b/src/test/java/io/anserini/collection/WikipediaCollectionTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.collection;
 
-import org.junit.Before;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+
+import org.junit.Before;
 
 public class WikipediaCollectionTest extends DocumentCollectionTest<WikipediaCollection.Document> {
   @Before

--- a/src/test/java/io/anserini/doc/DataModel.java
+++ b/src/test/java/io/anserini/doc/DataModel.java
@@ -16,13 +16,13 @@
 
 package io.anserini.doc;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class DataModel {
   private static final String INDEX_COMMAND = "bin/run.sh io.anserini.index.IndexCollection";

--- a/src/test/java/io/anserini/doc/GenerateReproductionDocsFromDocumentCollectionTest.java
+++ b/src/test/java/io/anserini/doc/GenerateReproductionDocsFromDocumentCollectionTest.java
@@ -16,12 +16,6 @@
 
 package io.anserini.doc;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.text.StringSubstitutor;
-import org.junit.Test;
-
 import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
@@ -36,9 +30,16 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.Scanner;
+import java.util.Set;
 import java.util.regex.Pattern;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.text.StringSubstitutor;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 public class GenerateReproductionDocsFromDocumentCollectionTest {
   private static final Map<String, List<String>> ORDERING = new LinkedHashMap<>();

--- a/src/test/java/io/anserini/doc/GenerateReproductionDocsFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/doc/GenerateReproductionDocsFromPrebuiltIndexesTest.java
@@ -16,17 +16,6 @@
 
 package io.anserini.doc;
 
-import io.anserini.reproduce.ReproduceFromPrebuiltIndexes.Condition;
-import io.anserini.reproduce.ReproduceFromPrebuiltIndexes.Config;
-import io.anserini.reproduce.ReproduceFromPrebuiltIndexes.Topic;
-import io.anserini.reproduce.ReproductionUtils;
-
-import org.apache.commons.io.FileUtils;
-import org.junit.Test;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -34,6 +23,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import io.anserini.reproduce.ReproduceFromPrebuiltIndexes.Condition;
+import io.anserini.reproduce.ReproduceFromPrebuiltIndexes.Config;
+import io.anserini.reproduce.ReproduceFromPrebuiltIndexes.Topic;
+import io.anserini.reproduce.ReproductionUtils;
 
 public class GenerateReproductionDocsFromPrebuiltIndexesTest {
   private static final String COMMAND_INDENT = "    ";

--- a/src/test/java/io/anserini/doc/JDIQ2018EffectivenessDocsTest.java
+++ b/src/test/java/io/anserini/doc/JDIQ2018EffectivenessDocsTest.java
@@ -16,19 +16,20 @@
 
 package io.anserini.doc;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.text.StringSubstitutor;
-import org.junit.Test;
-
 import java.io.File;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Scanner;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringSubstitutor;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 @SuppressWarnings("unchecked")
 public class JDIQ2018EffectivenessDocsTest {

--- a/src/test/java/io/anserini/encoder/EncodeQueryTest.java
+++ b/src/test/java/io/anserini/encoder/EncodeQueryTest.java
@@ -16,17 +16,6 @@
 
 package io.anserini.encoder;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.config.Configurator;
-import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -36,6 +25,19 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
 
 @LuceneTestCase.SuppressSysoutChecks(bugUrl = "output comes from args4j and EncodeQuery stderr")
 public class EncodeQueryTest extends StdOutStdErrRedirectableLuceneTestCase {

--- a/src/test/java/io/anserini/encoder/dense/ArcticEmbedLEncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/dense/ArcticEmbedLEncoderInferenceTest.java
@@ -16,13 +16,14 @@
 
 package io.anserini.encoder.dense;
 
-import ai.onnxruntime.OrtException;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import ai.onnxruntime.OrtException;
 
 public class ArcticEmbedLEncoderInferenceTest extends DenseEncoderInferenceTest {
   private static final DenseExampleOutputPair[] EXAMPLES = {

--- a/src/test/java/io/anserini/encoder/dense/BgeBaseEn15EncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/dense/BgeBaseEn15EncoderInferenceTest.java
@@ -16,13 +16,14 @@
 
 package io.anserini.encoder.dense;
 
-import ai.onnxruntime.OrtException;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import ai.onnxruntime.OrtException;
 
 public class BgeBaseEn15EncoderInferenceTest extends DenseEncoderInferenceTest {
   private static final DenseExampleOutputPair[] EXAMPLES = {

--- a/src/test/java/io/anserini/encoder/dense/BgeLargeEn15EncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/dense/BgeLargeEn15EncoderInferenceTest.java
@@ -16,13 +16,14 @@
 
 package io.anserini.encoder.dense;
 
-import ai.onnxruntime.OrtException;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import ai.onnxruntime.OrtException;
 
 public class BgeLargeEn15EncoderInferenceTest extends DenseEncoderInferenceTest {
   private static final DenseExampleOutputPair[] EXAMPLES = {

--- a/src/test/java/io/anserini/encoder/dense/CosDprDistilEncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/dense/CosDprDistilEncoderInferenceTest.java
@@ -16,13 +16,14 @@
 
 package io.anserini.encoder.dense;
 
-import ai.onnxruntime.OrtException;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import ai.onnxruntime.OrtException;
 
 public class CosDprDistilEncoderInferenceTest extends DenseEncoderInferenceTest {
   private static final DenseExampleOutputPair[] EXAMPLES = {

--- a/src/test/java/io/anserini/encoder/dense/DenseEncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/dense/DenseEncoderInferenceTest.java
@@ -16,9 +16,9 @@
 
 package io.anserini.encoder.dense;
 
-import ai.onnxruntime.OrtException;
-
 import static org.junit.Assert.assertArrayEquals;
+
+import ai.onnxruntime.OrtException;
 
 public class DenseEncoderInferenceTest {
   public void testExamples(DenseExampleOutputPair[] examples, DenseEncoder encoder) throws OrtException {

--- a/src/test/java/io/anserini/encoder/sparse/BaseSparseEncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/sparse/BaseSparseEncoderInferenceTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.encoder.sparse;
 
-import ai.onnxruntime.OrtException;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import ai.onnxruntime.OrtException;
 
 public class BaseSparseEncoderInferenceTest {
   public void testExamples(SparseExampleOutputPair[] examples, SparseEncoder encoder) throws OrtException {

--- a/src/test/java/io/anserini/encoder/sparse/SpladePlusPlusEnsembleDistilEncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/sparse/SpladePlusPlusEnsembleDistilEncoderInferenceTest.java
@@ -16,15 +16,16 @@
 
 package io.anserini.encoder.sparse;
 
-import ai.onnxruntime.OrtException;
-import org.junit.Test;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import ai.onnxruntime.OrtException;
 
 public class SpladePlusPlusEnsembleDistilEncoderInferenceTest extends BaseSparseEncoderInferenceTest {
 

--- a/src/test/java/io/anserini/encoder/sparse/SpladePlusPlusSelfDistilEncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/sparse/SpladePlusPlusSelfDistilEncoderInferenceTest.java
@@ -16,15 +16,16 @@
 
 package io.anserini.encoder.sparse;
 
-import ai.onnxruntime.OrtException;
-import org.junit.Test;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import ai.onnxruntime.OrtException;
 
 public class SpladePlusPlusSelfDistilEncoderInferenceTest extends BaseSparseEncoderInferenceTest {
 

--- a/src/test/java/io/anserini/encoder/sparse/SpladeV3EncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/sparse/SpladeV3EncoderInferenceTest.java
@@ -16,15 +16,16 @@
 
 package io.anserini.encoder.sparse;
 
-import ai.onnxruntime.OrtException;
-import org.junit.Test;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import ai.onnxruntime.OrtException;
 
 public class SpladeV3EncoderInferenceTest extends BaseSparseEncoderInferenceTest {
 

--- a/src/test/java/io/anserini/encoder/sparse/UniCoilEncoderInferenceTest.java
+++ b/src/test/java/io/anserini/encoder/sparse/UniCoilEncoderInferenceTest.java
@@ -16,15 +16,16 @@
 
 package io.anserini.encoder.sparse;
 
-import ai.onnxruntime.OrtException;
-import org.junit.Test;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import ai.onnxruntime.OrtException;
 
 public class UniCoilEncoderInferenceTest extends BaseSparseEncoderInferenceTest {
 

--- a/src/test/java/io/anserini/eval/ExcludeDocsTest.java
+++ b/src/test/java/io/anserini/eval/ExcludeDocsTest.java
@@ -18,13 +18,13 @@ package io.anserini.eval;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
-import org.junit.BeforeClass;
-import io.anserini.fusion.FuseRuns;
-import io.anserini.search.ScoredDoc;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.anserini.fusion.FuseRuns;
+import io.anserini.search.ScoredDoc;
 
 
 public class ExcludeDocsTest {

--- a/src/test/java/io/anserini/eval/RelevanceJudgmentsTest.java
+++ b/src/test/java/io/anserini/eval/RelevanceJudgmentsTest.java
@@ -16,8 +16,6 @@
 
 package io.anserini.eval;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -25,6 +23,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Path;
+
+import org.junit.Test;
 
 import io.anserini.util.CacheDirectoryResolver;
 

--- a/src/test/java/io/anserini/fusion/RunsFuserTest.java
+++ b/src/test/java/io/anserini/fusion/RunsFuserTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.fusion;
 
-import java.util.Locale;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
@@ -29,9 +29,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import io.anserini.search.ScoredDocs;
-
 import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
+import io.anserini.search.ScoredDocs;
 
 public class RunsFuserTest extends StdOutStdErrRedirectableLuceneTestCase {
   @BeforeClass

--- a/src/test/java/io/anserini/index/BasicIndexOperationsTest.java
+++ b/src/test/java/io/anserini/index/BasicIndexOperationsTest.java
@@ -16,9 +16,11 @@
 
 package io.anserini.index;
 
-import io.anserini.analysis.AnalyzerUtils;
-import io.anserini.collection.DocumentCollection;
-import io.anserini.collection.JsonCollection;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;
@@ -52,11 +54,9 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.util.HashMap;
-import java.util.Map;
+import io.anserini.analysis.AnalyzerUtils;
+import io.anserini.collection.DocumentCollection;
+import io.anserini.collection.JsonCollection;
 
 public class BasicIndexOperationsTest extends IndexerTestBase {
   private final static PrintStream standardOut = System.out;

--- a/src/test/java/io/anserini/index/CloneIndexTest.java
+++ b/src/test/java/io/anserini/index/CloneIndexTest.java
@@ -16,6 +16,12 @@
 
 package io.anserini.index;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.Iterator;
+
 import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.index.CodecReader;
@@ -36,12 +42,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.nio.file.Path;
-import java.util.Iterator;
 
 public class CloneIndexTest extends IndexerTestBase {
   private final static PrintStream standardOut = System.out;

--- a/src/test/java/io/anserini/index/GeoIndexerTestBase.java
+++ b/src/test/java/io/anserini/index/GeoIndexerTestBase.java
@@ -16,6 +16,13 @@
 
 package io.anserini.index;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.ParseException;
+import java.util.List;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.LatLonDocValuesField;
@@ -31,13 +38,6 @@ import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.After;
 import org.junit.Before;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.text.ParseException;
-import java.util.List;
 
 public class GeoIndexerTestBase extends LuceneTestCase {
   protected Path tempDir1;

--- a/src/test/java/io/anserini/index/IndexerTestBase.java
+++ b/src/test/java/io/anserini/index/IndexerTestBase.java
@@ -16,6 +16,10 @@
 
 package io.anserini.index;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Locale;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.document.BinaryDocValuesField;
@@ -34,10 +38,6 @@ import org.junit.After;
 import org.junit.Before;
 
 import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Locale;
 
 public class IndexerTestBase extends StdOutStdErrRedirectableLuceneTestCase {
   protected Path tempDir1;

--- a/src/test/java/io/anserini/index/IndexerWithEmptyDocumentTestBase.java
+++ b/src/test/java/io/anserini/index/IndexerWithEmptyDocumentTestBase.java
@@ -16,6 +16,9 @@
 
 package io.anserini.index;
 
+import java.io.IOException;
+import java.nio.file.Path;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.document.BinaryDocValuesField;
@@ -34,9 +37,6 @@ import org.junit.After;
 import org.junit.Before;
 
 import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
-
-import java.io.IOException;
-import java.nio.file.Path;
 
 public class IndexerWithEmptyDocumentTestBase extends StdOutStdErrRedirectableLuceneTestCase {
   protected Path tempDir1;

--- a/src/test/java/io/anserini/index/PrebuiltIndexHandlerTest.java
+++ b/src/test/java/io/anserini/index/PrebuiltIndexHandlerTest.java
@@ -16,10 +16,10 @@
 
 package io.anserini.index;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;

--- a/src/test/java/io/anserini/index/SimpleIndexerTest.java
+++ b/src/test/java/io/anserini/index/SimpleIndexerTest.java
@@ -16,22 +16,24 @@
 
 package io.anserini.index;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.anserini.collection.FileSegment;
-import io.anserini.collection.JsonCollection;
-import io.anserini.search.ScoredDoc;
-import io.anserini.search.SimpleSearcher;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.anserini.collection.FileSegment;
+import io.anserini.collection.JsonCollection;
+import io.anserini.search.ScoredDoc;
+import io.anserini.search.SimpleSearcher;
 
 public class SimpleIndexerTest extends LuceneTestCase {
   @BeforeClass

--- a/src/test/java/io/anserini/index/generator/CoreGeneratorTest.java
+++ b/src/test/java/io/anserini/index/generator/CoreGeneratorTest.java
@@ -16,6 +16,9 @@
 
 package io.anserini.index.generator;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.io.StringReader;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -23,7 +26,6 @@ import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.StringField;
-import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -114,6 +116,7 @@ public class CoreGeneratorTest {
           break;
         }
       }
+      assertNotNull(tokenStreamField);
       assertEquals(nonStemmingAnalyzer.tokenStream(null, new StringReader(fieldString)),
         tokenStreamField.tokenStream(null, null));
     });

--- a/src/test/java/io/anserini/index/generator/GeoGeneratorTest.java
+++ b/src/test/java/io/anserini/index/generator/GeoGeneratorTest.java
@@ -16,12 +16,8 @@
 
 package io.anserini.index.generator;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
-import io.anserini.collection.JsonCollection;
-import io.anserini.index.Constants;
-import io.anserini.index.IndexCollection;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.LatLonDocValuesField;
@@ -31,7 +27,13 @@ import org.apache.lucene.index.IndexableField;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import io.anserini.collection.JsonCollection;
+import io.anserini.index.Constants;
+import io.anserini.index.IndexCollection;
 
 public class GeoGeneratorTest {
   private JsonCollection.Document geoDoc;

--- a/src/test/java/io/anserini/integration/AclAnthologyEndToEndTest.java
+++ b/src/test/java/io/anserini/integration/AclAnthologyEndToEndTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.integration;
 
+import java.util.Map;
+
 import io.anserini.collection.AclAnthology;
 import io.anserini.index.IndexCollection;
 import io.anserini.index.generator.AclAnthologyGenerator;
-
-import java.util.Map;
 
 public class AclAnthologyEndToEndTest extends EndToEndTest {
   @Override

--- a/src/test/java/io/anserini/integration/BibtexEndToEndTest.java
+++ b/src/test/java/io/anserini/integration/BibtexEndToEndTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.integration;
 
+import java.util.Map;
+
 import io.anserini.collection.BibtexCollection;
 import io.anserini.index.IndexCollection;
 import io.anserini.index.generator.BibtexGenerator;
-
-import java.util.Map;
 
 public class BibtexEndToEndTest extends EndToEndTest {
   @Override

--- a/src/test/java/io/anserini/integration/C4EndToEndTest.java
+++ b/src/test/java/io/anserini/integration/C4EndToEndTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.integration;
 
+import java.util.Map;
+
 import io.anserini.collection.C4Collection;
 import io.anserini.index.IndexCollection;
 import io.anserini.index.generator.C4Generator;
-
-import java.util.Map;
 
 public class C4EndToEndTest extends EndToEndTest {
   @Override

--- a/src/test/java/io/anserini/integration/CoreEndToEndTest.java
+++ b/src/test/java/io/anserini/integration/CoreEndToEndTest.java
@@ -16,16 +16,16 @@
 
 package io.anserini.integration;
 
-import io.anserini.collection.CoreCollection;
-import io.anserini.index.AbstractIndexer;
-import io.anserini.index.IndexCollection;
-import io.anserini.index.generator.CoreGenerator;
-
 import java.util.Map;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.BeforeClass;
+
+import io.anserini.collection.CoreCollection;
+import io.anserini.index.AbstractIndexer;
+import io.anserini.index.IndexCollection;
+import io.anserini.index.generator.CoreGenerator;
 
 public class CoreEndToEndTest extends EndToEndTest {
   @BeforeClass

--- a/src/test/java/io/anserini/integration/FineWebEndToEndTest.java
+++ b/src/test/java/io/anserini/integration/FineWebEndToEndTest.java
@@ -16,10 +16,10 @@
 
 package io.anserini.integration;
 
+import java.util.Map;
+
 import io.anserini.collection.FineWebCollection;
 import io.anserini.index.IndexCollection;
-
-import java.util.Map;
 
 public class FineWebEndToEndTest extends EndToEndTest {
   @Override

--- a/src/test/java/io/anserini/integration/JsonEndToEndBasicTest.java
+++ b/src/test/java/io/anserini/integration/JsonEndToEndBasicTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.integration;
 
+import java.util.Map;
+
 import io.anserini.collection.JsonCollection;
 import io.anserini.index.IndexCollection;
 import io.anserini.search.SearchCollection;
-
-import java.util.Map;
 
 public class JsonEndToEndBasicTest extends EndToEndTest {
   @Override

--- a/src/test/java/io/anserini/integration/JsonEndToEndPretokenizedTest.java
+++ b/src/test/java/io/anserini/integration/JsonEndToEndPretokenizedTest.java
@@ -16,13 +16,13 @@
 
 package io.anserini.integration;
 
+import java.util.List;
+import java.util.Map;
+
 import io.anserini.collection.JsonCollection;
 import io.anserini.index.IndexCollection;
 import io.anserini.index.generator.DefaultLuceneDocumentGenerator;
 import io.anserini.search.SearchCollection;
-
-import java.util.List;
-import java.util.Map;
 
 public class JsonEndToEndPretokenizedTest extends EndToEndTest {
   @Override

--- a/src/test/java/io/anserini/integration/JsonEndToEndZhTest.java
+++ b/src/test/java/io/anserini/integration/JsonEndToEndZhTest.java
@@ -16,13 +16,13 @@
 
 package io.anserini.integration;
 
+import java.util.ArrayList;
+import java.util.Map;
+
 import io.anserini.collection.JsonCollection;
 import io.anserini.index.IndexCollection;
 import io.anserini.index.generator.DefaultLuceneDocumentGenerator;
 import io.anserini.search.SearchCollection;
-
-import java.util.ArrayList;
-import java.util.Map;
 
 public class JsonEndToEndZhTest extends EndToEndTest {
   @Override

--- a/src/test/java/io/anserini/integration/JsonVectorEndToEndTest.java
+++ b/src/test/java/io/anserini/integration/JsonVectorEndToEndTest.java
@@ -16,13 +16,13 @@
 
 package io.anserini.integration;
 
+import java.util.ArrayList;
+import java.util.Map;
+
 import io.anserini.collection.JsonVectorCollection;
 import io.anserini.index.IndexCollection;
 import io.anserini.index.generator.DefaultLuceneDocumentGenerator;
 import io.anserini.search.SearchCollection;
-
-import java.util.ArrayList;
-import java.util.Map;
 
 public class JsonVectorEndToEndTest extends EndToEndTest {
   @Override

--- a/src/test/java/io/anserini/integration/MultiThreadingSearchTest.java
+++ b/src/test/java/io/anserini/integration/MultiThreadingSearchTest.java
@@ -16,10 +16,6 @@
 
 package io.anserini.integration;
 
-import io.anserini.collection.TrecCollection;
-import io.anserini.index.IndexCollection;
-import io.anserini.search.SearchCollection;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -27,6 +23,10 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import io.anserini.collection.TrecCollection;
+import io.anserini.index.IndexCollection;
+import io.anserini.search.SearchCollection;
 
 public class MultiThreadingSearchTest extends EndToEndTest {
   private Map<String, Set<String>> runsForQuery = new HashMap<>();

--- a/src/test/java/io/anserini/integration/SmolTalkEndToEndTest.java
+++ b/src/test/java/io/anserini/integration/SmolTalkEndToEndTest.java
@@ -16,10 +16,10 @@
 
 package io.anserini.integration;
 
+import java.util.Map;
+
 import io.anserini.collection.SmolTalkCollection;
 import io.anserini.index.IndexCollection;
-
-import java.util.Map;
 
 /**
  * End-to-end test for {@link SmolTalkCollection}.

--- a/src/test/java/io/anserini/integration/TrecEndToEndExternalStopwordsTest.java
+++ b/src/test/java/io/anserini/integration/TrecEndToEndExternalStopwordsTest.java
@@ -16,12 +16,12 @@
 
 package io.anserini.integration;
 
-import io.anserini.collection.TrecCollection;
-import io.anserini.index.IndexCollection;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
+import io.anserini.collection.TrecCollection;
+import io.anserini.index.IndexCollection;
 
 public class TrecEndToEndExternalStopwordsTest extends EndToEndTest {
   @Override

--- a/src/test/java/io/anserini/integration/TrecEndToEndPassageTest.java
+++ b/src/test/java/io/anserini/integration/TrecEndToEndPassageTest.java
@@ -16,13 +16,13 @@
 
 package io.anserini.integration;
 
-import io.anserini.collection.TrecCollection;
-import io.anserini.index.IndexCollection;
-import io.anserini.search.SearchCollection;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
+import io.anserini.collection.TrecCollection;
+import io.anserini.index.IndexCollection;
+import io.anserini.search.SearchCollection;
 
 public class TrecEndToEndPassageTest extends EndToEndTest {
   @Override

--- a/src/test/java/io/anserini/integration/TrecEndToEndTest.java
+++ b/src/test/java/io/anserini/integration/TrecEndToEndTest.java
@@ -16,13 +16,13 @@
 
 package io.anserini.integration;
 
-import io.anserini.collection.TrecCollection;
-import io.anserini.index.IndexCollection;
-import io.anserini.search.SearchCollection;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
+import io.anserini.collection.TrecCollection;
+import io.anserini.index.IndexCollection;
+import io.anserini.search.SearchCollection;
 
 public class TrecEndToEndTest extends EndToEndTest {
   @Override

--- a/src/test/java/io/anserini/integration/TrecEndToEndWhitelistTest.java
+++ b/src/test/java/io/anserini/integration/TrecEndToEndWhitelistTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.integration;
 
-import io.anserini.collection.TrecCollection;
-import io.anserini.index.IndexCollection;
-
 import java.util.List;
 import java.util.Map;
+
+import io.anserini.collection.TrecCollection;
+import io.anserini.index.IndexCollection;
 
 public class TrecEndToEndWhitelistTest extends EndToEndTest {
   @Override

--- a/src/test/java/io/anserini/integration/TweetEndToEndTest.java
+++ b/src/test/java/io/anserini/integration/TweetEndToEndTest.java
@@ -16,15 +16,16 @@
 
 package io.anserini.integration;
 
-import io.anserini.collection.TweetCollection;
-import io.anserini.index.AbstractIndexer;
-import io.anserini.index.IndexCollection;
-import io.anserini.index.generator.TweetGenerator;
+import java.util.Map;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.BeforeClass;
 
-import java.util.Map;
+import io.anserini.collection.TweetCollection;
+import io.anserini.index.AbstractIndexer;
+import io.anserini.index.IndexCollection;
+import io.anserini.index.generator.TweetGenerator;
 
 public class TweetEndToEndTest extends EndToEndTest {
   @BeforeClass

--- a/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/io/anserini/reproduce/RunJavaReproductionCommandsTest.java
+++ b/src/test/java/io/anserini/reproduce/RunJavaReproductionCommandsTest.java
@@ -29,8 +29,8 @@ import java.util.List;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
-import org.junit.BeforeClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import io.anserini.StdOutStdErrRedirectableLuceneTestCase;

--- a/src/test/java/io/anserini/reproduce/SummarizeLogsFromDocumentCollectionTest.java
+++ b/src/test/java/io/anserini/reproduce/SummarizeLogsFromDocumentCollectionTest.java
@@ -20,10 +20,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/src/test/java/io/anserini/search/ScoredDocsTest.java
+++ b/src/test/java/io/anserini/search/ScoredDocsTest.java
@@ -16,11 +16,10 @@
 
 package io.anserini.search;
 
-import io.anserini.index.Constants;
-import io.anserini.index.IndexCollection;
-import io.anserini.index.IndexerTestBase;
-import io.anserini.search.query.BagOfWordsQueryGenerator;
-import io.anserini.search.query.QueryGenerator;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.TreeMap;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
@@ -32,9 +31,11 @@ import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.store.FSDirectory;
 import org.junit.Test;
 
-import java.nio.file.Paths;
-import java.util.Map;
-import java.util.TreeMap;
+import io.anserini.index.Constants;
+import io.anserini.index.IndexCollection;
+import io.anserini.index.IndexerTestBase;
+import io.anserini.search.query.BagOfWordsQueryGenerator;
+import io.anserini.search.query.QueryGenerator;
 
 public class ScoredDocsTest extends IndexerTestBase {
   @Test

--- a/src/test/java/io/anserini/search/SearchCollectionTest.java
+++ b/src/test/java/io/anserini/search/SearchCollectionTest.java
@@ -21,7 +21,6 @@ import java.io.File;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/src/test/java/io/anserini/search/SearchFlatDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchFlatDenseVectorsTest.java
@@ -33,8 +33,6 @@ import io.anserini.TestUtils;
 import io.anserini.index.AbstractIndexer;
 import io.anserini.index.IndexFlatDenseVectors;
 
-import static org.junit.Assert.assertTrue;
-
 /**
  * Tests for {@link SearchFlatDenseVectors}
  */

--- a/src/test/java/io/anserini/search/SimpleGeoSearcherTest.java
+++ b/src/test/java/io/anserini/search/SimpleGeoSearcherTest.java
@@ -1,6 +1,5 @@
 package io.anserini.search;
 
-import io.anserini.index.GeoIndexerTestBase;
 import org.apache.lucene.document.LatLonDocValuesField;
 import org.apache.lucene.document.LatLonShape;
 import org.apache.lucene.document.ShapeField;
@@ -9,6 +8,8 @@ import org.apache.lucene.geo.Line;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.junit.Test;
+
+import io.anserini.index.GeoIndexerTestBase;
 
 public class SimpleGeoSearcherTest extends GeoIndexerTestBase {
   @Test

--- a/src/test/java/io/anserini/search/SimpleImpactSearcherPrebuiltTest.java
+++ b/src/test/java/io/anserini/search/SimpleImpactSearcherPrebuiltTest.java
@@ -16,12 +16,12 @@
 
 package io.anserini.search;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class SimpleImpactSearcherPrebuiltTest {
   @Test

--- a/src/test/java/io/anserini/search/SimpleImpactSearcherTest.java
+++ b/src/test/java/io/anserini/search/SimpleImpactSearcherTest.java
@@ -16,13 +16,15 @@
 
 package io.anserini.search;
 
-import io.anserini.index.IndexerTestBase;
-import io.anserini.index.Constants;
-import org.junit.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.junit.Test;
+
+import io.anserini.index.Constants;
+import io.anserini.index.IndexerTestBase;
 
 public class SimpleImpactSearcherTest extends IndexerTestBase {
   private static final Map<String, Integer> EXPECTED_ENCODED_QUERY = new HashMap<>();

--- a/src/test/java/io/anserini/search/SimpleSearcherTest.java
+++ b/src/test/java/io/anserini/search/SimpleSearcherTest.java
@@ -16,9 +16,11 @@
 
 package io.anserini.search;
 
-import io.anserini.index.IndexerTestBase;
-import io.anserini.analysis.DefaultEnglishAnalyzer;
-import io.anserini.index.Constants;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.lucene.analysis.ar.ArabicAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.Term;
@@ -27,10 +29,9 @@ import org.apache.lucene.search.similarities.BM25Similarity;
 import org.apache.lucene.search.similarities.LMDirichletSimilarity;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import io.anserini.analysis.DefaultEnglishAnalyzer;
+import io.anserini.index.Constants;
+import io.anserini.index.IndexerTestBase;
 
 public class SimpleSearcherTest extends IndexerTestBase {
   @Test

--- a/src/test/java/io/anserini/search/query/BagOfWordsQueryGeneratorTest.java
+++ b/src/test/java/io/anserini/search/query/BagOfWordsQueryGeneratorTest.java
@@ -16,14 +16,15 @@
 
 package io.anserini.search.query;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.Query;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import io.anserini.index.IndexCollection;

--- a/src/test/java/io/anserini/search/query/Covid19QueryGeneratorTest.java
+++ b/src/test/java/io/anserini/search/query/Covid19QueryGeneratorTest.java
@@ -16,11 +16,13 @@
 
 package io.anserini.search.query;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import io.anserini.index.Constants;
-import io.anserini.index.IndexCollection;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
@@ -31,9 +33,8 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import io.anserini.index.Constants;
+import io.anserini.index.IndexCollection;
 
 public class Covid19QueryGeneratorTest {
   @Test

--- a/src/test/java/io/anserini/search/query/DisjunctionMaxQueryGeneratorTest.java
+++ b/src/test/java/io/anserini/search/query/DisjunctionMaxQueryGeneratorTest.java
@@ -16,7 +16,8 @@
 
 package io.anserini.search.query;
 
-import io.anserini.index.IndexCollection;
+import java.util.Map;
+
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
@@ -24,7 +25,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Test;
 
-import java.util.Map;
+import io.anserini.index.IndexCollection;
 
 public class DisjunctionMaxQueryGeneratorTest extends LuceneTestCase {
   @Test

--- a/src/test/java/io/anserini/search/query/PhraseQueryGeneratorTest.java
+++ b/src/test/java/io/anserini/search/query/PhraseQueryGeneratorTest.java
@@ -16,14 +16,15 @@
 
 package io.anserini.search.query;
 
-import io.anserini.index.IndexCollection;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import io.anserini.index.IndexCollection;
 
 public class PhraseQueryGeneratorTest {
   @Test

--- a/src/test/java/io/anserini/search/query/QuerySideBm25QueryGeneratorTest.java
+++ b/src/test/java/io/anserini/search/query/QuerySideBm25QueryGeneratorTest.java
@@ -16,6 +16,9 @@
 
 package io.anserini.search.query;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -30,8 +33,6 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.FSDirectory;
 import org.junit.After;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/src/test/java/io/anserini/search/query/SdmQueryTest.java
+++ b/src/test/java/io/anserini/search/query/SdmQueryTest.java
@@ -16,6 +16,9 @@
 
 package io.anserini.search.query;
 
+import java.io.IOException;
+import java.nio.file.Path;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.document.Document;
@@ -40,9 +43,6 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.nio.file.Path;
 
 public class SdmQueryTest extends LuceneTestCase {
 

--- a/src/test/java/io/anserini/search/topicreader/BackgroundLinkingTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/BackgroundLinkingTopicReaderTest.java
@@ -16,14 +16,14 @@
 
 package io.anserini.search.topicreader;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class BackgroundLinkingTopicReaderTest {
 

--- a/src/test/java/io/anserini/search/topicreader/CacmTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/CacmTopicReaderTest.java
@@ -16,14 +16,14 @@
 
 package io.anserini.search.topicreader;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class CacmTopicReaderTest {
 

--- a/src/test/java/io/anserini/search/topicreader/CarTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/CarTopicReaderTest.java
@@ -16,9 +16,7 @@
 
 package io.anserini.search.topicreader;
 
-import io.anserini.analysis.AnalyzerUtils;
-import io.anserini.index.IndexCollection;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -26,7 +24,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import io.anserini.analysis.AnalyzerUtils;
+import io.anserini.index.IndexCollection;
 
 public class CarTopicReaderTest {
 

--- a/src/test/java/io/anserini/search/topicreader/CovidTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/CovidTopicReaderTest.java
@@ -16,14 +16,14 @@
 
 package io.anserini.search.topicreader;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class CovidTopicReaderTest {
 

--- a/src/test/java/io/anserini/search/topicreader/DprJsonlTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/DprJsonlTopicReaderTest.java
@@ -16,14 +16,14 @@
 
 package io.anserini.search.topicreader;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class DprJsonlTopicReaderTest {
 

--- a/src/test/java/io/anserini/search/topicreader/DprNqTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/DprNqTopicReaderTest.java
@@ -16,14 +16,14 @@
 
 package io.anserini.search.topicreader;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class DprNqTopicReaderTest {
 

--- a/src/test/java/io/anserini/search/topicreader/EpidemicQATopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/EpidemicQATopicReaderTest.java
@@ -16,14 +16,14 @@
 
 package io.anserini.search.topicreader;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class EpidemicQATopicReaderTest {
   @Test

--- a/src/test/java/io/anserini/search/topicreader/JsonStringTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/JsonStringTopicReaderTest.java
@@ -16,14 +16,14 @@
 
 package io.anserini.search.topicreader;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class JsonStringTopicReaderTest {
 

--- a/src/test/java/io/anserini/search/topicreader/MicroblogTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/MicroblogTopicReaderTest.java
@@ -16,14 +16,14 @@
 
 package io.anserini.search.topicreader;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class MicroblogTopicReaderTest {
 

--- a/src/test/java/io/anserini/search/topicreader/NtcirTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/NtcirTopicReaderTest.java
@@ -16,7 +16,7 @@
 
 package io.anserini.search.topicreader;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -24,7 +24,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class NtcirTopicReaderTest {
 

--- a/src/test/java/io/anserini/search/topicreader/PrioritizedWebTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/PrioritizedWebTopicReaderTest.java
@@ -16,7 +16,7 @@
 
 package io.anserini.search.topicreader;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -24,7 +24,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class PrioritizedWebTopicReaderTest {
   @Test

--- a/src/test/java/io/anserini/search/topicreader/TrecTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TrecTopicReaderTest.java
@@ -16,14 +16,14 @@
 
 package io.anserini.search.topicreader;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class TrecTopicReaderTest {
 

--- a/src/test/java/io/anserini/search/topicreader/TsvIntTopicReaderGzTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TsvIntTopicReaderGzTest.java
@@ -16,14 +16,14 @@
 
 package io.anserini.search.topicreader;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class TsvIntTopicReaderGzTest {
 

--- a/src/test/java/io/anserini/search/topicreader/TsvIntTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TsvIntTopicReaderTest.java
@@ -16,14 +16,14 @@
 
 package io.anserini.search.topicreader;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class TsvIntTopicReaderTest {
 

--- a/src/test/java/io/anserini/search/topicreader/TsvStringTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TsvStringTopicReaderTest.java
@@ -16,14 +16,14 @@
 
 package io.anserini.search.topicreader;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class TsvStringTopicReaderTest {
 

--- a/src/test/java/io/anserini/search/topicreader/WebTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/WebTopicReaderTest.java
@@ -16,7 +16,7 @@
 
 package io.anserini.search.topicreader;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -24,7 +24,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class WebTopicReaderTest {
 

--- a/src/test/java/io/anserini/search/topicreader/WebxmlTopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/WebxmlTopicReaderTest.java
@@ -16,14 +16,14 @@
 
 package io.anserini.search.topicreader;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class WebxmlTopicReaderTest {
 

--- a/src/test/java/io/anserini/util/ExtractAverageDocumentLengthTest.java
+++ b/src/test/java/io/anserini/util/ExtractAverageDocumentLengthTest.java
@@ -16,12 +16,12 @@
 
 package io.anserini.util;
 
-import io.anserini.index.IndexerWithEmptyDocumentTestBase;
+import java.util.Locale;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.Locale;
+import io.anserini.index.IndexerWithEmptyDocumentTestBase;
 
 public class ExtractAverageDocumentLengthTest extends IndexerWithEmptyDocumentTestBase {
   @BeforeClass

--- a/src/test/java/io/anserini/util/ExtractDocumentLengthsTest.java
+++ b/src/test/java/io/anserini/util/ExtractDocumentLengthsTest.java
@@ -16,18 +16,19 @@
 
 package io.anserini.util;
 
-import io.anserini.index.IndexerWithEmptyDocumentTestBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.anserini.index.IndexerWithEmptyDocumentTestBase;
 
 public class ExtractDocumentLengthsTest extends IndexerWithEmptyDocumentTestBase {
   private static final Random rand = new Random();

--- a/src/test/java/io/anserini/util/ExtractNormsTest.java
+++ b/src/test/java/io/anserini/util/ExtractNormsTest.java
@@ -16,18 +16,19 @@
 
 package io.anserini.util;
 
-import io.anserini.index.IndexerWithEmptyDocumentTestBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.anserini.index.IndexerWithEmptyDocumentTestBase;
 
 public class ExtractNormsTest extends IndexerWithEmptyDocumentTestBase {
   private static final Random rand = new Random();

--- a/src/test/java/io/anserini/util/FeatureVectorTest.java
+++ b/src/test/java/io/anserini/util/FeatureVectorTest.java
@@ -16,11 +16,11 @@
 
 package io.anserini.util;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
-import org.junit.Test;
-
 import java.util.Arrays;
 import java.util.HashSet;
+
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.junit.Test;
 
 public class FeatureVectorTest extends LuceneTestCase {
   private final FeatureVector createAndAddFeatureWeights1() {


### PR DESCRIPTION
## Summary

- Normalize import ordering across Anserini test classes.
- Keep changes behavior-preserving and scoped to `src/test/java`.

## Validation

- `bin/build.sh`

Validation passed with `Tests run: 1034, Failures: 0, Errors: 0, Skipped: 0`.