### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -657,3 +657,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-01 (commit [`fb2fd258`](https://github.com/castorini/anserini/commit/fb2fd258024cc87133e8c07c5316ad3e9a82407f))
 + Results reproduced by [@mohamedshakir3](https://github.com/mohamedshakir3) on 2026-05-02 (commit [`ec9cf56`](https://github.com/castorini/anserini/commit/ec9cf5624a1d01ee026b97a2639229bd6ff648f3))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`a74898d`](https://github.com/castorini/anserini/commit/a74898de2d1596990663d0ecef21330521b858aa))
++ Results reproduced by [@Bashir486](https://github.com/Bashir486) on 2026-05-08 (commit [`974e8f0e0f7ffab839930f874b37e809ab95d4df`](https://github.com/castorini/anserini/commit/974e8f0e0f7ffab839930f874b37e809ab95d4df))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -205,3 +205,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-01 (commit [`fb2fd258`](https://github.com/castorini/anserini/commit/fb2fd258024cc87133e8c07c5316ad3e9a82407f))
 + Results reproduced by [@mohamedshakir3](https://github.com/mohamedshakir3) on 2026-05-02 (commit [`ec9cf56`](https://github.com/castorini/anserini/commit/ec9cf5624a1d01ee026b97a2639229bd6ff648f3))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`a74898d`](https://github.com/castorini/anserini/commit/a74898de2d1596990663d0ecef21330521b858aa))
++ Results reproduced by [@Bashir486](https://github.com/Bashir486) on 2026-05-10 (commit [`5fbdb0895791a0ef143635989c0252f6d23c56d5`](https://github.com/castorini/anserini/commit/5fbdb0895791a0ef143635989c0252f6d23c56d5))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -564,3 +564,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-01 (commit [`fb2fd258`](https://github.com/castorini/anserini/commit/fb2fd258024cc87133e8c07c5316ad3e9a82407f))
 + Results reproduced by [@mohamedshakir3](https://github.com/mohamedshakir3) on 2026-05-02 (commit [`ec9cf56`](https://github.com/castorini/anserini/commit/ec9cf5624a1d01ee026b97a2639229bd6ff648f3))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`a74898d`](https://github.com/castorini/anserini/commit/a74898de2d1596990663d0ecef21330521b858aa))
++ Results reproduced by [@Bashir486](https://github.com/Bashir486) on 2026-05-08 (commit [`974e8f0e0f7ffab839930f874b37e809ab95d4df`](https://github.com/castorini/anserini/commit/974e8f0e0f7ffab839930f874b37e809ab95d4df))


### PR DESCRIPTION
Update: I have now completed all three Anserini onboarding lessons fully.

**Lesson 1 - Start Here (start-here.md):**
- Completed full MS MARCO data tour
- Verified 6980 queries, 7437 qrels, 532k training judgments
- filter_queries.py run and verified

**Lesson 2 - BM25 MS MARCO Passage (experiments-msmarco-passage.md):**
- MRR@10 = 0.18741 (MS MARCO eval)
- MAP = 0.1957, Recall@1000 = 0.8573 (trec_eval)
- MRR@10 = 0.1875 using prebuilt index
- Used fatjar directly instead of bin/run.sh (appassembler not generated by Maven build)

**Lesson 3 - Dense Retrieval BGE HNSW (experiments-msmarco-passage2.md):**
- MRR@10 = 0.3521 (confirms dense retrieval superiority over BM25)
- 26GB HNSW index downloaded from HuggingFace castorini prebuilt indexes

**Environment:**
- OS: WSL2 Ubuntu 24.04
- Java: OpenJDK 21.0.10
- Anserini: 2.0.1-SNAPSHOT
- Hardware: Windows 10 laptop, 8GB Java heap

Note: 
1. experiments-msmarco-passage2.md diff shows +3 -1 because the upstream file was missing a newline after the last entry (mazleon's line).
2. Used java -cp target/anserini-2.0.1-SNAPSHOT-fatjar.jar directly instead
of bin/run.sh, as the appassembler plugin did not generate the bin/ scripts
during Maven build. The fatjar approach produces identical results.