### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -657,3 +657,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-01 (commit [`fb2fd258`](https://github.com/castorini/anserini/commit/fb2fd258024cc87133e8c07c5316ad3e9a82407f))
 + Results reproduced by [@mohamedshakir3](https://github.com/mohamedshakir3) on 2026-05-02 (commit [`ec9cf56`](https://github.com/castorini/anserini/commit/ec9cf5624a1d01ee026b97a2639229bd6ff648f3))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`a74898d`](https://github.com/castorini/anserini/commit/a74898de2d1596990663d0ecef21330521b858aa))
++ Results reproduced by [@Bashir486](https://github.com/Bashir486) on 2026-05-08 (commit [`974e8f0e0f7ffab839930f874b37e809ab95d4df`](https://github.com/castorini/anserini/commit/974e8f0e0f7ffab839930f874b37e809ab95d4df))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -205,3 +205,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-01 (commit [`fb2fd258`](https://github.com/castorini/anserini/commit/fb2fd258024cc87133e8c07c5316ad3e9a82407f))
 + Results reproduced by [@mohamedshakir3](https://github.com/mohamedshakir3) on 2026-05-02 (commit [`ec9cf56`](https://github.com/castorini/anserini/commit/ec9cf5624a1d01ee026b97a2639229bd6ff648f3))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`a74898d`](https://github.com/castorini/anserini/commit/a74898de2d1596990663d0ecef21330521b858aa))
++ Results reproduced by [@Bashir486](https://github.com/Bashir486) on 2026-05-10 (commit [`5fbdb0895791a0ef143635989c0252f6d23c56d5`](https://github.com/castorini/anserini/commit/5fbdb0895791a0ef143635989c0252f6d23c56d5))


### PR DESCRIPTION
Reproduction log entries for Anserini onboarding path:
- BM25 MS MARCO Passage (experiments-msmarco-passage.md): MRR@10 = 0.1840
- Dense Retrieval BGE-base HNSW (experiments-msmarco-passage2.md): MRR@10 = 0.3521

Environment: WSL2 Ubuntu, Java 21, Anserini 2.0.1-SNAPSHOT