### PR TITLE
[codex] Make reproduction output locale-stable

### DIFF
--- a/src/main/java/io/anserini/reproduce/ReproduceFromDocumentCollection.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromDocumentCollection.java
@@ -173,7 +173,7 @@ public class ReproduceFromDocumentCollection {
     try {
       parser.parseArgument(args);
     } catch (CmdLineException exception) {
-      System.err.println(String.format("Error: %s", exception.getMessage()));
+      System.err.println(String.format(Locale.ROOT, "Error: %s", exception.getMessage()));
       CliUtils.printUsage(parser, ReproduceFromDocumentCollection.class, argsOrdering);
 
       return;
@@ -197,7 +197,7 @@ public class ReproduceFromDocumentCollection {
     }
 
     if (parsedArgs.show) {
-      String resourceName = String.format("%s/%s.yaml", CONFIG_DIRECTORY, parsedArgs.config);
+      String resourceName = String.format(Locale.ROOT, "%s/%s.yaml", CONFIG_DIRECTORY, parsedArgs.config);
       try (InputStream yamlStream = ReproductionUtils.loadResourceStream(resourceName, ReproduceFromDocumentCollection.class)) {
         System.out.print(new String(yamlStream.readAllBytes(), StandardCharsets.UTF_8));
       }
@@ -216,7 +216,7 @@ public class ReproduceFromDocumentCollection {
   private static void run(Args args) throws IOException, InterruptedException, URISyntaxException, NoSuchAlgorithmException {
     ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
     JsonNode yaml;
-    String resourceName = String.format("%s/%s.yaml", CONFIG_DIRECTORY, args.config);
+    String resourceName = String.format(Locale.ROOT, "%s/%s.yaml", CONFIG_DIRECTORY, args.config);
     try (InputStream yamlStream = ReproductionUtils.loadResourceStream(resourceName, ReproduceFromDocumentCollection.class)) {
       yaml = mapper.readTree(yamlStream);
     }
@@ -260,7 +260,7 @@ public class ReproduceFromDocumentCollection {
       LOG.info("Resolved corpus path is {}", corpusPath);
 
       if (corpusPath == null) {
-        throw new RuntimeException(String.format("Unable to find the corpus '%s': looked in %s",
+        throw new RuntimeException(String.format(Locale.ROOT, "Unable to find the corpus '%s': looked in %s",
             yaml.get("corpus").asText(), getCorpusRoots()));
       }
 
@@ -299,7 +299,7 @@ public class ReproduceFromDocumentCollection {
               long value = Long.parseLong(parts[1].trim());
               long expected = stats.get(stat).asLong();
               if (value != expected) {
-                System.out.printf("%s: expected=%d, actual=%d%n", stat, expected, value);
+                System.out.printf(Locale.ROOT, "%s: expected=%d, actual=%d%n", stat, expected, value);
                 throw new AssertionError(stat + " mismatch");
               }
               LOG.info(line);
@@ -447,7 +447,7 @@ public class ReproduceFromDocumentCollection {
       }
     }
 
-    return Paths.get("runs", String.format("run.%s.%s.%s.txt", indexPart, id, modelName)).toString();
+    return Paths.get("runs", String.format(Locale.ROOT, "run.%s.%s.%s.txt", indexPart, id, modelName)).toString();
   }
 
   private static List<String> constructSearchCommands(JsonNode yaml) {
@@ -861,7 +861,7 @@ public class ReproduceFromDocumentCollection {
     byte[] digest = md.digest();
     StringBuilder sb = new StringBuilder();
     for (byte b : digest) {
-      sb.append(String.format("%02x", b));
+      sb.append(String.format(Locale.ROOT, "%02x", b));
     }
 
     return sb.toString();

--- a/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
@@ -86,7 +86,7 @@ public class ReproduceFromPrebuiltIndexes {
     try {
       parser.parseArgument(args);
     } catch (CmdLineException exception) {
-      System.err.println(String.format("Error: %s", exception.getMessage()));
+      System.err.println(String.format(Locale.ROOT, "Error: %s", exception.getMessage()));
       CliUtils.printUsage(parser, ReproduceFromPrebuiltIndexes.class, argsOrdering);
 
       return;
@@ -110,7 +110,7 @@ public class ReproduceFromPrebuiltIndexes {
     }
 
     if (parsedArgs.show) {
-      String resourceName = String.format("%s/%s.yaml", CONFIG_DIRECTORY, parsedArgs.config);
+      String resourceName = String.format(Locale.ROOT, "%s/%s.yaml", CONFIG_DIRECTORY, parsedArgs.config);
       try (InputStream yamlStream = ReproductionUtils.loadResourceStream(resourceName, ReproduceFromPrebuiltIndexes.class)) {
         System.out.print(new String(yamlStream.readAllBytes(), StandardCharsets.UTF_8));
       }
@@ -131,10 +131,10 @@ public class ReproduceFromPrebuiltIndexes {
 
     String fatjarPath = new File(ReproduceFromPrebuiltIndexes.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getPath();
     String classpath = Files.isDirectory(Paths.get(fatjarPath)) ? System.getProperty("java.class.path") : fatjarPath;
-    String guardedClasspath = classpath.contains(" ") ? String.format("\"%s\"", classpath) : classpath;
+    String guardedClasspath = classpath.contains(" ") ? String.format(Locale.ROOT, "\"%s\"", classpath) : classpath;
 
     final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-    String resourceName = String.format("%s/%s.yaml", CONFIG_DIRECTORY, configName);
+    String resourceName = String.format(Locale.ROOT, "%s/%s.yaml", CONFIG_DIRECTORY, configName);
     Config config;
     try (InputStream yamlStream = ReproductionUtils.loadResourceStream(resourceName, ReproduceFromPrebuiltIndexes.class)) {
       config = mapper.readValue(yamlStream, Config.class);
@@ -158,7 +158,7 @@ public class ReproduceFromPrebuiltIndexes {
     }
 
     if (!uniqueIndexNames.isEmpty()) {
-      System.out.printf("Indexes referenced by this run (%d total):%n", uniqueIndexNames.size());
+      System.out.printf(Locale.ROOT, "Indexes referenced by this run (%d total):%n", uniqueIndexNames.size());
 
       // First pass: compute rows and totals so we can size columns dynamically.
       long totalBytes = 0L;
@@ -220,26 +220,26 @@ public class ReproduceFromPrebuiltIndexes {
       }
 
       final String fmt = "%-" + nameWidth + "s  %12s  %12s  %-" + pathWidth + "s%n";
-      System.out.printf(fmt, "name", "size on disk", "download size", "path");
-      System.out.printf(fmt, repeat('-', nameWidth), repeat('-', 12), repeat('-', 12), repeat('-', pathWidth));
+      System.out.printf(Locale.ROOT, fmt, "name", "size on disk", "download size", "path");
+      System.out.printf(Locale.ROOT, fmt, repeat('-', nameWidth), repeat('-', 12), repeat('-', 12), repeat('-', pathWidth));
 
       for (String[] r : rows) {
-        System.out.printf(fmt, r[0], r[1], r[2], r[3]);
+        System.out.printf(Locale.ROOT, fmt, r[0], r[1], r[2], r[3]);
       }
       // Add total row at the end with no path.
-      System.out.printf(fmt, "total", IndexReaderUtils.formatSize(totalBytes), IndexReaderUtils.formatSize(totalDownloadBytes), "-");
+      System.out.printf(Locale.ROOT, fmt, "total", IndexReaderUtils.formatSize(totalBytes), IndexReaderUtils.formatSize(totalDownloadBytes), "-");
 
-      System.out.printf("%nTotal size across %d of %d indexes: %s%n%n", presentCount, uniqueIndexNames.size(), IndexReaderUtils.formatSize(totalBytes));
+      System.out.printf(Locale.ROOT, "%nTotal size across %d of %d indexes: %s%n%n", presentCount, uniqueIndexNames.size(), IndexReaderUtils.formatSize(totalBytes));
     }
 
     for (Condition condition : config.conditions) {
-      System.out.printf("# Running condition \"%s\": %s \n%n", condition.name, condition.display);
+      System.out.printf(Locale.ROOT, "# Running condition \"%s\": %s \n%n", condition.name, condition.display);
       for (Topic topic : condition.topics) {
         System.out.println("  - topic_key: " + topic.topic_key + "\n");
 
-        final String output = runsDir.resolve(String.format("run.%s.%s.%s.txt", configName, condition.name, topic.topic_key)).toString();
+        final String output = runsDir.resolve(String.format(Locale.ROOT, "run.%s.%s.%s.txt", configName, condition.name, topic.topic_key)).toString();
 
-        String command = String.format("%s $fatjar %s %s", ReproductionUtils.Constants.JAVA_PREFIX, ReproductionUtils.Constants.JVM_ARGS, condition.command)
+        String command = String.format(Locale.ROOT, "%s $fatjar %s %s", ReproductionUtils.Constants.JAVA_PREFIX, ReproductionUtils.Constants.JVM_ARGS, condition.command)
             .replace("$fatjar", guardedClasspath)
             .replace("$threads", "16")
             .replace("$topics", topic.topic_key)
@@ -309,13 +309,13 @@ public class ReproduceFromPrebuiltIndexes {
               double delta = Math.abs(score - expected.get(metric));
 
               if (score > expected.get(metric)) {
-                System.out.printf("    %8s: %.4f %s expected %.4f%n", metric, score, ReproductionUtils.Constants.OKISH, expected.get(metric));
+                System.out.printf(Locale.ROOT, "    %8s: %.4f %s expected %.4f%n", metric, score, ReproductionUtils.Constants.OKISH, expected.get(metric));
               } else if (delta < 0.00001) {
-                System.out.printf("    %8s: %.4f %s%n", metric, score, ReproductionUtils.Constants.OK);
+                System.out.printf(Locale.ROOT, "    %8s: %.4f %s%n", metric, score, ReproductionUtils.Constants.OK);
               } else if (delta < 0.0002) {
-                System.out.printf("    %8s: %.4f %s expected %.4f%n", metric, score, ReproductionUtils.Constants.OKISH, expected.get(metric));
+                System.out.printf(Locale.ROOT, "    %8s: %.4f %s expected %.4f%n", metric, score, ReproductionUtils.Constants.OKISH, expected.get(metric));
               } else {
-                System.out.printf("    %8s: %.4f %s expected %.4f%n", metric, score, ReproductionUtils.Constants.FAIL, expected.get(metric));
+                System.out.printf(Locale.ROOT, "    %8s: %.4f %s expected %.4f%n", metric, score, ReproductionUtils.Constants.FAIL, expected.get(metric));
               }
             } catch (RuntimeException e) {
               System.out.println("    Evaluation command failed for metric: " + metric);
@@ -466,8 +466,8 @@ public class ReproduceFromPrebuiltIndexes {
     String summaryFormat = "%-" + conditionWidth + "s  %-" + topicWidth + "s  %-" + metricWidth + "s  %" + expectedWidth + "s%n";
     StringBuilder summary = new StringBuilder();
     summary.append("Summary").append(System.lineSeparator());
-    summary.append(String.format(summaryFormat, "condition", "topic", "metric", "expected"));
-    summary.append(String.format(summaryFormat,
+    summary.append(String.format(Locale.ROOT, summaryFormat, "condition", "topic", "metric", "expected"));
+    summary.append(String.format(Locale.ROOT, summaryFormat,
       repeat('-', conditionWidth), repeat('-', topicWidth), repeat('-', metricWidth), repeat('-', expectedWidth)));
 
     String previousCondition = null;
@@ -475,7 +475,7 @@ public class ReproduceFromPrebuiltIndexes {
       if (previousCondition != null && !row[0].equals(previousCondition)) {
         summary.append(System.lineSeparator());
       }
-      summary.append(String.format(summaryFormat, row[0], row[1], row[2], row[3]));
+      summary.append(String.format(Locale.ROOT, summaryFormat, row[0], row[1], row[2], row[3]));
       previousCondition = row[0];
     }
     summary.append(System.lineSeparator());

--- a/src/main/java/io/anserini/reproduce/ReproductionUtils.java
+++ b/src/main/java/io/anserini/reproduce/ReproductionUtils.java
@@ -32,6 +32,7 @@ import java.util.Enumeration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -41,7 +42,7 @@ import org.apache.logging.log4j.Logger;
 public final class ReproductionUtils {
   private static final Logger LOG = LogManager.getLogger(ReproductionUtils.class);
 
-  private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z").withZone(ZoneId.systemDefault());
+  private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z", Locale.ROOT).withZone(ZoneId.systemDefault());
 
   private ReproductionUtils() {}
 
@@ -106,7 +107,7 @@ public final class ReproductionUtils {
     long hours = seconds / 3600;
     long minutes = (seconds % 3600) / 60;
     long secs = seconds % 60;
-    return String.format("%s%02d:%02d:%02d", duration.isNegative() ? "-" : "", hours, minutes, secs);
+    return String.format(Locale.ROOT, "%s%02d:%02d:%02d", duration.isNegative() ? "-" : "", hours, minutes, secs);
   }
 
   public static String escapeJson(String value) {

--- a/src/main/java/io/anserini/reproduce/RunJavaReproductionCommands.java
+++ b/src/main/java/io/anserini/reproduce/RunJavaReproductionCommands.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
@@ -93,7 +94,7 @@ public class RunJavaReproductionCommands {
     try {
       parser.parseArgument(args);
     } catch (CmdLineException e) {
-      System.err.println(String.format("Error: %s", e.getMessage()));
+      System.err.println(String.format(Locale.ROOT, "Error: %s", e.getMessage()));
       CliUtils.printUsage(parser, RunJavaReproductionCommands.class, argsOrdering);
       return;
     }
@@ -163,7 +164,7 @@ public class RunJavaReproductionCommands {
         nextCommand++;
       }
 
-      String loadString = loadAvailable ? String.format("%.1f", currentLoad) : "N/A";
+      String loadString = loadAvailable ? String.format(Locale.ROOT, "%.1f", currentLoad) : "N/A";
       LOG.info("Current load: {} (threshold = {}), active jobs: {} (max = {})", loadString, args.load, active.size(), args.max);
 
       if (active.size() > 0) {
@@ -275,11 +276,11 @@ public class RunJavaReproductionCommands {
 
         boolean fromPrebuilt = resource.contains("prebuilt");
         if (fromPrebuilt && !command.contains("--runs-directory")) {
-          command = String.format("%s --runs-directory %s", command, runsDirectory);
+          command = String.format(Locale.ROOT, "%s --runs-directory %s", command, runsDirectory);
         }
 
-        String logFile = Paths.get(logsDirectory, String.format("log.%s.%s.txt", fromPrebuilt ? "from-prebuilt-indexes" : "from-document-collection", configName)).toString();
-        commands.add(String.format("%s %s %s %s > %s 2>&1", ReproductionUtils.Constants.JAVA_PREFIX, fatjarPath, ReproductionUtils.Constants.JVM_ARGS, command, logFile));
+        String logFile = Paths.get(logsDirectory, String.format(Locale.ROOT, "log.%s.%s.txt", fromPrebuilt ? "from-prebuilt-indexes" : "from-document-collection", configName)).toString();
+        commands.add(String.format(Locale.ROOT, "%s %s %s %s > %s 2>&1", ReproductionUtils.Constants.JAVA_PREFIX, fatjarPath, ReproductionUtils.Constants.JVM_ARGS, command, logFile));
       }
     }
 

--- a/src/main/java/io/anserini/reproduce/SummarizeLogsFromDocumentCollection.java
+++ b/src/main/java/io/anserini/reproduce/SummarizeLogsFromDocumentCollection.java
@@ -81,7 +81,7 @@ public class SummarizeLogsFromDocumentCollection {
     try {
       parser.parseArgument(args);
     } catch (CmdLineException e) {
-      System.err.println(String.format("Error: %s", e.getMessage()));
+      System.err.println(String.format(Locale.ROOT, "Error: %s", e.getMessage()));
       CliUtils.printUsage(parser, SummarizeLogsFromDocumentCollection.class, argsOrdering);
       return;
     }

--- a/src/main/java/io/anserini/reproduce/SummarizeLogsFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/SummarizeLogsFromPrebuiltIndexes.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -70,7 +71,7 @@ public class SummarizeLogsFromPrebuiltIndexes {
     try {
       parser.parseArgument(args);
     } catch (CmdLineException e) {
-      System.err.println(String.format("Error: %s", e.getMessage()));
+      System.err.println(String.format(Locale.ROOT, "Error: %s", e.getMessage()));
       CliUtils.printUsage(parser, SummarizeLogsFromPrebuiltIndexes.class, argsOrdering);
       return;
     }

--- a/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import org.junit.After;
@@ -103,16 +104,25 @@ public class ReproduceFromPrebuiltIndexesTest extends StdOutStdErrRedirectableLu
   @Test
   public void testCacmEndToEnd() throws Exception {
     Path runsDirectory = createTempDir("runs");
+    Locale previousLocale = Locale.getDefault();
 
-    ReproduceFromPrebuiltIndexes.main(new String[] {
-        "--config", "cacm",
-        "--runs-directory", runsDirectory.toString()
-    });
+    try {
+      Locale.setDefault(Locale.forLanguageTag("ar-LB"));
+      ReproduceFromPrebuiltIndexes.main(new String[] {
+          "--config", "cacm",
+          "--runs-directory", runsDirectory.toString()
+      });
+    } finally {
+      Locale.setDefault(previousLocale);
+    }
 
     String output = out.toString();
     assertTrue(output, output.contains("Run successfully completed!"));
-    assertTrue(output, output.matches("(?s).*MAP: 0[.,]3123.*"));
-    assertTrue(output, output.matches("(?s).*P30: 0[.,]1942.*"));
+    assertTrue(output, output.contains("Indexes referenced by this run (1 total):"));
+    assertTrue(output, output.contains("Total size across 1 of 1 indexes:"));
+    assertTrue(output, output.contains("MAP: 0.3123"));
+    assertTrue(output, output.contains("P30: 0.1942"));
+    assertTrue(output, output.matches("(?s).*Duration:\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}.*"));
     assertFalse(output.contains("NumberFormatException"));
     assertTrue(Files.exists(runsDirectory.resolve("run.cacm.bm25.cacm.txt")));
   }


### PR DESCRIPTION
## Summary

- Make reproduction package formatting locale-stable with `Locale.ROOT`.
- Prevent randomized locale runs from emitting localized digits/decimal separators in reproduction logs.
- Add regression coverage for `ReproduceFromPrebuiltIndexesTest` using `ar-LB`.

## Validation

- `mvn -Dtest=ReproduceFromPrebuiltIndexesTest test`
- `mvn -Dtest=ReproduceFromPrebuiltIndexesTest#testCacmEndToEnd -Dtests.seed=C3765A39C8A9E9A5 -Dtests.locale=ar-LB -Dtests.timezone=Africa/Asmara -Dtests.asserts=true -Dtests.file.encoding=UTF-8 test`
- `mvn -Dtest=ReproduceFromPrebuiltIndexesTest,ReproduceFromDocumentCollectionTest,SummarizeLogsFromDocumentCollectionTest,SummarizeLogsFromPrebuiltIndexesTest,RunJavaReproductionCommandsTest test`
- `mvn -Dtest=RunJavaReproductionCommandsTest test`