### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -658,3 +658,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@mohamedshakir3](https://github.com/mohamedshakir3) on 2026-05-02 (commit [`ec9cf56`](https://github.com/castorini/anserini/commit/ec9cf5624a1d01ee026b97a2639229bd6ff648f3))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`a74898d`](https://github.com/castorini/anserini/commit/a74898de2d1596990663d0ecef21330521b858aa))
 + Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-09 (commit [`deb4c7b`](https://github.com/castorini/anserini/commit/deb4c7bbfaba1ae36d8d7b07d2b7da84f5ab662d))
++ Results reproduced by [@Adebara123](https://github.com/Adebara123) on 2026-05-15 (commit [`4d16490`](https://github.com/castorini/anserini/commit/4d1649025fa16c2b2c0941983d850ba187554804))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -206,3 +206,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@mohamedshakir3](https://github.com/mohamedshakir3) on 2026-05-02 (commit [`ec9cf56`](https://github.com/castorini/anserini/commit/ec9cf5624a1d01ee026b97a2639229bd6ff648f3))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`a74898d`](https://github.com/castorini/anserini/commit/a74898de2d1596990663d0ecef21330521b858aa))
 + Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-14 (commit [`deb4c7b`](https://github.com/castorini/anserini/commit/deb4c7bbfaba1ae36d8d7b07d2b7da84f5ab662d))
++ Results reproduced by [@Adebara123](https://github.com/Adebara123) on 2026-05-15 (commit [`4d16490`](https://github.com/castorini/anserini/commit/4d1649025fa16c2b2c0941983d850ba187554804))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -565,3 +565,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@mohamedshakir3](https://github.com/mohamedshakir3) on 2026-05-02 (commit [`ec9cf56`](https://github.com/castorini/anserini/commit/ec9cf5624a1d01ee026b97a2639229bd6ff648f3))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`a74898d`](https://github.com/castorini/anserini/commit/a74898de2d1596990663d0ecef21330521b858aa))
 + Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-09 (commit [`deb4c7b`](https://github.com/castorini/anserini/commit/deb4c7bbfaba1ae36d8d7b07d2b7da84f5ab662d))
++ Results reproduced by [@Adebara123](https://github.com/Adebara123) on 2026-05-15 (commit [`4d16490`](https://github.com/castorini/anserini/commit/4d1649025fa16c2b2c0941983d850ba187554804))


### PR DESCRIPTION
## Summary

Reproduced the MS MARCO Passage onboarding experiments end-to-end on macOS — both the sparse BM25 path (`start-here.md` → `experiments-msmarco-passage.md`) and the dense BGE-base + HNSW path (`experiments-msmarco-passage2.md`).

## Results

| Doc | Metric | My result | Published target |
|---|---|---|---|
| `experiments-msmarco-passage.md` (BM25) | MRR@10 (msmarco_passage_eval.py) | `0.18741227770955546` | `0.18741227770955546` |
| `experiments-msmarco-passage.md` (BM25) | MAP | `0.1957` | `0.1957` |
| `experiments-msmarco-passage.md` (BM25) | Recall@1000 | `0.8573` | `0.8573` |
| `experiments-msmarco-passage.md` (BM25, per-qid 1048585) | recip_rank | `1.0000` | `1.0000` |
| `experiments-msmarco-passage2.md` (BGE-base + HNSW) | MRR@10 | `0.3521` | `0.3521` |

All four targets match exactly.

## Environment

- macOS 26.2 (Darwin 25.2.0), Apple Silicon (arm64), 16 GB RAM
- OpenJDK 21.0.11 (Homebrew `openjdk@21`)
- Apache Maven 3.9.15
- `trec_eval` 9.0.4 built from `tools/eval/trec_eval.9.0.4.tar.gz`
- `ndeval` built from `tools/eval/ndeval`
- Anserini commit `4d16490` (current `master` HEAD at time of reproduction)

## Build

- Used `bin/qbuild.sh` (i.e. `mvn clean package -DskipTests`) to produce `target/anserini-2.1.1-SNAPSHOT-fatjar.jar`.
- The full `bin/build.sh` had test failures from network-dependent encoder tests (`OnnxEncoderTest`, `CosDprDistilEncoderInferenceTest`, `ArcticEmbedLEncoderInferenceTest`) timing out while fetching ONNX models. None of these are on the BM25 or HNSW retrieval code paths, so the experiment results are unaffected.

## Notes on running with 16 GB RAM

- `bin/run.sh` hardcodes `-Xms512M -Xmx192G`. Combined with `-threads 9` during MS MARCO Passage indexing, this caused macOS to OOM-kill the JVM after ~33% of the corpus had been indexed.
- Workaround: invoked `java` directly with `-Xmx8G -threads 3`. Indexing then completed in 1m52s with 8,841,823 documents and 0 errors / 0 unindexable / 0 skipped, producing a 4.2 GB index — matching the published expected output.

## Notes on the HNSW prebuilt-index download

The 24 GB `lucene-hnsw.msmarco-v1-passage.bge-base-en-v1.5` tarball from HuggingFace was unreliable on a residential connection — HF throttled long-running connections and the presigned S3 URL embedded in the redirect expires after 1 hour. Two issues observed in `io.anserini.util.PrebuiltIndexHandler`:

1. On retry it restarts the download **from byte 0** rather than resuming via HTTP `Range`, which means slow/flaky connections may never converge across the 3-attempt budget.
2. The handler checks for the **extracted** index directory at `<cache>/<filename-minus-.tar.gz>.<md5>/` but not for the cached tarball at `<cache>/<filename>.tar.gz`. So if the tarball is present but extraction was never done, the handler re-downloads it (and overwrites my cached copy in the process when I tried to short-circuit the flow).

Workaround that finally got the index in place:
1. Downloaded the tarball externally with `aria2c -c -x 8 -s 8` (resumable, 8 parallel connections) using a `while; do aria2c ...; done` loop to auto-recover from periodic SSL handshake errors and URL expirations.
2. Verified `md5 == 00a577f689d90f95e6c5611438b0af3d`.
3. Manually `tar -xzf` into the cache dir and `mv lucene-hnsw.msmarco-v1-passage.bge-base-en-v1.5.20240117.53514b lucene-hnsw.msmarco-v1-passage.bge-base-en-v1.5.20240117.53514b.00a577f689d90f95e6c5611438b0af3d` — matching `PrebuiltIndexHandler.fetch()`'s expected `indexPath`.
4. Re-ran `SearchHnswDenseVectors` — log emitted `Index already exists at <path>: skipping downloading.` and search proceeded.

These would be useful upstream improvements but are out of scope for this PR.

## Minor observation

The dense-retrieval command in `experiments-msmarco-passage2.md` uses `-hits 1000`, but the resulting run file contains exactly 100 hits per query (`6980 × 100 = 698,000` lines), because `SearchHnswDenseVectors`'s default `efSearch=100` caps the beam. MRR@10 (the documented success metric) is unaffected. Mentioning in case it's worth a clarifying note in the guide.

## Outcome

Everything worked end-to-end. All published metrics reproduced exactly.