### PR TITLE
Add SPLADE-v3 reproduction log entry

### DIFF
--- a/docs/reproduce/from-document-collection/msmarco-v1-passage.splade-v3.onnx.md
+++ b/docs/reproduce/from-document-collection/msmarco-v1-passage.splade-v3.onnx.md
@@ -110,4 +110,4 @@ With the above commands, you should be able to reproduce the following results:
 To add to this reproduction log, modify [this template](../../../src/main/resources/reproduce/from-document-collection/docgen/msmarco-v1-passage.splade-v3.onnx.template) and run `bin/build.sh` to rebuild the documentation.
 
 + Results reproduced by [@lintool](https://github.com/lintool) on 2025-06-01 (commit [`847378d`](https://github.com/castorini/anserini/commit/847378da49168629bee56e9e82ff8c1a94a87ef4))
-+ Results reproduced by [@Bashir486](https://github.com/Bashir486) on 2026-05-23 (commit [`878b97d`](https://github.com/castorini/anserini/commit/878b97d))
++ Results reproduced by [@Bashir486](https://github.com/Bashir486) on 2026-05-23 (commit [`878b97d`](https://github.com/castorini/anserini/commit/878b97da258ea6350c1cb3693f684ae337fc5e56))

--- a/docs/reproduce/from-document-collection/msmarco-v1-passage.splade-v3.onnx.md
+++ b/docs/reproduce/from-document-collection/msmarco-v1-passage.splade-v3.onnx.md
@@ -110,3 +110,4 @@ With the above commands, you should be able to reproduce the following results:
 To add to this reproduction log, modify [this template](../../../src/main/resources/reproduce/from-document-collection/docgen/msmarco-v1-passage.splade-v3.onnx.template) and run `bin/build.sh` to rebuild the documentation.
 
 + Results reproduced by [@lintool](https://github.com/lintool) on 2025-06-01 (commit [`847378d`](https://github.com/castorini/anserini/commit/847378da49168629bee56e9e82ff8c1a94a87ef4))
++ Results reproduced by [@Bashir486](https://github.com/Bashir486) on 2026-05-23 (commit [`878b97d`](https://github.com/castorini/anserini/commit/878b97d))

--- a/src/main/resources/reproduce/from-document-collection/docgen/msmarco-v1-passage.splade-v3.onnx.template
+++ b/src/main/resources/reproduce/from-document-collection/docgen/msmarco-v1-passage.splade-v3.onnx.template
@@ -87,4 +87,4 @@ ${effectiveness}
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
 
 + Results reproduced by [@lintool](https://github.com/lintool) on 2025-06-01 (commit [`847378d`](https://github.com/castorini/anserini/commit/847378da49168629bee56e9e82ff8c1a94a87ef4))
-+ Results reproduced by [@Bashir486](https://github.com/Bashir486) on 2026-05-23 (commit [`878b97d`](https://github.com/castorini/anserini/commit/878b97d))
++ Results reproduced by [@Bashir486](https://github.com/Bashir486) on 2026-05-23 (commit [`878b97d`](https://github.com/castorini/anserini/commit/878b97da258ea6350c1cb3693f684ae337fc5e56))

--- a/src/main/resources/reproduce/from-document-collection/docgen/msmarco-v1-passage.splade-v3.onnx.template
+++ b/src/main/resources/reproduce/from-document-collection/docgen/msmarco-v1-passage.splade-v3.onnx.template
@@ -87,3 +87,4 @@ ${effectiveness}
 To add to this reproduction log, modify [this template](${template}) and run `bin/build.sh` to rebuild the documentation.
 
 + Results reproduced by [@lintool](https://github.com/lintool) on 2025-06-01 (commit [`847378d`](https://github.com/castorini/anserini/commit/847378da49168629bee56e9e82ff8c1a94a87ef4))
++ Results reproduced by [@Bashir486](https://github.com/Bashir486) on 2026-05-23 (commit [`878b97d`](https://github.com/castorini/anserini/commit/878b97d))


### PR DESCRIPTION
Added reproduction log entry for SPLADE-v3 ONNX reproduction following successful reproduction on the latest upstream commit.
