### PR TITLE
[codex] Improve prebuilt index dry-run size table

### DIFF
--- a/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
@@ -47,7 +47,6 @@ import io.anserini.cli.CliUtils;
 
 import io.anserini.eval.TrecEval;
 import io.anserini.index.IndexReaderUtils;
-import io.anserini.util.CacheDirectoryResolver;
 import io.anserini.util.LoggingBootstrap;
 import io.anserini.util.PrebuiltIndexHandler;
 
@@ -164,7 +163,7 @@ public class ReproduceFromPrebuiltIndexes {
       long totalBytes = 0L;
       long totalDownloadBytes = 0L;
       int presentCount = 0;
-      java.util.List<String[]> rows = new java.util.ArrayList<>(); // [name, sizeOnDisk, downloadSize, path]
+      java.util.List<String[]> rows = new java.util.ArrayList<>(); // [name, downloadSize, sizeOnDisk, path]
 
       for (String idx : uniqueIndexNames) {
         String name = idx;
@@ -179,10 +178,10 @@ public class ReproduceFromPrebuiltIndexes {
             downloadSizeStr = IndexReaderUtils.formatSize(indexHandler.getSize());
             totalDownloadBytes += indexHandler.getSize();
           }
-          Path prebuiltPath = expectedPrebuiltPath(idx);
-          pathStr = prebuiltPath == null ? "-" : prebuiltPath.toAbsolutePath().toString();
+          Path prebuiltPath = indexHandler.getIndexPath();
           long sz = -1L;
           if (prebuiltPath != null && Files.exists(prebuiltPath)) {
+            pathStr = prebuiltPath.toAbsolutePath().toString();
             // Ignore symlinks per request; measure directory as-is
             sz = IndexReaderUtils.findDirectorySize(prebuiltPath);
           }
@@ -208,26 +207,26 @@ public class ReproduceFromPrebuiltIndexes {
           }
         }
 
-        rows.add(new String[] { name, sizeOnDiskStr, downloadSizeStr, pathStr });
+        rows.add(new String[] { name, downloadSizeStr, sizeOnDiskStr, pathStr });
       }
 
       // Compute dynamic widths for first and last columns.
       int nameWidth = Math.max("name".length(), uniqueIndexNames.stream().mapToInt(String::length).max().orElse(4));
       nameWidth = Math.max(nameWidth, "total".length());
-      int pathWidth = "path".length();
+      int pathWidth = "local path".length();
       for (String[] r : rows) {
         if (r[3] != null) pathWidth = Math.max(pathWidth, r[3].length());
       }
 
       final String fmt = "%-" + nameWidth + "s  %12s  %12s  %-" + pathWidth + "s%n";
-      System.out.printf(Locale.ROOT, fmt, "name", "size on disk", "download size", "path");
+      System.out.printf(Locale.ROOT, fmt, "name", "download size", "size on disk", "local path");
       System.out.printf(Locale.ROOT, fmt, repeat('-', nameWidth), repeat('-', 12), repeat('-', 12), repeat('-', pathWidth));
 
       for (String[] r : rows) {
         System.out.printf(Locale.ROOT, fmt, r[0], r[1], r[2], r[3]);
       }
       // Add total row at the end with no path.
-      System.out.printf(Locale.ROOT, fmt, "total", IndexReaderUtils.formatSize(totalBytes), IndexReaderUtils.formatSize(totalDownloadBytes), "-");
+      System.out.printf(Locale.ROOT, fmt, "total", IndexReaderUtils.formatSize(totalDownloadBytes), IndexReaderUtils.formatSize(totalBytes), "-");
 
       System.out.printf(Locale.ROOT, "%nTotal size across %d of %d indexes: %s%n%n", presentCount, uniqueIndexNames.size(), IndexReaderUtils.formatSize(totalBytes));
     }
@@ -388,24 +387,6 @@ public class ReproduceFromPrebuiltIndexes {
       }
     }
     return null;
-  }
-
-  private static Path expectedPrebuiltPath(String indexName) {
-    try {
-      PrebuiltIndexHandler handler = PrebuiltIndexHandler.get(indexName);
-      String cacheRoot = CacheDirectoryResolver.getIndexCachePath().toString();
-      String base = handler.getFilename();
-      if (base.endsWith(".tar.gz")) {
-        base = base.substring(0, base.length() - ".tar.gz".length());
-      } else if (base.endsWith(".tar")) {
-        base = base.substring(0, base.length() - ".tar".length());
-      } else if (base.endsWith(".gz")) {
-        base = base.substring(0, base.length() - ".gz".length());
-      }
-      return Path.of(cacheRoot, base + "." + handler.getMD5());
-    } catch (Exception e) {
-      return null;
-    }
   }
 
   private static Path resolveSingleSymlinkChild(Path p) throws IOException {

--- a/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
@@ -226,7 +226,7 @@ public class ReproduceFromPrebuiltIndexes {
         System.out.printf(Locale.ROOT, fmt, r[0], r[1], r[2], r[3]);
       }
       // Add total row at the end with no path.
-      System.out.printf(Locale.ROOT, fmt, "total", IndexReaderUtils.formatSize(totalDownloadBytes), IndexReaderUtils.formatSize(totalBytes), "-");
+      System.out.printf(Locale.ROOT, fmt, "total", IndexReaderUtils.formatSize(totalDownloadBytes), IndexReaderUtils.formatSize(totalBytes), "");
 
       System.out.printf(Locale.ROOT, "%nTotal size across %d of %d indexes: %s%n%n", presentCount, uniqueIndexNames.size(), IndexReaderUtils.formatSize(totalBytes));
     }

--- a/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
@@ -34,6 +34,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
+
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
@@ -44,7 +46,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import io.anserini.cli.CliUtils;
-
 import io.anserini.eval.TrecEval;
 import io.anserini.index.IndexReaderUtils;
 import io.anserini.util.LoggingBootstrap;
@@ -163,7 +164,7 @@ public class ReproduceFromPrebuiltIndexes {
       long totalBytes = 0L;
       long totalDownloadBytes = 0L;
       int presentCount = 0;
-      java.util.List<String[]> rows = new java.util.ArrayList<>(); // [name, downloadSize, sizeOnDisk, path]
+      List<String[]> rows = new ArrayList<>(); // [name, downloadSize, sizeOnDisk, path]
 
       for (String idx : uniqueIndexNames) {
         String name = idx;
@@ -392,8 +393,8 @@ public class ReproduceFromPrebuiltIndexes {
   private static Path resolveSingleSymlinkChild(Path p) throws IOException {
     Path pathForSize = p;
     if (Files.isDirectory(p)) {
-      try (java.util.stream.Stream<Path> children = Files.list(p)) {
-        java.util.List<Path> entries = children.toList();
+      try (Stream<Path> children = Files.list(p)) {
+        List<Path> entries = children.toList();
         if (entries.size() == 1 && Files.isSymbolicLink(entries.get(0))) {
           Path link = entries.get(0);
           // Try to resolve to an absolute path using toRealPath if possible.

--- a/src/main/java/io/anserini/util/PrebuiltIndexHandler.java
+++ b/src/main/java/io/anserini/util/PrebuiltIndexHandler.java
@@ -101,8 +101,6 @@ public class PrebuiltIndexHandler {
   }
 
   public void fetch(String cacheDirectory) throws IOException {
-    this.cacheDirectory = cacheDirectory;
-
     if (!Path.of(cacheDirectory).toFile().exists()) {
       try {
         Files.createDirectories(Path.of(cacheDirectory));
@@ -111,11 +109,7 @@ public class PrebuiltIndexHandler {
       }
     }
 
-    downloadFilePath = Path.of(cacheDirectory, this.entry.filename);
-    String downloadFilePathString = downloadFilePath.toString();
-    indexPath = Path.of((downloadFilePathString.endsWith(".gz") ?
-        downloadFilePathString.substring(0, downloadFilePathString.length() - ".tar.gz".length()) :
-        downloadFilePathString.substring(0, downloadFilePathString.length() - ".tar".length())) + "." + this.entry.md5);
+    setCachePaths(cacheDirectory);
 
     if (indexPath.toFile().exists()) {
       LOG.info(String.format("Index already exists at %s: skipping downloading.", indexPath));
@@ -286,7 +280,30 @@ public class PrebuiltIndexHandler {
     LOG.info("Finished unpacking {}. Final index location: {}.", this.entry.name, indexPath);
   }
 
+  private void setCachePaths(String cacheDirectory) {
+    this.cacheDirectory = cacheDirectory;
+    downloadFilePath = Path.of(cacheDirectory, this.entry.filename);
+    String downloadFilePathString = downloadFilePath.toString();
+    indexPath = Path.of(stripArchiveSuffix(downloadFilePathString) + "." + this.entry.md5);
+  }
+
+  private static String stripArchiveSuffix(String path) {
+    if (path.endsWith(".tar.gz")) {
+      return path.substring(0, path.length() - ".tar.gz".length());
+    } else if (path.endsWith(".tar")) {
+      return path.substring(0, path.length() - ".tar".length());
+    } else if (path.endsWith(".gz")) {
+      return path.substring(0, path.length() - ".gz".length());
+    }
+
+    return path;
+  }
+
   public Path getIndexPath() {
+    if (indexPath == null) {
+      setCachePaths(CacheDirectoryResolver.getIndexCachePath().toString());
+    }
+
     return this.indexPath;
   }
 

--- a/src/main/java/io/anserini/util/PrebuiltIndexHandler.java
+++ b/src/main/java/io/anserini/util/PrebuiltIndexHandler.java
@@ -109,7 +109,7 @@ public class PrebuiltIndexHandler {
       }
     }
 
-    setCachePaths(cacheDirectory);
+    resolveCachePaths(cacheDirectory);
 
     if (indexPath.toFile().exists()) {
       LOG.info(String.format("Index already exists at %s: skipping downloading.", indexPath));
@@ -280,7 +280,7 @@ public class PrebuiltIndexHandler {
     LOG.info("Finished unpacking {}. Final index location: {}.", this.entry.name, indexPath);
   }
 
-  private void setCachePaths(String cacheDirectory) {
+  private void resolveCachePaths(String cacheDirectory) {
     this.cacheDirectory = cacheDirectory;
     downloadFilePath = Path.of(cacheDirectory, this.entry.filename);
     String downloadFilePathString = downloadFilePath.toString();
@@ -301,7 +301,7 @@ public class PrebuiltIndexHandler {
 
   public Path getIndexPath() {
     if (indexPath == null) {
-      setCachePaths(CacheDirectoryResolver.getIndexCachePath().toString());
+      resolveCachePaths(CacheDirectoryResolver.getIndexCachePath().toString());
     }
 
     return this.indexPath;

--- a/src/main/java/io/anserini/util/PrebuiltIndexHandler.java
+++ b/src/main/java/io/anserini/util/PrebuiltIndexHandler.java
@@ -82,8 +82,6 @@ public class PrebuiltIndexHandler {
       this.entry = entry;
     } else if ((entry = PrebuiltHnswIndex.get(name)) != null) {
       this.entry = entry;
-    } else if (PrebuiltHnswIndex.get(name) != null) {
-      this.entry = entry;
     } else {
       throw new IOException("Index not found!");
     }
@@ -122,13 +120,13 @@ public class PrebuiltIndexHandler {
       throw new IOException(String.format("Invalid URL syntax for index download: %s", e.getMessage()), e);
     }
 
-    if (this.entry.size != -1) {
+    if (entry.size != -1) {
       long downloadedSize = Files.size(downloadFilePath);
-      if (downloadedSize != this.entry.size) {
+      if (downloadedSize != entry.size) {
         throw new IOException(String.format("Downloaded size mismatch: expected %s bytes but got %s bytes.",
-            this.entry.size, downloadedSize));
+            entry.size, downloadedSize));
       }
-      LOG.info("Verified downloaded size for {}: {}.", this.entry.name, formatSize(downloadedSize));
+      LOG.info("Verified downloaded size for {}: {}.", entry.name, formatSize(downloadedSize));
     }
 
     try {
@@ -141,17 +139,17 @@ public class PrebuiltIndexHandler {
 
   private void download() throws IOException, URISyntaxException {
     IOException lastException = null;
-    for (String urlString : this.entry.urls) {
+    for (String urlString : entry.urls) {
       for (int attempt = 1; attempt <= MAX_DOWNLOAD_ATTEMPTS; attempt++) {
         LOG.info("Downloading index {} from {} to {} (attempt {}/{}).",
-            this.entry.name, urlString, downloadFilePath, attempt, MAX_DOWNLOAD_ATTEMPTS);
+            entry.name, urlString, downloadFilePath, attempt, MAX_DOWNLOAD_ATTEMPTS);
         try {
           downloadFromUrl(urlString);
-          LOG.info("Verifying checksum for {} at {}.", this.entry.name, downloadFilePath);
-          if (!verifyChecksum(downloadFilePath, this.entry.md5)) {
-            throw new IOException(String.format("Downloaded file checksum mismatch: expected md5 %s.", this.entry.md5));
+          LOG.info("Verifying checksum for {} at {}.", entry.name, downloadFilePath);
+          if (!verifyChecksum(downloadFilePath, entry.md5)) {
+            throw new IOException(String.format("Downloaded file checksum mismatch: expected md5 %s.", entry.md5));
           }
-          LOG.info("Verified checksum for {}: md5 {}.", this.entry.name, this.entry.md5);
+          LOG.info("Verified checksum for {}: md5 {}.", entry.name, entry.md5);
           return;
         } catch (IOException e) {
           lastException = e;
@@ -166,7 +164,7 @@ public class PrebuiltIndexHandler {
     }
 
     throw new IOException(String.format("Unable to download index %s after trying %s URL(s) with %s attempt(s) each.",
-        this.entry.name, this.entry.urls.length, MAX_DOWNLOAD_ATTEMPTS), lastException);
+        entry.name, entry.urls.length, MAX_DOWNLOAD_ATTEMPTS), lastException);
   }
 
   private void downloadFromUrl(String urlString) throws IOException, URISyntaxException {
@@ -181,9 +179,9 @@ public class PrebuiltIndexHandler {
         FileOutputStream fileOS = new FileOutputStream(downloadFilePath.toFile())) {
 
       if (hasKnownSize) {
-        LOG.info("Starting download of {} (size: {}).", this.entry.name, formatSize(size));
+        LOG.info("Starting download of {} (size: {}).", entry.name, formatSize(size));
       } else {
-        LOG.info("Starting download of {} (size unknown).", this.entry.name);
+        LOG.info("Starting download of {} (size unknown).", entry.name);
       }
 
       byte[] buffer = new byte[DOWNLOAD_BUFFER_SIZE];
@@ -199,9 +197,9 @@ public class PrebuiltIndexHandler {
       }
 
       if (hasKnownSize) {
-        LOG.info("Finished downloading {} ({}).", this.entry.name, formatSize(downloaded));
+        LOG.info("Finished downloading {} ({}).", entry.name, formatSize(downloaded));
       } else {
-        LOG.info("Finished downloading {}.", this.entry.name);
+        LOG.info("Finished downloading {}.", entry.name);
       }
 
     } finally {
@@ -216,7 +214,7 @@ public class PrebuiltIndexHandler {
 
     long percent = Math.min(100, downloaded * 100 / size);
     while (percent >= nextLoggedPercent && nextLoggedPercent <= 100) {
-      LOG.info("Downloading {}: {}% ({}/{})", this.entry.name, nextLoggedPercent, formatSize(downloaded), formatSize(size));
+      LOG.info("Downloading {}: {}% ({}/{})", entry.name, nextLoggedPercent, formatSize(downloaded), formatSize(size));
       nextLoggedPercent += DOWNLOAD_LOG_INTERVAL_PERCENT;
     }
 
@@ -237,7 +235,7 @@ public class PrebuiltIndexHandler {
   }
 
   private void decompress() throws IOException, InterruptedException {
-    LOG.info("Preparing to unpack {} from {} into cache directory {}.", this.entry.name, downloadFilePath, cacheDirectory);
+    LOG.info("Preparing to unpack {} from {} into cache directory {}.", entry.name, downloadFilePath, cacheDirectory);
 
     if (!downloadFilePath.toFile().exists()) {
       throw new IOException(String.format("Unexpected error: %s not found.", downloadFilePath));
@@ -275,16 +273,16 @@ public class PrebuiltIndexHandler {
 
     String tarFilePathString = tarFilePath.toString();
     Path unpackedIndexPath = Path.of(tarFilePathString.substring(0, tarFilePathString.length() - ".tar".length()));
-    LOG.info("Moving unpacked index from {} to {}.", unpackedIndexPath, this.indexPath);
-    Files.move(unpackedIndexPath, this.indexPath);
-    LOG.info("Finished unpacking {}. Final index location: {}.", this.entry.name, indexPath);
+    LOG.info("Moving unpacked index from {} to {}.", unpackedIndexPath, indexPath);
+    Files.move(unpackedIndexPath, indexPath);
+    LOG.info("Finished unpacking {}. Final index location: {}.", entry.name, indexPath);
   }
 
   private void resolveCachePaths(String cacheDirectory) {
     this.cacheDirectory = cacheDirectory;
-    downloadFilePath = Path.of(cacheDirectory, this.entry.filename);
+    downloadFilePath = Path.of(cacheDirectory, entry.filename);
     String downloadFilePathString = downloadFilePath.toString();
-    indexPath = Path.of(stripArchiveSuffix(downloadFilePathString) + "." + this.entry.md5);
+    indexPath = Path.of(stripArchiveSuffix(downloadFilePathString) + "." + entry.md5);
   }
 
   private static String stripArchiveSuffix(String path) {
@@ -304,18 +302,18 @@ public class PrebuiltIndexHandler {
       resolveCachePaths(CacheDirectoryResolver.getIndexCachePath().toString());
     }
 
-    return this.indexPath;
+    return indexPath;
   }
 
   public long getSize() {
-    return this.entry.size;
+    return entry.size;
   }
 
   public String getFilename() {
-    return this.entry.filename;
+    return entry.filename;
   }
 
   public String getMD5() {
-    return this.entry.md5;
+    return entry.md5;
   }
 }

--- a/src/main/resources/reproduce/from-prebuilt-indexes/commands/from-prebuilt-indexes.txt
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/commands/from-prebuilt-indexes.txt
@@ -1,5 +1,5 @@
-io.anserini.reproduce.ReproduceFromPrebuiltIndexes --config bright
 io.anserini.reproduce.ReproduceFromPrebuiltIndexes --config beir
+io.anserini.reproduce.ReproduceFromPrebuiltIndexes --config bright
 io.anserini.reproduce.ReproduceFromPrebuiltIndexes --config msmarco-v1-passage
 io.anserini.reproduce.ReproduceFromPrebuiltIndexes --config msmarco-v1-doc
 io.anserini.reproduce.ReproduceFromPrebuiltIndexes --config msmarco-v2-passage

--- a/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
@@ -104,6 +104,29 @@ public class ReproduceFromPrebuiltIndexesTest extends StdOutStdErrRedirectableLu
   }
 
   @Test
+  public void testDryRunOmitsPathForMissingPrebuiltIndex() throws Exception {
+    Path cacheDirectory = createTempDir("pyserini-cache");
+    String previousCacheDirectory = System.getProperty(CacheDirectoryResolver.CACHE_PROPERTY);
+
+    try {
+      System.setProperty(CacheDirectoryResolver.CACHE_PROPERTY, cacheDirectory.toString());
+
+      ReproduceFromPrebuiltIndexes.main(new String[] {"--config", "cacm", "--dry-run"});
+    } finally {
+      if (previousCacheDirectory == null) {
+        System.clearProperty(CacheDirectoryResolver.CACHE_PROPERTY);
+      } else {
+        System.setProperty(CacheDirectoryResolver.CACHE_PROPERTY, previousCacheDirectory);
+      }
+    }
+
+    String output = out.toString();
+    assertTrue(output, output.contains("Indexes referenced by this run (1 total):"));
+    assertTrue(output, output.matches("(?s).*\\ncacm\\s+[0-9.]+ [A-Z]+B\\s+-\\s+-\\s*\\n.*"));
+    assertFalse(output, output.contains(cacheDirectory.resolve("indexes").toString()));
+  }
+
+  @Test
   public void testBeirDryRunReportsPlainTarIndexSize() throws Exception {
     Path cacheDirectory = createTempDir("pyserini-cache");
     String previousCacheDirectory = System.getProperty(CacheDirectoryResolver.CACHE_PROPERTY);
@@ -130,7 +153,8 @@ public class ReproduceFromPrebuiltIndexesTest extends StdOutStdErrRedirectableLu
 
     String output = out.toString();
     assertTrue(output, output.contains("beir-v1.0.0-trec-covid.bge-base-en-v1.5.flat"));
-    assertTrue(output, output.matches("(?s).*beir-v1\\.0\\.0-trec-covid\\.bge-base-en-v1\\.5\\.flat\\s+6\\.0 B\\s+506\\.5 MB.*"));
+    assertTrue(output, output.matches("(?s).*beir-v1\\.0\\.0-trec-covid\\.bge-base-en-v1\\.5\\.flat\\s+506\\.5 MB\\s+6\\.0 B.*"));
+    assertTrue(output, output.contains(indexDirectory.toAbsolutePath().toString()));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Show `download size` before `size on disk` in prebuilt-index dry-run summaries.
- Rename the path column to `local path` and only show a path when the local index exists.
- Reuse `PrebuiltIndexHandler` path resolution for dry-run summaries.

## Validation

- `mvn -Dtest=ReproduceFromPrebuiltIndexesTest#testDryRunOmitsPathForMissingPrebuiltIndex,ReproduceFromPrebuiltIndexesTest#testBeirDryRunReportsPlainTarIndexSize test`
- `bin/qbuild.sh`
- `bin/run.sh io.anserini.reproduce.ReproduceFromPrebuiltIndexes --config bright --dry-run`