### PR TITLE
[codex] Update SPLADE-v3 ONNX reproduction topics

### DIFF
--- a/docs/reproduce/from-document-collection/dl19-passage.splade-v3.onnx.md
+++ b/docs/reproduce/from-document-collection/dl19-passage.splade-v3.onnx.md
@@ -80,43 +80,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v1-passage.splade-v3/ \
-  -topics tools/topics-and-qrels/topics.dl19-passage.splade-v3.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl19-passage.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl19-passage.splade-v3.txt \
-  -impact -pretokenized &
+  -output runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl19-passage.txt \
+  -impact -pretokenized -encoder SpladeV3 &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v1-passage.splade-v3/ \
-  -topics tools/topics-and-qrels/topics.dl19-passage.splade-v3.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl19-passage.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl19-passage.splade-v3.txt \
-  -impact -pretokenized -rm3 &
+  -output runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl19-passage.txt \
+  -impact -pretokenized -rm3 -encoder SpladeV3 &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v1-passage.splade-v3/ \
-  -topics tools/topics-and-qrels/topics.dl19-passage.splade-v3.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl19-passage.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl19-passage.splade-v3.txt \
-  -impact -pretokenized -rocchio &
+  -output runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl19-passage.txt \
+  -impact -pretokenized -rocchio -encoder SpladeV3 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl19-passage.splade-v3.txt
-bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl19-passage.splade-v3.txt
-bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl19-passage.splade-v3.txt
-bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl19-passage.splade-v3.txt
+bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl19-passage.txt
+bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl19-passage.txt
+bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl19-passage.txt
+bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl19-passage.txt
 
-bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl19-passage.splade-v3.txt
-bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl19-passage.splade-v3.txt
-bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl19-passage.splade-v3.txt
-bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl19-passage.splade-v3.txt
+bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl19-passage.txt
+bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl19-passage.txt
+bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl19-passage.txt
+bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl19-passage.txt
 
-bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl19-passage.splade-v3.txt
-bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl19-passage.splade-v3.txt
-bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl19-passage.splade-v3.txt
-bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl19-passage.splade-v3.txt
+bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl19-passage.txt
+bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl19-passage.txt
+bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl19-passage.txt
+bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl19-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl19-passage.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/dl20-passage.splade-v3.onnx.md
+++ b/docs/reproduce/from-document-collection/dl20-passage.splade-v3.onnx.md
@@ -80,43 +80,43 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v1-passage.splade-v3/ \
-  -topics tools/topics-and-qrels/topics.dl20.splade-v3.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl20.splade-v3.txt \
-  -impact -pretokenized &
+  -output runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl20.txt \
+  -impact -pretokenized -encoder SpladeV3 &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v1-passage.splade-v3/ \
-  -topics tools/topics-and-qrels/topics.dl20.splade-v3.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl20.splade-v3.txt \
-  -impact -pretokenized -rm3 &
+  -output runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl20.txt \
+  -impact -pretokenized -rm3 -encoder SpladeV3 &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v1-passage.splade-v3/ \
-  -topics tools/topics-and-qrels/topics.dl20.splade-v3.tsv.gz \
+  -topics tools/topics-and-qrels/topics.dl20.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl20.splade-v3.txt \
-  -impact -pretokenized -rocchio &
+  -output runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl20.txt \
+  -impact -pretokenized -rocchio -encoder SpladeV3 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl20.splade-v3.txt
-bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl20.splade-v3.txt
-bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl20.splade-v3.txt
-bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl20.splade-v3.txt
+bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl20.txt
+bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl20.txt
+bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl20.txt
+bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.dl20.txt
 
-bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl20.splade-v3.txt
-bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl20.splade-v3.txt
-bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl20.splade-v3.txt
-bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl20.splade-v3.txt
+bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl20.txt
+bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl20.txt
+bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl20.txt
+bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rm3.topics.dl20.txt
 
-bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl20.splade-v3.txt
-bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl20.splade-v3.txt
-bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl20.splade-v3.txt
-bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl20.splade-v3.txt
+bin/trec_eval -m map -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl20.txt
+bin/trec_eval -m ndcg_cut.10 -c tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl20.txt
+bin/trec_eval -m recall.100 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl20.txt
+bin/trec_eval -m recall.1000 -c -l 2 tools/topics-and-qrels/qrels.dl20-passage.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx+rocchio.topics.dl20.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/msmarco-v1-passage.splade-v3.onnx.md
+++ b/docs/reproduce/from-document-collection/msmarco-v1-passage.splade-v3.onnx.md
@@ -76,19 +76,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v1-passage.splade-v3/ \
-  -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.splade-v3.tsv.gz \
+  -topics tools/topics-and-qrels/topics.msmarco-passage.dev-subset.txt \
   -topicReader TsvInt \
-  -output runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.msmarco-passage.dev-subset.splade-v3.txt \
-  -impact -pretokenized &
+  -output runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.msmarco-passage.dev-subset.txt \
+  -impact -pretokenized -encoder SpladeV3 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.msmarco-passage.dev-subset.splade-v3.txt
-bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.msmarco-passage.dev-subset.splade-v3.txt
-bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.msmarco-passage.dev-subset.splade-v3.txt
-bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.msmarco-passage.dev-subset.splade-v3.txt
+bin/trec_eval -c -m map tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.msmarco-passage.dev-subset.txt
+bin/trec_eval -c -M 10 -m recip_rank tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.msmarco-passage.dev-subset.txt
+bin/trec_eval -c -m recall.100 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.msmarco-passage.dev-subset.txt
+bin/trec_eval -c -m recall.1000 tools/topics-and-qrels/qrels.msmarco-passage.dev-subset.txt runs/run.msmarco-passage-splade-v3.splade-v3-onnx.topics.msmarco-passage.dev-subset.txt
 ```
 
 ## Effectiveness

--- a/src/main/resources/reproduce/from-document-collection/configs/dl19-passage.splade-v3.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/dl19-passage.splade-v3.onnx.yaml
@@ -49,13 +49,13 @@ topic_reader: TsvInt
 topics:
   - name: "[DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)"
     id: dl19
-    path: topics.dl19-passage.splade-v3.tsv.gz
+    path: topics.dl19-passage.txt
     qrel: qrels.dl19-passage.txt
 
 models:
   - name: splade-v3-onnx
     display: SPLADEv3
-    params: -impact -pretokenized
+    params: -impact -pretokenized -encoder SpladeV3
     results:
       AP@1000:
         - 0.5231
@@ -67,7 +67,7 @@ models:
         - 0.8791
   - name: splade-v3-onnx+rm3
     display: +RM3
-    params: -impact -pretokenized -rm3
+    params: -impact -pretokenized -rm3 -encoder SpladeV3
     results:
       AP@1000:
         - 0.5296
@@ -79,7 +79,7 @@ models:
         - 0.8625
   - name: splade-v3-onnx+rocchio
     display: +Rocchio
-    params: -impact -pretokenized -rocchio
+    params: -impact -pretokenized -rocchio -encoder SpladeV3
     results:
       AP@1000:
         - 0.5374

--- a/src/main/resources/reproduce/from-document-collection/configs/dl20-passage.splade-v3.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/dl20-passage.splade-v3.onnx.yaml
@@ -49,13 +49,13 @@ topic_reader: TsvInt
 topics:
   - name: "[DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)"
     id: dl20
-    path: topics.dl20.splade-v3.tsv.gz
+    path: topics.dl20.txt
     qrel: qrels.dl20-passage.txt
 
 models:
   - name: splade-v3-onnx
     display: SPLADEv3
-    params: -impact -pretokenized
+    params: -impact -pretokenized -encoder SpladeV3
     results:
       AP@1000:
         - 0.5402
@@ -67,7 +67,7 @@ models:
         - 0.9039
   - name: splade-v3-onnx+rm3
     display: +RM3
-    params: -impact -pretokenized -rm3
+    params: -impact -pretokenized -rm3 -encoder SpladeV3
     results:
       AP@1000:
         - 0.5493
@@ -79,7 +79,7 @@ models:
         - 0.9316
   - name: splade-v3-onnx+rocchio
     display: +Rocchio
-    params: -impact -pretokenized -rocchio
+    params: -impact -pretokenized -rocchio -encoder SpladeV3
     results:
       AP@1000:
         - 0.5456

--- a/src/main/resources/reproduce/from-document-collection/configs/msmarco-v1-passage.splade-v3.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/msmarco-v1-passage.splade-v3.onnx.yaml
@@ -49,13 +49,13 @@ topic_reader: TsvInt
 topics:
   - name: "[MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)"
     id: dev
-    path: topics.msmarco-passage.dev-subset.splade-v3.tsv.gz
+    path: topics.msmarco-passage.dev-subset.txt
     qrel: qrels.msmarco-passage.dev-subset.txt
 
 models:
   - name: splade-v3-onnx
     display: SPLADEv3
-    params: -impact -pretokenized
+    params: -impact -pretokenized -encoder SpladeV3
     results:
       AP@1000:
         - 0.4049


### PR DESCRIPTION
## Summary

- Update MS MARCO passage SPLADE-v3 ONNX reproduction configs to use raw text topic files with `-encoder SpladeV3`.
- Refresh the corresponding generated reproduction docs and run filenames.

## Validation

- `git diff --stat -- docs/reproduce/from-document-collection/dl19-passage.splade-v3.onnx.md docs/reproduce/from-document-collection/dl20-passage.splade-v3.onnx.md docs/reproduce/from-document-collection/msmarco-v1-passage.splade-v3.onnx.md src/main/resources/reproduce/from-document-collection/configs/dl19-passage.splade-v3.onnx.yaml src/main/resources/reproduce/from-document-collection/configs/dl20-passage.splade-v3.onnx.yaml src/main/resources/reproduce/from-document-collection/configs/msmarco-v1-passage.splade-v3.onnx.yaml`