### PR TITLE
Added Reproduction Log

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -658,3 +658,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@mohamedshakir3](https://github.com/mohamedshakir3) on 2026-05-02 (commit [`ec9cf56`](https://github.com/castorini/anserini/commit/ec9cf5624a1d01ee026b97a2639229bd6ff648f3))
 + Results reproduced by [@mazleon](https://github.com/mazleon) on 2026-05-03 (commit [`a74898d`](https://github.com/castorini/anserini/commit/a74898de2d1596990663d0ecef21330521b858aa))
 + Results reproduced by [@VanshJain4](https://github.com/VanshJain4) on 2026-05-09 (commit [`deb4c7b`](https://github.com/castorini/anserini/commit/deb4c7bbfaba1ae36d8d7b07d2b7da84f5ab662d))
++ Results reproduced by [@david23131](https://github.com/david23131) on 2026-05-17 (commit [`ced49181`](https://github.com/castorini/anserini/commit/ced49181906437191253faf474dcc33ac78e3a7f))


### PR DESCRIPTION
Just finished "experiments-msmarco-passage.md". I want to share some issues I encountered along with some personal thoughts.

Problems found:
1. When I try to install pyserini, the command "pip install pyserini==latest" didn't work on my computer, it gives the following error: 
<img width="804" height="55" alt="((orsarind) daviddonotousessusunus-MacBook-Air-X pio install pyserinieslatest" src="https://github.com/user-attachments/assets/4b69853f-bee3-4a41-b595-24a133bb6aae" />
so I have to use the command "pip install --upgrade pyserini" instead to ensure I have the latest version installed

2. When I try to get the rankings of relevant docid, I need to execute the command "export OPENAI_API_KEY="sk-placeholder" before the BM25 search script, otherwise I will receive the following error: 
<img width="1253" height="359" alt="Screenshot 2026-05-17 at 1 37 33 PM" src="https://github.com/user-attachments/assets/2e8f5654-0327-4d2e-8e96-7ad0009db135" />


3. Since I'm using pyserini (I'm more comfortable with python), I need to convert some of the commands into python language. I think it would be better to have a separate command provided for people who works in pyserini environment. (If this is intended, please ignore)

5. Just a small issue, I'm thinking maybe it would be clearer to making sure user have trec_eval installed on their computer before introducing the following command?
<img width="467" height="76" alt="Screenshot 2026-05-17 at 3 02 26 PM" src="https://github.com/user-attachments/assets/b1f18702-11a4-474f-afd0-cf37aa9d5810" />

Personal thoughts:
1. When reading the evaluation algorithm for BM25, especially the sentence "We look at the rank position of the first relevant docid. If it..." I thought about it and noticed the flaw of this algorithm, that is, the first relevant dicid in many cases isn’t the most relevant docid, so it leads to inaccuracy when determining the overall score. I asked Gemini about this and it says more advanced search benchmarks fix this issue by moving away from MRR and use an upgraded metric called NDCG (Normalized Discounted Cumulative Gain). Hopefully I can get more information regarding this in the later readings.