### PR TITLE
Add onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -664,3 +664,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@masud70](https://github.com/masud70) on 2026-05-23 (commit [`878b97d`](https://github.com/castorini/anserini/commit/878b97da258ea6350c1cb3693f684ae337fc5e56))
 + Results reproduced by [@ibot1](https://github.com/ibot1) on 2026-05-23 (commit [`878b97d`](https://github.com/castorini/anserini/commit/878b97da258ea6350c1cb3693f684ae337fc5e56))
 + Results reproduced by [@ReyhanehAhani](https://github.com/ReyhanehAhani) on 2026-05-25 (commit [`11703ed`](https://github.com/castorini/anserini/commit/11703ed8f9354fb4ea0dc4960cee1b5e14ee6561))
++ Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -212,3 +212,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@masud70](https://github.com/masud70) on 2026-05-23 (commit [`878b97d`](https://github.com/castorini/anserini/commit/878b97da258ea6350c1cb3693f684ae337fc5e56))
 + Results reproduced by [@ibot1](https://github.com/ibot1) on 2026-05-23 (commit [`878b97d`](https://github.com/castorini/anserini/commit/878b97da258ea6350c1cb3693f684ae337fc5e56))
 + Results reproduced by [@ReyhanehAhani](https://github.com/ReyhanehAhani) on 2026-05-25 (commit [`11703ed`](https://github.com/castorini/anserini/commit/11703ed8f9354fb4ea0dc4960cee1b5e14ee6561))
++ Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -571,3 +571,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@masud70](https://github.com/masud70) on 2026-05-23 (commit [`878b97d`](https://github.com/castorini/anserini/commit/878b97da258ea6350c1cb3693f684ae337fc5e56))
 + Results reproduced by [@ibot1](https://github.com/ibot1) on 2026-05-23 (commit [`878b97d`](https://github.com/castorini/anserini/commit/878b97da258ea6350c1cb3693f684ae337fc5e56))
 + Results reproduced by [@ReyhanehAhani](https://github.com/ReyhanehAhani) on 2026-05-25 (commit [`11703ed`](https://github.com/castorini/anserini/commit/11703ed8f9354fb4ea0dc4960cee1b5e14ee6561))
++ Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))


### PR DESCRIPTION
# Summary

Reproduced the Foundations of Retrieval onboarding tasks in Anserini and added reproduction-log entries.

## Environment

- macOS 15.7.3 on Apple Silicon
- Conda environment: `jimmy-ir`
- Java: OpenJDK 21.0.10
- Maven: 3.9.16
- Anserini commit: `6663a15bffe0242e927c53744e5b140ce1a0bcba`

## Tasks

- `docs/start-here.md`
  - MS MARCO archive MD5: `31644046b18952c1386cd4564ba2ae69`
  - converted documents: 8,841,823
  - `queries.dev.small.tsv` lines: 6,980
  - dev qrels lines: 7,437
  - train qrels lines: 532,761
- `docs/experiments-msmarco-passage.md`
  - MS MARCO MRR@10: `0.18741227770955546`
  - MAP: `0.1957`
  - recall@1000: `0.8573`
  - query `1048585` reciprocal rank: `1.0000`
- `docs/experiments-msmarco-passage2.md`
  - prebuilt BM25 reciprocal rank: `0.1875`
  - BGE dense reciprocal rank: `0.3521`

## Notes

- Only reproduction-log documentation edits are included.
- Datasets, indexes, runs, and caches are not committed.
