### PR TITLE
Update states from ko analyzer update

### DIFF
--- a/docs/reproduce/from-document-collection/miracl-v1.0-ko-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ko-aca.md
@@ -57,6 +57,6 @@ With the above commands, you should be able to reproduce the following results:
 
 | **nDCG@10**                                                      | **BM25**   |
 |:-----------------------------------------------------------------|:----------:|
-| [MIRACL (Korean): dev](https://github.com/project-miracl/miracl) | 0.4485     |
+| [MIRACL (Korean): dev](https://github.com/project-miracl/miracl) | 0.4857     |
 | **R@100**                                                        | **BM25**   |
-| [MIRACL (Korean): dev](https://github.com/project-miracl/miracl) | 0.8218     |
+| [MIRACL (Korean): dev](https://github.com/project-miracl/miracl) | 0.8528     |

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ko.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ko.md
@@ -55,6 +55,6 @@ With the above commands, you should be able to reproduce the following results:
 
 | **nDCG@10**                                                      | **BM25**   |
 |:-----------------------------------------------------------------|:----------:|
-| [MIRACL (Korean): dev](https://github.com/project-miracl/miracl) | 0.4190     |
+| [MIRACL (Korean): dev](https://github.com/project-miracl/miracl) | 0.4533     |
 | **R@100**                                                        | **BM25**   |
-| [MIRACL (Korean): dev](https://github.com/project-miracl/miracl) | 0.7831     |
+| [MIRACL (Korean): dev](https://github.com/project-miracl/miracl) | 0.8579     |

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-ko-aca.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-ko-aca.md
@@ -70,10 +70,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **MRR@100**                                                      | **BM25**   |
 |:-----------------------------------------------------------------|:----------:|
-| [Mr. TyDi (Korean): train](https://github.com/castorini/mr.tydi) | 0.2694     |
-| [Mr. TyDi (Korean): dev](https://github.com/castorini/mr.tydi)   | 0.3100     |
-| [Mr. TyDi (Korean): test](https://github.com/castorini/mr.tydi)  | 0.2907     |
+| [Mr. TyDi (Korean): train](https://github.com/castorini/mr.tydi) | 0.3030     |
+| [Mr. TyDi (Korean): dev](https://github.com/castorini/mr.tydi)   | 0.3317     |
+| [Mr. TyDi (Korean): test](https://github.com/castorini/mr.tydi)  | 0.3074     |
 | **R@100**                                                        | **BM25**   |
-| [Mr. TyDi (Korean): train](https://github.com/castorini/mr.tydi) | 0.6483     |
-| [Mr. TyDi (Korean): dev](https://github.com/castorini/mr.tydi)   | 0.6898     |
-| [Mr. TyDi (Korean): test](https://github.com/castorini/mr.tydi)  | 0.6433     |
+| [Mr. TyDi (Korean): train](https://github.com/castorini/mr.tydi) | 0.7077     |
+| [Mr. TyDi (Korean): dev](https://github.com/castorini/mr.tydi)   | 0.7409     |
+| [Mr. TyDi (Korean): test](https://github.com/castorini/mr.tydi)  | 0.6928     |

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-ko.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-ko.md
@@ -68,10 +68,10 @@ With the above commands, you should be able to reproduce the following results:
 
 | **MRR@100**                                                      | **BM25**   |
 |:-----------------------------------------------------------------|:----------:|
-| [Mr. TyDi (Korean): train](https://github.com/castorini/mr.tydi) | 0.2596     |
-| [Mr. TyDi (Korean): dev](https://github.com/castorini/mr.tydi)   | 0.2888     |
-| [Mr. TyDi (Korean): test](https://github.com/castorini/mr.tydi)  | 0.2848     |
+| [Mr. TyDi (Korean): train](https://github.com/castorini/mr.tydi) | 0.3072     |
+| [Mr. TyDi (Korean): dev](https://github.com/castorini/mr.tydi)   | 0.3280     |
+| [Mr. TyDi (Korean): test](https://github.com/castorini/mr.tydi)  | 0.3040     |
 | **R@100**                                                        | **BM25**   |
-| [Mr. TyDi (Korean): train](https://github.com/castorini/mr.tydi) | 0.6178     |
-| [Mr. TyDi (Korean): dev](https://github.com/castorini/mr.tydi)   | 0.6733     |
-| [Mr. TyDi (Korean): test](https://github.com/castorini/mr.tydi)  | 0.6188     |
+| [Mr. TyDi (Korean): train](https://github.com/castorini/mr.tydi) | 0.7162     |
+| [Mr. TyDi (Korean): dev](https://github.com/castorini/mr.tydi)   | 0.7343     |
+| [Mr. TyDi (Korean): test](https://github.com/castorini/mr.tydi)  | 0.6924     |

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ko-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ko-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language ko -useAutoC
 index_stats:
   documents: 1486752
   documents (non-empty): 1486752
-  total terms: 247477047
+  total terms: 198545012
 
 metrics:
   - metric: nDCG@10
@@ -41,6 +41,6 @@ models:
     params: -bm25 -hits 100 -language ko -useAutoCompositeAnalyzer
     results:
       nDCG@10:
-        - 0.4485
+        - 0.4857
       R@100:
-        - 0.8218
+        - 0.8528

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ko.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ko.yaml
@@ -9,8 +9,8 @@ index_threads: 8
 index_options: -storePositions -storeDocvectors -storeRaw -language ko
 index_stats:
   documents: 1486752
-  documents (non-empty): 1486752
-  total terms: 121464424
+  documents (non-empty): 1486749
+  total terms: 72532389
 
 metrics:
   - metric: nDCG@10
@@ -41,6 +41,6 @@ models:
     params: -bm25 -hits 100 -language ko
     results:
       nDCG@10:
-        - 0.4190
+        - 0.4533
       R@100:
-        - 0.7831
+        - 0.8579

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ko-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ko-aca.yaml
@@ -10,7 +10,7 @@ index_options: -storePositions -storeDocvectors -storeRaw -language ko -useAutoC
 index_stats:
   documents: 1496126
   documents (non-empty): 1496126
-  total terms: 249266634
+  total terms: 200134200
 
 metrics:
   - metric: MRR@100
@@ -49,10 +49,10 @@ models:
     params: -bm25 -hits 100 -language ko -useAutoCompositeAnalyzer
     results:
       MRR@100:
-        - 0.2694
-        - 0.3100
-        - 0.2907
+        - 0.3030
+        - 0.3317
+        - 0.3074
       R@100:
-        - 0.6483
-        - 0.6898
-        - 0.6433
+        - 0.7077
+        - 0.7409
+        - 0.6928

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ko.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ko.yaml
@@ -9,8 +9,8 @@ index_threads: 1
 index_options: -storePositions -storeDocvectors -storeRaw -language ko
 index_stats:
   documents: 1496126
-  documents (non-empty): 1496126
-  total terms: 122217295
+  documents (non-empty): 1496123
+  total terms: 73084884
 
 metrics:
   - metric: MRR@100
@@ -49,10 +49,10 @@ models:
     params: -bm25 -hits 100 -language ko
     results:
       MRR@100:
-        - 0.2596
-        - 0.2888
-        - 0.2848
+        - 0.3072
+        - 0.3280
+        - 0.3040
       R@100:
-        - 0.6178
-        - 0.6733
-        - 0.6188
+        - 0.7162
+        - 0.7343
+        - 0.6924


### PR DESCRIPTION
As a result of merging #2174 and `ko` analyzer update, we need to update Mr.TyDi and MIRACL scores.