### PR TITLE
[codex] Add BRIGHT and BEIR prebuilt reproduction docs

### DIFF
--- a/docs/ref-reproduce-from-prebuilt-indexes.md
+++ b/docs/ref-reproduce-from-prebuilt-indexes.md
@@ -4,6 +4,8 @@
 Anserini ships with many [prebuilt indexes](prebuilt-indexes.md), which allows anyone to reproduce experimental results without needing access to the document collection.
 These experiments are grouped around configs, each of which focus on a specific corpus:
 
++ [BEIR](reproduce/from-prebuilt-indexes/beir.md)
++ [BRIGHT](reproduce/from-prebuilt-indexes/bright.md)
 + [MS MARCO V1 passage](reproduce/from-prebuilt-indexes/msmarco-v1-passage.md)
 + [MS MARCO V1 doc](reproduce/from-prebuilt-indexes/msmarco-v1-doc.md)
 + [MS MARCO V2 passage](reproduce/from-prebuilt-indexes/msmarco-v2-passage.md)

--- a/docs/reproduce/from-prebuilt-indexes/beir.md
+++ b/docs/reproduce/from-prebuilt-indexes/beir.md
@@ -1,0 +1,3765 @@
+# <img src="../../anserini-logo.png" height="30" /> BEIR
+
+**Anserini reproductions from prebuilt indexes**
+
++ **Corpus**: BEIR
++ **Config**: [beir.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/beir.yaml)
+
+## Summary
+
+The table below summarizes effectiveness in terms of nDCG@10.
+For more metrics, refer to the config directly.
+
+Key:
+
++ **BM25f** = BM25, flat bag-of-words baseline
++ **BM25mf** = BM25, multifield bag-of-words baseline
++ **SPLADE** = SPLADE-v3 (ONNX)
++ **BGE** = bge-base-en-v1.5 w/ flat indexes (ONNX)
++ **RRF** = Fusion: RRF (BM25 + BGE)
++ **Avg** = Fusion: Average (BM25 + BGE) with normalization
+
+| corpus | [BM25f](#condition-1) | [BM25mf](#condition-2) | [SPLADE](#condition-3) | [BGE](#condition-4) | [RRF](#condition-5) | [Avg](#condition-6) |
+| --- | --- | --- | --- | --- | --- | --- |
+| trec-covid | 0.5947 | 0.6559 | 0.7299 | 0.7815 | 0.8041 | 0.7956 |
+| bioasq | 0.5225 | 0.4646 | 0.5142 | 0.4148 | 0.5278 | 0.5428 |
+| nfcorpus | 0.3218 | 0.3254 | 0.3629 | 0.3738 | 0.3725 | 0.3785 |
+| nq | 0.3055 | 0.3285 | 0.5842 | 0.5415 | 0.4831 | 0.5183 |
+| hotpotqa | 0.6330 | 0.6027 | 0.6884 | 0.7259 | 0.7389 | 0.7658 |
+| fiqa | 0.2361 | 0.2361 | 0.3798 | 0.4065 | 0.3671 | 0.3942 |
+| signal1m | 0.3304 | 0.3304 | 0.2465 | 0.2886 | 0.3533 | 0.3626 |
+| trec-news | 0.3952 | 0.3977 | 0.4365 | 0.4424 | 0.4855 | 0.5008 |
+| robust04 | 0.4070 | 0.4070 | 0.4952 | 0.4435 | 0.5070 | 0.5127 |
+| arguana | 0.3970 | 0.4142 | 0.4862 | 0.6375 | 0.5626 | 0.5738 |
+| webis-touche2020 | 0.4422 | 0.3673 | 0.3086 | 0.2571 | 0.3771 | 0.3755 |
+| cqadupstack-android | 0.3801 | 0.3709 | 0.4109 | 0.5076 | 0.4652 | 0.4868 |
+| cqadupstack-english | 0.3453 | 0.3321 | 0.4255 | 0.4857 | 0.4461 | 0.4678 |
+| cqadupstack-gaming | 0.4822 | 0.4418 | 0.5193 | 0.5967 | 0.5615 | 0.5818 |
+| cqadupstack-gis | 0.2901 | 0.2904 | 0.3236 | 0.4131 | 0.3679 | 0.3937 |
+| cqadupstack-mathematica | 0.2015 | 0.2046 | 0.2445 | 0.3163 | 0.2751 | 0.2951 |
+| cqadupstack-physics | 0.3214 | 0.3248 | 0.3753 | 0.4724 | 0.4143 | 0.4375 |
+| cqadupstack-programmers | 0.2802 | 0.2963 | 0.3387 | 0.4238 | 0.3715 | 0.4005 |
+| cqadupstack-stats | 0.2711 | 0.2790 | 0.3137 | 0.3728 | 0.3414 | 0.3534 |
+| cqadupstack-tex | 0.2244 | 0.2086 | 0.2493 | 0.3115 | 0.2931 | 0.3090 |
+| cqadupstack-unix | 0.2749 | 0.2788 | 0.3196 | 0.4220 | 0.3597 | 0.3853 |
+| cqadupstack-webmasters | 0.3059 | 0.3008 | 0.3250 | 0.4072 | 0.3711 | 0.3857 |
+| cqadupstack-wordpress | 0.2483 | 0.2562 | 0.2807 | 0.3547 | 0.3353 | 0.3546 |
+| quora | 0.7886 | 0.7886 | 0.8141 | 0.8876 | 0.8682 | 0.8858 |
+| dbpedia-entity | 0.3180 | 0.3128 | 0.4476 | 0.4073 | 0.4190 | 0.4374 |
+| scidocs | 0.1490 | 0.1581 | 0.1567 | 0.2172 | 0.1948 | 0.2019 |
+| fever | 0.6513 | 0.7530 | 0.8015 | 0.8629 | 0.8108 | 0.8584 |
+| climate-fever | 0.1651 | 0.2129 | 0.2625 | 0.3117 | 0.2812 | 0.2946 |
+| scifact | 0.6789 | 0.6647 | 0.7140 | 0.7408 | 0.7420 | 0.7472 |
+
+
+
+## Commands
+
+In the commands below:
+
++ Set `$fatjar` to the actual Anserini fatjar.
++ Set JVM args to `-Xms512M -Xmx192G -Dslf4j.internal.verbosity=WARN --add-modules jdk.incubator.vector`.
+
+Something like:
+
+```bash
+export fatjar=`ls -d {.,target}/anserini-*-fatjar.jar(N)`
+
+# for zsh
+export jvm_args=(-Xms512M -Xmx192G -Dslf4j.internal.verbosity=WARN --add-modules jdk.incubator.vector)
+
+# for bash
+export jvm_args="-Xms512M -Xmx192G -Dslf4j.internal.verbosity=WARN --add-modules jdk.incubator.vector"
+```
+
+<a id="condition-1"></a>
+
+### 1. BM25, flat bag-of-words baseline
+
+**Config**: [beir.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/beir.yaml)
+
+#### trec-covid
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-trec-covid.flat \
+    -topics beir-trec-covid \
+    -output runs/run.beir.flat.trec-covid.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-trec-covid.test runs/run.beir.flat.trec-covid.txt
+```
+
+#### bioasq
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-bioasq.flat \
+    -topics beir-bioasq \
+    -output runs/run.beir.flat.bioasq.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-bioasq.test runs/run.beir.flat.bioasq.txt
+```
+
+#### nfcorpus
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-nfcorpus.flat \
+    -topics beir-nfcorpus \
+    -output runs/run.beir.flat.nfcorpus.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-nfcorpus.test runs/run.beir.flat.nfcorpus.txt
+```
+
+#### nq
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-nq.flat \
+    -topics beir-nq \
+    -output runs/run.beir.flat.nq.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-nq.test runs/run.beir.flat.nq.txt
+```
+
+#### hotpotqa
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-hotpotqa.flat \
+    -topics beir-hotpotqa \
+    -output runs/run.beir.flat.hotpotqa.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-hotpotqa.test runs/run.beir.flat.hotpotqa.txt
+```
+
+#### fiqa
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-fiqa.flat \
+    -topics beir-fiqa \
+    -output runs/run.beir.flat.fiqa.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-fiqa.test runs/run.beir.flat.fiqa.txt
+```
+
+#### signal1m
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-signal1m.flat \
+    -topics beir-signal1m \
+    -output runs/run.beir.flat.signal1m.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-signal1m.test runs/run.beir.flat.signal1m.txt
+```
+
+#### trec-news
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-trec-news.flat \
+    -topics beir-trec-news \
+    -output runs/run.beir.flat.trec-news.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-trec-news.test runs/run.beir.flat.trec-news.txt
+```
+
+#### robust04
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-robust04.flat \
+    -topics beir-robust04 \
+    -output runs/run.beir.flat.robust04.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-robust04.test runs/run.beir.flat.robust04.txt
+```
+
+#### arguana
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-arguana.flat \
+    -topics beir-arguana \
+    -output runs/run.beir.flat.arguana.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-arguana.test runs/run.beir.flat.arguana.txt
+```
+
+#### webis-touche2020
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-webis-touche2020.flat \
+    -topics beir-webis-touche2020 \
+    -output runs/run.beir.flat.webis-touche2020.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-webis-touche2020.test runs/run.beir.flat.webis-touche2020.txt
+```
+
+#### cqadupstack-android
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-android.flat \
+    -topics beir-cqadupstack-android \
+    -output runs/run.beir.flat.cqadupstack-android.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-android.test runs/run.beir.flat.cqadupstack-android.txt
+```
+
+#### cqadupstack-english
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-english.flat \
+    -topics beir-cqadupstack-english \
+    -output runs/run.beir.flat.cqadupstack-english.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-english.test runs/run.beir.flat.cqadupstack-english.txt
+```
+
+#### cqadupstack-gaming
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-gaming.flat \
+    -topics beir-cqadupstack-gaming \
+    -output runs/run.beir.flat.cqadupstack-gaming.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-gaming.test runs/run.beir.flat.cqadupstack-gaming.txt
+```
+
+#### cqadupstack-gis
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-gis.flat \
+    -topics beir-cqadupstack-gis \
+    -output runs/run.beir.flat.cqadupstack-gis.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-gis.test runs/run.beir.flat.cqadupstack-gis.txt
+```
+
+#### cqadupstack-mathematica
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-mathematica.flat \
+    -topics beir-cqadupstack-mathematica \
+    -output runs/run.beir.flat.cqadupstack-mathematica.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-mathematica.test runs/run.beir.flat.cqadupstack-mathematica.txt
+```
+
+#### cqadupstack-physics
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-physics.flat \
+    -topics beir-cqadupstack-physics \
+    -output runs/run.beir.flat.cqadupstack-physics.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-physics.test runs/run.beir.flat.cqadupstack-physics.txt
+```
+
+#### cqadupstack-programmers
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-programmers.flat \
+    -topics beir-cqadupstack-programmers \
+    -output runs/run.beir.flat.cqadupstack-programmers.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-programmers.test runs/run.beir.flat.cqadupstack-programmers.txt
+```
+
+#### cqadupstack-stats
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-stats.flat \
+    -topics beir-cqadupstack-stats \
+    -output runs/run.beir.flat.cqadupstack-stats.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-stats.test runs/run.beir.flat.cqadupstack-stats.txt
+```
+
+#### cqadupstack-tex
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-tex.flat \
+    -topics beir-cqadupstack-tex \
+    -output runs/run.beir.flat.cqadupstack-tex.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-tex.test runs/run.beir.flat.cqadupstack-tex.txt
+```
+
+#### cqadupstack-unix
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-unix.flat \
+    -topics beir-cqadupstack-unix \
+    -output runs/run.beir.flat.cqadupstack-unix.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-unix.test runs/run.beir.flat.cqadupstack-unix.txt
+```
+
+#### cqadupstack-webmasters
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-webmasters.flat \
+    -topics beir-cqadupstack-webmasters \
+    -output runs/run.beir.flat.cqadupstack-webmasters.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-webmasters.test runs/run.beir.flat.cqadupstack-webmasters.txt
+```
+
+#### cqadupstack-wordpress
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-wordpress.flat \
+    -topics beir-cqadupstack-wordpress \
+    -output runs/run.beir.flat.cqadupstack-wordpress.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-wordpress.test runs/run.beir.flat.cqadupstack-wordpress.txt
+```
+
+#### quora
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-quora.flat \
+    -topics beir-quora \
+    -output runs/run.beir.flat.quora.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-quora.test runs/run.beir.flat.quora.txt
+```
+
+#### dbpedia-entity
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-dbpedia-entity.flat \
+    -topics beir-dbpedia-entity \
+    -output runs/run.beir.flat.dbpedia-entity.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-dbpedia-entity.test runs/run.beir.flat.dbpedia-entity.txt
+```
+
+#### scidocs
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-scidocs.flat \
+    -topics beir-scidocs \
+    -output runs/run.beir.flat.scidocs.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-scidocs.test runs/run.beir.flat.scidocs.txt
+```
+
+#### fever
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-fever.flat \
+    -topics beir-fever \
+    -output runs/run.beir.flat.fever.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-fever.test runs/run.beir.flat.fever.txt
+```
+
+#### climate-fever
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-climate-fever.flat \
+    -topics beir-climate-fever \
+    -output runs/run.beir.flat.climate-fever.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-climate-fever.test runs/run.beir.flat.climate-fever.txt
+```
+
+#### scifact
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-scifact.flat \
+    -topics beir-scifact \
+    -output runs/run.beir.flat.scifact.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-scifact.test runs/run.beir.flat.scifact.txt
+```
+
+<a id="condition-2"></a>
+
+### 2. BM25, multifield bag-of-words baseline
+
+**Config**: [beir.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/beir.yaml)
+
+#### trec-covid
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-trec-covid.multifield \
+    -topics beir-trec-covid \
+    -output runs/run.beir.multifield.trec-covid.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-trec-covid.test runs/run.beir.multifield.trec-covid.txt
+```
+
+#### bioasq
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-bioasq.multifield \
+    -topics beir-bioasq \
+    -output runs/run.beir.multifield.bioasq.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-bioasq.test runs/run.beir.multifield.bioasq.txt
+```
+
+#### nfcorpus
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-nfcorpus.multifield \
+    -topics beir-nfcorpus \
+    -output runs/run.beir.multifield.nfcorpus.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-nfcorpus.test runs/run.beir.multifield.nfcorpus.txt
+```
+
+#### nq
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-nq.multifield \
+    -topics beir-nq \
+    -output runs/run.beir.multifield.nq.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-nq.test runs/run.beir.multifield.nq.txt
+```
+
+#### hotpotqa
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-hotpotqa.multifield \
+    -topics beir-hotpotqa \
+    -output runs/run.beir.multifield.hotpotqa.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-hotpotqa.test runs/run.beir.multifield.hotpotqa.txt
+```
+
+#### fiqa
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-fiqa.multifield \
+    -topics beir-fiqa \
+    -output runs/run.beir.multifield.fiqa.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-fiqa.test runs/run.beir.multifield.fiqa.txt
+```
+
+#### signal1m
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-signal1m.multifield \
+    -topics beir-signal1m \
+    -output runs/run.beir.multifield.signal1m.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-signal1m.test runs/run.beir.multifield.signal1m.txt
+```
+
+#### trec-news
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-trec-news.multifield \
+    -topics beir-trec-news \
+    -output runs/run.beir.multifield.trec-news.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-trec-news.test runs/run.beir.multifield.trec-news.txt
+```
+
+#### robust04
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-robust04.multifield \
+    -topics beir-robust04 \
+    -output runs/run.beir.multifield.robust04.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-robust04.test runs/run.beir.multifield.robust04.txt
+```
+
+#### arguana
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-arguana.multifield \
+    -topics beir-arguana \
+    -output runs/run.beir.multifield.arguana.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-arguana.test runs/run.beir.multifield.arguana.txt
+```
+
+#### webis-touche2020
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-webis-touche2020.multifield \
+    -topics beir-webis-touche2020 \
+    -output runs/run.beir.multifield.webis-touche2020.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-webis-touche2020.test runs/run.beir.multifield.webis-touche2020.txt
+```
+
+#### cqadupstack-android
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-android.multifield \
+    -topics beir-cqadupstack-android \
+    -output runs/run.beir.multifield.cqadupstack-android.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-android.test runs/run.beir.multifield.cqadupstack-android.txt
+```
+
+#### cqadupstack-english
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-english.multifield \
+    -topics beir-cqadupstack-english \
+    -output runs/run.beir.multifield.cqadupstack-english.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-english.test runs/run.beir.multifield.cqadupstack-english.txt
+```
+
+#### cqadupstack-gaming
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-gaming.multifield \
+    -topics beir-cqadupstack-gaming \
+    -output runs/run.beir.multifield.cqadupstack-gaming.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-gaming.test runs/run.beir.multifield.cqadupstack-gaming.txt
+```
+
+#### cqadupstack-gis
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-gis.multifield \
+    -topics beir-cqadupstack-gis \
+    -output runs/run.beir.multifield.cqadupstack-gis.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-gis.test runs/run.beir.multifield.cqadupstack-gis.txt
+```
+
+#### cqadupstack-mathematica
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-mathematica.multifield \
+    -topics beir-cqadupstack-mathematica \
+    -output runs/run.beir.multifield.cqadupstack-mathematica.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-mathematica.test runs/run.beir.multifield.cqadupstack-mathematica.txt
+```
+
+#### cqadupstack-physics
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-physics.multifield \
+    -topics beir-cqadupstack-physics \
+    -output runs/run.beir.multifield.cqadupstack-physics.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-physics.test runs/run.beir.multifield.cqadupstack-physics.txt
+```
+
+#### cqadupstack-programmers
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-programmers.multifield \
+    -topics beir-cqadupstack-programmers \
+    -output runs/run.beir.multifield.cqadupstack-programmers.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-programmers.test runs/run.beir.multifield.cqadupstack-programmers.txt
+```
+
+#### cqadupstack-stats
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-stats.multifield \
+    -topics beir-cqadupstack-stats \
+    -output runs/run.beir.multifield.cqadupstack-stats.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-stats.test runs/run.beir.multifield.cqadupstack-stats.txt
+```
+
+#### cqadupstack-tex
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-tex.multifield \
+    -topics beir-cqadupstack-tex \
+    -output runs/run.beir.multifield.cqadupstack-tex.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-tex.test runs/run.beir.multifield.cqadupstack-tex.txt
+```
+
+#### cqadupstack-unix
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-unix.multifield \
+    -topics beir-cqadupstack-unix \
+    -output runs/run.beir.multifield.cqadupstack-unix.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-unix.test runs/run.beir.multifield.cqadupstack-unix.txt
+```
+
+#### cqadupstack-webmasters
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-webmasters.multifield \
+    -topics beir-cqadupstack-webmasters \
+    -output runs/run.beir.multifield.cqadupstack-webmasters.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-webmasters.test runs/run.beir.multifield.cqadupstack-webmasters.txt
+```
+
+#### cqadupstack-wordpress
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-wordpress.multifield \
+    -topics beir-cqadupstack-wordpress \
+    -output runs/run.beir.multifield.cqadupstack-wordpress.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-wordpress.test runs/run.beir.multifield.cqadupstack-wordpress.txt
+```
+
+#### quora
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-quora.multifield \
+    -topics beir-quora \
+    -output runs/run.beir.multifield.quora.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-quora.test runs/run.beir.multifield.quora.txt
+```
+
+#### dbpedia-entity
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-dbpedia-entity.multifield \
+    -topics beir-dbpedia-entity \
+    -output runs/run.beir.multifield.dbpedia-entity.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-dbpedia-entity.test runs/run.beir.multifield.dbpedia-entity.txt
+```
+
+#### scidocs
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-scidocs.multifield \
+    -topics beir-scidocs \
+    -output runs/run.beir.multifield.scidocs.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-scidocs.test runs/run.beir.multifield.scidocs.txt
+```
+
+#### fever
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-fever.multifield \
+    -topics beir-fever \
+    -output runs/run.beir.multifield.fever.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-fever.test runs/run.beir.multifield.fever.txt
+```
+
+#### climate-fever
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-climate-fever.multifield \
+    -topics beir-climate-fever \
+    -output runs/run.beir.multifield.climate-fever.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-climate-fever.test runs/run.beir.multifield.climate-fever.txt
+```
+
+#### scifact
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-scifact.multifield \
+    -topics beir-scifact \
+    -output runs/run.beir.multifield.scifact.txt \
+    -bm25 \
+    -removeQuery \
+    -fields contents=1.0 \
+    title=1.0
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-scifact.test runs/run.beir.multifield.scifact.txt
+```
+
+<a id="condition-3"></a>
+
+### 3. SPLADE-v3 (ONNX)
+
+**Config**: [beir.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/beir.yaml)
+
+#### trec-covid
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-trec-covid.splade-v3 \
+    -topics beir-trec-covid \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.trec-covid.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-trec-covid.test runs/run.beir.splade-v3.onnx.trec-covid.txt
+```
+
+#### bioasq
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-bioasq.splade-v3 \
+    -topics beir-bioasq \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.bioasq.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-bioasq.test runs/run.beir.splade-v3.onnx.bioasq.txt
+```
+
+#### nfcorpus
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-nfcorpus.splade-v3 \
+    -topics beir-nfcorpus \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.nfcorpus.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-nfcorpus.test runs/run.beir.splade-v3.onnx.nfcorpus.txt
+```
+
+#### nq
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-nq.splade-v3 \
+    -topics beir-nq \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.nq.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-nq.test runs/run.beir.splade-v3.onnx.nq.txt
+```
+
+#### hotpotqa
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-hotpotqa.splade-v3 \
+    -topics beir-hotpotqa \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.hotpotqa.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-hotpotqa.test runs/run.beir.splade-v3.onnx.hotpotqa.txt
+```
+
+#### fiqa
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-fiqa.splade-v3 \
+    -topics beir-fiqa \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.fiqa.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-fiqa.test runs/run.beir.splade-v3.onnx.fiqa.txt
+```
+
+#### signal1m
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-signal1m.splade-v3 \
+    -topics beir-signal1m \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.signal1m.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-signal1m.test runs/run.beir.splade-v3.onnx.signal1m.txt
+```
+
+#### trec-news
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-trec-news.splade-v3 \
+    -topics beir-trec-news \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.trec-news.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-trec-news.test runs/run.beir.splade-v3.onnx.trec-news.txt
+```
+
+#### robust04
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-robust04.splade-v3 \
+    -topics beir-robust04 \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.robust04.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-robust04.test runs/run.beir.splade-v3.onnx.robust04.txt
+```
+
+#### arguana
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-arguana.splade-v3 \
+    -topics beir-arguana \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.arguana.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-arguana.test runs/run.beir.splade-v3.onnx.arguana.txt
+```
+
+#### webis-touche2020
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-webis-touche2020.splade-v3 \
+    -topics beir-webis-touche2020 \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.webis-touche2020.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-webis-touche2020.test runs/run.beir.splade-v3.onnx.webis-touche2020.txt
+```
+
+#### cqadupstack-android
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-android.splade-v3 \
+    -topics beir-cqadupstack-android \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.cqadupstack-android.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-android.test runs/run.beir.splade-v3.onnx.cqadupstack-android.txt
+```
+
+#### cqadupstack-english
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-english.splade-v3 \
+    -topics beir-cqadupstack-english \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.cqadupstack-english.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-english.test runs/run.beir.splade-v3.onnx.cqadupstack-english.txt
+```
+
+#### cqadupstack-gaming
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-gaming.splade-v3 \
+    -topics beir-cqadupstack-gaming \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.cqadupstack-gaming.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-gaming.test runs/run.beir.splade-v3.onnx.cqadupstack-gaming.txt
+```
+
+#### cqadupstack-gis
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-gis.splade-v3 \
+    -topics beir-cqadupstack-gis \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.cqadupstack-gis.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-gis.test runs/run.beir.splade-v3.onnx.cqadupstack-gis.txt
+```
+
+#### cqadupstack-mathematica
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-mathematica.splade-v3 \
+    -topics beir-cqadupstack-mathematica \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.cqadupstack-mathematica.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-mathematica.test runs/run.beir.splade-v3.onnx.cqadupstack-mathematica.txt
+```
+
+#### cqadupstack-physics
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-physics.splade-v3 \
+    -topics beir-cqadupstack-physics \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.cqadupstack-physics.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-physics.test runs/run.beir.splade-v3.onnx.cqadupstack-physics.txt
+```
+
+#### cqadupstack-programmers
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-programmers.splade-v3 \
+    -topics beir-cqadupstack-programmers \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.cqadupstack-programmers.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-programmers.test runs/run.beir.splade-v3.onnx.cqadupstack-programmers.txt
+```
+
+#### cqadupstack-stats
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-stats.splade-v3 \
+    -topics beir-cqadupstack-stats \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.cqadupstack-stats.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-stats.test runs/run.beir.splade-v3.onnx.cqadupstack-stats.txt
+```
+
+#### cqadupstack-tex
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-tex.splade-v3 \
+    -topics beir-cqadupstack-tex \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.cqadupstack-tex.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-tex.test runs/run.beir.splade-v3.onnx.cqadupstack-tex.txt
+```
+
+#### cqadupstack-unix
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-unix.splade-v3 \
+    -topics beir-cqadupstack-unix \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.cqadupstack-unix.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-unix.test runs/run.beir.splade-v3.onnx.cqadupstack-unix.txt
+```
+
+#### cqadupstack-webmasters
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-webmasters.splade-v3 \
+    -topics beir-cqadupstack-webmasters \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.cqadupstack-webmasters.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-webmasters.test runs/run.beir.splade-v3.onnx.cqadupstack-webmasters.txt
+```
+
+#### cqadupstack-wordpress
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-wordpress.splade-v3 \
+    -topics beir-cqadupstack-wordpress \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.cqadupstack-wordpress.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-wordpress.test runs/run.beir.splade-v3.onnx.cqadupstack-wordpress.txt
+```
+
+#### quora
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-quora.splade-v3 \
+    -topics beir-quora \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.quora.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-quora.test runs/run.beir.splade-v3.onnx.quora.txt
+```
+
+#### dbpedia-entity
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-dbpedia-entity.splade-v3 \
+    -topics beir-dbpedia-entity \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.dbpedia-entity.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-dbpedia-entity.test runs/run.beir.splade-v3.onnx.dbpedia-entity.txt
+```
+
+#### scidocs
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-scidocs.splade-v3 \
+    -topics beir-scidocs \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.scidocs.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-scidocs.test runs/run.beir.splade-v3.onnx.scidocs.txt
+```
+
+#### fever
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-fever.splade-v3 \
+    -topics beir-fever \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.fever.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-fever.test runs/run.beir.splade-v3.onnx.fever.txt
+```
+
+#### climate-fever
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-climate-fever.splade-v3 \
+    -topics beir-climate-fever \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.climate-fever.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-climate-fever.test runs/run.beir.splade-v3.onnx.climate-fever.txt
+```
+
+#### scifact
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index beir-v1.0.0-scifact.splade-v3 \
+    -topics beir-scifact \
+    -encoder SpladeV3 \
+    -output runs/run.beir.splade-v3.onnx.scifact.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-scifact.test runs/run.beir.splade-v3.onnx.scifact.txt
+```
+
+<a id="condition-4"></a>
+
+### 4. bge-base-en-v1.5 w/ flat indexes (ONNX)
+
+**Config**: [beir.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/beir.yaml)
+
+#### trec-covid
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat \
+    -topics beir-trec-covid \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.trec-covid.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-trec-covid.test runs/run.beir.bge-base-en-v1.5.flat.onnx.trec-covid.txt
+```
+
+#### bioasq
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-bioasq.bge-base-en-v1.5.flat \
+    -topics beir-bioasq \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.bioasq.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-bioasq.test runs/run.beir.bge-base-en-v1.5.flat.onnx.bioasq.txt
+```
+
+#### nfcorpus
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-nfcorpus.bge-base-en-v1.5.flat \
+    -topics beir-nfcorpus \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.nfcorpus.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-nfcorpus.test runs/run.beir.bge-base-en-v1.5.flat.onnx.nfcorpus.txt
+```
+
+#### nq
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-nq.bge-base-en-v1.5.flat \
+    -topics beir-nq \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.nq.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-nq.test runs/run.beir.bge-base-en-v1.5.flat.onnx.nq.txt
+```
+
+#### hotpotqa
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-hotpotqa.bge-base-en-v1.5.flat \
+    -topics beir-hotpotqa \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.hotpotqa.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-hotpotqa.test runs/run.beir.bge-base-en-v1.5.flat.onnx.hotpotqa.txt
+```
+
+#### fiqa
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-fiqa.bge-base-en-v1.5.flat \
+    -topics beir-fiqa \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.fiqa.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-fiqa.test runs/run.beir.bge-base-en-v1.5.flat.onnx.fiqa.txt
+```
+
+#### signal1m
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-signal1m.bge-base-en-v1.5.flat \
+    -topics beir-signal1m \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.signal1m.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-signal1m.test runs/run.beir.bge-base-en-v1.5.flat.onnx.signal1m.txt
+```
+
+#### trec-news
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-trec-news.bge-base-en-v1.5.flat \
+    -topics beir-trec-news \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.trec-news.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-trec-news.test runs/run.beir.bge-base-en-v1.5.flat.onnx.trec-news.txt
+```
+
+#### robust04
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-robust04.bge-base-en-v1.5.flat \
+    -topics beir-robust04 \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.robust04.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-robust04.test runs/run.beir.bge-base-en-v1.5.flat.onnx.robust04.txt
+```
+
+#### arguana
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-arguana.bge-base-en-v1.5.flat \
+    -topics beir-arguana \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.arguana.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-arguana.test runs/run.beir.bge-base-en-v1.5.flat.onnx.arguana.txt
+```
+
+#### webis-touche2020
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-webis-touche2020.bge-base-en-v1.5.flat \
+    -topics beir-webis-touche2020 \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.webis-touche2020.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-webis-touche2020.test runs/run.beir.bge-base-en-v1.5.flat.onnx.webis-touche2020.txt
+```
+
+#### cqadupstack-android
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-android.bge-base-en-v1.5.flat \
+    -topics beir-cqadupstack-android \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-android.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-android.test runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-android.txt
+```
+
+#### cqadupstack-english
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-english.bge-base-en-v1.5.flat \
+    -topics beir-cqadupstack-english \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-english.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-english.test runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-english.txt
+```
+
+#### cqadupstack-gaming
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-gaming.bge-base-en-v1.5.flat \
+    -topics beir-cqadupstack-gaming \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-gaming.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-gaming.test runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-gaming.txt
+```
+
+#### cqadupstack-gis
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-gis.bge-base-en-v1.5.flat \
+    -topics beir-cqadupstack-gis \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-gis.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-gis.test runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-gis.txt
+```
+
+#### cqadupstack-mathematica
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-mathematica.bge-base-en-v1.5.flat \
+    -topics beir-cqadupstack-mathematica \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-mathematica.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-mathematica.test runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-mathematica.txt
+```
+
+#### cqadupstack-physics
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-physics.bge-base-en-v1.5.flat \
+    -topics beir-cqadupstack-physics \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-physics.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-physics.test runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-physics.txt
+```
+
+#### cqadupstack-programmers
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-programmers.bge-base-en-v1.5.flat \
+    -topics beir-cqadupstack-programmers \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-programmers.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-programmers.test runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-programmers.txt
+```
+
+#### cqadupstack-stats
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-stats.bge-base-en-v1.5.flat \
+    -topics beir-cqadupstack-stats \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-stats.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-stats.test runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-stats.txt
+```
+
+#### cqadupstack-tex
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-tex.bge-base-en-v1.5.flat \
+    -topics beir-cqadupstack-tex \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-tex.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-tex.test runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-tex.txt
+```
+
+#### cqadupstack-unix
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-unix.bge-base-en-v1.5.flat \
+    -topics beir-cqadupstack-unix \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-unix.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-unix.test runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-unix.txt
+```
+
+#### cqadupstack-webmasters
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-webmasters.bge-base-en-v1.5.flat \
+    -topics beir-cqadupstack-webmasters \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-webmasters.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-webmasters.test runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-webmasters.txt
+```
+
+#### cqadupstack-wordpress
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-cqadupstack-wordpress.bge-base-en-v1.5.flat \
+    -topics beir-cqadupstack-wordpress \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-wordpress.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-wordpress.test runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-wordpress.txt
+```
+
+#### quora
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-quora.bge-base-en-v1.5.flat \
+    -topics beir-quora \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.quora.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-quora.test runs/run.beir.bge-base-en-v1.5.flat.onnx.quora.txt
+```
+
+#### dbpedia-entity
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-dbpedia-entity.bge-base-en-v1.5.flat \
+    -topics beir-dbpedia-entity \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.dbpedia-entity.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-dbpedia-entity.test runs/run.beir.bge-base-en-v1.5.flat.onnx.dbpedia-entity.txt
+```
+
+#### scidocs
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-scidocs.bge-base-en-v1.5.flat \
+    -topics beir-scidocs \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.scidocs.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-scidocs.test runs/run.beir.bge-base-en-v1.5.flat.onnx.scidocs.txt
+```
+
+#### fever
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-fever.bge-base-en-v1.5.flat \
+    -topics beir-fever \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.fever.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-fever.test runs/run.beir.bge-base-en-v1.5.flat.onnx.fever.txt
+```
+
+#### climate-fever
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-climate-fever.bge-base-en-v1.5.flat \
+    -topics beir-climate-fever \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.climate-fever.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-climate-fever.test runs/run.beir.bge-base-en-v1.5.flat.onnx.climate-fever.txt
+```
+
+#### scifact
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index beir-v1.0.0-scifact.bge-base-en-v1.5.flat \
+    -topics beir-scifact \
+    -encoder BgeBaseEn15 \
+    -output runs/run.beir.bge-base-en-v1.5.flat.onnx.scifact.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-scifact.test runs/run.beir.bge-base-en-v1.5.flat.onnx.scifact.txt
+```
+
+<a id="condition-5"></a>
+
+### 5. Fusion: RRF (BM25 + BGE)
+
+**Config**: [beir.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/beir.yaml)
+
+#### trec-covid
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.trec-covid.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.trec-covid.txt \
+    -output runs/run.beir.fusion-rrf.trec-covid.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-trec-covid.test runs/run.beir.fusion-rrf.trec-covid.txt
+```
+
+#### bioasq
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.bioasq.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.bioasq.txt \
+    -output runs/run.beir.fusion-rrf.bioasq.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-bioasq.test runs/run.beir.fusion-rrf.bioasq.txt
+```
+
+#### nfcorpus
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.nfcorpus.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.nfcorpus.txt \
+    -output runs/run.beir.fusion-rrf.nfcorpus.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-nfcorpus.test runs/run.beir.fusion-rrf.nfcorpus.txt
+```
+
+#### nq
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.nq.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.nq.txt \
+    -output runs/run.beir.fusion-rrf.nq.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-nq.test runs/run.beir.fusion-rrf.nq.txt
+```
+
+#### hotpotqa
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.hotpotqa.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.hotpotqa.txt \
+    -output runs/run.beir.fusion-rrf.hotpotqa.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-hotpotqa.test runs/run.beir.fusion-rrf.hotpotqa.txt
+```
+
+#### fiqa
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.fiqa.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.fiqa.txt \
+    -output runs/run.beir.fusion-rrf.fiqa.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-fiqa.test runs/run.beir.fusion-rrf.fiqa.txt
+```
+
+#### signal1m
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.signal1m.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.signal1m.txt \
+    -output runs/run.beir.fusion-rrf.signal1m.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-signal1m.test runs/run.beir.fusion-rrf.signal1m.txt
+```
+
+#### trec-news
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.trec-news.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.trec-news.txt \
+    -output runs/run.beir.fusion-rrf.trec-news.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-trec-news.test runs/run.beir.fusion-rrf.trec-news.txt
+```
+
+#### robust04
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.robust04.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.robust04.txt \
+    -output runs/run.beir.fusion-rrf.robust04.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-robust04.test runs/run.beir.fusion-rrf.robust04.txt
+```
+
+#### arguana
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.arguana.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.arguana.txt \
+    -output runs/run.beir.fusion-rrf.arguana.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-arguana.test runs/run.beir.fusion-rrf.arguana.txt
+```
+
+#### webis-touche2020
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.webis-touche2020.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.webis-touche2020.txt \
+    -output runs/run.beir.fusion-rrf.webis-touche2020.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-webis-touche2020.test runs/run.beir.fusion-rrf.webis-touche2020.txt
+```
+
+#### cqadupstack-android
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-android.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-android.txt \
+    -output runs/run.beir.fusion-rrf.cqadupstack-android.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-android.test runs/run.beir.fusion-rrf.cqadupstack-android.txt
+```
+
+#### cqadupstack-english
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-english.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-english.txt \
+    -output runs/run.beir.fusion-rrf.cqadupstack-english.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-english.test runs/run.beir.fusion-rrf.cqadupstack-english.txt
+```
+
+#### cqadupstack-gaming
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-gaming.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-gaming.txt \
+    -output runs/run.beir.fusion-rrf.cqadupstack-gaming.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-gaming.test runs/run.beir.fusion-rrf.cqadupstack-gaming.txt
+```
+
+#### cqadupstack-gis
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-gis.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-gis.txt \
+    -output runs/run.beir.fusion-rrf.cqadupstack-gis.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-gis.test runs/run.beir.fusion-rrf.cqadupstack-gis.txt
+```
+
+#### cqadupstack-mathematica
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-mathematica.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-mathematica.txt \
+    -output runs/run.beir.fusion-rrf.cqadupstack-mathematica.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-mathematica.test runs/run.beir.fusion-rrf.cqadupstack-mathematica.txt
+```
+
+#### cqadupstack-physics
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-physics.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-physics.txt \
+    -output runs/run.beir.fusion-rrf.cqadupstack-physics.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-physics.test runs/run.beir.fusion-rrf.cqadupstack-physics.txt
+```
+
+#### cqadupstack-programmers
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-programmers.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-programmers.txt \
+    -output runs/run.beir.fusion-rrf.cqadupstack-programmers.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-programmers.test runs/run.beir.fusion-rrf.cqadupstack-programmers.txt
+```
+
+#### cqadupstack-stats
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-stats.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-stats.txt \
+    -output runs/run.beir.fusion-rrf.cqadupstack-stats.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-stats.test runs/run.beir.fusion-rrf.cqadupstack-stats.txt
+```
+
+#### cqadupstack-tex
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-tex.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-tex.txt \
+    -output runs/run.beir.fusion-rrf.cqadupstack-tex.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-tex.test runs/run.beir.fusion-rrf.cqadupstack-tex.txt
+```
+
+#### cqadupstack-unix
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-unix.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-unix.txt \
+    -output runs/run.beir.fusion-rrf.cqadupstack-unix.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-unix.test runs/run.beir.fusion-rrf.cqadupstack-unix.txt
+```
+
+#### cqadupstack-webmasters
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-webmasters.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-webmasters.txt \
+    -output runs/run.beir.fusion-rrf.cqadupstack-webmasters.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-webmasters.test runs/run.beir.fusion-rrf.cqadupstack-webmasters.txt
+```
+
+#### cqadupstack-wordpress
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-wordpress.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-wordpress.txt \
+    -output runs/run.beir.fusion-rrf.cqadupstack-wordpress.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-wordpress.test runs/run.beir.fusion-rrf.cqadupstack-wordpress.txt
+```
+
+#### quora
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.quora.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.quora.txt \
+    -output runs/run.beir.fusion-rrf.quora.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-quora.test runs/run.beir.fusion-rrf.quora.txt
+```
+
+#### dbpedia-entity
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.dbpedia-entity.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.dbpedia-entity.txt \
+    -output runs/run.beir.fusion-rrf.dbpedia-entity.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-dbpedia-entity.test runs/run.beir.fusion-rrf.dbpedia-entity.txt
+```
+
+#### scidocs
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.scidocs.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.scidocs.txt \
+    -output runs/run.beir.fusion-rrf.scidocs.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-scidocs.test runs/run.beir.fusion-rrf.scidocs.txt
+```
+
+#### fever
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.fever.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.fever.txt \
+    -output runs/run.beir.fusion-rrf.fever.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-fever.test runs/run.beir.fusion-rrf.fever.txt
+```
+
+#### climate-fever
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.climate-fever.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.climate-fever.txt \
+    -output runs/run.beir.fusion-rrf.climate-fever.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-climate-fever.test runs/run.beir.fusion-rrf.climate-fever.txt
+```
+
+#### scifact
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.scifact.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.scifact.txt \
+    -output runs/run.beir.fusion-rrf.scifact.txt \
+    -method rrf \
+    -k 1000 \
+    -depth 1000 \
+    -rrf_k 60
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-scifact.test runs/run.beir.fusion-rrf.scifact.txt
+```
+
+<a id="condition-6"></a>
+
+### 6. Fusion: Average (BM25 + BGE) with normalization
+
+**Config**: [beir.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/beir.yaml)
+
+#### trec-covid
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.trec-covid.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.trec-covid.txt \
+    -output runs/run.beir.fusion-avg.trec-covid.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-trec-covid.test runs/run.beir.fusion-avg.trec-covid.txt
+```
+
+#### bioasq
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.bioasq.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.bioasq.txt \
+    -output runs/run.beir.fusion-avg.bioasq.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-bioasq.test runs/run.beir.fusion-avg.bioasq.txt
+```
+
+#### nfcorpus
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.nfcorpus.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.nfcorpus.txt \
+    -output runs/run.beir.fusion-avg.nfcorpus.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-nfcorpus.test runs/run.beir.fusion-avg.nfcorpus.txt
+```
+
+#### nq
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.nq.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.nq.txt \
+    -output runs/run.beir.fusion-avg.nq.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-nq.test runs/run.beir.fusion-avg.nq.txt
+```
+
+#### hotpotqa
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.hotpotqa.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.hotpotqa.txt \
+    -output runs/run.beir.fusion-avg.hotpotqa.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-hotpotqa.test runs/run.beir.fusion-avg.hotpotqa.txt
+```
+
+#### fiqa
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.fiqa.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.fiqa.txt \
+    -output runs/run.beir.fusion-avg.fiqa.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-fiqa.test runs/run.beir.fusion-avg.fiqa.txt
+```
+
+#### signal1m
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.signal1m.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.signal1m.txt \
+    -output runs/run.beir.fusion-avg.signal1m.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-signal1m.test runs/run.beir.fusion-avg.signal1m.txt
+```
+
+#### trec-news
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.trec-news.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.trec-news.txt \
+    -output runs/run.beir.fusion-avg.trec-news.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-trec-news.test runs/run.beir.fusion-avg.trec-news.txt
+```
+
+#### robust04
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.robust04.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.robust04.txt \
+    -output runs/run.beir.fusion-avg.robust04.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-robust04.test runs/run.beir.fusion-avg.robust04.txt
+```
+
+#### arguana
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.arguana.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.arguana.txt \
+    -output runs/run.beir.fusion-avg.arguana.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-arguana.test runs/run.beir.fusion-avg.arguana.txt
+```
+
+#### webis-touche2020
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.webis-touche2020.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.webis-touche2020.txt \
+    -output runs/run.beir.fusion-avg.webis-touche2020.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-webis-touche2020.test runs/run.beir.fusion-avg.webis-touche2020.txt
+```
+
+#### cqadupstack-android
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-android.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-android.txt \
+    -output runs/run.beir.fusion-avg.cqadupstack-android.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-android.test runs/run.beir.fusion-avg.cqadupstack-android.txt
+```
+
+#### cqadupstack-english
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-english.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-english.txt \
+    -output runs/run.beir.fusion-avg.cqadupstack-english.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-english.test runs/run.beir.fusion-avg.cqadupstack-english.txt
+```
+
+#### cqadupstack-gaming
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-gaming.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-gaming.txt \
+    -output runs/run.beir.fusion-avg.cqadupstack-gaming.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-gaming.test runs/run.beir.fusion-avg.cqadupstack-gaming.txt
+```
+
+#### cqadupstack-gis
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-gis.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-gis.txt \
+    -output runs/run.beir.fusion-avg.cqadupstack-gis.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-gis.test runs/run.beir.fusion-avg.cqadupstack-gis.txt
+```
+
+#### cqadupstack-mathematica
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-mathematica.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-mathematica.txt \
+    -output runs/run.beir.fusion-avg.cqadupstack-mathematica.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-mathematica.test runs/run.beir.fusion-avg.cqadupstack-mathematica.txt
+```
+
+#### cqadupstack-physics
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-physics.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-physics.txt \
+    -output runs/run.beir.fusion-avg.cqadupstack-physics.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-physics.test runs/run.beir.fusion-avg.cqadupstack-physics.txt
+```
+
+#### cqadupstack-programmers
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-programmers.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-programmers.txt \
+    -output runs/run.beir.fusion-avg.cqadupstack-programmers.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-programmers.test runs/run.beir.fusion-avg.cqadupstack-programmers.txt
+```
+
+#### cqadupstack-stats
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-stats.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-stats.txt \
+    -output runs/run.beir.fusion-avg.cqadupstack-stats.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-stats.test runs/run.beir.fusion-avg.cqadupstack-stats.txt
+```
+
+#### cqadupstack-tex
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-tex.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-tex.txt \
+    -output runs/run.beir.fusion-avg.cqadupstack-tex.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-tex.test runs/run.beir.fusion-avg.cqadupstack-tex.txt
+```
+
+#### cqadupstack-unix
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-unix.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-unix.txt \
+    -output runs/run.beir.fusion-avg.cqadupstack-unix.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-unix.test runs/run.beir.fusion-avg.cqadupstack-unix.txt
+```
+
+#### cqadupstack-webmasters
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-webmasters.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-webmasters.txt \
+    -output runs/run.beir.fusion-avg.cqadupstack-webmasters.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-webmasters.test runs/run.beir.fusion-avg.cqadupstack-webmasters.txt
+```
+
+#### cqadupstack-wordpress
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.cqadupstack-wordpress.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.cqadupstack-wordpress.txt \
+    -output runs/run.beir.fusion-avg.cqadupstack-wordpress.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-cqadupstack-wordpress.test runs/run.beir.fusion-avg.cqadupstack-wordpress.txt
+```
+
+#### quora
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.quora.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.quora.txt \
+    -output runs/run.beir.fusion-avg.quora.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-quora.test runs/run.beir.fusion-avg.quora.txt
+```
+
+#### dbpedia-entity
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.dbpedia-entity.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.dbpedia-entity.txt \
+    -output runs/run.beir.fusion-avg.dbpedia-entity.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-dbpedia-entity.test runs/run.beir.fusion-avg.dbpedia-entity.txt
+```
+
+#### scidocs
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.scidocs.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.scidocs.txt \
+    -output runs/run.beir.fusion-avg.scidocs.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-scidocs.test runs/run.beir.fusion-avg.scidocs.txt
+```
+
+#### fever
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.fever.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.fever.txt \
+    -output runs/run.beir.fusion-avg.fever.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-fever.test runs/run.beir.fusion-avg.fever.txt
+```
+
+#### climate-fever
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.climate-fever.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.climate-fever.txt \
+    -output runs/run.beir.fusion-avg.climate-fever.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-climate-fever.test runs/run.beir.fusion-avg.climate-fever.txt
+```
+
+#### scifact
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.fusion.FuseRuns \
+    -runs runs/run.beir.flat.scifact.txt \
+    runs/run.beir.bge-base-en-v1.5.flat.onnx.scifact.txt \
+    -output runs/run.beir.fusion-avg.scifact.txt \
+    -method average \
+    -k 1000 \
+    -depth 1000 \
+    -min_max_normalization
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 beir-v1.0.0-scifact.test runs/run.beir.fusion-avg.scifact.txt
+```
+
+

--- a/docs/reproduce/from-prebuilt-indexes/beir.md
+++ b/docs/reproduce/from-prebuilt-indexes/beir.md
@@ -16,8 +16,8 @@ Key:
 + **BM25mf** = BM25, multifield bag-of-words baseline
 + **SPLADE** = SPLADE-v3 (ONNX)
 + **BGE** = bge-base-en-v1.5 w/ flat indexes (ONNX)
-+ **RRF** = Fusion: RRF (BM25 + BGE)
-+ **Avg** = Fusion: Average (BM25 + BGE) with normalization
++ **RRF** = Fusion: RRF (BM25f + BGE)
++ **Avg** = Fusion: Average (BM25f + BGE) with normalization
 
 | corpus | [BM25f](#condition-1) | [BM25mf](#condition-2) | [SPLADE](#condition-3) | [BGE](#condition-4) | [RRF](#condition-5) | [Avg](#condition-6) |
 | --- | --- | --- | --- | --- | --- | --- |

--- a/docs/reproduce/from-prebuilt-indexes/bright.md
+++ b/docs/reproduce/from-prebuilt-indexes/bright.md
@@ -1,0 +1,1064 @@
+# <img src="../../anserini-logo.png" height="30" /> BRIGHT
+
+**Anserini reproductions from prebuilt indexes**
+
++ **Corpus**: BRIGHT
++ **Config**: [bright.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/bright.yaml)
+
+## Summary
+
+The table below summarizes effectiveness in terms of nDCG@10.
+For more metrics, refer to the config directly.
+
+Key:
+
++ **BM25** = BM25, bag-of-words baseline
++ **BM25qs** = BM25, query-side BM25 baseline
++ **SPLADE** = SPLADE-v3 (ONNX)
++ **BGE** = bge-large-en-v1.5 w/ flat indexes (ONNX)
+
+| corpus | [BM25](#condition-1) | [BM25qs](#condition-2) | [SPLADE](#condition-3) | [BGE](#condition-4) |
+| --- | --- | --- | --- | --- |
+| biology | 0.1824 | 0.1972 | 0.2101 | 0.1242 |
+| earth-science | 0.2791 | 0.2789 | 0.2670 | 0.2545 |
+| economics | 0.1645 | 0.1518 | 0.1604 | 0.1662 |
+| psychology | 0.1342 | 0.1266 | 0.1527 | 0.1805 |
+| robotics | 0.1091 | 0.1390 | 0.1578 | 0.1230 |
+| stackoverflow | 0.1626 | 0.1855 | 0.1290 | 0.1099 |
+| sustainable-living | 0.1613 | 0.1515 | 0.1497 | 0.1440 |
+| leetcode | 0.2471 | 0.2497 | 0.2603 | 0.2668 |
+| pony | 0.0434 | 0.0789 | 0.1440 | 0.0338 |
+| aops | 0.0645 | 0.0627 | 0.0692 | 0.0638 |
+| theoremqa-questions | 0.0733 | 0.1036 | 0.1113 | 0.1411 |
+| theoremqa-theorems | 0.0214 | 0.0492 | 0.0554 | 0.0532 |
+
+
+
+## Commands
+
+In the commands below:
+
++ Set `$fatjar` to the actual Anserini fatjar.
++ Set JVM args to `-Xms512M -Xmx192G -Dslf4j.internal.verbosity=WARN --add-modules jdk.incubator.vector`.
+
+Something like:
+
+```bash
+export fatjar=`ls -d {.,target}/anserini-*-fatjar.jar(N)`
+
+# for zsh
+export jvm_args=(-Xms512M -Xmx192G -Dslf4j.internal.verbosity=WARN --add-modules jdk.incubator.vector)
+
+# for bash
+export jvm_args="-Xms512M -Xmx192G -Dslf4j.internal.verbosity=WARN --add-modules jdk.incubator.vector"
+```
+
+<a id="condition-1"></a>
+
+### 1. BM25, bag-of-words baseline
+
+**Config**: [bright.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/bright.yaml)
+
+#### biology
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-biology \
+    -topics bright-biology \
+    -output runs/run.bright.bm25.biology.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-biology runs/run.bright.bm25.biology.txt
+```
+
+#### earth-science
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-earth-science \
+    -topics bright-earth-science \
+    -output runs/run.bright.bm25.earth-science.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-earth-science runs/run.bright.bm25.earth-science.txt
+```
+
+#### economics
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-economics \
+    -topics bright-economics \
+    -output runs/run.bright.bm25.economics.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-economics runs/run.bright.bm25.economics.txt
+```
+
+#### psychology
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-psychology \
+    -topics bright-psychology \
+    -output runs/run.bright.bm25.psychology.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-psychology runs/run.bright.bm25.psychology.txt
+```
+
+#### robotics
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-robotics \
+    -topics bright-robotics \
+    -output runs/run.bright.bm25.robotics.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-robotics runs/run.bright.bm25.robotics.txt
+```
+
+#### stackoverflow
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-stackoverflow \
+    -topics bright-stackoverflow \
+    -output runs/run.bright.bm25.stackoverflow.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-stackoverflow runs/run.bright.bm25.stackoverflow.txt
+```
+
+#### sustainable-living
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-sustainable-living \
+    -topics bright-sustainable-living \
+    -output runs/run.bright.bm25.sustainable-living.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-sustainable-living runs/run.bright.bm25.sustainable-living.txt
+```
+
+#### leetcode
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-leetcode \
+    -topics bright-leetcode \
+    -output runs/run.bright.bm25.leetcode.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-leetcode runs/run.bright.bm25.leetcode.txt
+```
+
+#### pony
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-pony \
+    -topics bright-pony \
+    -output runs/run.bright.bm25.pony.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-pony runs/run.bright.bm25.pony.txt
+```
+
+#### aops
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-aops \
+    -topics bright-aops \
+    -output runs/run.bright.bm25.aops.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-aops runs/run.bright.bm25.aops.txt
+```
+
+#### theoremqa-questions
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-theoremqa-questions \
+    -topics bright-theoremqa-questions \
+    -output runs/run.bright.bm25.theoremqa-questions.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-theoremqa-questions runs/run.bright.bm25.theoremqa-questions.txt
+```
+
+#### theoremqa-theorems
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-theoremqa-theorems \
+    -topics bright-theoremqa-theorems \
+    -output runs/run.bright.bm25.theoremqa-theorems.txt \
+    -bm25 \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-theoremqa-theorems runs/run.bright.bm25.theoremqa-theorems.txt
+```
+
+<a id="condition-2"></a>
+
+### 2. BM25, query-side BM25 baseline
+
+**Config**: [bright.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/bright.yaml)
+
+#### biology
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-biology \
+    -topics bright-biology \
+    -output runs/run.bright.bm25qs.biology.txt \
+    -bm25.querySide \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-biology runs/run.bright.bm25qs.biology.txt
+```
+
+#### earth-science
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-earth-science \
+    -topics bright-earth-science \
+    -output runs/run.bright.bm25qs.earth-science.txt \
+    -bm25.querySide \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-earth-science runs/run.bright.bm25qs.earth-science.txt
+```
+
+#### economics
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-economics \
+    -topics bright-economics \
+    -output runs/run.bright.bm25qs.economics.txt \
+    -bm25.querySide \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-economics runs/run.bright.bm25qs.economics.txt
+```
+
+#### psychology
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-psychology \
+    -topics bright-psychology \
+    -output runs/run.bright.bm25qs.psychology.txt \
+    -bm25.querySide \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-psychology runs/run.bright.bm25qs.psychology.txt
+```
+
+#### robotics
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-robotics \
+    -topics bright-robotics \
+    -output runs/run.bright.bm25qs.robotics.txt \
+    -bm25.querySide \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-robotics runs/run.bright.bm25qs.robotics.txt
+```
+
+#### stackoverflow
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-stackoverflow \
+    -topics bright-stackoverflow \
+    -output runs/run.bright.bm25qs.stackoverflow.txt \
+    -bm25.querySide \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-stackoverflow runs/run.bright.bm25qs.stackoverflow.txt
+```
+
+#### sustainable-living
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-sustainable-living \
+    -topics bright-sustainable-living \
+    -output runs/run.bright.bm25qs.sustainable-living.txt \
+    -bm25.querySide \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-sustainable-living runs/run.bright.bm25qs.sustainable-living.txt
+```
+
+#### leetcode
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-leetcode \
+    -topics bright-leetcode \
+    -output runs/run.bright.bm25qs.leetcode.txt \
+    -bm25.querySide \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-leetcode runs/run.bright.bm25qs.leetcode.txt
+```
+
+#### pony
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-pony \
+    -topics bright-pony \
+    -output runs/run.bright.bm25qs.pony.txt \
+    -bm25.querySide \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-pony runs/run.bright.bm25qs.pony.txt
+```
+
+#### aops
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-aops \
+    -topics bright-aops \
+    -output runs/run.bright.bm25qs.aops.txt \
+    -bm25.querySide \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-aops runs/run.bright.bm25qs.aops.txt
+```
+
+#### theoremqa-questions
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-theoremqa-questions \
+    -topics bright-theoremqa-questions \
+    -output runs/run.bright.bm25qs.theoremqa-questions.txt \
+    -bm25.querySide \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-theoremqa-questions runs/run.bright.bm25qs.theoremqa-questions.txt
+```
+
+#### theoremqa-theorems
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-theoremqa-theorems \
+    -topics bright-theoremqa-theorems \
+    -output runs/run.bright.bm25qs.theoremqa-theorems.txt \
+    -bm25.querySide \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-theoremqa-theorems runs/run.bright.bm25qs.theoremqa-theorems.txt
+```
+
+<a id="condition-3"></a>
+
+### 3. SPLADE-v3 (ONNX)
+
+**Config**: [bright.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/bright.yaml)
+
+#### biology
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-biology.splade-v3 \
+    -topics bright-biology \
+    -encoder SpladeV3 \
+    -output runs/run.bright.splade-v3.onnx.biology.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-biology runs/run.bright.splade-v3.onnx.biology.txt
+```
+
+#### earth-science
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-earth-science.splade-v3 \
+    -topics bright-earth-science \
+    -encoder SpladeV3 \
+    -output runs/run.bright.splade-v3.onnx.earth-science.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-earth-science runs/run.bright.splade-v3.onnx.earth-science.txt
+```
+
+#### economics
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-economics.splade-v3 \
+    -topics bright-economics \
+    -encoder SpladeV3 \
+    -output runs/run.bright.splade-v3.onnx.economics.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-economics runs/run.bright.splade-v3.onnx.economics.txt
+```
+
+#### psychology
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-psychology.splade-v3 \
+    -topics bright-psychology \
+    -encoder SpladeV3 \
+    -output runs/run.bright.splade-v3.onnx.psychology.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-psychology runs/run.bright.splade-v3.onnx.psychology.txt
+```
+
+#### robotics
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-robotics.splade-v3 \
+    -topics bright-robotics \
+    -encoder SpladeV3 \
+    -output runs/run.bright.splade-v3.onnx.robotics.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-robotics runs/run.bright.splade-v3.onnx.robotics.txt
+```
+
+#### stackoverflow
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-stackoverflow.splade-v3 \
+    -topics bright-stackoverflow \
+    -encoder SpladeV3 \
+    -output runs/run.bright.splade-v3.onnx.stackoverflow.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-stackoverflow runs/run.bright.splade-v3.onnx.stackoverflow.txt
+```
+
+#### sustainable-living
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-sustainable-living.splade-v3 \
+    -topics bright-sustainable-living \
+    -encoder SpladeV3 \
+    -output runs/run.bright.splade-v3.onnx.sustainable-living.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-sustainable-living runs/run.bright.splade-v3.onnx.sustainable-living.txt
+```
+
+#### pony
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-pony.splade-v3 \
+    -topics bright-pony \
+    -encoder SpladeV3 \
+    -output runs/run.bright.splade-v3.onnx.pony.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-pony runs/run.bright.splade-v3.onnx.pony.txt
+```
+
+#### leetcode
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-leetcode.splade-v3 \
+    -topics bright-leetcode \
+    -encoder SpladeV3 \
+    -output runs/run.bright.splade-v3.onnx.leetcode.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-leetcode runs/run.bright.splade-v3.onnx.leetcode.txt
+```
+
+#### aops
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-aops.splade-v3 \
+    -topics bright-aops \
+    -encoder SpladeV3 \
+    -output runs/run.bright.splade-v3.onnx.aops.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-aops runs/run.bright.splade-v3.onnx.aops.txt
+```
+
+#### theoremqa-questions
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-theoremqa-questions.splade-v3 \
+    -topics bright-theoremqa-questions \
+    -encoder SpladeV3 \
+    -output runs/run.bright.splade-v3.onnx.theoremqa-questions.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-theoremqa-questions runs/run.bright.splade-v3.onnx.theoremqa-questions.txt
+```
+
+#### theoremqa-theorems
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index bright-theoremqa-theorems.splade-v3 \
+    -topics bright-theoremqa-theorems \
+    -encoder SpladeV3 \
+    -output runs/run.bright.splade-v3.onnx.theoremqa-theorems.txt \
+    -impact \
+    -pretokenized \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-theoremqa-theorems runs/run.bright.splade-v3.onnx.theoremqa-theorems.txt
+```
+
+<a id="condition-4"></a>
+
+### 4. bge-large-en-v1.5 w/ flat indexes (ONNX)
+
+**Config**: [bright.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/bright.yaml)
+
+#### biology
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index bright-biology.bge-large-en-v1.5.flat \
+    -topics bright-biology \
+    -encoder BgeLargeEn15 \
+    -output runs/run.bright.bge-large-en-v1.5.flat.onnx.biology.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-biology runs/run.bright.bge-large-en-v1.5.flat.onnx.biology.txt
+```
+
+#### earth-science
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index bright-earth-science.bge-large-en-v1.5.flat \
+    -topics bright-earth-science \
+    -encoder BgeLargeEn15 \
+    -output runs/run.bright.bge-large-en-v1.5.flat.onnx.earth-science.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-earth-science runs/run.bright.bge-large-en-v1.5.flat.onnx.earth-science.txt
+```
+
+#### economics
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index bright-economics.bge-large-en-v1.5.flat \
+    -topics bright-economics \
+    -encoder BgeLargeEn15 \
+    -output runs/run.bright.bge-large-en-v1.5.flat.onnx.economics.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-economics runs/run.bright.bge-large-en-v1.5.flat.onnx.economics.txt
+```
+
+#### psychology
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index bright-psychology.bge-large-en-v1.5.flat \
+    -topics bright-psychology \
+    -encoder BgeLargeEn15 \
+    -output runs/run.bright.bge-large-en-v1.5.flat.onnx.psychology.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-psychology runs/run.bright.bge-large-en-v1.5.flat.onnx.psychology.txt
+```
+
+#### robotics
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index bright-robotics.bge-large-en-v1.5.flat \
+    -topics bright-robotics \
+    -encoder BgeLargeEn15 \
+    -output runs/run.bright.bge-large-en-v1.5.flat.onnx.robotics.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-robotics runs/run.bright.bge-large-en-v1.5.flat.onnx.robotics.txt
+```
+
+#### stackoverflow
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index bright-stackoverflow.bge-large-en-v1.5.flat \
+    -topics bright-stackoverflow \
+    -encoder BgeLargeEn15 \
+    -output runs/run.bright.bge-large-en-v1.5.flat.onnx.stackoverflow.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-stackoverflow runs/run.bright.bge-large-en-v1.5.flat.onnx.stackoverflow.txt
+```
+
+#### sustainable-living
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index bright-sustainable-living.bge-large-en-v1.5.flat \
+    -topics bright-sustainable-living \
+    -encoder BgeLargeEn15 \
+    -output runs/run.bright.bge-large-en-v1.5.flat.onnx.sustainable-living.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-sustainable-living runs/run.bright.bge-large-en-v1.5.flat.onnx.sustainable-living.txt
+```
+
+#### pony
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index bright-pony.bge-large-en-v1.5.flat \
+    -topics bright-pony \
+    -encoder BgeLargeEn15 \
+    -output runs/run.bright.bge-large-en-v1.5.flat.onnx.pony.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-pony runs/run.bright.bge-large-en-v1.5.flat.onnx.pony.txt
+```
+
+#### leetcode
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index bright-leetcode.bge-large-en-v1.5.flat \
+    -topics bright-leetcode \
+    -encoder BgeLargeEn15 \
+    -output runs/run.bright.bge-large-en-v1.5.flat.onnx.leetcode.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-leetcode runs/run.bright.bge-large-en-v1.5.flat.onnx.leetcode.txt
+```
+
+#### aops
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index bright-aops.bge-large-en-v1.5.flat \
+    -topics bright-aops \
+    -encoder BgeLargeEn15 \
+    -output runs/run.bright.bge-large-en-v1.5.flat.onnx.aops.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-aops runs/run.bright.bge-large-en-v1.5.flat.onnx.aops.txt
+```
+
+#### theoremqa-questions
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index bright-theoremqa-questions.bge-large-en-v1.5.flat \
+    -topics bright-theoremqa-questions \
+    -encoder BgeLargeEn15 \
+    -output runs/run.bright.bge-large-en-v1.5.flat.onnx.theoremqa-questions.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-theoremqa-questions runs/run.bright.bge-large-en-v1.5.flat.onnx.theoremqa-questions.txt
+```
+
+#### theoremqa-theorems
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchFlatDenseVectors \
+    -threads 16 \
+    -index bright-theoremqa-theorems.bge-large-en-v1.5.flat \
+    -topics bright-theoremqa-theorems \
+    -encoder BgeLargeEn15 \
+    -output runs/run.bright.bge-large-en-v1.5.flat.onnx.theoremqa-theorems.txt \
+    -removeQuery
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 bright-theoremqa-theorems runs/run.bright.bge-large-en-v1.5.flat.onnx.theoremqa-theorems.txt
+```
+
+

--- a/docs/reproduce/from-prebuilt-indexes/msmarco-v1-doc.md
+++ b/docs/reproduce/from-prebuilt-indexes/msmarco-v1-doc.md
@@ -53,6 +53,8 @@ export jvm_args="-Xms512M -Xmx192G -Dslf4j.internal.verbosity=WARN --add-modules
 
 ### 1. BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
 
+**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
+
 #### msmarco-doc.dev
 
 Retrieval command:
@@ -121,6 +123,8 @@ java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm
 
 ### 2. BM25 complete doc with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
 
+**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
+
 #### msmarco-doc.dev
 
 Retrieval command:
@@ -188,6 +192,8 @@ java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm
 <a id="condition-3"></a>
 
 ### 3. BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
+
+**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
 
 #### msmarco-doc.dev
 
@@ -266,6 +272,8 @@ java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm
 
 ### 4. BM25 segmented doc with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
 
+**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
+
 #### msmarco-doc.dev
 
 Retrieval command:
@@ -342,6 +350,8 @@ java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm
 <a id="condition-5"></a>
 
 ### 5. uniCOIL with doc2query-T5 (ONNX)
+
+**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
 
 #### msmarco-doc.dev
 
@@ -426,6 +436,8 @@ java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.un
 
 ### 6. BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
 
+**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
+
 #### msmarco-doc.dev
 
 Retrieval command:
@@ -494,6 +506,8 @@ java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm
 
 ### 7. BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index
 
+**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
+
 #### msmarco-doc.dev
 
 Retrieval command:
@@ -561,6 +575,8 @@ java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm
 <a id="condition-8"></a>
 
 ### 8. BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
+
+**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
 
 #### msmarco-doc.dev
 
@@ -638,6 +654,8 @@ java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm
 <a id="condition-9"></a>
 
 ### 9. BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index
+
+**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
 
 #### msmarco-doc.dev
 

--- a/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
@@ -495,6 +495,9 @@ public class ReproduceFromPrebuiltIndexes {
     public String display;
 
     @JsonProperty
+    public String short_name;
+
+    @JsonProperty
     public String display_html;
 
     @JsonProperty

--- a/src/main/resources/reproduce/from-prebuilt-indexes/configs/beir.yaml
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/configs/beir.yaml
@@ -1,6 +1,7 @@
 conditions:
   - name: flat
     display: "BM25, flat bag-of-words baseline"
+    short_name: BM25f
     command: io.anserini.search.SearchCollection -threads $threads -index beir-v1.0.0-$topics.flat -topics beir-$topics -output $output -bm25 -removeQuery
     topics:
       - topic_key: trec-covid
@@ -179,6 +180,7 @@ conditions:
           nDCG@10: "-c -m ndcg_cut.10"
   - name: multifield
     display: "BM25, multifield bag-of-words baseline"
+    short_name: BM25mf
     command: io.anserini.search.SearchCollection -threads $threads -index beir-v1.0.0-$topics.multifield -topics beir-$topics -output $output -bm25 -removeQuery -fields contents=1.0 title=1.0
     topics:
       - topic_key: trec-covid
@@ -357,6 +359,7 @@ conditions:
           nDCG@10: "-c -m ndcg_cut.10"
   - name: splade-v3.onnx
     display: "SPLADE-v3 (ONNX)"
+    short_name: SPLADE
     command: io.anserini.search.SearchCollection -threads $threads -index beir-v1.0.0-$topics.splade-v3 -topics beir-$topics -encoder SpladeV3 -output $output -impact -pretokenized -removeQuery
     topics:
     - topic_key: trec-covid
@@ -535,6 +538,7 @@ conditions:
         nDCG@10: "-c -m ndcg_cut.10"
   - name: bge-base-en-v1.5.flat.onnx
     display: "bge-base-en-v1.5 w/ flat indexes (ONNX)"
+    short_name: BGE
     command: io.anserini.search.SearchFlatDenseVectors -threads $threads -index beir-v1.0.0-$topics.bge-base-en-v1.5.flat -topics beir-$topics -encoder BgeBaseEn15 -output $output -removeQuery
     topics:
       - topic_key: trec-covid
@@ -713,6 +717,7 @@ conditions:
           nDCG@10: "-c -m ndcg_cut.10"
   - name: fusion-rrf
     display: "Fusion: RRF (BM25 + BGE)"
+    short_name: RRF
     command: io.anserini.fusion.FuseRuns -runs $runs_directory/run.beir.flat.$topics.txt $runs_directory/run.beir.bge-base-en-v1.5.flat.onnx.$topics.txt -output $output -method rrf -k 1000 -depth 1000 -rrf_k 60
     topics:
       - topic_key: trec-covid
@@ -891,6 +896,7 @@ conditions:
           nDCG@10: "-c -m ndcg_cut.10"
   - name: fusion-avg
     display: "Fusion: Average (BM25 + BGE) with normalization"
+    short_name: Avg
     command: io.anserini.fusion.FuseRuns -runs $runs_directory/run.beir.flat.$topics.txt $runs_directory/run.beir.bge-base-en-v1.5.flat.onnx.$topics.txt -output $output -method average -k 1000 -depth 1000 -min_max_normalization
     topics:
       - topic_key: trec-covid

--- a/src/main/resources/reproduce/from-prebuilt-indexes/configs/bright.yaml
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/configs/bright.yaml
@@ -1,6 +1,7 @@
 conditions:
   - name: bm25
     display: "BM25, bag-of-words baseline"
+    short_name: BM25
     command: io.anserini.search.SearchCollection -threads $threads -index bright-$topics -topics bright-$topics -output $output -bm25 -removeQuery
     topics:
       - topic_key: biology
@@ -77,6 +78,7 @@ conditions:
           nDCG@10: "-c -m ndcg_cut.10"
   - name: bm25qs
     display: "BM25, query-side BM25 baseline"
+    short_name: BM25qs
     command: io.anserini.search.SearchCollection -threads $threads -index bright-$topics -topics bright-$topics -output $output -bm25.querySide -removeQuery
     topics:
       - topic_key: biology
@@ -153,6 +155,7 @@ conditions:
           nDCG@10: "-c -m ndcg_cut.10"
   - name: splade-v3.onnx
     display: "SPLADE-v3 (ONNX)"
+    short_name: SPLADE
     command: io.anserini.search.SearchCollection -threads $threads -index bright-$topics.splade-v3 -topics bright-$topics -encoder SpladeV3 -output $output -impact -pretokenized -removeQuery
     topics:
       - topic_key: biology
@@ -229,6 +232,7 @@ conditions:
           nDCG@10: "-c -m ndcg_cut.10"
   - name: bge-large-en-v1.5.flat.onnx
     display: "bge-large-en-v1.5 w/ flat indexes (ONNX)"
+    short_name: BGE
     command: io.anserini.search.SearchFlatDenseVectors -threads $threads -index bright-$topics.bge-large-en-v1.5.flat -topics bright-$topics -encoder BgeLargeEn15 -output $output -removeQuery
     topics:
       - topic_key: biology

--- a/src/main/resources/reproduce/from-prebuilt-indexes/docgen/beir.template
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/docgen/beir.template
@@ -1,0 +1,43 @@
+# <img src="../../anserini-logo.png" height="30" /> BEIR
+
+**Anserini reproductions from prebuilt indexes**
+
++ **Corpus**: BEIR
++ **Config**: ${config}
+
+## Summary
+
+The table below summarizes effectiveness in terms of nDCG@10.
+For more metrics, refer to the config directly.
+
+Key:
+
++ **BM25f** = BM25, flat bag-of-words baseline
++ **BM25mf** = BM25, multifield bag-of-words baseline
++ **SPLADE** = SPLADE-v3 (ONNX)
++ **BGE** = bge-base-en-v1.5 w/ flat indexes (ONNX)
++ **RRF** = Fusion: RRF (BM25 + BGE)
++ **Avg** = Fusion: Average (BM25 + BGE) with normalization
+
+${summary}
+
+## Commands
+
+In the commands below:
+
++ Set `$fatjar` to the actual Anserini fatjar.
++ Set JVM args to `${jvm_args}`.
+
+Something like:
+
+```bash
+export fatjar=`ls -d {.,target}/anserini-*-fatjar.jar(N)`
+
+# for zsh
+export jvm_args=(${jvm_args})
+
+# for bash
+export jvm_args="${jvm_args}"
+```
+
+${commands}

--- a/src/main/resources/reproduce/from-prebuilt-indexes/docgen/beir.template
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/docgen/beir.template
@@ -16,8 +16,8 @@ Key:
 + **BM25mf** = BM25, multifield bag-of-words baseline
 + **SPLADE** = SPLADE-v3 (ONNX)
 + **BGE** = bge-base-en-v1.5 w/ flat indexes (ONNX)
-+ **RRF** = Fusion: RRF (BM25 + BGE)
-+ **Avg** = Fusion: Average (BM25 + BGE) with normalization
++ **RRF** = Fusion: RRF (BM25f + BGE)
++ **Avg** = Fusion: Average (BM25f + BGE) with normalization
 
 ${summary}
 

--- a/src/main/resources/reproduce/from-prebuilt-indexes/docgen/bright.template
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/docgen/bright.template
@@ -1,0 +1,41 @@
+# <img src="../../anserini-logo.png" height="30" /> BRIGHT
+
+**Anserini reproductions from prebuilt indexes**
+
++ **Corpus**: BRIGHT
++ **Config**: ${config}
+
+## Summary
+
+The table below summarizes effectiveness in terms of nDCG@10.
+For more metrics, refer to the config directly.
+
+Key:
+
++ **BM25** = BM25, bag-of-words baseline
++ **BM25qs** = BM25, query-side BM25 baseline
++ **SPLADE** = SPLADE-v3 (ONNX)
++ **BGE** = bge-large-en-v1.5 w/ flat indexes (ONNX)
+
+${summary}
+
+## Commands
+
+In the commands below:
+
++ Set `$fatjar` to the actual Anserini fatjar.
++ Set JVM args to `${jvm_args}`.
+
+Something like:
+
+```bash
+export fatjar=`ls -d {.,target}/anserini-*-fatjar.jar(N)`
+
+# for zsh
+export jvm_args=(${jvm_args})
+
+# for bash
+export jvm_args="${jvm_args}"
+```
+
+${commands}

--- a/src/test/java/io/anserini/doc/GenerateReproductionDocsFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/doc/GenerateReproductionDocsFromPrebuiltIndexesTest.java
@@ -79,19 +79,6 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
         .replace("$output", runOutputPath(runTag, conditionName, topicKey))
         .replace("$runs_directory", ReproductionUtils.Constants.DEFAULT_RUNS_DIRECTORY);
 
-    if ("bge-base-en-v1.5.hnsw.onnx".equals(conditionName)) {
-      String efSearch = switch (topicKey) {
-        case "bioasq" -> "11000";
-        case "nq" -> "2000";
-        case "hotpotqa", "fever" -> "6000";
-        default -> null;
-      };
-
-      if (efSearch != null) {
-        command = command.replaceFirst("(?<=\\s-efSearch\\s)\\d+", efSearch);
-      }
-    }
-
     return command;
   }
 
@@ -139,7 +126,7 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
     return new ReportContext(yamlPath, runTag, config, template, output, configLink);
   }
 
-  private static String buildSummary(Config config, List<SummaryColumn> columns) {
+  private static String buildSummaryInRows(Config config, List<SummaryColumn> columns) {
     StringBuilder summary = new StringBuilder();
     summary.append("| # | name");
     for (SummaryColumn column : columns) {
@@ -187,6 +174,39 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
     return summary.toString();
   }
 
+  private static String buildSummaryInColumns(Config config, String metric, Function<Condition, String> conditionHeading) {
+    StringBuilder summary = new StringBuilder();
+    summary.append("| corpus");
+    for (int i = 0; i < config.conditions.size(); i++) {
+      summary.append(" | ").append(String.format("[%s](#condition-%d)", conditionHeading.apply(config.conditions.get(i)), i + 1));
+    }
+    summary.append(" |\n");
+
+    summary.append("| ---");
+    for (int i = 0; i < config.conditions.size(); i++) {
+      summary.append(" | ---");
+    }
+    summary.append(" |\n");
+
+    for (Topic topic : config.conditions.get(0).topics) {
+      summary.append(String.format("| %s", topic.topic_key));
+      for (Condition condition : config.conditions) {
+        Double score = null;
+        for (Topic conditionTopic : condition.topics) {
+          if (conditionTopic.topic_key.equals(topic.topic_key) && conditionTopic.expected_scores != null) {
+            score = conditionTopic.expected_scores.get(metric);
+            break;
+          }
+        }
+        summary.append(" | ").append(score == null ? "" : String.format("%.4f", score));
+      }
+      summary.append(" |\n");
+    }
+
+    summary.append("\n");
+    return summary.toString();
+  }
+
   private static String buildCommandSections(ReportContext context, boolean includeConfigPerCondition,
       BiFunction<Topic, Condition, String> topicHeading) {
     StringBuilder command = new StringBuilder();
@@ -216,21 +236,35 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
     return matches ? topic.expected_scores.get(metric) : null;
   }
 
-  private static void generateReport(String yamlConfig, List<SummaryColumn> columns, boolean includeConfigPerCondition,
+  private static String shortNameOrDisplay(Condition condition) {
+    return condition.short_name == null ? condition.display : condition.short_name;
+  }
+
+  private static void generateReportInRows(String yamlConfig, List<SummaryColumn> columns, boolean includeConfigPerCondition,
       BiFunction<Topic, Condition, String> topicHeading) throws Exception {
     ReportContext context = loadReportContext(yamlConfig);
     String commands = buildCommandSections(context, includeConfigPerCondition, topicHeading);
+    writeReport(context, buildSummaryInRows(context.config(), columns), commands);
+  }
 
+  private static void generateReportInColumns(String yamlConfig, String metric, Function<Condition, String> conditionHeading,
+      boolean includeConfigPerCondition, BiFunction<Topic, Condition, String> topicHeading) throws Exception {
+    ReportContext context = loadReportContext(yamlConfig);
+    String commands = buildCommandSections(context, includeConfigPerCondition, topicHeading);
+    writeReport(context, buildSummaryInColumns(context.config(), metric, conditionHeading), commands);
+  }
+
+  private static void writeReport(ReportContext context, String summary, String commands) throws Exception {
     FileUtils.writeStringToFile(context.output(), context.template()
         .replace("${config}", context.configLink())
         .replace("${jvm_args}", ReproductionUtils.Constants.JVM_ARGS)
-        .replace("${summary}", buildSummary(context.config(), columns))
+        .replace("${summary}", summary)
         .replace("${commands}", commands)
         .replace("${command}", commands), StandardCharsets.UTF_8);
   }
 
   private static void generateMsMarcoV1PassageReport(String yamlConfig) throws Exception {
-    generateReport(yamlConfig, List.of(
+    generateReportInRows(yamlConfig, List.of(
         new SummaryColumn("dev", topic -> score(topic, topic.topic_key.startsWith("msmarco-v1-passage.dev"), "MRR@10")),
         new SummaryColumn("DL19", topic -> score(topic, topic.topic_key.startsWith("dl19-passage"), "nDCG@10")),
         new SummaryColumn("DL20", topic -> score(topic, topic.topic_key.startsWith("dl20-passage"), "nDCG@10"))),
@@ -243,7 +277,7 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
   }
 
   private static void generateMsMarcoV1DocReport(String yamlConfig) throws Exception {
-    generateReport(yamlConfig, List.of(
+    generateReportInRows(yamlConfig, List.of(
         new SummaryColumn("dev", topic -> score(topic, topic.topic_key.startsWith("msmarco-doc.dev"), "MRR@100")),
         new SummaryColumn("DL19", topic -> score(topic, topic.topic_key.startsWith("dl19-doc"), "nDCG@10")),
         new SummaryColumn("DL20", topic -> score(topic, topic.topic_key.startsWith("dl20-doc"), "nDCG@10"))),
@@ -256,7 +290,7 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
   }
 
   private static void generateMsMarcoV2PassageReport(String yamlConfig) throws Exception {
-    generateReport(yamlConfig, List.of(
+    generateReportInRows(yamlConfig, List.of(
         new SummaryColumn("dev", topic -> score(topic, matchesTopicPrefix(topic.topic_key, "msmarco-v2-passage.dev"), "MRR@100")),
         new SummaryColumn("dev2", topic -> score(topic, matchesTopicPrefix(topic.topic_key, "msmarco-v2-passage.dev2"), "MRR@100")),
         new SummaryColumn("DL21", topic -> score(topic, topic.topic_key.startsWith("dl21"), "nDCG@10")),
@@ -271,7 +305,7 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
   }
 
   private static void generateMsMarcoV2DocReport(String yamlConfig) throws Exception {
-    generateReport(yamlConfig, List.of(
+    generateReportInRows(yamlConfig, List.of(
         new SummaryColumn("dev", topic -> score(topic, matchesTopicPrefix(topic.topic_key, "msmarco-v2-doc.dev"), "MRR@100")),
         new SummaryColumn("dev2", topic -> score(topic, matchesTopicPrefix(topic.topic_key, "msmarco-v2-doc.dev2"), "MRR@100")),
         new SummaryColumn("DL21", topic -> score(topic, topic.topic_key.startsWith("dl21"), "nDCG@10")),
@@ -286,7 +320,7 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
   }
 
   private static void generateMsMarcoV21DocReport(String yamlConfig) throws Exception {
-    generateReport(yamlConfig, List.of(
+    generateReportInRows(yamlConfig, List.of(
         new SummaryColumn("dev", topic -> score(topic, topic.topic_key.equals("msmarco-v2-doc.dev"), "MRR@100")),
         new SummaryColumn("dev2", topic -> score(topic, topic.topic_key.equals("msmarco-v2-doc.dev2"), "MRR@100")),
         new SummaryColumn("DL21", topic -> score(topic, topic.topic_key.startsWith("dl21-doc"), "nDCG@10")),
@@ -302,7 +336,7 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
   }
 
   private static void generateMsMarcoV21SegmentedDocReport(String yamlConfig) throws Exception {
-    generateReport(yamlConfig, List.of(
+    generateReportInRows(yamlConfig, List.of(
         new SummaryColumn("RAG24 ☂️", topic -> score(topic, topic.eval_key.equals("rag24.test-umbrela-all"), "nDCG@20")),
         new SummaryColumn("RAG24 NIST", topic -> score(topic, topic.eval_key.equals("rag24.test"), "nDCG@20")),
         new SummaryColumn("RAG25 ☂️", topic -> score(topic, topic.eval_key.equals("rag25.test-umbrela2"), "nDCG@30")),
@@ -313,5 +347,27 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
   @Test
   public void generateMsMarcoV21SegmentedDocReport() throws Exception {
     generateMsMarcoV21SegmentedDocReport("msmarco-v2.1-doc-segmented.yaml");
+  }
+
+  private static void generateBrightReport(String yamlConfig) throws Exception {
+    generateReportInColumns(yamlConfig, "nDCG@10",
+        GenerateReproductionDocsFromPrebuiltIndexesTest::shortNameOrDisplay, true,
+        (topic, condition) -> topic.topic_key);
+  }
+
+  @Test
+  public void generateBrightReport() throws Exception {
+    generateBrightReport("bright.yaml");
+  }
+
+  private static void generateBeirReport(String yamlConfig) throws Exception {
+    generateReportInColumns(yamlConfig, "nDCG@10",
+        GenerateReproductionDocsFromPrebuiltIndexesTest::shortNameOrDisplay, true,
+        (topic, condition) -> topic.topic_key);
+  }
+
+  @Test
+  public void generateBeirReport() throws Exception {
+    generateBeirReport("beir.yaml");
   }
 }

--- a/src/test/java/io/anserini/doc/GenerateReproductionDocsFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/doc/GenerateReproductionDocsFromPrebuiltIndexesTest.java
@@ -174,11 +174,13 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
     return summary.toString();
   }
 
-  private static String buildSummaryInColumns(Config config, String metric, Function<Condition, String> conditionHeading) {
+  private static String buildSummaryInColumns(Config config, String metric) {
     StringBuilder summary = new StringBuilder();
     summary.append("| corpus");
     for (int i = 0; i < config.conditions.size(); i++) {
-      summary.append(" | ").append(String.format("[%s](#condition-%d)", conditionHeading.apply(config.conditions.get(i)), i + 1));
+      Condition condition = config.conditions.get(i);
+      String heading = condition.short_name == null ? condition.display : condition.short_name;
+      summary.append(" | ").append(String.format("[%s](#condition-%d)", heading, i + 1));
     }
     summary.append(" |\n");
 
@@ -236,10 +238,6 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
     return matches ? topic.expected_scores.get(metric) : null;
   }
 
-  private static String shortNameOrDisplay(Condition condition) {
-    return condition.short_name == null ? condition.display : condition.short_name;
-  }
-
   private static void generateReportInRows(String yamlConfig, List<SummaryColumn> columns, boolean includeConfigPerCondition,
       BiFunction<Topic, Condition, String> topicHeading) throws Exception {
     ReportContext context = loadReportContext(yamlConfig);
@@ -247,11 +245,11 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
     writeReport(context, buildSummaryInRows(context.config(), columns), commands);
   }
 
-  private static void generateReportInColumns(String yamlConfig, String metric, Function<Condition, String> conditionHeading,
-      boolean includeConfigPerCondition, BiFunction<Topic, Condition, String> topicHeading) throws Exception {
+  private static void generateReportInColumns(String yamlConfig, String metric, boolean includeConfigPerCondition,
+      BiFunction<Topic, Condition, String> topicHeading) throws Exception {
     ReportContext context = loadReportContext(yamlConfig);
     String commands = buildCommandSections(context, includeConfigPerCondition, topicHeading);
-    writeReport(context, buildSummaryInColumns(context.config(), metric, conditionHeading), commands);
+    writeReport(context, buildSummaryInColumns(context.config(), metric), commands);
   }
 
   private static void writeReport(ReportContext context, String summary, String commands) throws Exception {
@@ -327,15 +325,13 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
 
   @Test
   public void generateBrightReport() throws Exception {
-    generateReportInColumns("bright.yaml", "nDCG@10",
-        GenerateReproductionDocsFromPrebuiltIndexesTest::shortNameOrDisplay, true,
+    generateReportInColumns("bright.yaml", "nDCG@10", true,
         (topic, condition) -> topic.topic_key);
   }
 
   @Test
   public void generateBeirReport() throws Exception {
-    generateReportInColumns("beir.yaml", "nDCG@10",
-        GenerateReproductionDocsFromPrebuiltIndexesTest::shortNameOrDisplay, true,
+    generateReportInColumns("beir.yaml", "nDCG@10", true,
         (topic, condition) -> topic.topic_key);
   }
 }

--- a/src/test/java/io/anserini/doc/GenerateReproductionDocsFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/doc/GenerateReproductionDocsFromPrebuiltIndexesTest.java
@@ -231,7 +231,7 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
     return command.toString();
   }
 
-  private static Double score(Topic topic, boolean matches, String metric) {
+  private static Double extractExpectedScore(Topic topic, boolean matches, String metric) {
     return matches ? topic.expected_scores.get(metric) : null;
   }
 
@@ -261,62 +261,62 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
   @Test
   public void generateMsMarcoV1PassageReport() throws Exception {
     generateReportInRows("msmarco-v1-passage.yaml", List.of(
-        new SummaryColumn("dev", topic -> score(topic, topic.topic_key.startsWith("msmarco-v1-passage.dev"), "MRR@10")),
-        new SummaryColumn("DL19", topic -> score(topic, topic.topic_key.startsWith("dl19-passage"), "nDCG@10")),
-        new SummaryColumn("DL20", topic -> score(topic, topic.topic_key.startsWith("dl20-passage"), "nDCG@10"))),
+        new SummaryColumn("dev", topic -> extractExpectedScore(topic, topic.topic_key.startsWith("msmarco-v1-passage.dev"), "MRR@10")),
+        new SummaryColumn("DL19", topic -> extractExpectedScore(topic, topic.topic_key.startsWith("dl19-passage"), "nDCG@10")),
+        new SummaryColumn("DL20", topic -> extractExpectedScore(topic, topic.topic_key.startsWith("dl20-passage"), "nDCG@10"))),
         (topic, condition) -> topic.topic_key);
   }
 
   @Test
   public void generateMsMarcoV1DocReport() throws Exception {
     generateReportInRows("msmarco-v1-doc.yaml", List.of(
-        new SummaryColumn("dev", topic -> score(topic, topic.topic_key.startsWith("msmarco-doc.dev"), "MRR@100")),
-        new SummaryColumn("DL19", topic -> score(topic, topic.topic_key.startsWith("dl19-doc"), "nDCG@10")),
-        new SummaryColumn("DL20", topic -> score(topic, topic.topic_key.startsWith("dl20-doc"), "nDCG@10"))),
+        new SummaryColumn("dev", topic -> extractExpectedScore(topic, topic.topic_key.startsWith("msmarco-doc.dev"), "MRR@100")),
+        new SummaryColumn("DL19", topic -> extractExpectedScore(topic, topic.topic_key.startsWith("dl19-doc"), "nDCG@10")),
+        new SummaryColumn("DL20", topic -> extractExpectedScore(topic, topic.topic_key.startsWith("dl20-doc"), "nDCG@10"))),
         (topic, condition) -> topic.topic_key);
   }
 
   @Test
   public void generateMsMarcoV2PassageReport() throws Exception {
     generateReportInRows("msmarco-v2-passage.yaml", List.of(
-        new SummaryColumn("dev", topic -> score(topic, matchesTopicPrefix(topic.topic_key, "msmarco-v2-passage.dev"), "MRR@100")),
-        new SummaryColumn("dev2", topic -> score(topic, matchesTopicPrefix(topic.topic_key, "msmarco-v2-passage.dev2"), "MRR@100")),
-        new SummaryColumn("DL21", topic -> score(topic, topic.topic_key.startsWith("dl21"), "nDCG@10")),
-        new SummaryColumn("DL22", topic -> score(topic, topic.topic_key.startsWith("dl22"), "nDCG@10")),
-        new SummaryColumn("DL23", topic -> score(topic, topic.topic_key.startsWith("dl23"), "nDCG@10"))),
+        new SummaryColumn("dev", topic -> extractExpectedScore(topic, matchesTopicPrefix(topic.topic_key, "msmarco-v2-passage.dev"), "MRR@100")),
+        new SummaryColumn("dev2", topic -> extractExpectedScore(topic, matchesTopicPrefix(topic.topic_key, "msmarco-v2-passage.dev2"), "MRR@100")),
+        new SummaryColumn("DL21", topic -> extractExpectedScore(topic, topic.topic_key.startsWith("dl21"), "nDCG@10")),
+        new SummaryColumn("DL22", topic -> extractExpectedScore(topic, topic.topic_key.startsWith("dl22"), "nDCG@10")),
+        new SummaryColumn("DL23", topic -> extractExpectedScore(topic, topic.topic_key.startsWith("dl23"), "nDCG@10"))),
         (topic, condition) -> topic.topic_key);
   }
 
   @Test
   public void generateMsMarcoV2DocReport() throws Exception {
     generateReportInRows("msmarco-v2-doc.yaml", List.of(
-        new SummaryColumn("dev", topic -> score(topic, matchesTopicPrefix(topic.topic_key, "msmarco-v2-doc.dev"), "MRR@100")),
-        new SummaryColumn("dev2", topic -> score(topic, matchesTopicPrefix(topic.topic_key, "msmarco-v2-doc.dev2"), "MRR@100")),
-        new SummaryColumn("DL21", topic -> score(topic, topic.topic_key.startsWith("dl21"), "nDCG@10")),
-        new SummaryColumn("DL22", topic -> score(topic, topic.topic_key.startsWith("dl22"), "nDCG@10")),
-        new SummaryColumn("DL23", topic -> score(topic, topic.topic_key.startsWith("dl23"), "nDCG@10"))),
+        new SummaryColumn("dev", topic -> extractExpectedScore(topic, matchesTopicPrefix(topic.topic_key, "msmarco-v2-doc.dev"), "MRR@100")),
+        new SummaryColumn("dev2", topic -> extractExpectedScore(topic, matchesTopicPrefix(topic.topic_key, "msmarco-v2-doc.dev2"), "MRR@100")),
+        new SummaryColumn("DL21", topic -> extractExpectedScore(topic, topic.topic_key.startsWith("dl21"), "nDCG@10")),
+        new SummaryColumn("DL22", topic -> extractExpectedScore(topic, topic.topic_key.startsWith("dl22"), "nDCG@10")),
+        new SummaryColumn("DL23", topic -> extractExpectedScore(topic, topic.topic_key.startsWith("dl23"), "nDCG@10"))),
         (topic, condition) -> topic.topic_key);
   }
 
   @Test
   public void generateMsMarcoV21DocReport() throws Exception {
     generateReportInRows("msmarco-v2.1-doc.yaml", List.of(
-        new SummaryColumn("dev", topic -> score(topic, topic.topic_key.equals("msmarco-v2-doc.dev"), "MRR@100")),
-        new SummaryColumn("dev2", topic -> score(topic, topic.topic_key.equals("msmarco-v2-doc.dev2"), "MRR@100")),
-        new SummaryColumn("DL21", topic -> score(topic, topic.topic_key.startsWith("dl21-doc"), "nDCG@10")),
-        new SummaryColumn("DL22", topic -> score(topic, topic.topic_key.startsWith("dl22-doc"), "nDCG@10")),
-        new SummaryColumn("DL23", topic -> score(topic, topic.topic_key.startsWith("dl23-doc"), "nDCG@10")),
-        new SummaryColumn("RAGgy", topic -> score(topic, topic.topic_key.startsWith("rag24"), "nDCG@10"))),
+        new SummaryColumn("dev", topic -> extractExpectedScore(topic, topic.topic_key.equals("msmarco-v2-doc.dev"), "MRR@100")),
+        new SummaryColumn("dev2", topic -> extractExpectedScore(topic, topic.topic_key.equals("msmarco-v2-doc.dev2"), "MRR@100")),
+        new SummaryColumn("DL21", topic -> extractExpectedScore(topic, topic.topic_key.startsWith("dl21-doc"), "nDCG@10")),
+        new SummaryColumn("DL22", topic -> extractExpectedScore(topic, topic.topic_key.startsWith("dl22-doc"), "nDCG@10")),
+        new SummaryColumn("DL23", topic -> extractExpectedScore(topic, topic.topic_key.startsWith("dl23-doc"), "nDCG@10")),
+        new SummaryColumn("RAGgy", topic -> extractExpectedScore(topic, topic.topic_key.startsWith("rag24"), "nDCG@10"))),
         (topic, condition) -> topic.topic_key);
   }
 
   @Test
   public void generateMsMarcoV21SegmentedDocReport() throws Exception {
     generateReportInRows("msmarco-v2.1-doc-segmented.yaml", List.of(
-        new SummaryColumn("RAG24 ☂️", topic -> score(topic, topic.eval_key.equals("rag24.test-umbrela-all"), "nDCG@20")),
-        new SummaryColumn("RAG24 NIST", topic -> score(topic, topic.eval_key.equals("rag24.test"), "nDCG@20")),
-        new SummaryColumn("RAG25 ☂️", topic -> score(topic, topic.eval_key.equals("rag25.test-umbrela2"), "nDCG@30")),
-        new SummaryColumn("RAG25 NIST", topic -> score(topic, topic.eval_key.equals("rag25.test"), "nDCG@30"))),
+        new SummaryColumn("RAG24 ☂️", topic -> extractExpectedScore(topic, topic.eval_key.equals("rag24.test-umbrela-all"), "nDCG@20")),
+        new SummaryColumn("RAG24 NIST", topic -> extractExpectedScore(topic, topic.eval_key.equals("rag24.test"), "nDCG@20")),
+        new SummaryColumn("RAG25 ☂️", topic -> extractExpectedScore(topic, topic.eval_key.equals("rag25.test-umbrela2"), "nDCG@30")),
+        new SummaryColumn("RAG25 NIST", topic -> extractExpectedScore(topic, topic.eval_key.equals("rag25.test"), "nDCG@30"))),
         (topic, condition) -> String.format("%s / %s", topic.topic_key, topic.eval_key));
   }
 

--- a/src/test/java/io/anserini/doc/GenerateReproductionDocsFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/doc/GenerateReproductionDocsFromPrebuiltIndexesTest.java
@@ -209,15 +209,12 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
     return summary.toString();
   }
 
-  private static String buildCommandSections(ReportContext context, boolean includeConfigPerCondition,
-      BiFunction<Topic, Condition, String> topicHeading) {
+  private static String buildCommandSections(ReportContext context, BiFunction<Topic, Condition, String> topicHeading) {
     StringBuilder command = new StringBuilder();
     int row = 1;
     for (Condition condition : context.config().conditions) {
       command.append(String.format("<a id=\"condition-%d\"></a>\n\n### %d. %s\n\n", row, row, condition.display));
-      if (includeConfigPerCondition) {
-        command.append(String.format("**Config**: %s\n\n", context.configLink()));
-      }
+      command.append(String.format("**Config**: %s\n\n", context.configLink()));
       row++;
 
       for (Topic topic : condition.topics) {
@@ -238,17 +235,17 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
     return matches ? topic.expected_scores.get(metric) : null;
   }
 
-  private static void generateReportInRows(String yamlConfig, List<SummaryColumn> columns, boolean includeConfigPerCondition,
+  private static void generateReportInRows(String yamlConfig, List<SummaryColumn> columns,
       BiFunction<Topic, Condition, String> topicHeading) throws Exception {
     ReportContext context = loadReportContext(yamlConfig);
-    String commands = buildCommandSections(context, includeConfigPerCondition, topicHeading);
+    String commands = buildCommandSections(context, topicHeading);
     writeReport(context, buildSummaryInRows(context.config(), columns), commands);
   }
 
-  private static void generateReportInColumns(String yamlConfig, String metric, boolean includeConfigPerCondition,
+  private static void generateReportInColumns(String yamlConfig, String metric,
       BiFunction<Topic, Condition, String> topicHeading) throws Exception {
     ReportContext context = loadReportContext(yamlConfig);
-    String commands = buildCommandSections(context, includeConfigPerCondition, topicHeading);
+    String commands = buildCommandSections(context, topicHeading);
     writeReport(context, buildSummaryInColumns(context.config(), metric), commands);
   }
 
@@ -267,7 +264,7 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
         new SummaryColumn("dev", topic -> score(topic, topic.topic_key.startsWith("msmarco-v1-passage.dev"), "MRR@10")),
         new SummaryColumn("DL19", topic -> score(topic, topic.topic_key.startsWith("dl19-passage"), "nDCG@10")),
         new SummaryColumn("DL20", topic -> score(topic, topic.topic_key.startsWith("dl20-passage"), "nDCG@10"))),
-        true, (topic, condition) -> topic.topic_key);
+        (topic, condition) -> topic.topic_key);
   }
 
   @Test
@@ -276,7 +273,7 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
         new SummaryColumn("dev", topic -> score(topic, topic.topic_key.startsWith("msmarco-doc.dev"), "MRR@100")),
         new SummaryColumn("DL19", topic -> score(topic, topic.topic_key.startsWith("dl19-doc"), "nDCG@10")),
         new SummaryColumn("DL20", topic -> score(topic, topic.topic_key.startsWith("dl20-doc"), "nDCG@10"))),
-        false, (topic, condition) -> topic.topic_key);
+        (topic, condition) -> topic.topic_key);
   }
 
   @Test
@@ -287,7 +284,7 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
         new SummaryColumn("DL21", topic -> score(topic, topic.topic_key.startsWith("dl21"), "nDCG@10")),
         new SummaryColumn("DL22", topic -> score(topic, topic.topic_key.startsWith("dl22"), "nDCG@10")),
         new SummaryColumn("DL23", topic -> score(topic, topic.topic_key.startsWith("dl23"), "nDCG@10"))),
-        true, (topic, condition) -> topic.topic_key);
+        (topic, condition) -> topic.topic_key);
   }
 
   @Test
@@ -298,7 +295,7 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
         new SummaryColumn("DL21", topic -> score(topic, topic.topic_key.startsWith("dl21"), "nDCG@10")),
         new SummaryColumn("DL22", topic -> score(topic, topic.topic_key.startsWith("dl22"), "nDCG@10")),
         new SummaryColumn("DL23", topic -> score(topic, topic.topic_key.startsWith("dl23"), "nDCG@10"))),
-        true, (topic, condition) -> topic.topic_key);
+        (topic, condition) -> topic.topic_key);
   }
 
   @Test
@@ -310,7 +307,7 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
         new SummaryColumn("DL22", topic -> score(topic, topic.topic_key.startsWith("dl22-doc"), "nDCG@10")),
         new SummaryColumn("DL23", topic -> score(topic, topic.topic_key.startsWith("dl23-doc"), "nDCG@10")),
         new SummaryColumn("RAGgy", topic -> score(topic, topic.topic_key.startsWith("rag24"), "nDCG@10"))),
-        true, (topic, condition) -> topic.topic_key);
+        (topic, condition) -> topic.topic_key);
   }
 
   @Test
@@ -320,18 +317,18 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
         new SummaryColumn("RAG24 NIST", topic -> score(topic, topic.eval_key.equals("rag24.test"), "nDCG@20")),
         new SummaryColumn("RAG25 ☂️", topic -> score(topic, topic.eval_key.equals("rag25.test-umbrela2"), "nDCG@30")),
         new SummaryColumn("RAG25 NIST", topic -> score(topic, topic.eval_key.equals("rag25.test"), "nDCG@30"))),
-        true, (topic, condition) -> String.format("%s / %s", topic.topic_key, topic.eval_key));
+        (topic, condition) -> String.format("%s / %s", topic.topic_key, topic.eval_key));
   }
 
   @Test
   public void generateBrightReport() throws Exception {
-    generateReportInColumns("bright.yaml", "nDCG@10", true,
+    generateReportInColumns("bright.yaml", "nDCG@10",
         (topic, condition) -> topic.topic_key);
   }
 
   @Test
   public void generateBeirReport() throws Exception {
-    generateReportInColumns("beir.yaml", "nDCG@10", true,
+    generateReportInColumns("beir.yaml", "nDCG@10",
         (topic, condition) -> topic.topic_key);
   }
 }

--- a/src/test/java/io/anserini/doc/GenerateReproductionDocsFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/doc/GenerateReproductionDocsFromPrebuiltIndexesTest.java
@@ -263,8 +263,9 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
         .replace("${command}", commands), StandardCharsets.UTF_8);
   }
 
-  private static void generateMsMarcoV1PassageReport(String yamlConfig) throws Exception {
-    generateReportInRows(yamlConfig, List.of(
+  @Test
+  public void generateMsMarcoV1PassageReport() throws Exception {
+    generateReportInRows("msmarco-v1-passage.yaml", List.of(
         new SummaryColumn("dev", topic -> score(topic, topic.topic_key.startsWith("msmarco-v1-passage.dev"), "MRR@10")),
         new SummaryColumn("DL19", topic -> score(topic, topic.topic_key.startsWith("dl19-passage"), "nDCG@10")),
         new SummaryColumn("DL20", topic -> score(topic, topic.topic_key.startsWith("dl20-passage"), "nDCG@10"))),
@@ -272,12 +273,8 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
   }
 
   @Test
-  public void generateMsMarcoV1PassageReport() throws Exception {
-    generateMsMarcoV1PassageReport("msmarco-v1-passage.yaml");
-  }
-
-  private static void generateMsMarcoV1DocReport(String yamlConfig) throws Exception {
-    generateReportInRows(yamlConfig, List.of(
+  public void generateMsMarcoV1DocReport() throws Exception {
+    generateReportInRows("msmarco-v1-doc.yaml", List.of(
         new SummaryColumn("dev", topic -> score(topic, topic.topic_key.startsWith("msmarco-doc.dev"), "MRR@100")),
         new SummaryColumn("DL19", topic -> score(topic, topic.topic_key.startsWith("dl19-doc"), "nDCG@10")),
         new SummaryColumn("DL20", topic -> score(topic, topic.topic_key.startsWith("dl20-doc"), "nDCG@10"))),
@@ -285,12 +282,8 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
   }
 
   @Test
-  public void generateMsMarcoV1DocReport() throws Exception {
-    generateMsMarcoV1DocReport("msmarco-v1-doc.yaml");
-  }
-
-  private static void generateMsMarcoV2PassageReport(String yamlConfig) throws Exception {
-    generateReportInRows(yamlConfig, List.of(
+  public void generateMsMarcoV2PassageReport() throws Exception {
+    generateReportInRows("msmarco-v2-passage.yaml", List.of(
         new SummaryColumn("dev", topic -> score(topic, matchesTopicPrefix(topic.topic_key, "msmarco-v2-passage.dev"), "MRR@100")),
         new SummaryColumn("dev2", topic -> score(topic, matchesTopicPrefix(topic.topic_key, "msmarco-v2-passage.dev2"), "MRR@100")),
         new SummaryColumn("DL21", topic -> score(topic, topic.topic_key.startsWith("dl21"), "nDCG@10")),
@@ -300,12 +293,8 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
   }
 
   @Test
-  public void generateMsMarcoV2PassageReport() throws Exception {
-    generateMsMarcoV2PassageReport("msmarco-v2-passage.yaml");
-  }
-
-  private static void generateMsMarcoV2DocReport(String yamlConfig) throws Exception {
-    generateReportInRows(yamlConfig, List.of(
+  public void generateMsMarcoV2DocReport() throws Exception {
+    generateReportInRows("msmarco-v2-doc.yaml", List.of(
         new SummaryColumn("dev", topic -> score(topic, matchesTopicPrefix(topic.topic_key, "msmarco-v2-doc.dev"), "MRR@100")),
         new SummaryColumn("dev2", topic -> score(topic, matchesTopicPrefix(topic.topic_key, "msmarco-v2-doc.dev2"), "MRR@100")),
         new SummaryColumn("DL21", topic -> score(topic, topic.topic_key.startsWith("dl21"), "nDCG@10")),
@@ -315,12 +304,8 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
   }
 
   @Test
-  public void generateMsMarcoV2DocReport() throws Exception {
-    generateMsMarcoV2DocReport("msmarco-v2-doc.yaml");
-  }
-
-  private static void generateMsMarcoV21DocReport(String yamlConfig) throws Exception {
-    generateReportInRows(yamlConfig, List.of(
+  public void generateMsMarcoV21DocReport() throws Exception {
+    generateReportInRows("msmarco-v2.1-doc.yaml", List.of(
         new SummaryColumn("dev", topic -> score(topic, topic.topic_key.equals("msmarco-v2-doc.dev"), "MRR@100")),
         new SummaryColumn("dev2", topic -> score(topic, topic.topic_key.equals("msmarco-v2-doc.dev2"), "MRR@100")),
         new SummaryColumn("DL21", topic -> score(topic, topic.topic_key.startsWith("dl21-doc"), "nDCG@10")),
@@ -331,12 +316,8 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
   }
 
   @Test
-  public void generateMsMarcoV21DocReport() throws Exception {
-    generateMsMarcoV21DocReport("msmarco-v2.1-doc.yaml");
-  }
-
-  private static void generateMsMarcoV21SegmentedDocReport(String yamlConfig) throws Exception {
-    generateReportInRows(yamlConfig, List.of(
+  public void generateMsMarcoV21SegmentedDocReport() throws Exception {
+    generateReportInRows("msmarco-v2.1-doc-segmented.yaml", List.of(
         new SummaryColumn("RAG24 ☂️", topic -> score(topic, topic.eval_key.equals("rag24.test-umbrela-all"), "nDCG@20")),
         new SummaryColumn("RAG24 NIST", topic -> score(topic, topic.eval_key.equals("rag24.test"), "nDCG@20")),
         new SummaryColumn("RAG25 ☂️", topic -> score(topic, topic.eval_key.equals("rag25.test-umbrela2"), "nDCG@30")),
@@ -345,29 +326,16 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
   }
 
   @Test
-  public void generateMsMarcoV21SegmentedDocReport() throws Exception {
-    generateMsMarcoV21SegmentedDocReport("msmarco-v2.1-doc-segmented.yaml");
-  }
-
-  private static void generateBrightReport(String yamlConfig) throws Exception {
-    generateReportInColumns(yamlConfig, "nDCG@10",
-        GenerateReproductionDocsFromPrebuiltIndexesTest::shortNameOrDisplay, true,
-        (topic, condition) -> topic.topic_key);
-  }
-
-  @Test
   public void generateBrightReport() throws Exception {
-    generateBrightReport("bright.yaml");
-  }
-
-  private static void generateBeirReport(String yamlConfig) throws Exception {
-    generateReportInColumns(yamlConfig, "nDCG@10",
+    generateReportInColumns("bright.yaml", "nDCG@10",
         GenerateReproductionDocsFromPrebuiltIndexesTest::shortNameOrDisplay, true,
         (topic, condition) -> topic.topic_key);
   }
 
   @Test
   public void generateBeirReport() throws Exception {
-    generateBeirReport("beir.yaml");
+    generateReportInColumns("beir.yaml", "nDCG@10",
+        GenerateReproductionDocsFromPrebuiltIndexesTest::shortNameOrDisplay, true,
+        (topic, condition) -> topic.topic_key);
   }
 }


### PR DESCRIPTION
## Summary

- Add generated prebuilt-index reproduction reports for BRIGHT and BEIR.
- Refactor doc generation into row-oriented and column-oriented summary paths.
- Use `short_name` metadata for BRIGHT/BEIR technique column headers.

## Validation

- `mvn -Dtest=GenerateReproductionDocsFromPrebuiltIndexesTest test`
- `bin/build.sh`