### PR TITLE
Add reproduction log entries for onboarding lessons (start-here, BM25, dense)

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -680,3 +680,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))
 + Results reproduced by [@amulyabenarji777](https://github.com/amulyabenarji777) on 2026-05-30 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))
 + Results reproduced by [@Maroibo](https://github.com/Maroibo) on 2026-06-01 (commit [`996836f`](https://github.com/castorini/anserini/commit/996836f12034eb5dfd1bfada72debf63fa059849))
++ Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`147521da`](https://github.com/castorini/anserini/commit/147521da48a3b71cf359fd35e32c0fff7fe86eb8))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -102,6 +102,19 @@ bin/run.sh io.anserini.index.IndexCollection \
 
 In this case, Lucene creates what is known as an **inverted index**.
 
+For sparse retrieval (like in BM25), the unit of matching is the term/token. So the index inverts the natural "document -> terms in the document" relation into "term -> documents containing the term":
+
+ "panthers"  -> [doc7, doc42, doc1031, ...]
+ "score"     -> [doc7, doc99, doc1031, ...]
+ "yesterday" -> [doc7, doc500, ...]
+
+At query time, you tokenize the query, look up each term's doc list, intersect/union them, and score the candidate docs with BM25. It's fast because most terms appear in only a tiny fraction of docs, so you don't touch the corpus. Instead, you only touch a handful of doc lists.
+
+This is the structure Lucene builds (and what Anserini uses). It only works because of two assumptions:
+
+ 1. Discrete tokens (you can hash "panthers").
+ 2. Exact term overlap matters (you only score docs that share ≥1 term with the query).
+
 Upon completion, we should have an index with 8,841,823 documents.
 The indexing speed may vary;
 On a modern desktop with an SSD, indexing takes a couple of minutes.

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -103,17 +103,17 @@ bin/run.sh io.anserini.index.IndexCollection \
 In this case, Lucene creates what is known as an **inverted index**.
 
 For sparse retrieval (like in BM25), the unit of matching is the term/token. So the index inverts the natural "document -> terms in the document" relation into "term -> documents containing the term":
-
+```
  "panthers"  -> [doc7, doc42, doc1031, ...]
  "score"     -> [doc7, doc99, doc1031, ...]
  "yesterday" -> [doc7, doc500, ...]
-
+```
 At query time, you tokenize the query, look up each term's doc list, intersect/union them, and score the candidate docs with BM25. It's fast because most terms appear in only a tiny fraction of docs, so you don't touch the corpus. Instead, you only touch a handful of doc lists.
 
 This is the structure Lucene builds (and what Anserini uses). It only works because of two assumptions:
 
- 1. Discrete tokens (you can hash "panthers").
- 2. Exact term overlap matters (you only score docs that share ≥1 term with the query).
+1. Discrete tokens (you can hash "panthers").
+2. Exact term overlap matters (you only score docs that share ≥1 term with the query).
 
 Upon completion, we should have an index with 8,841,823 documents.
 The indexing speed may vary;

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -102,19 +102,6 @@ bin/run.sh io.anserini.index.IndexCollection \
 
 In this case, Lucene creates what is known as an **inverted index**.
 
-For sparse retrieval (like in BM25), the unit of matching is the term/token. So the index inverts the natural "document -> terms in the document" relation into "term -> documents containing the term":
-```
- "panthers"  -> [doc7, doc42, doc1031, ...]
- "score"     -> [doc7, doc99, doc1031, ...]
- "yesterday" -> [doc7, doc500, ...]
-```
-At query time, you tokenize the query, look up each term's doc list, intersect/union them, and score the candidate docs with BM25. It's fast because most terms appear in only a tiny fraction of docs, so you don't touch the corpus. Instead, you only touch a handful of doc lists.
-
-This is the structure Lucene builds (and what Anserini uses). It only works because of two assumptions:
-
-1. Discrete tokens (you can hash "panthers").
-2. Exact term overlap matters (you only score docs that share ≥1 term with the query).
-
 Upon completion, we should have an index with 8,841,823 documents.
 The indexing speed may vary;
 On a modern desktop with an SSD, indexing takes a couple of minutes.

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -667,4 +667,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))
 + Results reproduced by [@amulyabenarji777](https://github.com/amulyabenarji777) on 2026-05-30 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))
 + Results reproduced by [@Maroibo](https://github.com/Maroibo) on 2026-06-01 (commit [`996836f`](https://github.com/castorini/anserini/commit/996836f12034eb5dfd1bfada72debf63fa059849))
-+ Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`147521da`](https://github.com/castorini/anserini/commit/147521da48a3b71cf359fd35e32c0fff7fe86eb8))
++ Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`147521d`](https://github.com/castorini/anserini/commit/147521da48a3b71cf359fd35e32c0fff7fe86eb8))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -215,3 +215,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))
 + Results reproduced by [@amulyabenarji777](https://github.com/amulyabenarji777) on 2026-05-30 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))
 + Results reproduced by [@Maroibo](https://github.com/Maroibo) on 2026-06-01 (commit [`996836f`](https://github.com/castorini/anserini/commit/996836f12034eb5dfd1bfada72debf63fa059849))
++ Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`147521da`](https://github.com/castorini/anserini/commit/147521da48a3b71cf359fd35e32c0fff7fe86eb8))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -215,4 +215,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))
 + Results reproduced by [@amulyabenarji777](https://github.com/amulyabenarji777) on 2026-05-30 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))
 + Results reproduced by [@Maroibo](https://github.com/Maroibo) on 2026-06-01 (commit [`996836f`](https://github.com/castorini/anserini/commit/996836f12034eb5dfd1bfada72debf63fa059849))
-+ Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`147521da`](https://github.com/castorini/anserini/commit/147521da48a3b71cf359fd35e32c0fff7fe86eb8))
++ Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`147521d`](https://github.com/castorini/anserini/commit/147521da48a3b71cf359fd35e32c0fff7fe86eb8))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -574,3 +574,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))
 + Results reproduced by [@amulyabenarji777](https://github.com/amulyabenarji777) on 2026-05-30 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))
 + Results reproduced by [@Maroibo](https://github.com/Maroibo) on 2026-06-01 (commit [`996836f`](https://github.com/castorini/anserini/commit/996836f12034eb5dfd1bfada72debf63fa059849))
++ Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`147521da`](https://github.com/castorini/anserini/commit/147521da48a3b71cf359fd35e32c0fff7fe86eb8))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -574,4 +574,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@grf932](https://github.com/grf932) on 2026-05-29 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))
 + Results reproduced by [@amulyabenarji777](https://github.com/amulyabenarji777) on 2026-05-30 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))
 + Results reproduced by [@Maroibo](https://github.com/Maroibo) on 2026-06-01 (commit [`996836f`](https://github.com/castorini/anserini/commit/996836f12034eb5dfd1bfada72debf63fa059849))
-+ Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`147521da`](https://github.com/castorini/anserini/commit/147521da48a3b71cf359fd35e32c0fff7fe86eb8))
++ Results reproduced by [@rhea2801](https://github.com/rhea2801) on 2026-06-06 (commit [`147521d`](https://github.com/castorini/anserini/commit/147521da48a3b71cf359fd35e32c0fff7fe86eb8))


### PR DESCRIPTION
 Hi! This is my go at the Foundations of Retrieval onboarding path.
 
 This PR adds reproduction log entries for:
 - `docs/start-here.md`
 - `docs/experiments-msmarco-passage.md` (BM25)
 - `docs/experiments-msmarco-passage2.md` (dense)
 
 ### Setup
 - OS: Ubuntu 22.04 on WSL2 (Windows 11)
 - Java: Temurin 21.0.4
 - Maven: 3.9.16
 - CPU:  Intel(R) Xeon(R) Platinum 8473C | Cores: 16 | RAM: 32GB
 
 ### Reproduction results
 - BM25 on MS MARCO dev.small: MRR@10 = 0.1840
 - BGE-base-en-v1.5 dense on MS MARCO dev.small: MRR@10 = 0.3521
 
 Everything worked without major issues.