### PR TITLE
[codex] Add uniCOIL ONNX reproduction configs

### DIFF
--- a/src/main/resources/reproduce/from-document-collection/configs/dl19-doc-segmented.unicoil.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/dl19-doc-segmented.unicoil.onnx.yaml
@@ -1,0 +1,91 @@
+---
+corpus: msmarco-doc-segmented-unicoil
+corpus_path: collections/msmarco/msmarco-doc-segmented-unicoil/
+
+download_url: https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil.tar
+download_checksum: 6a00e2c0c375cb1e52c83ae5ac377ebb
+
+index_path: indexes/lucene-inverted.msmarco-v1-doc-segmented.unicoil/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 16
+index_options: -impact -pretokenized -storeDocvectors
+index_stats:
+  documents: 20545677
+  documents (non-empty): 20545677
+  total terms: 214505277898
+
+metrics:
+  - metric: AP@100
+    command: bin/trec_eval
+    params: -c -M 100 -m map # Note, this is different DL 2019 passage ranking!
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topics:
+  - name: "[DL19 (Doc)](https://trec.nist.gov/data/deep2019.html)"
+    id: dl19
+    path: topics.dl19-doc.txt
+    qrel: qrels.dl19-doc.txt
+
+models:
+  - name: unicoil
+    display: uniCOIL (with doc2query-T5 expansions)
+    params: -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -encoder UniCoil
+    results:
+      AP@100:
+        - 0.2789
+      nDCG@10:
+        - 0.6396
+      R@100:
+        - 0.4099
+      R@1000:
+        - 0.6652
+  - name: unicoil+rm3
+    display: +RM3
+    params: -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -encoder UniCoil
+    results:
+      AP@100:
+        - 0.3136
+      nDCG@10:
+        - 0.6781
+      R@100:
+        - 0.4501
+      R@1000:
+        - 0.7275
+  - name: unicoil+rocchio
+    display: +Rocchio
+    params: -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -encoder UniCoil
+    results:
+      AP@100:
+        - 0.3199
+      nDCG@10:
+        - 0.6839
+      R@100:
+        - 0.4539
+      R@1000:
+        - 0.7305

--- a/src/main/resources/reproduce/from-document-collection/configs/dl19-passage.unicoil.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/dl19-passage.unicoil.onnx.yaml
@@ -1,0 +1,91 @@
+---
+corpus: msmarco-passage-unicoil
+corpus_path: collections/msmarco/msmarco-passage-unicoil/
+
+download_url: https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil.tar
+download_checksum: 78eef752c78c8691f7d61600ceed306f
+
+index_path: indexes/lucene-inverted.msmarco-v1-passage.unicoil/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 16
+index_options: -impact -pretokenized -storeDocvectors
+index_stats:
+  documents: 8841823
+  documents (non-empty): 8841823
+  total terms: 44495093768
+
+metrics:
+  - metric: AP@1000
+    command: bin/trec_eval
+    params: -m map -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -m ndcg_cut.10 -c
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -m recall.100 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -m recall.1000 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topics:
+  - name: "[DL19 (Passage)](https://trec.nist.gov/data/deep2019.html)"
+    id: dl19
+    path: topics.dl19-passage.txt
+    qrel: qrels.dl19-passage.txt
+
+models:
+  - name: unicoil
+    display: uniCOIL (with doc2query-T5 expansions)
+    params: -impact -pretokenized -encoder UniCoil
+    results:
+      AP@1000:
+        - 0.4612
+      nDCG@10:
+        - 0.7024
+      R@100:
+        - 0.6054
+      R@1000:
+        - 0.8292
+  - name: unicoil+rm3
+    display: +RM3
+    params: -impact -pretokenized -rm3 -encoder UniCoil
+    results:
+      AP@1000:
+        - 0.4641
+      nDCG@10:
+        - 0.6761
+      R@100:
+        - 0.6207
+      R@1000:
+        - 0.8598
+  - name: unicoil+rocchio
+    display: +Rocchio
+    params: -impact -pretokenized -rocchio -encoder UniCoil
+    results:
+      AP@1000:
+        - 0.4603
+      nDCG@10:
+        - 0.6658
+      R@100:
+        - 0.6211
+      R@1000:
+        - 0.8515

--- a/src/main/resources/reproduce/from-document-collection/configs/dl20-doc-segmented.unicoil.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/dl20-doc-segmented.unicoil.onnx.yaml
@@ -1,0 +1,91 @@
+---
+corpus: msmarco-doc-segmented-unicoil
+corpus_path: collections/msmarco/msmarco-doc-segmented-unicoil/
+
+download_url: https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil.tar
+download_checksum: 6a00e2c0c375cb1e52c83ae5ac377ebb
+
+index_path: indexes/lucene-inverted.msmarco-v1-doc-segmented.unicoil/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 16
+index_options: -impact -pretokenized -storeDocvectors
+index_stats:
+  documents: 20545677
+  documents (non-empty): 20545677
+  total terms: 214505277898
+
+metrics:
+  - metric: AP@100
+    command: bin/trec_eval
+    params: -c -M 100 -m map # Note, this is different DL 2020 passage ranking!
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topics:
+  - name: "[DL20 (Doc)](https://trec.nist.gov/data/deep2020.html)"
+    id: dl20
+    path: topics.dl20.txt
+    qrel: qrels.dl20-doc.txt
+
+models:
+  - name: unicoil
+    display: uniCOIL (with doc2query-T5 expansions)
+    params: -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -encoder UniCoil
+    results:
+      AP@100:
+        - 0.3882
+      nDCG@10:
+        - 0.6033
+      R@100:
+        - 0.6210
+      R@1000:
+        - 0.7869
+  - name: unicoil+rm3
+    display: +RM3
+    params: -impact -pretokenized -rm3 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -encoder UniCoil
+    results:
+      AP@100:
+        - 0.4262
+      nDCG@10:
+        - 0.6220
+      R@100:
+        - 0.6499
+      R@1000:
+        - 0.8229
+  - name: unicoil+rocchio
+    display: +Rocchio
+    params: -impact -pretokenized -rocchio -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -encoder UniCoil
+    results:
+      AP@100:
+        - 0.4342
+      nDCG@10:
+        - 0.6219
+      R@100:
+        - 0.6624
+      R@1000:
+        - 0.8290

--- a/src/main/resources/reproduce/from-document-collection/configs/dl20-passage.unicoil.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/dl20-passage.unicoil.onnx.yaml
@@ -1,0 +1,91 @@
+---
+corpus: msmarco-passage-unicoil
+corpus_path: collections/msmarco/msmarco-passage-unicoil/
+
+download_url: https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil.tar
+download_checksum: 78eef752c78c8691f7d61600ceed306f
+
+index_path: indexes/lucene-inverted.msmarco-v1-passage.unicoil/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 16
+index_options: -impact -pretokenized -storeDocvectors
+index_stats:
+  documents: 8841823
+  documents (non-empty): 8841823
+  total terms: 44495093768
+
+metrics:
+  - metric: AP@1000
+    command: bin/trec_eval
+    params: -m map -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -m ndcg_cut.10 -c
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -m recall.100 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -m recall.1000 -c -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topics:
+  - name: "[DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)"
+    id: dl20
+    path: topics.dl20.txt
+    qrel: qrels.dl20-passage.txt
+
+models:
+  - name: unicoil
+    display: uniCOIL (with doc2query-T5 expansions)
+    params: -impact -pretokenized -encoder UniCoil
+    results:
+      AP@1000:
+        - 0.4430
+      nDCG@10:
+        - 0.6745
+      R@100:
+        - 0.7006
+      R@1000:
+        - 0.8430
+  - name: unicoil+rm3
+    display: +RM3
+    params: -impact -pretokenized -rm3 -encoder UniCoil
+    results:
+      AP@1000:
+        - 0.4478
+      nDCG@10:
+        - 0.6497
+      R@100:
+        - 0.6822
+      R@1000:
+        - 0.8417
+  - name: unicoil+rocchio
+    display: +Rocchio
+    params: -impact -pretokenized -rocchio -encoder UniCoil
+    results:
+      AP@1000:
+        - 0.4539
+      nDCG@10:
+        - 0.6599
+      R@100:
+        - 0.7096
+      R@1000:
+        - 0.8610

--- a/src/main/resources/reproduce/from-document-collection/configs/dl21-doc-segmented.unicoil.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/dl21-doc-segmented.unicoil.onnx.yaml
@@ -1,0 +1,105 @@
+---
+corpus: msmarco-v2-doc-segmented-unicoil-0shot-v2
+corpus_path: collections/msmarco/msmarco_v2_doc_segmented_unicoil_0shot_v2/
+
+download_url: https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco_v2_doc_segmented_unicoil_0shot_v2.tar
+download_checksum: c5639748c2cbad0152e10b0ebde3b804
+download_corpus: msmarco_v2_doc_segmented_unicoil_0shot_v2
+
+index_path: indexes/lucene-inverted.msmarco-v2-doc-segmented.unicoil-0shot-v2/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 24
+index_options: -impact -pretokenized -storeRaw
+index_stats:
+  documents: 124131414
+  documents (non-empty): 124131414
+  total terms: 1204542769110
+
+metrics:
+  - metric: MAP@100
+    command: bin/trec_eval
+    params: -c -M 100 -m map
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: no
+  - metric: MRR@100
+    command: bin/trec_eval
+    params: -c -M 100 -m recip_rank
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: true
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: true
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topics:
+  - name: "[DL21 (Doc)](https://microsoft.github.io/msmarco/TREC-Deep-Learning)"
+    id: dl21
+    path: topics.dl21.txt
+    qrel: qrels.dl21-doc.txt
+
+models:
+  - name: unicoil
+    display: uniCOIL (with doc2query-T5) zero-shot
+    params: -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.2718
+      MRR@100:
+        - 0.9684
+      nDCG@10:
+        - 0.6783
+      R@100:
+        - 0.3700
+      R@1000:
+        - 0.7069
+  - name: unicoil+rm3
+    display: +RM3
+    params: -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -rm3 -collection JsonVectorCollection -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.3293
+      MRR@100:
+        - 0.9357
+      nDCG@10:
+        - 0.6980
+      R@100:
+        - 0.4233
+      R@1000:
+        - 0.7611
+  - name: unicoil+rocchio
+    display: +Rocchio
+    params: -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -rocchio -collection JsonVectorCollection -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.3434
+      MRR@100:
+        - 0.9649
+      nDCG@10:
+        - 0.7061
+      R@100:
+        - 0.4374
+      R@1000:
+        - 0.7809

--- a/src/main/resources/reproduce/from-document-collection/configs/dl21-passage.unicoil.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/dl21-passage.unicoil.onnx.yaml
@@ -1,0 +1,105 @@
+---
+corpus: msmarco-v2-passage-unicoil-0shot
+corpus_path: collections/msmarco/msmarco_v2_passage_unicoil_0shot/
+
+download_url: https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco_v2_passage_unicoil_0shot.tar
+download_checksum: 1949a00bfd5e1f1a230a04bbc1f01539
+download_corpus: msmarco_v2_passage_unicoil_0shot
+
+index_path: indexes/lucene-inverted.msmarco-v2-passage.unicoil-0shot/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 24
+index_options: -impact -pretokenized -storeRaw
+index_stats:
+  documents: 138364198
+  documents (non-empty): 138364198
+  total terms: 775253560148
+
+metrics:
+  - metric: MAP@100
+    command: bin/trec_eval
+    params: -c -M 100 -m map -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: MRR@100
+    command: bin/trec_eval
+    params: -c -M 100 -m recip_rank -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100 -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000 -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topics:
+  - name: "[DL21 (Passage)](https://microsoft.github.io/msmarco/TREC-Deep-Learning)"
+    id: dl21
+    path: topics.dl21.txt
+    qrel: qrels.dl21-passage.txt
+
+models:
+  - name: unicoil
+    display: uniCOIL (with doc2query-T5) zero-shot
+    params: -impact -pretokenized -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.2538
+      MRR@100:
+        - 0.7311
+      nDCG@10:
+        - 0.6159
+      R@100:
+        - 0.4731
+      R@1000:
+        - 0.7551
+  - name: unicoil+rm3
+    display: +RM3
+    params: -impact -pretokenized -rm3 -collection JsonVectorCollection -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.2869
+      MRR@100:
+        - 0.7399
+      nDCG@10:
+        - 0.6164
+      R@100:
+        - 0.5141
+      R@1000:
+        - 0.7889
+  - name: unicoil+rocchio
+    display: +Rocchio
+    params: -impact -pretokenized -rocchio -collection JsonVectorCollection -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.2890
+      MRR@100:
+        - 0.7749
+      nDCG@10:
+        - 0.6383
+      R@100:
+        - 0.5147
+      R@1000:
+        - 0.8096

--- a/src/main/resources/reproduce/from-document-collection/configs/dl22-doc-segmented.unicoil.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/dl22-doc-segmented.unicoil.onnx.yaml
@@ -1,0 +1,105 @@
+---
+corpus: msmarco-v2-doc-segmented-unicoil-0shot-v2
+corpus_path: collections/msmarco/msmarco_v2_doc_segmented_unicoil_0shot_v2/
+
+download_url: https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco_v2_doc_segmented_unicoil_0shot_v2.tar
+download_checksum: c5639748c2cbad0152e10b0ebde3b804
+download_corpus: msmarco_v2_doc_segmented_unicoil_0shot_v2
+
+index_path: indexes/lucene-inverted.msmarco-v2-doc-segmented.unicoil-0shot-v2/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 24
+index_options: -impact -pretokenized -storeRaw
+index_stats:
+  documents: 124131414
+  documents (non-empty): 124131414
+  total terms: 1204542769110
+
+metrics:
+  - metric: MAP@100
+    command: bin/trec_eval
+    params: -c -M 100 -m map
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: no
+  - metric: MRR@100
+    command: bin/trec_eval
+    params: -c -M 100 -m recip_rank
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: true
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: true
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topics:
+  - name: "[DL22 (Doc)](https://microsoft.github.io/msmarco/TREC-Deep-Learning)"
+    id: dl22
+    path: topics.dl22.txt
+    qrel: qrels.dl22-doc.txt
+
+models:
+  - name: unicoil
+    display: uniCOIL (with doc2query-T5)
+    params: -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.1400
+      MRR@100:
+        - 0.8170
+      nDCG@10:
+        - 0.4451
+      R@100:
+        - 0.2656
+      R@1000:
+        - 0.5235
+  - name: unicoil+rm3
+    display: +RM3
+    params: -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -rm3 -collection JsonVectorCollection -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.1598
+      MRR@100:
+        - 0.8293
+      nDCG@10:
+        - 0.4570
+      R@100:
+        - 0.2810
+      R@1000:
+        - 0.5586
+  - name: unicoil+rocchio
+    display: +Rocchio
+    params: -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -rocchio -collection JsonVectorCollection -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.1701
+      MRR@100:
+        - 0.8315
+      nDCG@10:
+        - 0.4767
+      R@100:
+        - 0.2991
+      R@1000:
+        - 0.5783

--- a/src/main/resources/reproduce/from-document-collection/configs/dl22-passage.unicoil.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/dl22-passage.unicoil.onnx.yaml
@@ -1,0 +1,105 @@
+---
+corpus: msmarco-v2-passage-unicoil-0shot
+corpus_path: collections/msmarco/msmarco_v2_passage_unicoil_0shot/
+
+download_url: https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco_v2_passage_unicoil_0shot.tar
+download_checksum: 1949a00bfd5e1f1a230a04bbc1f01539
+download_corpus: msmarco_v2_passage_unicoil_0shot
+
+index_path: indexes/lucene-inverted.msmarco-v2-passage.unicoil-0shot/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 24
+index_options: -impact -pretokenized -storeRaw
+index_stats:
+  documents: 138364198
+  documents (non-empty): 138364198
+  total terms: 775253560148
+
+metrics:
+  - metric: MAP@100
+    command: bin/trec_eval
+    params: -c -M 100 -m map -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: MRR@100
+    command: bin/trec_eval
+    params: -c -M 100 -m recip_rank -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100 -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000 -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topics:
+  - name: "[DL22 (Passage)](https://microsoft.github.io/msmarco/TREC-Deep-Learning)"
+    id: dl22
+    path: topics.dl22.txt
+    qrel: qrels.dl22-passage.txt
+
+models:
+  - name: unicoil
+    display: uniCOIL (with doc2query-T5)
+    params: -impact -pretokenized -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.1050
+      MRR@100:
+        - 0.5831
+      nDCG@10:
+        - 0.4614
+      R@100:
+        - 0.2716
+      R@1000:
+        - 0.5253
+  - name: unicoil+rm3
+    display: +RM3
+    params: -impact -pretokenized -rm3 -collection JsonVectorCollection -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.1170
+      MRR@100:
+        - 0.5634
+      nDCG@10:
+        - 0.4608
+      R@100:
+        - 0.2751
+      R@1000:
+        - 0.5372
+  - name: unicoil+rocchio
+    display: +Rocchio
+    params: -impact -pretokenized -rocchio -collection JsonVectorCollection -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.1225
+      MRR@100:
+        - 0.5577
+      nDCG@10:
+        - 0.4886
+      R@100:
+        - 0.2860
+      R@1000:
+        - 0.5559

--- a/src/main/resources/reproduce/from-document-collection/configs/dl23-doc-segmented.unicoil.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/dl23-doc-segmented.unicoil.onnx.yaml
@@ -1,0 +1,105 @@
+---
+corpus: msmarco-v2-doc-segmented-unicoil-0shot-v2
+corpus_path: collections/msmarco/msmarco_v2_doc_segmented_unicoil_0shot_v2/
+
+download_url: https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco_v2_doc_segmented_unicoil_0shot_v2.tar
+download_checksum: c5639748c2cbad0152e10b0ebde3b804
+download_corpus: msmarco_v2_doc_segmented_unicoil_0shot_v2
+
+index_path: indexes/lucene-inverted.msmarco-v2-doc-segmented.unicoil-0shot-v2/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 24
+index_options: -impact -pretokenized -storeRaw
+index_stats:
+  documents: 124131414
+  documents (non-empty): 124131414
+  total terms: 1204542769110
+
+metrics:
+  - metric: MAP@100
+    command: bin/trec_eval
+    params: -c -M 100 -m map
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: no
+  - metric: MRR@100
+    command: bin/trec_eval
+    params: -c -M 100 -m recip_rank
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: true
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: true
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topics:
+  - name: "[DL23 (Doc)](https://microsoft.github.io/msmarco/TREC-Deep-Learning)"
+    id: dl23
+    path: topics.dl23.txt
+    qrel: qrels.dl23-doc.txt
+
+models:
+  - name: unicoil
+    display: uniCOIL (with doc2query-T5)
+    params: -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.1554
+      MRR@100:
+        - 0.7793
+      nDCG@10:
+        - 0.4149
+      R@100:
+        - 0.3101
+      R@1000:
+        - 0.5753
+  - name: unicoil+rm3
+    display: +RM3
+    params: -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -rm3 -collection JsonVectorCollection -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.1832
+      MRR@100:
+        - 0.7931
+      nDCG@10:
+        - 0.4477
+      R@100:
+        - 0.3380
+      R@1000:
+        - 0.6067
+  - name: unicoil+rocchio
+    display: +Rocchio
+    params: -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -impact -pretokenized -rocchio -collection JsonVectorCollection -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.1844
+      MRR@100:
+        - 0.7943
+      nDCG@10:
+        - 0.4284
+      R@100:
+        - 0.3450
+      R@1000:
+        - 0.6257

--- a/src/main/resources/reproduce/from-document-collection/configs/dl23-passage.unicoil.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/dl23-passage.unicoil.onnx.yaml
@@ -1,0 +1,105 @@
+---
+corpus: msmarco-v2-passage-unicoil-0shot
+corpus_path: collections/msmarco/msmarco_v2_passage_unicoil_0shot/
+
+download_url: https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco_v2_passage_unicoil_0shot.tar
+download_checksum: 1949a00bfd5e1f1a230a04bbc1f01539
+download_corpus: msmarco_v2_passage_unicoil_0shot
+
+index_path: indexes/lucene-inverted.msmarco-v2-passage.unicoil-0shot/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 24
+index_options: -impact -pretokenized -storeRaw
+index_stats:
+  documents: 138364198
+  documents (non-empty): 138364198
+  total terms: 775253560148
+
+metrics:
+  - metric: MAP@100
+    command: bin/trec_eval
+    params: -c -M 100 -m map -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: MRR@100
+    command: bin/trec_eval
+    params: -c -M 100 -m recip_rank -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: nDCG@10
+    command: bin/trec_eval
+    params: -c -m ndcg_cut.10
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100 -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000 -l 2
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topics:
+  - name: "[DL23 (Passage)](https://microsoft.github.io/msmarco/TREC-Deep-Learning)"
+    id: dl23
+    path: topics.dl23.txt
+    qrel: qrels.dl23-passage.txt
+
+models:
+  - name: unicoil
+    display: uniCOIL (with doc2query-T5)
+    params: -impact -pretokenized -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.1437
+      MRR@100:
+        - 0.6424
+      nDCG@10:
+        - 0.3855
+      R@100:
+        - 0.3293
+      R@1000:
+        - 0.5541
+  - name: unicoil+rm3
+    display: +RM3
+    params: -impact -pretokenized -rm3 -collection JsonVectorCollection -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.1363
+      MRR@100:
+        - 0.5697
+      nDCG@10:
+        - 0.3776
+      R@100:
+        - 0.3126
+      R@1000:
+        - 0.5541
+  - name: unicoil+rocchio
+    display: +Rocchio
+    params: -impact -pretokenized -rocchio -collection JsonVectorCollection -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.1491
+      MRR@100:
+        - 0.6385
+      nDCG@10:
+        - 0.3938
+      R@100:
+        - 0.3351
+      R@1000:
+        - 0.5742

--- a/src/main/resources/reproduce/from-document-collection/configs/msmarco-v1-doc-segmented.unicoil.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/msmarco-v1-doc-segmented.unicoil.onnx.yaml
@@ -1,0 +1,67 @@
+---
+corpus: msmarco-doc-segmented-unicoil
+corpus_path: collections/msmarco/msmarco-doc-segmented-unicoil/
+
+download_url: https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-doc-segmented-unicoil.tar
+download_checksum: 6a00e2c0c375cb1e52c83ae5ac377ebb
+
+index_path: indexes/lucene-inverted.msmarco-v1-doc-segmented.unicoil/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 16
+index_options: -impact -pretokenized -storeDocvectors
+index_stats:
+  documents: 20545677
+  documents (non-empty): 20545677
+  total terms: 214505277898
+
+metrics:
+  - metric: AP@1000
+    command: bin/trec_eval
+    params: -c -m map
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: RR@100
+    command: bin/trec_eval
+    params: -c -M 100 -m recip_rank
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topics:
+  - name: "[MS MARCO Doc: Dev](https://github.com/microsoft/MSMARCO-Document-Ranking)"
+    id: dev
+    path: topics.msmarco-doc.dev.txt
+    qrel: qrels.msmarco-doc.dev.txt
+
+models:
+  - name: unicoil
+    display: uniCOIL (with doc2query-T5 expansions)
+    params: -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -encoder UniCoil
+    results:
+      AP@1000:
+        - 0.3535
+      RR@100:
+        - 0.3531
+      R@100:
+        - 0.8858
+      R@1000:
+        - 0.9546

--- a/src/main/resources/reproduce/from-document-collection/configs/msmarco-v1-passage.unicoil.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/msmarco-v1-passage.unicoil.onnx.yaml
@@ -1,0 +1,67 @@
+---
+corpus: msmarco-passage-unicoil
+corpus_path: collections/msmarco/msmarco-passage-unicoil/
+
+download_url: https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco-passage-unicoil.tar
+download_checksum: 78eef752c78c8691f7d61600ceed306f
+
+index_path: indexes/lucene-inverted.msmarco-v1-passage.unicoil/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 16
+index_options: -impact -pretokenized -storeDocvectors
+index_stats:
+  documents: 8841823
+  documents (non-empty): 8841823
+  total terms: 44495093768
+
+metrics:
+  - metric: AP@1000
+    command: bin/trec_eval
+    params: -c -m map
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: RR@10
+    command: bin/trec_eval
+    params: -c -M 10 -m recip_rank
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topics:
+  - name: "[MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)"
+    id: dev
+    path: topics.msmarco-passage.dev-subset.txt
+    qrel: qrels.msmarco-passage.dev-subset.txt
+
+models:
+  - name: unicoil
+    display: uniCOIL (with doc2query-T5 expansions)
+    params: -impact -pretokenized -encoder UniCoil
+    results:
+      AP@1000:
+        - 0.3568
+      RR@10:
+        - 0.3509
+      R@100:
+        - 0.8619
+      R@1000:
+        - 0.9583

--- a/src/main/resources/reproduce/from-document-collection/configs/msmarco-v2-doc-segmented.unicoil.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/msmarco-v2-doc-segmented.unicoil.onnx.yaml
@@ -1,0 +1,76 @@
+---
+corpus: msmarco-v2-doc-segmented-unicoil-0shot-v2
+corpus_path: collections/msmarco/msmarco_v2_doc_segmented_unicoil_0shot_v2/
+
+download_url: https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco_v2_doc_segmented_unicoil_0shot_v2.tar
+download_checksum: c5639748c2cbad0152e10b0ebde3b804
+download_corpus: msmarco_v2_doc_segmented_unicoil_0shot_v2
+
+index_path: indexes/lucene-inverted.msmarco-v2-doc-segmented.unicoil-0shot-v2/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 24
+index_options: -impact -pretokenized -storeRaw
+index_stats:
+  documents: 124131414
+  documents (non-empty): 124131414
+  total terms: 1204542769110
+
+metrics:
+  - metric: MAP@100
+    command: bin/trec_eval
+    params: -c -M 100 -m map
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: true
+  - metric: MRR@100
+    command: bin/trec_eval
+    params: -c -M 100 -m recip_rank
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: true
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topics:
+  - name: "[MS MARCO V2 Doc: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)"
+    id: dev
+    path: topics.msmarco-v2-doc.dev.txt
+    qrel: qrels.msmarco-v2-doc.dev.txt
+  - name: "[MS MARCO V2 Doc: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)"
+    id: dev2
+    path: topics.msmarco-v2-doc.dev2.txt
+    qrel: qrels.msmarco-v2-doc.dev2.txt
+
+models:
+  - name: unicoil
+    display: uniCOIL (with doc2query-T5)
+    params: -parallelism 16 -impact -pretokenized -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter "#" -selectMaxPassage.hits 1000 -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.2388
+        - 0.2422
+      MRR@100:
+        - 0.2419
+        - 0.2445
+      R@100:
+        - 0.7791
+        - 0.7759
+      R@1000:
+        - 0.9122
+        - 0.9172

--- a/src/main/resources/reproduce/from-document-collection/configs/msmarco-v2-passage.unicoil.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/msmarco-v2-passage.unicoil.onnx.yaml
@@ -1,0 +1,76 @@
+---
+corpus: msmarco-v2-passage-unicoil-0shot
+corpus_path: collections/msmarco/msmarco_v2_passage_unicoil_0shot/
+
+download_url: https://rgw.cs.uwaterloo.ca/JIMMYLIN-bucket0/data/msmarco_v2_passage_unicoil_0shot.tar
+download_checksum: 1949a00bfd5e1f1a230a04bbc1f01539
+download_corpus: msmarco_v2_passage_unicoil_0shot
+
+index_path: indexes/lucene-inverted.msmarco-v2-passage.unicoil-0shot/
+collection_class: JsonVectorCollection
+generator_class: DefaultLuceneDocumentGenerator
+index_threads: 24
+index_options: -impact -pretokenized -storeRaw
+index_stats:
+  documents: 138364198
+  documents (non-empty): 138364198
+  total terms: 775253560148
+
+metrics:
+  - metric: MAP@100
+    command: bin/trec_eval
+    params: -c -M 100 -m map
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: true
+  - metric: MRR@100
+    command: bin/trec_eval
+    params: -c -M 100 -m recip_rank
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: true
+  - metric: R@100
+    command: bin/trec_eval
+    params: -c -m recall.100
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+  - metric: R@1000
+    command: bin/trec_eval
+    params: -c -m recall.1000
+    separator: "\t"
+    parse_index: 2
+    metric_precision: 4
+    can_combine: false
+
+topic_reader: TsvInt
+topics:
+  - name: "[MS MARCO V2 Passage: Dev](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)"
+    id: dev
+    path: topics.msmarco-v2-passage.dev.txt
+    qrel: qrels.msmarco-v2-passage.dev.txt
+  - name: "[MS MARCO V2 Passage: Dev2](https://microsoft.github.io/msmarco/TREC-Deep-Learning.html)"
+    id: dev2
+    path: topics.msmarco-v2-passage.dev2.txt
+    qrel: qrels.msmarco-v2-passage.dev2.txt
+
+models:
+  - name: unicoil
+    display: uniCOIL (with doc2query-T5)
+    params: -parallelism 16 -impact -pretokenized -encoder UniCoil
+    results:
+      MAP@100:
+        - 0.1485
+        - 0.1561
+      MRR@100:
+        - 0.1499
+        - 0.1577
+      R@100:
+        - 0.5518
+        - 0.5661
+      R@1000:
+        - 0.7616
+        - 0.7671


### PR DESCRIPTION
## Summary

- Add ONNX-backed uniCOIL reproduction configs for MS MARCO v1/v2 and TREC DL19-DL23 passage/doc-segmented tasks.
- Use plain topic files with `-encoder UniCoil` while preserving existing reported metric values from the cached configs.

## Validation

- `git diff --cached --check`
- Not run; config-only change.