### PR TITLE
[codex] Add related skills pointer to fatjar setup skill

### DIFF
--- a/.agents/skills/install-anserini-fatjar/SKILL.md
+++ b/.agents/skills/install-anserini-fatjar/SKILL.md
@@ -143,6 +143,21 @@ java -cp "$ANSERINI_JAR" <main-class> <args>
 Keep all commands pinned to the same jar version unless the user asks to change
 versions.
 
+## Related Skills
+
+Canonical Anserini skills live at:
+
+```text
+https://github.com/castorini/anserini/tree/master/.agents/skills
+```
+
+After fatjar setup:
+
+- Use `$anserini-cli` for command-line usage, registry lookup, search, and REST examples.
+- Use `$anserini-reproduction` for reproduction workflows and result verification.
+- Do not use `$install-anserini-dev-env` unless the user needs a source checkout,
+  local code changes, or a jar built from source.
+
 ## Troubleshooting
 
 - No fatjar found: download the release fatjar from Maven Central and set

--- a/.agents/skills/install-anserini-fatjar/SKILL.md
+++ b/.agents/skills/install-anserini-fatjar/SKILL.md
@@ -2,7 +2,7 @@
 name: install-anserini-fatjar
 description: Install and verify Anserini quickly by downloading the published fatjar from Maven Central instead of cloning or building the source repository. Use when users want fast setup, smoke tests, or CLI examples from a released Anserini jar.
 metadata:
-  version: v0.2.0
+  version: v0.2.1
 ---
 
 # Install Anserini Fatjar


### PR DESCRIPTION
## Summary

- Add a concise related-skills section to `$install-anserini-fatjar`.
- Point agents to the canonical `.agents/skills` directory on `master`.
- Clarify that `$install-anserini-dev-env` is only needed for source checkout, local changes, or source-built jars.

## Validation

- `rg -n "Related Skills|install-anserini-dev-env|anserini-cli|anserini-reproduction" .agents/skills/install-anserini-fatjar/SKILL.md`