### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -657,3 +657,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-01 (commit [`fb2fd258`](https://github.com/castorini/anserini/commit/fb2fd258024cc87133e8c07c5316ad3e9a82407f))
 + Results reproduced by [@mohamedshakir3](https://github.com/mohamedshakir3) on 2026-05-02 (commit [`ec9cf56`](https://github.com/castorini/anserini/commit/ec9cf5624a1d01ee026b97a2639229bd6ff648f3))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`a74898d`](https://github.com/castorini/anserini/commit/a74898de2d1596990663d0ecef21330521b858aa))
++ Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-09 (commit [`deb4c7b`](https://github.com/castorini/anserini/commit/deb4c7bbfaba1ae36d8d7b07d2b7da84f5ab662d))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -205,3 +205,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-01 (commit [`fb2fd258`](https://github.com/castorini/anserini/commit/fb2fd258024cc87133e8c07c5316ad3e9a82407f))
 + Results reproduced by [@mohamedshakir3](https://github.com/mohamedshakir3) on 2026-05-02 (commit [`ec9cf56`](https://github.com/castorini/anserini/commit/ec9cf5624a1d01ee026b97a2639229bd6ff648f3))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`a74898d`](https://github.com/castorini/anserini/commit/a74898de2d1596990663d0ecef21330521b858aa))
++ Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-14 (commit [`deb4c7b`](https://github.com/castorini/anserini/commit/deb4c7bbfaba1ae36d8d7b07d2b7da84f5ab662d))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -564,3 +564,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@blissuche90](https://github.com/blissuche90) on 2026-05-01 (commit [`fb2fd258`](https://github.com/castorini/anserini/commit/fb2fd258024cc87133e8c07c5316ad3e9a82407f))
 + Results reproduced by [@mohamedshakir3](https://github.com/mohamedshakir3) on 2026-05-02 (commit [`ec9cf56`](https://github.com/castorini/anserini/commit/ec9cf5624a1d01ee026b97a2639229bd6ff648f3))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`a74898d`](https://github.com/castorini/anserini/commit/a74898de2d1596990663d0ecef21330521b858aa))
++ Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-09 (commit [`deb4c7b`](https://github.com/castorini/anserini/commit/deb4c7bbfaba1ae36d8d7b07d2b7da84f5ab662d))


### PR DESCRIPTION
Adding myself to the reproduction logs for lessons 1, 2, 3 of the onboarding path.

Environment:
- L1+L2: macOS 26.3 (Apple Silicon, 16 GB RAM)
- L3: moved to an Ubuntu 24.04 Vast.ai box because the 24 GB BGE HNSW index didn't fit on the laptop
- Java 21 (openjdk@21), Maven 3.8/3.9
- Anserini master @ deb4c7b, tools/ @ b6a89ce

L1 (start-here.md): MS MARCO tour done. Tarball MD5 31644046b18952c1386cd4564ba2ae69 verified, 8,841,823 passages converted to JSONL (9 shards), 6,980 dev queries after filter, 7,437 qrels.

L2 (experiments-msmarco-passage.md): BM25 with the tuned k1=0.82, b=0.68.
MRR@10 = 0.18741227770955546, MAP = 0.1957, R@1000 = 0.8573. All three match the doc.

L3 (experiments-msmarco-passage2.md): BM25 over the prebuilt msmarco-v1-passage index, then dense BGE over msmarco-v1-passage.bge-base-en-v1.5.hnsw. BM25 prebuilt MRR@10 = 0.1875, BGE MRR@10 = 0.3521. Both match.

Notes:

The mvn build with tests hung for ~3.5 hours on what I'm guessing was a stalled HTTP connection inside the surefire suite (it was downloading qrels fixtures from anserini-tools/master, and one of them stopped responding without ever timing out). Rebuilt with -DskipTests in ~2 min, verified the build by running the toolkit on MS MARCO end to end. Could be worth a heads-up in the doc for people on flaky networks.

bin/run.sh's hardcoded -Xmx192G is fine on a server but pushed my 16 GB Mac past what jetsam tolerates (killed the JVM at about 39% indexed). The doc anticipates this so I just invoked java with -Xmx10G and -threads 4 directly. Out of curiosity I ran git log --follow on bin/run.sh and the 192G was bumped from 64G in f9f73c2 as part of the Parquet regressions PR — looks incidental to the dense-vector workload there. If a configurable env-var override would be welcome, happy to send that as a separate PR.

The collectionandqueries.tar.gz download from msmarco.z22.web.core.windows.net came back truncated for me (got 72 MB instead of the ~1 GB the MD5 expected). The Waterloo mirror at rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0 worked first try.
