### PR TITLE
[codex] Fix prebuilt index tar size reporting

### DIFF
--- a/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
@@ -397,6 +397,8 @@ public class ReproduceFromPrebuiltIndexes {
       String base = handler.getFilename();
       if (base.endsWith(".tar.gz")) {
         base = base.substring(0, base.length() - ".tar.gz".length());
+      } else if (base.endsWith(".tar")) {
+        base = base.substring(0, base.length() - ".tar".length());
       } else if (base.endsWith(".gz")) {
         base = base.substring(0, base.length() - ".gz".length());
       }

--- a/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
@@ -31,6 +31,8 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
+import io.anserini.util.CacheDirectoryResolver;
+import io.anserini.util.PrebuiltIndexHandler;
 
 public class ReproduceFromPrebuiltIndexesTest extends StdOutStdErrRedirectableLuceneTestCase {
   @Before
@@ -99,6 +101,36 @@ public class ReproduceFromPrebuiltIndexesTest extends StdOutStdErrRedirectableLu
     assertTrue(out.toString().contains("# Running condition"));
     assertTrue(out.toString().contains("Retrieval command"));
     assertTrue(out.toString().contains("Eval command"));
+  }
+
+  @Test
+  public void testBeirDryRunReportsPlainTarIndexSize() throws Exception {
+    Path cacheDirectory = createTempDir("pyserini-cache");
+    String previousCacheDirectory = System.getProperty(CacheDirectoryResolver.CACHE_PROPERTY);
+    PrebuiltIndexHandler handler = PrebuiltIndexHandler.get("beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat");
+    assertNotNull(handler);
+    assertTrue(handler.getFilename().endsWith(".tar"));
+
+    String filenameBase = handler.getFilename().substring(0, handler.getFilename().length() - ".tar".length());
+    Path indexDirectory = cacheDirectory.resolve("indexes").resolve(filenameBase + "." + handler.getMD5());
+
+    try {
+      System.setProperty(CacheDirectoryResolver.CACHE_PROPERTY, cacheDirectory.toString());
+      Files.createDirectories(indexDirectory);
+      Files.writeString(indexDirectory.resolve("marker"), "marker");
+
+      ReproduceFromPrebuiltIndexes.main(new String[] {"--config", "beir", "--dry-run"});
+    } finally {
+      if (previousCacheDirectory == null) {
+        System.clearProperty(CacheDirectoryResolver.CACHE_PROPERTY);
+      } else {
+        System.setProperty(CacheDirectoryResolver.CACHE_PROPERTY, previousCacheDirectory);
+      }
+    }
+
+    String output = out.toString();
+    assertTrue(output, output.contains("beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat"));
+    assertTrue(output, output.matches("(?s).*beir-v1\\.0\\.0-trec-covid\\.bge-base-en-v1\\.5\\.flat\\s+6\\.0 B\\s+506\\.5 MB.*"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Fix dry-run prebuilt index path resolution for plain `.tar` archives.
- Add regression coverage for BEIR BGE flat-vector indexes reporting `size on disk`.
- Align dry-run path inference with `PrebuiltIndexHandler.fetch()` archive extraction behavior.

## Validation

- `mvn -Dtest=ReproduceFromPrebuiltIndexesTest test`
- `bin/qbuild.sh`
- `java -cp target/anserini-2.2.1-SNAPSHOT-fatjar.jar io.anserini.reproduce.ReproduceFromPrebuiltIndexes --config beir --dry-run | sed -n '1,125p'`