### PR TITLE
[codex] Standardize MS MARCO reproduction index docs

### DIFF
--- a/docs/ref-reproduce-from-document-collections.md
+++ b/docs/ref-reproduce-from-document-collections.md
@@ -9,11 +9,11 @@ This [catalog](./ref-reproduce-from-document-collections-catalog.md) enumerates 
 ## Table of Contents
 
 + [MS MARCO V1 Passage](reproduce/from-document-collection-summaries/msmarco-v1-passage.md)
-+ [MS MARCO V1 Document](reproduce/from-document-collection-summaries/msmarco-v1-doc.md)
++ [MS MARCO V1 Doc](reproduce/from-document-collection-summaries/msmarco-v1-doc.md)
 + [MS MARCO V2 Passage](reproduce/from-document-collection-summaries/msmarco-v2-passage.md)
-+ [MS MARCO V2 Document](reproduce/from-document-collection-summaries/msmarco-v2-doc.md)
-+ [MS MARCO V2.1 Segmented Document](reproduce/from-document-collection-summaries/msmarco-v2.1-segmented-doc.md)
-+ [MS MARCO V2.1 Document](reproduce/from-document-collection-summaries/msmarco-v2.1-doc.md)
++ [MS MARCO V2 Doc](reproduce/from-document-collection-summaries/msmarco-v2-doc.md)
++ [MS MARCO V2.1 Segmented Doc](reproduce/from-document-collection-summaries/msmarco-v2.1-segmented-doc.md)
++ [MS MARCO V2.1 Doc](reproduce/from-document-collection-summaries/msmarco-v2.1-doc.md)
 + [BEIR](reproduce/from-document-collection-summaries/beir.md)
 + [BRIGHT](reproduce/from-document-collection-summaries/bright.md)
 + [Multilingual Test Collections](reproduce/from-document-collection-summaries/multilingual.md): MIRACL, Mr. TyDi, CIRAL, TREC NeuCLIR, HC4, NTCIR-8 ACLIA, CLEF 2006 French, TREC 2002 Arabic, FIRE 2012 Bengali + Hindi

--- a/docs/ref-reproduce-from-prebuilt-indexes.md
+++ b/docs/ref-reproduce-from-prebuilt-indexes.md
@@ -7,10 +7,10 @@ These experiments are grouped around configs, each of which focus on a specific 
 ## Table of Contents
 
 + [MS MARCO V1 Passage](reproduce/from-prebuilt-indexes/msmarco-v1-passage.md)
-+ [MS MARCO V1 Document](reproduce/from-prebuilt-indexes/msmarco-v1-doc.md)
++ [MS MARCO V1 Doc](reproduce/from-prebuilt-indexes/msmarco-v1-doc.md)
 + [MS MARCO V2 Passage](reproduce/from-prebuilt-indexes/msmarco-v2-passage.md)
-+ [MS MARCO V2 Document](reproduce/from-prebuilt-indexes/msmarco-v2-doc.md)
-+ [MS MARCO V2.1 Segmented Document](reproduce/from-prebuilt-indexes/msmarco-v2.1-doc-segmented.md)
-+ [MS MARCO V2.1 Document](reproduce/from-prebuilt-indexes/msmarco-v2.1-doc.md)
++ [MS MARCO V2 Doc](reproduce/from-prebuilt-indexes/msmarco-v2-doc.md)
++ [MS MARCO V2.1 Segmented Doc](reproduce/from-prebuilt-indexes/msmarco-v2.1-doc-segmented.md)
++ [MS MARCO V2.1 Doc](reproduce/from-prebuilt-indexes/msmarco-v2.1-doc.md)
 + [BEIR](reproduce/from-prebuilt-indexes/beir.md)
 + [BRIGHT](reproduce/from-prebuilt-indexes/bright.md)

--- a/docs/reproduce/from-prebuilt-indexes/msmarco-v1-doc.md
+++ b/docs/reproduce/from-prebuilt-indexes/msmarco-v1-doc.md
@@ -18,17 +18,19 @@ Key:
 
 | # | name | dev | DL19 | DL20 |
 | --- | --- | --- | --- | --- |
-| [1](#condition-1) | BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.2299 | 0.5176 | 0.5286 |
-| [2](#condition-2) | BM25 complete doc with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.2880 | 0.5968 | 0.5885 |
-| [3](#condition-3) | BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.2684 | 0.5302 | 0.5281 |
-| [4](#condition-4) | BM25 segmented doc with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.3179 | 0.6119 | 0.5957 |
-| [5](#condition-5) | uniCOIL with doc2query-T5 (ONNX) | 0.3531 | 0.6396 | 0.6033 |
-| [6](#condition-6) | BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index | 0.2299 | 0.5176 | 0.5286 |
-| [7](#condition-7) | BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index | 0.2299 | 0.5176 | 0.5286 |
-| [8](#condition-8) | BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index | 0.2684 | 0.5302 | 0.5281 |
-| [9](#condition-9) | BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index | 0.2684 | 0.5302 | 0.5281 |
+| [1](#condition-1) | BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index | 0.2299 | 0.5176 | 0.5286 |
+| [2](#condition-2) | BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index | 0.2299 | 0.5176 | 0.5286 |
+| [3](#condition-3) | BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) + Rocchio, regular index |  | 0.5256 | 0.5192 |
+| [4](#condition-4) | BM25 complete doc with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.2880 | 0.5968 | 0.5885 |
+| [5](#condition-5) | BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index | 0.2684 | 0.5302 | 0.5281 |
+| [6](#condition-6) | BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index | 0.2684 | 0.5302 | 0.5281 |
+| [7](#condition-7) | BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) + Rocchio, regular index |  | 0.5570 | 0.5226 |
+| [8](#condition-8) | BM25 segmented doc with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.3179 | 0.6119 | 0.5957 |
+| [9](#condition-9) | uniCOIL with doc2query-T5 (ONNX) | 0.3531 | 0.6396 | 0.6033 |
 
 
+
+The BM25 "slim index" does not contain the document texts, whereas the BM25 "regular index" does contain document texts (and hence supports pseudo-relevance feedback with on-the-fly document parsing).
 
 ## Commands
 
@@ -51,7 +53,77 @@ export jvm_args="-Xms512M -Xmx192G -Dslf4j.internal.verbosity=WARN --add-modules
 
 <a id="condition-1"></a>
 
-### 1. BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
+### 1. BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
+
+**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
+
+#### msmarco-doc.dev
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v1-doc-slim \
+    -topics msmarco-doc.dev \
+    -output runs/run.msmarco-v1-doc.bm25-doc-default-slim.msmarco-doc.dev.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-doc.dev runs/run.msmarco-v1-doc.bm25-doc-default-slim.msmarco-doc.dev.txt
+```
+
+#### dl19-doc
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v1-doc-slim \
+    -topics dl19-doc \
+    -output runs/run.msmarco-v1-doc.bm25-doc-default-slim.dl19-doc.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map dl19-doc runs/run.msmarco-v1-doc.bm25-doc-default-slim.dl19-doc.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-default-slim.dl19-doc.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-default-slim.dl19-doc.txt
+```
+
+#### dl20-doc
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v1-doc-slim \
+    -topics dl20-doc \
+    -output runs/run.msmarco-v1-doc.bm25-doc-default-slim.dl20-doc.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map dl20-doc runs/run.msmarco-v1-doc.bm25-doc-default-slim.dl20-doc.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-default-slim.dl20-doc.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-default-slim.dl20-doc.txt
+```
+
+<a id="condition-2"></a>
+
+### 2. BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index
 
 **Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
 
@@ -119,9 +191,63 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-doc runs/run.msmarco-v1-doc.bm
 java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-default.dl20-doc.txt
 ```
 
-<a id="condition-2"></a>
+<a id="condition-3"></a>
 
-### 2. BM25 complete doc with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
+### 3. BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) + Rocchio, regular index
+
+**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
+
+#### dl19-doc
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v1-doc \
+    -topics dl19-doc \
+    -output runs/run.msmarco-v1-doc.bm25-doc-default-rocchio.dl19-doc.txt \
+    -hits 1000 \
+    -bm25 \
+    -rocchio \
+    -collection JsonCollection
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map dl19-doc runs/run.msmarco-v1-doc.bm25-doc-default-rocchio.dl19-doc.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-default-rocchio.dl19-doc.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-default-rocchio.dl19-doc.txt
+```
+
+#### dl20-doc
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v1-doc \
+    -topics dl20-doc \
+    -output runs/run.msmarco-v1-doc.bm25-doc-default-rocchio.dl20-doc.txt \
+    -hits 1000 \
+    -bm25 \
+    -rocchio \
+    -collection JsonCollection
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map dl20-doc runs/run.msmarco-v1-doc.bm25-doc-default-rocchio.dl20-doc.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-default-rocchio.dl20-doc.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-default-rocchio.dl20-doc.txt
+```
+
+<a id="condition-4"></a>
+
+### 4. BM25 complete doc with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
 
 **Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
 
@@ -189,9 +315,94 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-doc runs/run.msmarco-v1-doc.bm
 java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm25-d2q-t5-doc-default.dl20-doc.txt
 ```
 
-<a id="condition-3"></a>
+<a id="condition-5"></a>
 
-### 3. BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
+### 5. BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
+
+**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
+
+#### msmarco-doc.dev
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v1-doc-segmented-slim \
+    -topics msmarco-doc.dev \
+    -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.msmarco-doc.dev.txt \
+    -bm25 \
+    -rocchio \
+    -collection JsonCollection \
+    -hits 10000 \
+    -selectMaxPassage \
+    -selectMaxPassage.delimiter \# \
+    -selectMaxPassage.hits 1000
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-doc.dev runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.msmarco-doc.dev.txt
+```
+
+#### dl19-doc
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v1-doc-segmented-slim \
+    -topics dl19-doc \
+    -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl19-doc.txt \
+    -bm25 \
+    -rocchio \
+    -collection JsonCollection \
+    -hits 10000 \
+    -selectMaxPassage \
+    -selectMaxPassage.delimiter \# \
+    -selectMaxPassage.hits 1000
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl19-doc.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl19-doc.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl19-doc.txt
+```
+
+#### dl20-doc
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v1-doc-segmented-slim \
+    -topics dl20-doc \
+    -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl20-doc.txt \
+    -bm25 \
+    -rocchio \
+    -collection JsonCollection \
+    -hits 10000 \
+    -selectMaxPassage \
+    -selectMaxPassage.delimiter \# \
+    -selectMaxPassage.hits 1000
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl20-doc.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl20-doc.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl20-doc.txt
+```
+
+<a id="condition-6"></a>
+
+### 6. BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index
 
 **Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
 
@@ -268,9 +479,65 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-doc runs/run.msmarco-v1-doc.bm
 java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl20-doc.txt
 ```
 
-<a id="condition-4"></a>
+<a id="condition-7"></a>
 
-### 4. BM25 segmented doc with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
+### 7. BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) + Rocchio, regular index
+
+**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
+
+#### dl19-doc
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v1-doc-segmented \
+    -topics dl19-doc \
+    -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl19-doc.txt \
+    -bm25 \
+    -hits 10000 \
+    -selectMaxPassage \
+    -selectMaxPassage.delimiter \# \
+    -selectMaxPassage.hits 1000
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl19-doc.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl19-doc.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl19-doc.txt
+```
+
+#### dl20-doc
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v1-doc-segmented \
+    -topics dl20-doc \
+    -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl20-doc.txt \
+    -bm25 \
+    -hits 10000 \
+    -selectMaxPassage \
+    -selectMaxPassage.delimiter \# \
+    -selectMaxPassage.hits 1000
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl20-doc.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl20-doc.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl20-doc.txt
+```
+
+<a id="condition-8"></a>
+
+### 8. BM25 segmented doc with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
 
 **Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
 
@@ -347,9 +614,9 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-doc runs/run.msmarco-v1-doc.bm
 java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm25-d2q-t5-doc-segmented-default.dl20-doc.txt
 ```
 
-<a id="condition-5"></a>
+<a id="condition-9"></a>
 
-### 5. uniCOIL with doc2query-T5 (ONNX)
+### 9. uniCOIL with doc2query-T5 (ONNX)
 
 **Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
 
@@ -430,304 +697,6 @@ Evaluation commands:
 java -cp $fatjar trec_eval -c -M 100 -m map dl20-doc runs/run.msmarco-v1-doc.unicoil.onnx.dl20-doc.txt
 java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-doc runs/run.msmarco-v1-doc.unicoil.onnx.dl20-doc.txt
 java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.unicoil.onnx.dl20-doc.txt
-```
-
-<a id="condition-6"></a>
-
-### 6. BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
-
-**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
-
-#### msmarco-doc.dev
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-doc-slim \
-    -topics msmarco-doc.dev \
-    -output runs/run.msmarco-v1-doc.bm25-doc-default-slim.msmarco-doc.dev.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-doc.dev runs/run.msmarco-v1-doc.bm25-doc-default-slim.msmarco-doc.dev.txt
-```
-
-#### dl19-doc
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-doc-slim \
-    -topics dl19-doc \
-    -output runs/run.msmarco-v1-doc.bm25-doc-default-slim.dl19-doc.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl19-doc runs/run.msmarco-v1-doc.bm25-doc-default-slim.dl19-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-default-slim.dl19-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-default-slim.dl19-doc.txt
-```
-
-#### dl20-doc
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-doc-slim \
-    -topics dl20-doc \
-    -output runs/run.msmarco-v1-doc.bm25-doc-default-slim.dl20-doc.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl20-doc runs/run.msmarco-v1-doc.bm25-doc-default-slim.dl20-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-default-slim.dl20-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-default-slim.dl20-doc.txt
-```
-
-<a id="condition-7"></a>
-
-### 7. BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index
-
-**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
-
-#### msmarco-doc.dev
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-doc-full \
-    -topics msmarco-doc.dev \
-    -output runs/run.msmarco-v1-doc.bm25-doc-default-full.msmarco-doc.dev.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-doc.dev runs/run.msmarco-v1-doc.bm25-doc-default-full.msmarco-doc.dev.txt
-```
-
-#### dl19-doc
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-doc-full \
-    -topics dl19-doc \
-    -output runs/run.msmarco-v1-doc.bm25-doc-default-full.dl19-doc.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl19-doc runs/run.msmarco-v1-doc.bm25-doc-default-full.dl19-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-default-full.dl19-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-default-full.dl19-doc.txt
-```
-
-#### dl20-doc
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-doc-full \
-    -topics dl20-doc \
-    -output runs/run.msmarco-v1-doc.bm25-doc-default-full.dl20-doc.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl20-doc runs/run.msmarco-v1-doc.bm25-doc-default-full.dl20-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-default-full.dl20-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-default-full.dl20-doc.txt
-```
-
-<a id="condition-8"></a>
-
-### 8. BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
-
-**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
-
-#### msmarco-doc.dev
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-doc-segmented-slim \
-    -topics msmarco-doc.dev \
-    -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.msmarco-doc.dev.txt \
-    -bm25 \
-    -hits 10000 \
-    -selectMaxPassage \
-    -selectMaxPassage.delimiter \# \
-    -selectMaxPassage.hits 1000
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-doc.dev runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.msmarco-doc.dev.txt
-```
-
-#### dl19-doc
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-doc-segmented-slim \
-    -topics dl19-doc \
-    -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl19-doc.txt \
-    -bm25 \
-    -hits 10000 \
-    -selectMaxPassage \
-    -selectMaxPassage.delimiter \# \
-    -selectMaxPassage.hits 1000
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl19-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl19-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl19-doc.txt
-```
-
-#### dl20-doc
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-doc-segmented-slim \
-    -topics dl20-doc \
-    -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl20-doc.txt \
-    -bm25 \
-    -hits 10000 \
-    -selectMaxPassage \
-    -selectMaxPassage.delimiter \# \
-    -selectMaxPassage.hits 1000
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl20-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl20-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl20-doc.txt
-```
-
-<a id="condition-9"></a>
-
-### 9. BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index
-
-**Config**: [msmarco-v1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml)
-
-#### msmarco-doc.dev
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-doc-segmented-full \
-    -topics msmarco-doc.dev \
-    -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default-full.msmarco-doc.dev.txt \
-    -bm25 \
-    -hits 10000 \
-    -selectMaxPassage \
-    -selectMaxPassage.delimiter \# \
-    -selectMaxPassage.hits 1000
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-doc.dev runs/run.msmarco-v1-doc.bm25-doc-segmented-default-full.msmarco-doc.dev.txt
-```
-
-#### dl19-doc
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-doc-segmented-full \
-    -topics dl19-doc \
-    -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default-full.dl19-doc.txt \
-    -bm25 \
-    -hits 10000 \
-    -selectMaxPassage \
-    -selectMaxPassage.delimiter \# \
-    -selectMaxPassage.hits 1000
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-full.dl19-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-full.dl19-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-full.dl19-doc.txt
-```
-
-#### dl20-doc
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-doc-segmented-full \
-    -topics dl20-doc \
-    -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default-full.dl20-doc.txt \
-    -bm25 \
-    -hits 10000 \
-    -selectMaxPassage \
-    -selectMaxPassage.delimiter \# \
-    -selectMaxPassage.hits 1000
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-full.dl20-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-full.dl20-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-full.dl20-doc.txt
 ```
 
 

--- a/docs/reproduce/from-prebuilt-indexes/msmarco-v1-doc.md
+++ b/docs/reproduce/from-prebuilt-indexes/msmarco-v1-doc.md
@@ -332,8 +332,6 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -topics msmarco-doc.dev \
     -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.msmarco-doc.dev.txt \
     -bm25 \
-    -rocchio \
-    -collection JsonCollection \
     -hits 10000 \
     -selectMaxPassage \
     -selectMaxPassage.delimiter \# \
@@ -357,8 +355,6 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -topics dl19-doc \
     -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl19-doc.txt \
     -bm25 \
-    -rocchio \
-    -collection JsonCollection \
     -hits 10000 \
     -selectMaxPassage \
     -selectMaxPassage.delimiter \# \
@@ -384,8 +380,6 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -topics dl20-doc \
     -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default-slim.dl20-doc.txt \
     -bm25 \
-    -rocchio \
-    -collection JsonCollection \
     -hits 10000 \
     -selectMaxPassage \
     -selectMaxPassage.delimiter \# \
@@ -494,8 +488,10 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -threads 16 \
     -index msmarco-v1-doc-segmented \
     -topics dl19-doc \
-    -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl19-doc.txt \
+    -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default-rocchio.dl19-doc.txt \
     -bm25 \
+    -rocchio \
+    -collection JsonCollection \
     -hits 10000 \
     -selectMaxPassage \
     -selectMaxPassage.delimiter \# \
@@ -505,9 +501,9 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
 Evaluation commands:
 
 ```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl19-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl19-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl19-doc.txt
+java -cp $fatjar trec_eval -c -M 100 -m map dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-rocchio.dl19-doc.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-rocchio.dl19-doc.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl19-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-rocchio.dl19-doc.txt
 ```
 
 #### dl20-doc
@@ -519,8 +515,10 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -threads 16 \
     -index msmarco-v1-doc-segmented \
     -topics dl20-doc \
-    -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl20-doc.txt \
+    -output runs/run.msmarco-v1-doc.bm25-doc-segmented-default-rocchio.dl20-doc.txt \
     -bm25 \
+    -rocchio \
+    -collection JsonCollection \
     -hits 10000 \
     -selectMaxPassage \
     -selectMaxPassage.delimiter \# \
@@ -530,9 +528,9 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
 Evaluation commands:
 
 ```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl20-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl20-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default.dl20-doc.txt
+java -cp $fatjar trec_eval -c -M 100 -m map dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-rocchio.dl20-doc.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-rocchio.dl20-doc.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl20-doc runs/run.msmarco-v1-doc.bm25-doc-segmented-default-rocchio.dl20-doc.txt
 ```
 
 <a id="condition-8"></a>

--- a/docs/reproduce/from-prebuilt-indexes/msmarco-v1-passage.md
+++ b/docs/reproduce/from-prebuilt-indexes/msmarco-v1-passage.md
@@ -18,15 +18,17 @@ Key:
 
 | # | name | dev | DL19 | DL20 |
 | --- | --- | --- | --- | --- |
-| [1](#condition-1) | BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.1840 | 0.5058 | 0.4796 |
-| [2](#condition-2) | BM25 with doc2query-T5  (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.2723 | 0.6417 | 0.6187 |
-| [3](#condition-3) | SPLADE-v3 (ONNX) | 0.4000 | 0.7264 | 0.7522 |
-| [4](#condition-4) | bge-base-en-v1.5 with HNSW (ONNX) | 0.3575 | 0.7016 | 0.6768 |
-| [5](#condition-5) | bge-base-en-v1.5 with quantized HNSW (ONNX) | 0.3575 | 0.7017 | 0.6767 |
-| [6](#condition-6) | BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index | 0.1840 | 0.5058 | 0.4796 |
-| [7](#condition-7) | BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index | 0.1840 | 0.5058 | 0.4796 |
+| [1](#condition-1) | BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index | 0.1840 | 0.5058 | 0.4796 |
+| [2](#condition-2) | BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index | 0.1840 | 0.5058 | 0.4796 |
+| [3](#condition-3) | BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) + Rocchio, regular index |  | 0.5275 | 0.4910 |
+| [4](#condition-4) | BM25 with doc2query-T5  (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.2723 | 0.6417 | 0.6187 |
+| [5](#condition-5) | SPLADE-v3 (ONNX) | 0.4000 | 0.7264 | 0.7522 |
+| [6](#condition-6) | bge-base-en-v1.5 with HNSW (ONNX) | 0.3575 | 0.7016 | 0.6768 |
+| [7](#condition-7) | bge-base-en-v1.5 with quantized HNSW (ONNX) | 0.3575 | 0.7017 | 0.6767 |
 
 
+
+The BM25 "slim index" does not contain the document texts, whereas the BM25 "regular index" does contain document texts (and hence supports pseudo-relevance feedback with on-the-fly document parsing).
 
 ## Commands
 
@@ -49,7 +51,78 @@ export jvm_args="-Xms512M -Xmx192G -Dslf4j.internal.verbosity=WARN --add-modules
 
 <a id="condition-1"></a>
 
-### 1. BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
+### 1. BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
+
+**Config**: [msmarco-v1-passage.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-passage.yaml)
+
+#### msmarco-v1-passage.dev
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v1-passage-slim \
+    -topics msmarco-v1-passage.dev \
+    -output runs/run.msmarco-v1-passage.bm25-slim.msmarco-v1-passage.dev.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 10 -m recip_rank msmarco-passage.dev runs/run.msmarco-v1-passage.bm25-slim.msmarco-v1-passage.dev.txt
+java -cp $fatjar trec_eval -c -m recall.1000 msmarco-passage.dev runs/run.msmarco-v1-passage.bm25-slim.msmarco-v1-passage.dev.txt
+```
+
+#### dl19-passage
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v1-passage-slim \
+    -topics dl19-passage \
+    -output runs/run.msmarco-v1-passage.bm25-slim.dl19-passage.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -l 2 -m map dl19-passage runs/run.msmarco-v1-passage.bm25-slim.dl19-passage.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl19-passage runs/run.msmarco-v1-passage.bm25-slim.dl19-passage.txt
+java -cp $fatjar trec_eval -c -l 2 -m recall.1000 dl19-passage runs/run.msmarco-v1-passage.bm25-slim.dl19-passage.txt
+```
+
+#### dl20-passage
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v1-passage-slim \
+    -topics dl20-passage \
+    -output runs/run.msmarco-v1-passage.bm25-slim.dl20-passage.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -l 2 -m map dl20-passage runs/run.msmarco-v1-passage.bm25-slim.dl20-passage.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-passage runs/run.msmarco-v1-passage.bm25-slim.dl20-passage.txt
+java -cp $fatjar trec_eval -c -l 2 -m recall.1000 dl20-passage runs/run.msmarco-v1-passage.bm25-slim.dl20-passage.txt
+```
+
+<a id="condition-2"></a>
+
+### 2. BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index
 
 **Config**: [msmarco-v1-passage.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-passage.yaml)
 
@@ -118,9 +191,63 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-passage runs/run.msmarco-v1-pa
 java -cp $fatjar trec_eval -c -l 2 -m recall.1000 dl20-passage runs/run.msmarco-v1-passage.bm25.dl20-passage.txt
 ```
 
-<a id="condition-2"></a>
+<a id="condition-3"></a>
 
-### 2. BM25 with doc2query-T5  (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
+### 3. BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) + Rocchio, regular index
+
+**Config**: [msmarco-v1-passage.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-passage.yaml)
+
+#### dl19-passage
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v1-passage \
+    -topics dl19-passage \
+    -output runs/run.msmarco-v1-passage.bm25-rocchio.dl19-passage.txt \
+    -hits 1000 \
+    -bm25 \
+    -rocchio \
+    -collection JsonCollection
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -l 2 -m map dl19-passage runs/run.msmarco-v1-passage.bm25-rocchio.dl19-passage.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl19-passage runs/run.msmarco-v1-passage.bm25-rocchio.dl19-passage.txt
+java -cp $fatjar trec_eval -c -l 2 -m recall.1000 dl19-passage runs/run.msmarco-v1-passage.bm25-rocchio.dl19-passage.txt
+```
+
+#### dl20-passage
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v1-passage \
+    -topics dl20-passage \
+    -output runs/run.msmarco-v1-passage.bm25-rocchio.dl20-passage.txt \
+    -hits 1000 \
+    -bm25 \
+    -rocchio \
+    -collection JsonCollection
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -l 2 -m map dl20-passage runs/run.msmarco-v1-passage.bm25-rocchio.dl20-passage.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-passage runs/run.msmarco-v1-passage.bm25-rocchio.dl20-passage.txt
+java -cp $fatjar trec_eval -c -l 2 -m recall.1000 dl20-passage runs/run.msmarco-v1-passage.bm25-rocchio.dl20-passage.txt
+```
+
+<a id="condition-4"></a>
+
+### 4. BM25 with doc2query-T5  (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
 
 **Config**: [msmarco-v1-passage.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-passage.yaml)
 
@@ -189,9 +316,9 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-passage runs/run.msmarco-v1-pa
 java -cp $fatjar trec_eval -c -l 2 -m recall.1000 dl20-passage runs/run.msmarco-v1-passage.bm25-d2q-t5.dl20-passage.txt
 ```
 
-<a id="condition-3"></a>
+<a id="condition-5"></a>
 
-### 3. SPLADE-v3 (ONNX)
+### 5. SPLADE-v3 (ONNX)
 
 **Config**: [msmarco-v1-passage.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-passage.yaml)
 
@@ -266,9 +393,9 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-passage runs/run.msmarco-v1-pa
 java -cp $fatjar trec_eval -c -l 2 -m recall.1000 dl20-passage runs/run.msmarco-v1-passage.splade-v3.onnx.dl20-passage.txt
 ```
 
-<a id="condition-4"></a>
+<a id="condition-6"></a>
 
-### 4. bge-base-en-v1.5 with HNSW (ONNX)
+### 6. bge-base-en-v1.5 with HNSW (ONNX)
 
 **Config**: [msmarco-v1-passage.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-passage.yaml)
 
@@ -340,9 +467,9 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-passage runs/run.msmarco-v1-pa
 java -cp $fatjar trec_eval -c -l 2 -m recall.1000 dl20-passage runs/run.msmarco-v1-passage.bge-base-en-v1.5.hnsw.onnx.dl20-passage.txt
 ```
 
-<a id="condition-5"></a>
+<a id="condition-7"></a>
 
-### 5. bge-base-en-v1.5 with quantized HNSW (ONNX)
+### 7. bge-base-en-v1.5 with quantized HNSW (ONNX)
 
 **Config**: [msmarco-v1-passage.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-passage.yaml)
 
@@ -412,148 +539,6 @@ Evaluation commands:
 java -cp $fatjar trec_eval -c -l 2 -m map dl20-passage runs/run.msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.dl20-passage.txt
 java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-passage runs/run.msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.dl20-passage.txt
 java -cp $fatjar trec_eval -c -l 2 -m recall.1000 dl20-passage runs/run.msmarco-v1-passage.bge-base-en-v1.5.hnsw-int8.onnx.dl20-passage.txt
-```
-
-<a id="condition-6"></a>
-
-### 6. BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
-
-**Config**: [msmarco-v1-passage.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-passage.yaml)
-
-#### msmarco-v1-passage.dev
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-passage-slim \
-    -topics msmarco-v1-passage.dev \
-    -output runs/run.msmarco-v1-passage.bm25-slim.msmarco-v1-passage.dev.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 10 -m recip_rank msmarco-passage.dev runs/run.msmarco-v1-passage.bm25-slim.msmarco-v1-passage.dev.txt
-java -cp $fatjar trec_eval -c -m recall.1000 msmarco-passage.dev runs/run.msmarco-v1-passage.bm25-slim.msmarco-v1-passage.dev.txt
-```
-
-#### dl19-passage
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-passage-slim \
-    -topics dl19-passage \
-    -output runs/run.msmarco-v1-passage.bm25-slim.dl19-passage.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -l 2 -m map dl19-passage runs/run.msmarco-v1-passage.bm25-slim.dl19-passage.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl19-passage runs/run.msmarco-v1-passage.bm25-slim.dl19-passage.txt
-java -cp $fatjar trec_eval -c -l 2 -m recall.1000 dl19-passage runs/run.msmarco-v1-passage.bm25-slim.dl19-passage.txt
-```
-
-#### dl20-passage
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-passage-slim \
-    -topics dl20-passage \
-    -output runs/run.msmarco-v1-passage.bm25-slim.dl20-passage.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -l 2 -m map dl20-passage runs/run.msmarco-v1-passage.bm25-slim.dl20-passage.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-passage runs/run.msmarco-v1-passage.bm25-slim.dl20-passage.txt
-java -cp $fatjar trec_eval -c -l 2 -m recall.1000 dl20-passage runs/run.msmarco-v1-passage.bm25-slim.dl20-passage.txt
-```
-
-<a id="condition-7"></a>
-
-### 7. BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index
-
-**Config**: [msmarco-v1-passage.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-passage.yaml)
-
-#### msmarco-v1-passage.dev
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-passage-full \
-    -topics msmarco-v1-passage.dev \
-    -output runs/run.msmarco-v1-passage.bm25-full.msmarco-v1-passage.dev.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 10 -m recip_rank msmarco-passage.dev runs/run.msmarco-v1-passage.bm25-full.msmarco-v1-passage.dev.txt
-java -cp $fatjar trec_eval -c -m recall.1000 msmarco-passage.dev runs/run.msmarco-v1-passage.bm25-full.msmarco-v1-passage.dev.txt
-```
-
-#### dl19-passage
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-passage-full \
-    -topics dl19-passage \
-    -output runs/run.msmarco-v1-passage.bm25-full.dl19-passage.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -l 2 -m map dl19-passage runs/run.msmarco-v1-passage.bm25-full.dl19-passage.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl19-passage runs/run.msmarco-v1-passage.bm25-full.dl19-passage.txt
-java -cp $fatjar trec_eval -c -l 2 -m recall.1000 dl19-passage runs/run.msmarco-v1-passage.bm25-full.dl19-passage.txt
-```
-
-#### dl20-passage
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v1-passage-full \
-    -topics dl20-passage \
-    -output runs/run.msmarco-v1-passage.bm25-full.dl20-passage.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -l 2 -m map dl20-passage runs/run.msmarco-v1-passage.bm25-full.dl20-passage.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl20-passage runs/run.msmarco-v1-passage.bm25-full.dl20-passage.txt
-java -cp $fatjar trec_eval -c -l 2 -m recall.1000 dl20-passage runs/run.msmarco-v1-passage.bm25-full.dl20-passage.txt
 ```
 
 

--- a/docs/reproduce/from-prebuilt-indexes/msmarco-v2-doc.md
+++ b/docs/reproduce/from-prebuilt-indexes/msmarco-v2-doc.md
@@ -20,13 +20,17 @@ Key:
 
 | # | name | dev | dev2 | DL21 | DL22 | DL23 |
 | --- | --- | --- | --- | --- | --- | --- |
-| [1](#condition-1) | BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.1572 | 0.1659 | 0.5116 | 0.2993 | 0.2946 |
-| [2](#condition-2) | BM25 with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.2011 | 0.2012 | 0.5792 | 0.3539 | 0.3511 |
-| [3](#condition-3) | BM25 segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.1896 | 0.1930 | 0.5776 | 0.3618 | 0.3405 |
-| [4](#condition-4) | BM25 segmented with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.2226 | 0.2234 | 0.6289 | 0.3975 | 0.3612 |
-| [5](#condition-5) | uniCOIL with doc2query-T5 (ONNX) | 0.2419 | 0.2445 | 0.6783 | 0.4451 | 0.4150 |
+| [1](#condition-1) | BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index | 0.1572 | 0.1659 | 0.5116 | 0.2993 | 0.2946 |
+| [2](#condition-2) | BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index | 0.1572 | 0.1659 | 0.5116 | 0.2993 | 0.2946 |
+| [3](#condition-3) | BM25 with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.2011 | 0.2012 | 0.5792 | 0.3539 | 0.3511 |
+| [4](#condition-4) | BM25 segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index | 0.1896 | 0.1930 | 0.5776 | 0.3618 | 0.3405 |
+| [5](#condition-5) | BM25 segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index | 0.1896 | 0.1930 | 0.5776 | 0.3618 | 0.3405 |
+| [6](#condition-6) | BM25 segmented with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.2226 | 0.2234 | 0.6289 | 0.3975 | 0.3612 |
+| [7](#condition-7) | uniCOIL with doc2query-T5 (ONNX) | 0.2419 | 0.2445 | 0.6783 | 0.4451 | 0.4150 |
 
 
+
+The BM25 "slim index" does not contain the document texts, whereas the BM25 "regular index" does contain document texts (and hence supports pseudo-relevance feedback with on-the-fly document parsing).
 
 ## Commands
 
@@ -49,7 +53,125 @@ export jvm_args="-Xms512M -Xmx192G -Dslf4j.internal.verbosity=WARN --add-modules
 
 <a id="condition-1"></a>
 
-### 1. BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
+### 1. BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
+
+**Config**: [msmarco-v2-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-doc.yaml)
+
+#### msmarco-v2-doc.dev
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2-doc-slim \
+    -topics msmarco-v2-doc.dev \
+    -output runs/run.msmarco-v2-doc.bm25-doc-default-slim.msmarco-v2-doc.dev.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2-doc.dev runs/run.msmarco-v2-doc.bm25-doc-default-slim.msmarco-v2-doc.dev.txt
+```
+
+#### msmarco-v2-doc.dev2
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2-doc-slim \
+    -topics msmarco-v2-doc.dev2 \
+    -output runs/run.msmarco-v2-doc.bm25-doc-default-slim.msmarco-v2-doc.dev2.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2-doc.dev2 runs/run.msmarco-v2-doc.bm25-doc-default-slim.msmarco-v2-doc.dev2.txt
+```
+
+#### dl21
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2-doc-slim \
+    -topics dl21 \
+    -output runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl21.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map dl21-doc runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl21.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl21-doc runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl21.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl21-doc runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl21.txt
+java -cp $fatjar trec_eval -c -m recall.100 dl21-doc runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl21.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl21-doc runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl21.txt
+```
+
+#### dl22
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2-doc-slim \
+    -topics dl22 \
+    -output runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl22.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map dl22-doc runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl22.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl22-doc runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl22.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl22-doc runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl22.txt
+java -cp $fatjar trec_eval -c -m recall.100 dl22-doc runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl22.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl22-doc runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl22.txt
+```
+
+#### dl23
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2-doc-slim \
+    -topics dl23 \
+    -output runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl23.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map dl23-doc runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl23.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl23-doc runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl23.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl23-doc runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl23.txt
+java -cp $fatjar trec_eval -c -m recall.100 dl23-doc runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl23.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl23-doc runs/run.msmarco-v2-doc.bm25-doc-default-slim.dl23.txt
+```
+
+<a id="condition-2"></a>
+
+### 2. BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index
 
 **Config**: [msmarco-v2-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-doc.yaml)
 
@@ -165,9 +287,9 @@ java -cp $fatjar trec_eval -c -m recall.100 dl23-doc runs/run.msmarco-v2-doc.bm2
 java -cp $fatjar trec_eval -c -m recall.1000 dl23-doc runs/run.msmarco-v2-doc.bm25-doc-default.dl23.txt
 ```
 
-<a id="condition-2"></a>
+<a id="condition-3"></a>
 
-### 2. BM25 with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
+### 3. BM25 with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
 
 **Config**: [msmarco-v2-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-doc.yaml)
 
@@ -283,9 +405,142 @@ java -cp $fatjar trec_eval -c -m recall.100 dl23-doc runs/run.msmarco-v2-doc.bm2
 java -cp $fatjar trec_eval -c -m recall.1000 dl23-doc runs/run.msmarco-v2-doc.bm25-d2q-t5-doc-default.dl23.txt
 ```
 
-<a id="condition-3"></a>
+<a id="condition-4"></a>
 
-### 3. BM25 segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
+### 4. BM25 segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
+
+**Config**: [msmarco-v2-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-doc.yaml)
+
+#### msmarco-v2-doc.dev
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2-doc-segmented-slim \
+    -topics msmarco-v2-doc.dev \
+    -output runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.msmarco-v2-doc.dev.txt \
+    -bm25 \
+    -hits 10000 \
+    -selectMaxPassage \
+    -selectMaxPassage.delimiter \# \
+    -selectMaxPassage.hits 1000
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2-doc.dev runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.msmarco-v2-doc.dev.txt
+```
+
+#### msmarco-v2-doc.dev2
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2-doc-segmented-slim \
+    -topics msmarco-v2-doc.dev2 \
+    -output runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.msmarco-v2-doc.dev2.txt \
+    -bm25 \
+    -hits 10000 \
+    -selectMaxPassage \
+    -selectMaxPassage.delimiter \# \
+    -selectMaxPassage.hits 1000
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2-doc.dev2 runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.msmarco-v2-doc.dev2.txt
+```
+
+#### dl21
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2-doc-segmented-slim \
+    -topics dl21 \
+    -output runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl21.txt \
+    -bm25 \
+    -hits 10000 \
+    -selectMaxPassage \
+    -selectMaxPassage.delimiter \# \
+    -selectMaxPassage.hits 1000
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map dl21-doc runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl21.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl21-doc runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl21.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl21-doc runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl21.txt
+java -cp $fatjar trec_eval -c -m recall.100 dl21-doc runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl21.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl21-doc runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl21.txt
+```
+
+#### dl22
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2-doc-segmented-slim \
+    -topics dl22 \
+    -output runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl22.txt \
+    -bm25 \
+    -hits 10000 \
+    -selectMaxPassage \
+    -selectMaxPassage.delimiter \# \
+    -selectMaxPassage.hits 1000
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map dl22-doc runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl22.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl22-doc runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl22.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl22-doc runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl22.txt
+java -cp $fatjar trec_eval -c -m recall.100 dl22-doc runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl22.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl22-doc runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl22.txt
+```
+
+#### dl23
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2-doc-segmented-slim \
+    -topics dl23 \
+    -output runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl23.txt \
+    -bm25 \
+    -hits 10000 \
+    -selectMaxPassage \
+    -selectMaxPassage.delimiter \# \
+    -selectMaxPassage.hits 1000
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map dl23-doc runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl23.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl23-doc runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl23.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl23-doc runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl23.txt
+java -cp $fatjar trec_eval -c -m recall.100 dl23-doc runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl23.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl23-doc runs/run.msmarco-v2-doc.bm25-doc-segmented-default-slim.dl23.txt
+```
+
+<a id="condition-5"></a>
+
+### 5. BM25 segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index
 
 **Config**: [msmarco-v2-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-doc.yaml)
 
@@ -416,9 +671,9 @@ java -cp $fatjar trec_eval -c -m recall.100 dl23-doc runs/run.msmarco-v2-doc.bm2
 java -cp $fatjar trec_eval -c -m recall.1000 dl23-doc runs/run.msmarco-v2-doc.bm25-doc-segmented-default.dl23.txt
 ```
 
-<a id="condition-4"></a>
+<a id="condition-6"></a>
 
-### 4. BM25 segmented with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
+### 6. BM25 segmented with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
 
 **Config**: [msmarco-v2-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-doc.yaml)
 
@@ -549,9 +804,9 @@ java -cp $fatjar trec_eval -c -m recall.100 dl23-doc runs/run.msmarco-v2-doc.bm2
 java -cp $fatjar trec_eval -c -m recall.1000 dl23-doc runs/run.msmarco-v2-doc.bm25-d2q-t5-doc-segmented-default.dl23.txt
 ```
 
-<a id="condition-5"></a>
+<a id="condition-7"></a>
 
-### 5. uniCOIL with doc2query-T5 (ONNX)
+### 7. uniCOIL with doc2query-T5 (ONNX)
 
 **Config**: [msmarco-v2-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-doc.yaml)
 

--- a/docs/reproduce/from-prebuilt-indexes/msmarco-v2-passage.md
+++ b/docs/reproduce/from-prebuilt-indexes/msmarco-v2-passage.md
@@ -20,13 +20,14 @@ Key:
 
 | # | name | dev | dev2 | DL21 | DL22 | DL23 |
 | --- | --- | --- | --- | --- | --- | --- |
-| [1](#condition-1) | BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.0719 | 0.0802 | 0.4458 | 0.2692 | 0.2627 |
-| [2](#condition-2) | BM25 with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.1072 | 0.1123 | 0.4816 | 0.3599 | 0.3156 |
-| [3](#condition-3) | uniCOIL with doc2query-T5 (ONNX) | 0.1499 | 0.1577 | 0.6159 | 0.4614 | 0.3855 |
-| [4](#condition-4) | BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index | 0.0719 | 0.0802 | 0.4458 | 0.2692 | 0.2627 |
-| [5](#condition-5) | BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index | 0.0719 | 0.0802 | 0.4458 | 0.2692 | 0.2627 |
+| [1](#condition-1) | BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index | 0.0719 | 0.0802 | 0.4458 | 0.2692 | 0.2627 |
+| [2](#condition-2) | BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index | 0.0719 | 0.0802 | 0.4458 | 0.2692 | 0.2627 |
+| [3](#condition-3) | BM25 with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.1072 | 0.1123 | 0.4816 | 0.3599 | 0.3156 |
+| [4](#condition-4) | uniCOIL with doc2query-T5 (ONNX) | 0.1499 | 0.1577 | 0.6159 | 0.4614 | 0.3855 |
 
 
+
+The BM25 "slim index" does not contain the document texts, whereas the BM25 "regular index" does contain document texts (and hence supports pseudo-relevance feedback with on-the-fly document parsing).
 
 ## Commands
 
@@ -49,7 +50,125 @@ export jvm_args="-Xms512M -Xmx192G -Dslf4j.internal.verbosity=WARN --add-modules
 
 <a id="condition-1"></a>
 
-### 1. BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
+### 1. BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
+
+**Config**: [msmarco-v2-passage.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-passage.yaml)
+
+#### msmarco-v2-passage.dev
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2-passage-slim \
+    -topics msmarco-v2-passage.dev \
+    -output runs/run.msmarco-v2-passage.bm25-slim.msmarco-v2-passage.dev.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2-passage.dev runs/run.msmarco-v2-passage.bm25-slim.msmarco-v2-passage.dev.txt
+```
+
+#### msmarco-v2-passage.dev2
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2-passage-slim \
+    -topics msmarco-v2-passage.dev2 \
+    -output runs/run.msmarco-v2-passage.bm25-slim.msmarco-v2-passage.dev2.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2-passage.dev2 runs/run.msmarco-v2-passage.bm25-slim.msmarco-v2-passage.dev2.txt
+```
+
+#### dl21
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2-passage-slim \
+    -topics dl21 \
+    -output runs/run.msmarco-v2-passage.bm25-slim.dl21.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map -l 2 dl21-passage runs/run.msmarco-v2-passage.bm25-slim.dl21.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank -l 2 dl21-passage runs/run.msmarco-v2-passage.bm25-slim.dl21.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl21-passage runs/run.msmarco-v2-passage.bm25-slim.dl21.txt
+java -cp $fatjar trec_eval -c -m recall.100 -l 2 dl21-passage runs/run.msmarco-v2-passage.bm25-slim.dl21.txt
+java -cp $fatjar trec_eval -c -m recall.1000 -l 2 dl21-passage runs/run.msmarco-v2-passage.bm25-slim.dl21.txt
+```
+
+#### dl22
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2-passage-slim \
+    -topics dl22 \
+    -output runs/run.msmarco-v2-passage.bm25-slim.dl22.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map -l 2 dl22-passage runs/run.msmarco-v2-passage.bm25-slim.dl22.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank -l 2 dl22-passage runs/run.msmarco-v2-passage.bm25-slim.dl22.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl22-passage runs/run.msmarco-v2-passage.bm25-slim.dl22.txt
+java -cp $fatjar trec_eval -c -m recall.100 -l 2 dl22-passage runs/run.msmarco-v2-passage.bm25-slim.dl22.txt
+java -cp $fatjar trec_eval -c -m recall.1000 -l 2 dl22-passage runs/run.msmarco-v2-passage.bm25-slim.dl22.txt
+```
+
+#### dl23
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2-passage-slim \
+    -topics dl23 \
+    -output runs/run.msmarco-v2-passage.bm25-slim.dl23.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -M 100 -m map -l 2 dl23-passage runs/run.msmarco-v2-passage.bm25-slim.dl23.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank -l 2 dl23-passage runs/run.msmarco-v2-passage.bm25-slim.dl23.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl23-passage runs/run.msmarco-v2-passage.bm25-slim.dl23.txt
+java -cp $fatjar trec_eval -c -m recall.100 -l 2 dl23-passage runs/run.msmarco-v2-passage.bm25-slim.dl23.txt
+java -cp $fatjar trec_eval -c -m recall.1000 -l 2 dl23-passage runs/run.msmarco-v2-passage.bm25-slim.dl23.txt
+```
+
+<a id="condition-2"></a>
+
+### 2. BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index
 
 **Config**: [msmarco-v2-passage.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-passage.yaml)
 
@@ -165,9 +284,9 @@ java -cp $fatjar trec_eval -c -m recall.100 -l 2 dl23-passage runs/run.msmarco-v
 java -cp $fatjar trec_eval -c -m recall.1000 -l 2 dl23-passage runs/run.msmarco-v2-passage.bm25.dl23.txt
 ```
 
-<a id="condition-2"></a>
+<a id="condition-3"></a>
 
-### 2. BM25 with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
+### 3. BM25 with doc2query-T5 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
 
 **Config**: [msmarco-v2-passage.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-passage.yaml)
 
@@ -283,9 +402,9 @@ java -cp $fatjar trec_eval -c -m recall.100 -l 2 dl23-passage runs/run.msmarco-v
 java -cp $fatjar trec_eval -c -m recall.1000 -l 2 dl23-passage runs/run.msmarco-v2-passage.bm25-d2q-t5.dl23.txt
 ```
 
-<a id="condition-3"></a>
+<a id="condition-4"></a>
 
-### 3. uniCOIL with doc2query-T5 (ONNX)
+### 4. uniCOIL with doc2query-T5 (ONNX)
 
 **Config**: [msmarco-v2-passage.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-passage.yaml)
 
@@ -409,242 +528,6 @@ java -cp $fatjar trec_eval -c -M 100 -m recip_rank -l 2 dl23-passage runs/run.ms
 java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl23-passage runs/run.msmarco-v2-passage.unicoil.onnx.dl23.txt
 java -cp $fatjar trec_eval -c -m recall.100 -l 2 dl23-passage runs/run.msmarco-v2-passage.unicoil.onnx.dl23.txt
 java -cp $fatjar trec_eval -c -m recall.1000 -l 2 dl23-passage runs/run.msmarco-v2-passage.unicoil.onnx.dl23.txt
-```
-
-<a id="condition-4"></a>
-
-### 4. BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
-
-**Config**: [msmarco-v2-passage.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-passage.yaml)
-
-#### msmarco-v2-passage.dev
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2-passage-slim \
-    -topics msmarco-v2-passage.dev \
-    -output runs/run.msmarco-v2-passage.bm25-slim.msmarco-v2-passage.dev.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2-passage.dev runs/run.msmarco-v2-passage.bm25-slim.msmarco-v2-passage.dev.txt
-```
-
-#### msmarco-v2-passage.dev2
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2-passage-slim \
-    -topics msmarco-v2-passage.dev2 \
-    -output runs/run.msmarco-v2-passage.bm25-slim.msmarco-v2-passage.dev2.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2-passage.dev2 runs/run.msmarco-v2-passage.bm25-slim.msmarco-v2-passage.dev2.txt
-```
-
-#### dl21
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2-passage-slim \
-    -topics dl21 \
-    -output runs/run.msmarco-v2-passage.bm25-slim.dl21.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map -l 2 dl21-passage runs/run.msmarco-v2-passage.bm25-slim.dl21.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank -l 2 dl21-passage runs/run.msmarco-v2-passage.bm25-slim.dl21.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl21-passage runs/run.msmarco-v2-passage.bm25-slim.dl21.txt
-java -cp $fatjar trec_eval -c -m recall.100 -l 2 dl21-passage runs/run.msmarco-v2-passage.bm25-slim.dl21.txt
-java -cp $fatjar trec_eval -c -m recall.1000 -l 2 dl21-passage runs/run.msmarco-v2-passage.bm25-slim.dl21.txt
-```
-
-#### dl22
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2-passage-slim \
-    -topics dl22 \
-    -output runs/run.msmarco-v2-passage.bm25-slim.dl22.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map -l 2 dl22-passage runs/run.msmarco-v2-passage.bm25-slim.dl22.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank -l 2 dl22-passage runs/run.msmarco-v2-passage.bm25-slim.dl22.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl22-passage runs/run.msmarco-v2-passage.bm25-slim.dl22.txt
-java -cp $fatjar trec_eval -c -m recall.100 -l 2 dl22-passage runs/run.msmarco-v2-passage.bm25-slim.dl22.txt
-java -cp $fatjar trec_eval -c -m recall.1000 -l 2 dl22-passage runs/run.msmarco-v2-passage.bm25-slim.dl22.txt
-```
-
-#### dl23
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2-passage-slim \
-    -topics dl23 \
-    -output runs/run.msmarco-v2-passage.bm25-slim.dl23.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map -l 2 dl23-passage runs/run.msmarco-v2-passage.bm25-slim.dl23.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank -l 2 dl23-passage runs/run.msmarco-v2-passage.bm25-slim.dl23.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl23-passage runs/run.msmarco-v2-passage.bm25-slim.dl23.txt
-java -cp $fatjar trec_eval -c -m recall.100 -l 2 dl23-passage runs/run.msmarco-v2-passage.bm25-slim.dl23.txt
-java -cp $fatjar trec_eval -c -m recall.1000 -l 2 dl23-passage runs/run.msmarco-v2-passage.bm25-slim.dl23.txt
-```
-
-<a id="condition-5"></a>
-
-### 5. BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index
-
-**Config**: [msmarco-v2-passage.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-passage.yaml)
-
-#### msmarco-v2-passage.dev
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2-passage-full \
-    -topics msmarco-v2-passage.dev \
-    -output runs/run.msmarco-v2-passage.bm25-full.msmarco-v2-passage.dev.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2-passage.dev runs/run.msmarco-v2-passage.bm25-full.msmarco-v2-passage.dev.txt
-```
-
-#### msmarco-v2-passage.dev2
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2-passage-full \
-    -topics msmarco-v2-passage.dev2 \
-    -output runs/run.msmarco-v2-passage.bm25-full.msmarco-v2-passage.dev2.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2-passage.dev2 runs/run.msmarco-v2-passage.bm25-full.msmarco-v2-passage.dev2.txt
-```
-
-#### dl21
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2-passage-full \
-    -topics dl21 \
-    -output runs/run.msmarco-v2-passage.bm25-full.dl21.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map -l 2 dl21-passage runs/run.msmarco-v2-passage.bm25-full.dl21.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank -l 2 dl21-passage runs/run.msmarco-v2-passage.bm25-full.dl21.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl21-passage runs/run.msmarco-v2-passage.bm25-full.dl21.txt
-java -cp $fatjar trec_eval -c -m recall.100 -l 2 dl21-passage runs/run.msmarco-v2-passage.bm25-full.dl21.txt
-java -cp $fatjar trec_eval -c -m recall.1000 -l 2 dl21-passage runs/run.msmarco-v2-passage.bm25-full.dl21.txt
-```
-
-#### dl22
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2-passage-full \
-    -topics dl22 \
-    -output runs/run.msmarco-v2-passage.bm25-full.dl22.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map -l 2 dl22-passage runs/run.msmarco-v2-passage.bm25-full.dl22.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank -l 2 dl22-passage runs/run.msmarco-v2-passage.bm25-full.dl22.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl22-passage runs/run.msmarco-v2-passage.bm25-full.dl22.txt
-java -cp $fatjar trec_eval -c -m recall.100 -l 2 dl22-passage runs/run.msmarco-v2-passage.bm25-full.dl22.txt
-java -cp $fatjar trec_eval -c -m recall.1000 -l 2 dl22-passage runs/run.msmarco-v2-passage.bm25-full.dl22.txt
-```
-
-#### dl23
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2-passage-full \
-    -topics dl23 \
-    -output runs/run.msmarco-v2-passage.bm25-full.dl23.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map -l 2 dl23-passage runs/run.msmarco-v2-passage.bm25-full.dl23.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank -l 2 dl23-passage runs/run.msmarco-v2-passage.bm25-full.dl23.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl23-passage runs/run.msmarco-v2-passage.bm25-full.dl23.txt
-java -cp $fatjar trec_eval -c -m recall.100 -l 2 dl23-passage runs/run.msmarco-v2-passage.bm25-full.dl23.txt
-java -cp $fatjar trec_eval -c -m recall.1000 -l 2 dl23-passage runs/run.msmarco-v2-passage.bm25-full.dl23.txt
 ```
 
 

--- a/docs/reproduce/from-prebuilt-indexes/msmarco-v2.1-doc-segmented.md
+++ b/docs/reproduce/from-prebuilt-indexes/msmarco-v2.1-doc-segmented.md
@@ -19,22 +19,23 @@ Key:
 
 | # | name | RAG24 ☂️ | RAG24 NIST | RAG25 ☂️ | RAG25 NIST |
 | --- | --- | --- | --- | --- | --- |
-| [1](#condition-1) | BM25 doc segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.3198 | 0.2809 | 0.3250 | 0.3468 |
-| [2](#condition-2) | SPLADE-v3 (ONNX) | 0.5167 | 0.4642 | 0.5838 | 0.5957 |
-| [3](#condition-3) | ArcticEmbed-L (shard00) with quantized HNSW (ONNX) | 0.3003 | 0.2449 | 0.2916 | 0.2793 |
-| [4](#condition-4) | ArcticEmbed-L (shard01) with quantized HNSW (ONNX) | 0.2599 | 0.2184 | 0.2581 | 0.2604 |
-| [5](#condition-5) | ArcticEmbed-L (shard02) with quantized HNSW (ONNX) | 0.2661 | 0.2211 | 0.2486 | 0.2429 |
-| [6](#condition-6) | ArcticEmbed-L (shard03) with quantized HNSW (ONNX) | 0.2705 | 0.2388 | 0.2609 | 0.2874 |
-| [7](#condition-7) | ArcticEmbed-L (shard04) with quantized HNSW (ONNX) | 0.2937 | 0.2253 | 0.2737 | 0.2687 |
-| [8](#condition-8) | ArcticEmbed-L (shard05) with quantized HNSW (ONNX) | 0.2590 | 0.2383 | 0.2190 | 0.2499 |
-| [9](#condition-9) | ArcticEmbed-L (shard06) with quantized HNSW (ONNX) | 0.2444 | 0.2336 | 0.1751 | 0.1783 |
-| [10](#condition-10) | ArcticEmbed-L (shard07) with quantized HNSW (ONNX) | 0.2417 | 0.2255 | 0.2178 | 0.2230 |
-| [11](#condition-11) | ArcticEmbed-L (shard08) with quantized HNSW (ONNX) | 0.2847 | 0.2765 | 0.2390 | 0.2312 |
-| [12](#condition-12) | ArcticEmbed-L (shard09) with quantized HNSW (ONNX) | 0.2432 | 0.2457 | 0.2170 | 0.2182 |
-| [13](#condition-13) | BM25 doc segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index | 0.3198 | 0.2809 | 0.3250 | 0.3468 |
-| [14](#condition-14) | BM25 doc segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index | 0.3198 | 0.2809 | 0.3250 | 0.3468 |
+| [1](#condition-1) | BM25 doc segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index | 0.3198 | 0.2809 | 0.3250 | 0.3468 |
+| [2](#condition-2) | BM25 doc segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index | 0.3198 | 0.2809 | 0.3250 | 0.3468 |
+| [3](#condition-3) | SPLADE-v3 (ONNX) | 0.5167 | 0.4642 | 0.5838 | 0.5957 |
+| [4](#condition-4) | ArcticEmbed-L (shard00) with quantized HNSW (ONNX) | 0.3003 | 0.2449 | 0.2916 | 0.2793 |
+| [5](#condition-5) | ArcticEmbed-L (shard01) with quantized HNSW (ONNX) | 0.2599 | 0.2184 | 0.2581 | 0.2604 |
+| [6](#condition-6) | ArcticEmbed-L (shard02) with quantized HNSW (ONNX) | 0.2661 | 0.2211 | 0.2486 | 0.2429 |
+| [7](#condition-7) | ArcticEmbed-L (shard03) with quantized HNSW (ONNX) | 0.2705 | 0.2388 | 0.2609 | 0.2874 |
+| [8](#condition-8) | ArcticEmbed-L (shard04) with quantized HNSW (ONNX) | 0.2937 | 0.2253 | 0.2737 | 0.2687 |
+| [9](#condition-9) | ArcticEmbed-L (shard05) with quantized HNSW (ONNX) | 0.2590 | 0.2383 | 0.2190 | 0.2499 |
+| [10](#condition-10) | ArcticEmbed-L (shard06) with quantized HNSW (ONNX) | 0.2444 | 0.2336 | 0.1751 | 0.1783 |
+| [11](#condition-11) | ArcticEmbed-L (shard07) with quantized HNSW (ONNX) | 0.2417 | 0.2255 | 0.2178 | 0.2230 |
+| [12](#condition-12) | ArcticEmbed-L (shard08) with quantized HNSW (ONNX) | 0.2847 | 0.2765 | 0.2390 | 0.2312 |
+| [13](#condition-13) | ArcticEmbed-L (shard09) with quantized HNSW (ONNX) | 0.2432 | 0.2457 | 0.2170 | 0.2182 |
 
 
+
+The BM25 "slim index" does not contain the document texts, whereas the BM25 "regular index" does contain document texts (and hence supports pseudo-relevance feedback with on-the-fly document parsing).
 
 ## Commands
 
@@ -57,7 +58,101 @@ export jvm_args="-Xms512M -Xmx192G -Dslf4j.internal.verbosity=WARN --add-modules
 
 <a id="condition-1"></a>
 
-### 1. BM25 doc segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
+### 1. BM25 doc segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
+
+**Config**: [msmarco-v2.1-doc-segmented.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml)
+
+#### rag24.test / rag24.test-umbrela-all
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2.1-doc-segmented-slim \
+    -topics rag24.test \
+    -output runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag24.test.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.20 rag24.test-umbrela-all runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag24.test.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag24.test-umbrela-all runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag24.test.txt
+java -cp $fatjar trec_eval -c -m recall.100 rag24.test-umbrela-all runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag24.test.txt
+```
+
+#### rag24.test / rag24.test
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2.1-doc-segmented-slim \
+    -topics rag24.test \
+    -output runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag24.test.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.20 rag24.test runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag24.test.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag24.test runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag24.test.txt
+java -cp $fatjar trec_eval -c -m recall.100 rag24.test runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag24.test.txt
+```
+
+#### rag25.test / rag25.test-umbrela2
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2.1-doc-segmented-slim \
+    -topics rag25.test \
+    -output runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag25.test.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag25.test.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag25.test.txt
+java -cp $fatjar trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag25.test.txt
+```
+
+#### rag25.test / rag25.test
+
+Retrieval command:
+
+```bash
+java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
+    -threads 16 \
+    -index msmarco-v2.1-doc-segmented-slim \
+    -topics rag25.test \
+    -output runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag25.test.txt \
+    -hits 1000 \
+    -bm25
+```
+
+Evaluation commands:
+
+```bash
+java -cp $fatjar trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag25.test.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag25.test.txt
+java -cp $fatjar trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag25.test.txt
+```
+
+<a id="condition-2"></a>
+
+### 2. BM25 doc segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index
 
 **Config**: [msmarco-v2.1-doc-segmented.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml)
 
@@ -149,9 +244,9 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-d
 java -cp $fatjar trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25.rag25.test.txt
 ```
 
-<a id="condition-2"></a>
+<a id="condition-3"></a>
 
-### 2. SPLADE-v3 (ONNX)
+### 3. SPLADE-v3 (ONNX)
 
 **Config**: [msmarco-v2.1-doc-segmented.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml)
 
@@ -255,9 +350,9 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-d
 java -cp $fatjar trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.splade-v3.onnx.rag25.test.txt
 ```
 
-<a id="condition-3"></a>
+<a id="condition-4"></a>
 
-### 3. ArcticEmbed-L (shard00) with quantized HNSW (ONNX)
+### 4. ArcticEmbed-L (shard00) with quantized HNSW (ONNX)
 
 **Config**: [msmarco-v2.1-doc-segmented.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml)
 
@@ -353,9 +448,9 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-d
 java -cp $fatjar trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.shard00.arctic-l.hnsw-int8.onnx.rag25.test.txt
 ```
 
-<a id="condition-4"></a>
+<a id="condition-5"></a>
 
-### 4. ArcticEmbed-L (shard01) with quantized HNSW (ONNX)
+### 5. ArcticEmbed-L (shard01) with quantized HNSW (ONNX)
 
 **Config**: [msmarco-v2.1-doc-segmented.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml)
 
@@ -451,9 +546,9 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-d
 java -cp $fatjar trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.shard01.arctic-l.hnsw-int8.onnx.rag25.test.txt
 ```
 
-<a id="condition-5"></a>
+<a id="condition-6"></a>
 
-### 5. ArcticEmbed-L (shard02) with quantized HNSW (ONNX)
+### 6. ArcticEmbed-L (shard02) with quantized HNSW (ONNX)
 
 **Config**: [msmarco-v2.1-doc-segmented.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml)
 
@@ -549,9 +644,9 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-d
 java -cp $fatjar trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.shard02.arctic-l.hnsw-int8.onnx.rag25.test.txt
 ```
 
-<a id="condition-6"></a>
+<a id="condition-7"></a>
 
-### 6. ArcticEmbed-L (shard03) with quantized HNSW (ONNX)
+### 7. ArcticEmbed-L (shard03) with quantized HNSW (ONNX)
 
 **Config**: [msmarco-v2.1-doc-segmented.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml)
 
@@ -647,9 +742,9 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-d
 java -cp $fatjar trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.shard03.arctic-l.hnsw-int8.onnx.rag25.test.txt
 ```
 
-<a id="condition-7"></a>
+<a id="condition-8"></a>
 
-### 7. ArcticEmbed-L (shard04) with quantized HNSW (ONNX)
+### 8. ArcticEmbed-L (shard04) with quantized HNSW (ONNX)
 
 **Config**: [msmarco-v2.1-doc-segmented.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml)
 
@@ -745,9 +840,9 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-d
 java -cp $fatjar trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.shard04.arctic-l.hnsw-int8.onnx.rag25.test.txt
 ```
 
-<a id="condition-8"></a>
+<a id="condition-9"></a>
 
-### 8. ArcticEmbed-L (shard05) with quantized HNSW (ONNX)
+### 9. ArcticEmbed-L (shard05) with quantized HNSW (ONNX)
 
 **Config**: [msmarco-v2.1-doc-segmented.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml)
 
@@ -843,9 +938,9 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-d
 java -cp $fatjar trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.shard05.arctic-l.hnsw-int8.onnx.rag25.test.txt
 ```
 
-<a id="condition-9"></a>
+<a id="condition-10"></a>
 
-### 9. ArcticEmbed-L (shard06) with quantized HNSW (ONNX)
+### 10. ArcticEmbed-L (shard06) with quantized HNSW (ONNX)
 
 **Config**: [msmarco-v2.1-doc-segmented.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml)
 
@@ -941,9 +1036,9 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-d
 java -cp $fatjar trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.shard06.arctic-l.hnsw-int8.onnx.rag25.test.txt
 ```
 
-<a id="condition-10"></a>
+<a id="condition-11"></a>
 
-### 10. ArcticEmbed-L (shard07) with quantized HNSW (ONNX)
+### 11. ArcticEmbed-L (shard07) with quantized HNSW (ONNX)
 
 **Config**: [msmarco-v2.1-doc-segmented.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml)
 
@@ -1039,9 +1134,9 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-d
 java -cp $fatjar trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.shard07.arctic-l.hnsw-int8.onnx.rag25.test.txt
 ```
 
-<a id="condition-11"></a>
+<a id="condition-12"></a>
 
-### 11. ArcticEmbed-L (shard08) with quantized HNSW (ONNX)
+### 12. ArcticEmbed-L (shard08) with quantized HNSW (ONNX)
 
 **Config**: [msmarco-v2.1-doc-segmented.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml)
 
@@ -1137,9 +1232,9 @@ java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-d
 java -cp $fatjar trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.shard08.arctic-l.hnsw-int8.onnx.rag25.test.txt
 ```
 
-<a id="condition-12"></a>
+<a id="condition-13"></a>
 
-### 12. ArcticEmbed-L (shard09) with quantized HNSW (ONNX)
+### 13. ArcticEmbed-L (shard09) with quantized HNSW (ONNX)
 
 **Config**: [msmarco-v2.1-doc-segmented.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml)
 
@@ -1233,194 +1328,6 @@ Evaluation commands:
 java -cp $fatjar trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented.shard09.arctic-l.hnsw-int8.onnx.rag25.test.txt
 java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.shard09.arctic-l.hnsw-int8.onnx.rag25.test.txt
 java -cp $fatjar trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.shard09.arctic-l.hnsw-int8.onnx.rag25.test.txt
-```
-
-<a id="condition-13"></a>
-
-### 13. BM25 doc segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
-
-**Config**: [msmarco-v2.1-doc-segmented.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml)
-
-#### rag24.test / rag24.test-umbrela-all
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc-segmented-slim \
-    -topics rag24.test \
-    -output runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag24.test.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -m ndcg_cut.20 rag24.test-umbrela-all runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag24.test.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag24.test-umbrela-all runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag24.test.txt
-java -cp $fatjar trec_eval -c -m recall.100 rag24.test-umbrela-all runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag24.test.txt
-```
-
-#### rag24.test / rag24.test
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc-segmented-slim \
-    -topics rag24.test \
-    -output runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag24.test.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -m ndcg_cut.20 rag24.test runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag24.test.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag24.test runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag24.test.txt
-java -cp $fatjar trec_eval -c -m recall.100 rag24.test runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag24.test.txt
-```
-
-#### rag25.test / rag25.test-umbrela2
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc-segmented-slim \
-    -topics rag25.test \
-    -output runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag25.test.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag25.test.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag25.test.txt
-java -cp $fatjar trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag25.test.txt
-```
-
-#### rag25.test / rag25.test
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc-segmented-slim \
-    -topics rag25.test \
-    -output runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag25.test.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag25.test.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag25.test.txt
-java -cp $fatjar trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-slim.rag25.test.txt
-```
-
-<a id="condition-14"></a>
-
-### 14. BM25 doc segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index
-
-**Config**: [msmarco-v2.1-doc-segmented.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml)
-
-#### rag24.test / rag24.test-umbrela-all
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc-segmented-full \
-    -topics rag24.test \
-    -output runs/run.msmarco-v2.1-doc-segmented.bm25-full.rag24.test.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -m ndcg_cut.20 rag24.test-umbrela-all runs/run.msmarco-v2.1-doc-segmented.bm25-full.rag24.test.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag24.test-umbrela-all runs/run.msmarco-v2.1-doc-segmented.bm25-full.rag24.test.txt
-java -cp $fatjar trec_eval -c -m recall.100 rag24.test-umbrela-all runs/run.msmarco-v2.1-doc-segmented.bm25-full.rag24.test.txt
-```
-
-#### rag24.test / rag24.test
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc-segmented-full \
-    -topics rag24.test \
-    -output runs/run.msmarco-v2.1-doc-segmented.bm25-full.rag24.test.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -m ndcg_cut.20 rag24.test runs/run.msmarco-v2.1-doc-segmented.bm25-full.rag24.test.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag24.test runs/run.msmarco-v2.1-doc-segmented.bm25-full.rag24.test.txt
-java -cp $fatjar trec_eval -c -m recall.100 rag24.test runs/run.msmarco-v2.1-doc-segmented.bm25-full.rag24.test.txt
-```
-
-#### rag25.test / rag25.test-umbrela2
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc-segmented-full \
-    -topics rag25.test \
-    -output runs/run.msmarco-v2.1-doc-segmented.bm25-full.rag25.test.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-full.rag25.test.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-full.rag25.test.txt
-java -cp $fatjar trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-full.rag25.test.txt
-```
-
-#### rag25.test / rag25.test
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc-segmented-full \
-    -topics rag25.test \
-    -output runs/run.msmarco-v2.1-doc-segmented.bm25-full.rag25.test.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-full.rag25.test.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-full.rag25.test.txt
-java -cp $fatjar trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-full.rag25.test.txt
 ```
 
 

--- a/docs/reproduce/from-prebuilt-indexes/msmarco-v2.1-doc.md
+++ b/docs/reproduce/from-prebuilt-indexes/msmarco-v2.1-doc.md
@@ -21,14 +21,14 @@ Key:
 
 | # | name | dev | dev2 | DL21 | DL22 | DL23 | RAGgy |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| [1](#condition-1) | BM25 doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.1654 | 0.1732 | 0.5183 | 0.2991 | 0.2914 | 0.3631 |
-| [2](#condition-2) | BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) | 0.1973 | 0.2000 | 0.5778 | 0.3576 | 0.3356 | 0.4227 |
-| [3](#condition-3) | BM25 doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index | 0.1654 | 0.1732 | 0.5183 | 0.2991 | 0.2914 | 0.3631 |
-| [4](#condition-4) | BM25 doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index | 0.1654 | 0.1732 | 0.5183 | 0.2991 | 0.2914 | 0.3631 |
-| [5](#condition-5) | BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index | 0.1973 | 0.2000 | 0.5778 | 0.3576 | 0.3356 | 0.4227 |
-| [6](#condition-6) | BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index | 0.1973 | 0.2000 | 0.5778 | 0.3576 | 0.3356 | 0.4227 |
+| [1](#condition-1) | BM25 doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index | 0.1654 | 0.1732 | 0.5183 | 0.2991 | 0.2914 | 0.3631 |
+| [2](#condition-2) | BM25 doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index | 0.1654 | 0.1732 | 0.5183 | 0.2991 | 0.2914 | 0.3631 |
+| [3](#condition-3) | BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index | 0.1973 | 0.2000 | 0.5778 | 0.3576 | 0.3356 | 0.4227 |
+| [4](#condition-4) | BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index | 0.1973 | 0.2000 | 0.5778 | 0.3576 | 0.3356 | 0.4227 |
 
 
+
+The BM25 "slim index" does not contain the document texts, whereas the BM25 "regular index" does contain document texts (and hence supports pseudo-relevance feedback with on-the-fly document parsing).
 
 ## Commands
 
@@ -51,309 +51,7 @@ export jvm_args="-Xms512M -Xmx192G -Dslf4j.internal.verbosity=WARN --add-modules
 
 <a id="condition-1"></a>
 
-### 1. BM25 doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
-
-**Config**: [msmarco-v2.1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc.yaml)
-
-#### msmarco-v2-doc.dev
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc \
-    -topics msmarco-v2-doc.dev \
-    -output runs/run.msmarco-v2.1-doc.bm25-doc.msmarco-v2-doc.dev.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev runs/run.msmarco-v2.1-doc.bm25-doc.msmarco-v2-doc.dev.txt
-```
-
-#### msmarco-v2-doc.dev2
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc \
-    -topics msmarco-v2-doc.dev2 \
-    -output runs/run.msmarco-v2.1-doc.bm25-doc.msmarco-v2-doc.dev2.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev2 runs/run.msmarco-v2.1-doc.bm25-doc.msmarco-v2-doc.dev2.txt
-```
-
-#### dl21-doc
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc \
-    -topics dl21-doc \
-    -output runs/run.msmarco-v2.1-doc.bm25-doc.dl21-doc.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl21-doc.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl21-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl21-doc.txt
-java -cp $fatjar trec_eval -c -m recall.100 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl21-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl21-doc.txt
-```
-
-#### dl22-doc
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc \
-    -topics dl22-doc \
-    -output runs/run.msmarco-v2.1-doc.bm25-doc.dl22-doc.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl22-doc.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl22-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl22-doc.txt
-java -cp $fatjar trec_eval -c -m recall.100 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl22-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl22-doc.txt
-```
-
-#### dl23-doc
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc \
-    -topics dl23-doc \
-    -output runs/run.msmarco-v2.1-doc.bm25-doc.dl23-doc.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl23-doc.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl23-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl23-doc.txt
-java -cp $fatjar trec_eval -c -m recall.100 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl23-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl23-doc.txt
-```
-
-#### rag24.raggy-dev
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc \
-    -topics rag24.raggy-dev \
-    -output runs/run.msmarco-v2.1-doc.bm25-doc.rag24.raggy-dev.txt \
-    -hits 1000 \
-    -bm25
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-doc.rag24.raggy-dev.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-doc.rag24.raggy-dev.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-doc.rag24.raggy-dev.txt
-java -cp $fatjar trec_eval -c -m recall.100 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-doc.rag24.raggy-dev.txt
-java -cp $fatjar trec_eval -c -m recall.1000 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-doc.rag24.raggy-dev.txt
-```
-
-<a id="condition-2"></a>
-
-### 2. BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)
-
-**Config**: [msmarco-v2.1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc.yaml)
-
-#### msmarco-v2-doc.dev
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc-segmented \
-    -topics msmarco-v2-doc.dev \
-    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc.msmarco-v2-doc.dev.txt \
-    -hits 10000 \
-    -bm25 \
-    -selectMaxPassage \
-    -selectMaxPassage.delimiter \# \
-    -selectMaxPassage.hits 1000
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc.msmarco-v2-doc.dev.txt
-```
-
-#### msmarco-v2-doc.dev2
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc-segmented \
-    -topics msmarco-v2-doc.dev2 \
-    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc.msmarco-v2-doc.dev2.txt \
-    -hits 10000 \
-    -bm25 \
-    -selectMaxPassage \
-    -selectMaxPassage.delimiter \# \
-    -selectMaxPassage.hits 1000
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev2 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.msmarco-v2-doc.dev2.txt
-```
-
-#### dl21-doc
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc-segmented \
-    -topics dl21-doc \
-    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl21-doc.txt \
-    -hits 10000 \
-    -bm25 \
-    -selectMaxPassage \
-    -selectMaxPassage.delimiter \# \
-    -selectMaxPassage.hits 1000
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl21-doc.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl21-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl21-doc.txt
-java -cp $fatjar trec_eval -c -m recall.100 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl21-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl21-doc.txt
-```
-
-#### dl22-doc
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc-segmented \
-    -topics dl22-doc \
-    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl22-doc.txt \
-    -hits 10000 \
-    -bm25 \
-    -selectMaxPassage \
-    -selectMaxPassage.delimiter \# \
-    -selectMaxPassage.hits 1000
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl22-doc.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl22-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl22-doc.txt
-java -cp $fatjar trec_eval -c -m recall.100 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl22-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl22-doc.txt
-```
-
-#### dl23-doc
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc-segmented \
-    -topics dl23-doc \
-    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl23-doc.txt \
-    -hits 10000 \
-    -bm25 \
-    -selectMaxPassage \
-    -selectMaxPassage.delimiter \# \
-    -selectMaxPassage.hits 1000
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl23-doc.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl23-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl23-doc.txt
-java -cp $fatjar trec_eval -c -m recall.100 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl23-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl23-doc.txt
-```
-
-#### rag24.raggy-dev
-
-Retrieval command:
-
-```bash
-java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
-    -threads 16 \
-    -index msmarco-v2.1-doc-segmented \
-    -topics rag24.raggy-dev \
-    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc.rag24.raggy-dev.txt \
-    -hits 10000 \
-    -bm25 \
-    -selectMaxPassage \
-    -selectMaxPassage.delimiter \# \
-    -selectMaxPassage.hits 1000
-```
-
-Evaluation commands:
-
-```bash
-java -cp $fatjar trec_eval -c -M 100 -m map rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc.rag24.raggy-dev.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc.rag24.raggy-dev.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc.rag24.raggy-dev.txt
-java -cp $fatjar trec_eval -c -m recall.100 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc.rag24.raggy-dev.txt
-java -cp $fatjar trec_eval -c -m recall.1000 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc.rag24.raggy-dev.txt
-```
-
-<a id="condition-3"></a>
-
-### 3. BM25 doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
+### 1. BM25 doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
 
 **Config**: [msmarco-v2.1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc.yaml)
 
@@ -493,9 +191,9 @@ java -cp $fatjar trec_eval -c -m recall.100 rag24.raggy-dev runs/run.msmarco-v2.
 java -cp $fatjar trec_eval -c -m recall.1000 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-doc-slim.rag24.raggy-dev.txt
 ```
 
-<a id="condition-4"></a>
+<a id="condition-2"></a>
 
-### 4. BM25 doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index
+### 2. BM25 doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index
 
 **Config**: [msmarco-v2.1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc.yaml)
 
@@ -506,9 +204,9 @@ Retrieval command:
 ```bash
 java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -threads 16 \
-    -index msmarco-v2.1-doc-full \
+    -index msmarco-v2.1-doc \
     -topics msmarco-v2-doc.dev \
-    -output runs/run.msmarco-v2.1-doc.bm25-doc-full.msmarco-v2-doc.dev.txt \
+    -output runs/run.msmarco-v2.1-doc.bm25-doc.msmarco-v2-doc.dev.txt \
     -hits 1000 \
     -bm25
 ```
@@ -516,7 +214,7 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
 Evaluation commands:
 
 ```bash
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev runs/run.msmarco-v2.1-doc.bm25-doc-full.msmarco-v2-doc.dev.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev runs/run.msmarco-v2.1-doc.bm25-doc.msmarco-v2-doc.dev.txt
 ```
 
 #### msmarco-v2-doc.dev2
@@ -526,9 +224,9 @@ Retrieval command:
 ```bash
 java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -threads 16 \
-    -index msmarco-v2.1-doc-full \
+    -index msmarco-v2.1-doc \
     -topics msmarco-v2-doc.dev2 \
-    -output runs/run.msmarco-v2.1-doc.bm25-doc-full.msmarco-v2-doc.dev2.txt \
+    -output runs/run.msmarco-v2.1-doc.bm25-doc.msmarco-v2-doc.dev2.txt \
     -hits 1000 \
     -bm25
 ```
@@ -536,7 +234,7 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
 Evaluation commands:
 
 ```bash
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev2 runs/run.msmarco-v2.1-doc.bm25-doc-full.msmarco-v2-doc.dev2.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev2 runs/run.msmarco-v2.1-doc.bm25-doc.msmarco-v2-doc.dev2.txt
 ```
 
 #### dl21-doc
@@ -546,9 +244,9 @@ Retrieval command:
 ```bash
 java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -threads 16 \
-    -index msmarco-v2.1-doc-full \
+    -index msmarco-v2.1-doc \
     -topics dl21-doc \
-    -output runs/run.msmarco-v2.1-doc.bm25-doc-full.dl21-doc.txt \
+    -output runs/run.msmarco-v2.1-doc.bm25-doc.dl21-doc.txt \
     -hits 1000 \
     -bm25
 ```
@@ -556,11 +254,11 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
 Evaluation commands:
 
 ```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc-full.dl21-doc.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc-full.dl21-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc-full.dl21-doc.txt
-java -cp $fatjar trec_eval -c -m recall.100 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc-full.dl21-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc-full.dl21-doc.txt
+java -cp $fatjar trec_eval -c -M 100 -m map dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl21-doc.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl21-doc.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl21-doc.txt
+java -cp $fatjar trec_eval -c -m recall.100 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl21-doc.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl21-doc.txt
 ```
 
 #### dl22-doc
@@ -570,9 +268,9 @@ Retrieval command:
 ```bash
 java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -threads 16 \
-    -index msmarco-v2.1-doc-full \
+    -index msmarco-v2.1-doc \
     -topics dl22-doc \
-    -output runs/run.msmarco-v2.1-doc.bm25-doc-full.dl22-doc.txt \
+    -output runs/run.msmarco-v2.1-doc.bm25-doc.dl22-doc.txt \
     -hits 1000 \
     -bm25
 ```
@@ -580,11 +278,11 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
 Evaluation commands:
 
 ```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc-full.dl22-doc.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc-full.dl22-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc-full.dl22-doc.txt
-java -cp $fatjar trec_eval -c -m recall.100 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc-full.dl22-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc-full.dl22-doc.txt
+java -cp $fatjar trec_eval -c -M 100 -m map dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl22-doc.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl22-doc.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl22-doc.txt
+java -cp $fatjar trec_eval -c -m recall.100 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl22-doc.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl22-doc.txt
 ```
 
 #### dl23-doc
@@ -594,9 +292,9 @@ Retrieval command:
 ```bash
 java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -threads 16 \
-    -index msmarco-v2.1-doc-full \
+    -index msmarco-v2.1-doc \
     -topics dl23-doc \
-    -output runs/run.msmarco-v2.1-doc.bm25-doc-full.dl23-doc.txt \
+    -output runs/run.msmarco-v2.1-doc.bm25-doc.dl23-doc.txt \
     -hits 1000 \
     -bm25
 ```
@@ -604,11 +302,11 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
 Evaluation commands:
 
 ```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc-full.dl23-doc.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc-full.dl23-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc-full.dl23-doc.txt
-java -cp $fatjar trec_eval -c -m recall.100 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc-full.dl23-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc-full.dl23-doc.txt
+java -cp $fatjar trec_eval -c -M 100 -m map dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl23-doc.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl23-doc.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl23-doc.txt
+java -cp $fatjar trec_eval -c -m recall.100 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl23-doc.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-doc.dl23-doc.txt
 ```
 
 #### rag24.raggy-dev
@@ -618,9 +316,9 @@ Retrieval command:
 ```bash
 java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -threads 16 \
-    -index msmarco-v2.1-doc-full \
+    -index msmarco-v2.1-doc \
     -topics rag24.raggy-dev \
-    -output runs/run.msmarco-v2.1-doc.bm25-doc-full.rag24.raggy-dev.txt \
+    -output runs/run.msmarco-v2.1-doc.bm25-doc.rag24.raggy-dev.txt \
     -hits 1000 \
     -bm25
 ```
@@ -628,16 +326,16 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
 Evaluation commands:
 
 ```bash
-java -cp $fatjar trec_eval -c -M 100 -m map rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-doc-full.rag24.raggy-dev.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-doc-full.rag24.raggy-dev.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-doc-full.rag24.raggy-dev.txt
-java -cp $fatjar trec_eval -c -m recall.100 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-doc-full.rag24.raggy-dev.txt
-java -cp $fatjar trec_eval -c -m recall.1000 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-doc-full.rag24.raggy-dev.txt
+java -cp $fatjar trec_eval -c -M 100 -m map rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-doc.rag24.raggy-dev.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-doc.rag24.raggy-dev.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-doc.rag24.raggy-dev.txt
+java -cp $fatjar trec_eval -c -m recall.100 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-doc.rag24.raggy-dev.txt
+java -cp $fatjar trec_eval -c -m recall.1000 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-doc.rag24.raggy-dev.txt
 ```
 
-<a id="condition-5"></a>
+<a id="condition-3"></a>
 
-### 5. BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
+### 3. BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index
 
 **Config**: [msmarco-v2.1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc.yaml)
 
@@ -795,9 +493,9 @@ java -cp $fatjar trec_eval -c -m recall.100 rag24.raggy-dev runs/run.msmarco-v2.
 java -cp $fatjar trec_eval -c -m recall.1000 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc-slim.rag24.raggy-dev.txt
 ```
 
-<a id="condition-6"></a>
+<a id="condition-4"></a>
 
-### 6. BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index
+### 4. BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index
 
 **Config**: [msmarco-v2.1-doc.yaml](../../../src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc.yaml)
 
@@ -808,9 +506,9 @@ Retrieval command:
 ```bash
 java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -threads 16 \
-    -index msmarco-v2.1-doc-segmented-full \
+    -index msmarco-v2.1-doc-segmented \
     -topics msmarco-v2-doc.dev \
-    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.msmarco-v2-doc.dev.txt \
+    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc.msmarco-v2-doc.dev.txt \
     -hits 10000 \
     -bm25 \
     -selectMaxPassage \
@@ -821,7 +519,7 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
 Evaluation commands:
 
 ```bash
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.msmarco-v2-doc.dev.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc.msmarco-v2-doc.dev.txt
 ```
 
 #### msmarco-v2-doc.dev2
@@ -831,9 +529,9 @@ Retrieval command:
 ```bash
 java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -threads 16 \
-    -index msmarco-v2.1-doc-segmented-full \
+    -index msmarco-v2.1-doc-segmented \
     -topics msmarco-v2-doc.dev2 \
-    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.msmarco-v2-doc.dev2.txt \
+    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc.msmarco-v2-doc.dev2.txt \
     -hits 10000 \
     -bm25 \
     -selectMaxPassage \
@@ -844,7 +542,7 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
 Evaluation commands:
 
 ```bash
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev2 runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.msmarco-v2-doc.dev2.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank msmarco-v2.1-doc.dev2 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.msmarco-v2-doc.dev2.txt
 ```
 
 #### dl21-doc
@@ -854,9 +552,9 @@ Retrieval command:
 ```bash
 java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -threads 16 \
-    -index msmarco-v2.1-doc-segmented-full \
+    -index msmarco-v2.1-doc-segmented \
     -topics dl21-doc \
-    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl21-doc.txt \
+    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl21-doc.txt \
     -hits 10000 \
     -bm25 \
     -selectMaxPassage \
@@ -867,11 +565,11 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
 Evaluation commands:
 
 ```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl21-doc.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl21-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl21-doc.txt
-java -cp $fatjar trec_eval -c -m recall.100 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl21-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl21-doc.txt
+java -cp $fatjar trec_eval -c -M 100 -m map dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl21-doc.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl21-doc.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl21-doc.txt
+java -cp $fatjar trec_eval -c -m recall.100 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl21-doc.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl21-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl21-doc.txt
 ```
 
 #### dl22-doc
@@ -881,9 +579,9 @@ Retrieval command:
 ```bash
 java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -threads 16 \
-    -index msmarco-v2.1-doc-segmented-full \
+    -index msmarco-v2.1-doc-segmented \
     -topics dl22-doc \
-    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl22-doc.txt \
+    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl22-doc.txt \
     -hits 10000 \
     -bm25 \
     -selectMaxPassage \
@@ -894,11 +592,11 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
 Evaluation commands:
 
 ```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl22-doc.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl22-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl22-doc.txt
-java -cp $fatjar trec_eval -c -m recall.100 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl22-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl22-doc.txt
+java -cp $fatjar trec_eval -c -M 100 -m map dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl22-doc.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl22-doc.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl22-doc.txt
+java -cp $fatjar trec_eval -c -m recall.100 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl22-doc.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl22-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl22-doc.txt
 ```
 
 #### dl23-doc
@@ -908,9 +606,9 @@ Retrieval command:
 ```bash
 java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -threads 16 \
-    -index msmarco-v2.1-doc-segmented-full \
+    -index msmarco-v2.1-doc-segmented \
     -topics dl23-doc \
-    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl23-doc.txt \
+    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl23-doc.txt \
     -hits 10000 \
     -bm25 \
     -selectMaxPassage \
@@ -921,11 +619,11 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
 Evaluation commands:
 
 ```bash
-java -cp $fatjar trec_eval -c -M 100 -m map dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl23-doc.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl23-doc.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl23-doc.txt
-java -cp $fatjar trec_eval -c -m recall.100 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl23-doc.txt
-java -cp $fatjar trec_eval -c -m recall.1000 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.dl23-doc.txt
+java -cp $fatjar trec_eval -c -M 100 -m map dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl23-doc.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl23-doc.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl23-doc.txt
+java -cp $fatjar trec_eval -c -m recall.100 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl23-doc.txt
+java -cp $fatjar trec_eval -c -m recall.1000 dl23-doc-msmarco-v2.1 runs/run.msmarco-v2.1-doc.bm25-segmented-doc.dl23-doc.txt
 ```
 
 #### rag24.raggy-dev
@@ -935,9 +633,9 @@ Retrieval command:
 ```bash
 java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
     -threads 16 \
-    -index msmarco-v2.1-doc-segmented-full \
+    -index msmarco-v2.1-doc-segmented \
     -topics rag24.raggy-dev \
-    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.rag24.raggy-dev.txt \
+    -output runs/run.msmarco-v2.1-doc.bm25-segmented-doc.rag24.raggy-dev.txt \
     -hits 10000 \
     -bm25 \
     -selectMaxPassage \
@@ -948,11 +646,11 @@ java -cp $fatjar $jvm_args io.anserini.search.SearchCollection \
 Evaluation commands:
 
 ```bash
-java -cp $fatjar trec_eval -c -M 100 -m map rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.rag24.raggy-dev.txt
-java -cp $fatjar trec_eval -c -M 100 -m recip_rank rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.rag24.raggy-dev.txt
-java -cp $fatjar trec_eval -c -m ndcg_cut.10 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.rag24.raggy-dev.txt
-java -cp $fatjar trec_eval -c -m recall.100 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.rag24.raggy-dev.txt
-java -cp $fatjar trec_eval -c -m recall.1000 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc-full.rag24.raggy-dev.txt
+java -cp $fatjar trec_eval -c -M 100 -m map rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc.rag24.raggy-dev.txt
+java -cp $fatjar trec_eval -c -M 100 -m recip_rank rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc.rag24.raggy-dev.txt
+java -cp $fatjar trec_eval -c -m ndcg_cut.10 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc.rag24.raggy-dev.txt
+java -cp $fatjar trec_eval -c -m recall.100 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc.rag24.raggy-dev.txt
+java -cp $fatjar trec_eval -c -m recall.1000 rag24.raggy-dev runs/run.msmarco-v2.1-doc.bm25-segmented-doc.rag24.raggy-dev.txt
 ```
 
 

--- a/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml
@@ -1,6 +1,36 @@
 conditions:
+  - name: bm25-doc-default-slim
+    display: "BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index"
+    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-doc-slim -topics $topics -output $output -hits 1000 -bm25
+    topics:
+      - topic_key: msmarco-doc.dev
+        eval_key: msmarco-doc.dev
+        expected_scores:
+          MRR@100: 0.2299
+        metric_definitions:
+          MRR@100: "-c -M 100 -m recip_rank"
+      - topic_key: dl19-doc
+        eval_key: dl19-doc
+        expected_scores:
+          AP@100: 0.2434
+          nDCG@10: 0.5176
+          R@1K: 0.6966
+        metric_definitions:
+          AP@100: "-c -M 100 -m map"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@1K: "-c -m recall.1000"
+      - topic_key: dl20-doc
+        eval_key: dl20-doc
+        expected_scores:
+          AP@100: 0.3793
+          nDCG@10: 0.5286
+          R@1K: 0.8085
+        metric_definitions:
+          AP@100: "-c -M 100 -m map"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@1K: "-c -m recall.1000"
   - name: bm25-doc-default
-    display: "BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)"
+    display: "BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index"
     command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-doc -topics $topics -output $output -hits 1000 -bm25
     topics:
       - topic_key: msmarco-doc.dev
@@ -25,6 +55,30 @@ conditions:
           AP@100: 0.3793
           nDCG@10: 0.5286
           R@1K: 0.8085
+        metric_definitions:
+          AP@100: "-c -M 100 -m map"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@1K: "-c -m recall.1000"
+  - name: bm25-doc-default-rocchio
+    display: "BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) + Rocchio, regular index"
+    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-doc -topics $topics -output $output -hits 1000 -bm25 -rocchio -collection JsonCollection
+    topics:
+      - topic_key: dl19-doc
+        eval_key: dl19-doc
+        expected_scores:
+          AP@100: 0.2811
+          nDCG@10: 0.5256
+          R@1K: 0.7546
+        metric_definitions:
+          AP@100: "-c -M 100 -m map"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@1K: "-c -m recall.1000"
+      - topic_key: dl20-doc
+        eval_key: dl20-doc
+        expected_scores:
+          AP@100: 0.4089
+          nDCG@10: 0.5192
+          R@1K: 0.8273
         metric_definitions:
           AP@100: "-c -M 100 -m map"
           nDCG@10: "-c -m ndcg_cut.10"
@@ -59,8 +113,38 @@ conditions:
           AP@100: "-c -M 100 -m map"
           nDCG@10: "-c -m ndcg_cut.10"
           R@1K: "-c -m recall.1000"
+  - name: bm25-doc-segmented-default-slim
+    display: "BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index"
+    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-doc-segmented-slim -topics $topics -output $output -bm25 -rocchio -collection JsonCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter \# -selectMaxPassage.hits 1000
+    topics:
+      - topic_key: msmarco-doc.dev
+        eval_key: msmarco-doc.dev
+        expected_scores:
+          MRR@100: 0.2684
+        metric_definitions:
+          MRR@100: "-c -M 100 -m recip_rank"
+      - topic_key: dl19-doc
+        eval_key: dl19-doc
+        expected_scores:
+          AP@100: 0.2449
+          nDCG@10: 0.5302
+          R@1K: 0.6871
+        metric_definitions:
+          AP@100: "-c -M 100 -m map"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@1K: "-c -m recall.1000"
+      - topic_key: dl20-doc
+        eval_key: dl20-doc
+        expected_scores:
+          AP@100: 0.3586
+          nDCG@10: 0.5281
+          R@1K: 0.7755
+        metric_definitions:
+          AP@100: "-c -M 100 -m map"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@1K: "-c -m recall.1000"
   - name: bm25-doc-segmented-default
-    display: "BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)"
+    display: "BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index"
     command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-doc-segmented -topics $topics -output $output -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter \# -selectMaxPassage.hits 1000
     topics:
       - topic_key: msmarco-doc.dev
@@ -85,6 +169,30 @@ conditions:
           AP@100: 0.3586
           nDCG@10: 0.5281
           R@1K: 0.7755
+        metric_definitions:
+          AP@100: "-c -M 100 -m map"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@1K: "-c -m recall.1000"
+  - name: bm25-doc-segmented-default
+    display: "BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) + Rocchio, regular index"
+    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-doc-segmented -topics $topics -output $output -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter \# -selectMaxPassage.hits 1000
+    topics:
+      - topic_key: dl19-doc
+        eval_key: dl19-doc
+        expected_scores:
+          AP@100: 0.2889
+          nDCG@10: 0.5570
+          R@1K: 0.7423
+        metric_definitions:
+          AP@100: "-c -M 100 -m map"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@1K: "-c -m recall.1000"
+      - topic_key: dl20-doc
+        eval_key: dl20-doc
+        expected_scores:
+          AP@100: 0.3830
+          nDCG@10: 0.5226
+          R@1K: 0.8102
         metric_definitions:
           AP@100: "-c -M 100 -m map"
           nDCG@10: "-c -m ndcg_cut.10"
@@ -145,126 +253,6 @@ conditions:
           AP@100: 0.3882
           nDCG@10: 0.6033
           R@1K: 0.7869
-        metric_definitions:
-          AP@100: "-c -M 100 -m map"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@1K: "-c -m recall.1000"
-  - name: bm25-doc-default-slim
-    display: "BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index"
-    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-doc-slim -topics $topics -output $output -hits 1000 -bm25
-    topics:
-      - topic_key: msmarco-doc.dev
-        eval_key: msmarco-doc.dev
-        expected_scores:
-          MRR@100: 0.2299
-        metric_definitions:
-          MRR@100: "-c -M 100 -m recip_rank"
-      - topic_key: dl19-doc
-        eval_key: dl19-doc
-        expected_scores:
-          AP@100: 0.2434
-          nDCG@10: 0.5176
-          R@1K: 0.6966
-        metric_definitions:
-          AP@100: "-c -M 100 -m map"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@1K: "-c -m recall.1000"
-      - topic_key: dl20-doc
-        eval_key: dl20-doc
-        expected_scores:
-          AP@100: 0.3793
-          nDCG@10: 0.5286
-          R@1K: 0.8085
-        metric_definitions:
-          AP@100: "-c -M 100 -m map"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@1K: "-c -m recall.1000"
-  - name: bm25-doc-default-full
-    display: "BM25 complete doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index"
-    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-doc-full -topics $topics -output $output -hits 1000 -bm25
-    topics:
-      - topic_key: msmarco-doc.dev
-        eval_key: msmarco-doc.dev
-        expected_scores:
-          MRR@100: 0.2299
-        metric_definitions:
-          MRR@100: "-c -M 100 -m recip_rank"
-      - topic_key: dl19-doc
-        eval_key: dl19-doc
-        expected_scores:
-          AP@100: 0.2434
-          nDCG@10: 0.5176
-          R@1K: 0.6966
-        metric_definitions:
-          AP@100: "-c -M 100 -m map"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@1K: "-c -m recall.1000"
-      - topic_key: dl20-doc
-        eval_key: dl20-doc
-        expected_scores:
-          AP@100: 0.3793
-          nDCG@10: 0.5286
-          R@1K: 0.8085
-        metric_definitions:
-          AP@100: "-c -M 100 -m map"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@1K: "-c -m recall.1000"
-  - name: bm25-doc-segmented-default-slim
-    display: "BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index"
-    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-doc-segmented-slim -topics $topics -output $output -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter \# -selectMaxPassage.hits 1000
-    topics:
-      - topic_key: msmarco-doc.dev
-        eval_key: msmarco-doc.dev
-        expected_scores:
-          MRR@100: 0.2684
-        metric_definitions:
-          MRR@100: "-c -M 100 -m recip_rank"
-      - topic_key: dl19-doc
-        eval_key: dl19-doc
-        expected_scores:
-          AP@100: 0.2449
-          nDCG@10: 0.5302
-          R@1K: 0.6871
-        metric_definitions:
-          AP@100: "-c -M 100 -m map"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@1K: "-c -m recall.1000"
-      - topic_key: dl20-doc
-        eval_key: dl20-doc
-        expected_scores:
-          AP@100: 0.3586
-          nDCG@10: 0.5281
-          R@1K: 0.7755
-        metric_definitions:
-          AP@100: "-c -M 100 -m map"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@1K: "-c -m recall.1000"
-  - name: bm25-doc-segmented-default-full
-    display: "BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index"
-    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-doc-segmented-full -topics $topics -output $output -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter \# -selectMaxPassage.hits 1000
-    topics:
-      - topic_key: msmarco-doc.dev
-        eval_key: msmarco-doc.dev
-        expected_scores:
-          MRR@100: 0.2684
-        metric_definitions:
-          MRR@100: "-c -M 100 -m recip_rank"
-      - topic_key: dl19-doc
-        eval_key: dl19-doc
-        expected_scores:
-          AP@100: 0.2449
-          nDCG@10: 0.5302
-          R@1K: 0.6871
-        metric_definitions:
-          AP@100: "-c -M 100 -m map"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@1K: "-c -m recall.1000"
-      - topic_key: dl20-doc
-        eval_key: dl20-doc
-        expected_scores:
-          AP@100: 0.3586
-          nDCG@10: 0.5281
-          R@1K: 0.7755
         metric_definitions:
           AP@100: "-c -M 100 -m map"
           nDCG@10: "-c -m ndcg_cut.10"

--- a/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-doc.yaml
@@ -115,7 +115,7 @@ conditions:
           R@1K: "-c -m recall.1000"
   - name: bm25-doc-segmented-default-slim
     display: "BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index"
-    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-doc-segmented-slim -topics $topics -output $output -bm25 -rocchio -collection JsonCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter \# -selectMaxPassage.hits 1000
+    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-doc-segmented-slim -topics $topics -output $output -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter \# -selectMaxPassage.hits 1000
     topics:
       - topic_key: msmarco-doc.dev
         eval_key: msmarco-doc.dev
@@ -173,9 +173,9 @@ conditions:
           AP@100: "-c -M 100 -m map"
           nDCG@10: "-c -m ndcg_cut.10"
           R@1K: "-c -m recall.1000"
-  - name: bm25-doc-segmented-default
+  - name: bm25-doc-segmented-default-rocchio
     display: "BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) + Rocchio, regular index"
-    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-doc-segmented -topics $topics -output $output -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter \# -selectMaxPassage.hits 1000
+    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-doc-segmented -topics $topics -output $output -bm25 -rocchio -collection JsonCollection -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter \# -selectMaxPassage.hits 1000
     topics:
       - topic_key: dl19-doc
         eval_key: dl19-doc

--- a/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-passage.yaml
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v1-passage.yaml
@@ -1,6 +1,38 @@
 conditions:
+  - name: bm25-slim
+    display: "BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index"
+    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-passage-slim -topics $topics -output $output -hits 1000 -bm25
+    topics:
+      - topic_key: msmarco-v1-passage.dev
+        eval_key: msmarco-passage.dev
+        expected_scores:
+          MRR@10: 0.1840
+          R@1K: 0.8526
+        metric_definitions:
+          MRR@10: "-c -M 10 -m recip_rank"
+          R@1K: "-c -m recall.1000"
+      - topic_key: dl19-passage
+        eval_key: dl19-passage
+        expected_scores:
+          MAP: 0.3013
+          nDCG@10: 0.5058
+          R@1K: 0.7501
+        metric_definitions:
+          MAP: "-c -l 2 -m map"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@1K: "-c -l 2 -m recall.1000"
+      - topic_key: dl20-passage
+        eval_key: dl20-passage
+        expected_scores:
+          MAP: 0.2856
+          nDCG@10: 0.4796
+          R@1K: 0.7863
+        metric_definitions:
+          MAP: "-c -l 2 -m map"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@1K: "-c -l 2 -m recall.1000"
   - name: bm25
-    display: "BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)"
+    display: "BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index"
     command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-passage -topics $topics -output $output -hits 1000 -bm25
     topics:
       - topic_key: msmarco-v1-passage.dev
@@ -27,6 +59,30 @@ conditions:
           MAP: 0.2856
           nDCG@10: 0.4796
           R@1K: 0.7863
+        metric_definitions:
+          MAP: "-c -l 2 -m map"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@1K: "-c -l 2 -m recall.1000"
+  - name: bm25-rocchio
+    display: "BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4) + Rocchio, regular index"
+    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-passage -topics $topics -output $output -hits 1000 -bm25 -rocchio -collection JsonCollection
+    topics:
+      - topic_key: dl19-passage
+        eval_key: dl19-passage
+        expected_scores:
+          MAP: 0.3474
+          nDCG@10: 0.5275
+          R@1K: 0.8007
+        metric_definitions:
+          MAP: "-c -l 2 -m map"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@1K: "-c -l 2 -m recall.1000"
+      - topic_key: dl20-passage
+        eval_key: dl20-passage
+        expected_scores:
+          MAP: 0.3115
+          nDCG@10: 0.4910
+          R@1K: 0.8156
         metric_definitions:
           MAP: "-c -l 2 -m map"
           nDCG@10: "-c -m ndcg_cut.10"
@@ -155,70 +211,6 @@ conditions:
           MAP: 0.4596
           nDCG@10: 0.6767
           R@1K: 0.8468
-        metric_definitions:
-          MAP: "-c -l 2 -m map"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@1K: "-c -l 2 -m recall.1000"
-  - name: bm25-slim
-    display: "BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index"
-    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-passage-slim -topics $topics -output $output -hits 1000 -bm25
-    topics:
-      - topic_key: msmarco-v1-passage.dev
-        eval_key: msmarco-passage.dev
-        expected_scores:
-          MRR@10: 0.1840
-          R@1K: 0.8526
-        metric_definitions:
-          MRR@10: "-c -M 10 -m recip_rank"
-          R@1K: "-c -m recall.1000"
-      - topic_key: dl19-passage
-        eval_key: dl19-passage
-        expected_scores:
-          MAP: 0.3013
-          nDCG@10: 0.5058
-          R@1K: 0.7501
-        metric_definitions:
-          MAP: "-c -l 2 -m map"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@1K: "-c -l 2 -m recall.1000"
-      - topic_key: dl20-passage
-        eval_key: dl20-passage
-        expected_scores:
-          MAP: 0.2856
-          nDCG@10: 0.4796
-          R@1K: 0.7863
-        metric_definitions:
-          MAP: "-c -l 2 -m map"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@1K: "-c -l 2 -m recall.1000"
-  - name: bm25-full
-    display: "BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index"
-    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v1-passage-full -topics $topics -output $output -hits 1000 -bm25
-    topics:
-      - topic_key: msmarco-v1-passage.dev
-        eval_key: msmarco-passage.dev
-        expected_scores:
-          MRR@10: 0.1840
-          R@1K: 0.8526
-        metric_definitions:
-          MRR@10: "-c -M 10 -m recip_rank"
-          R@1K: "-c -m recall.1000"
-      - topic_key: dl19-passage
-        eval_key: dl19-passage
-        expected_scores:
-          MAP: 0.3013
-          nDCG@10: 0.5058
-          R@1K: 0.7501
-        metric_definitions:
-          MAP: "-c -l 2 -m map"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@1K: "-c -l 2 -m recall.1000"
-      - topic_key: dl20-passage
-        eval_key: dl20-passage
-        expected_scores:
-          MAP: 0.2856
-          nDCG@10: 0.4796
-          R@1K: 0.7863
         metric_definitions:
           MAP: "-c -l 2 -m map"
           nDCG@10: "-c -m ndcg_cut.10"

--- a/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-doc.yaml
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-doc.yaml
@@ -1,6 +1,64 @@
 conditions:
+  - name: bm25-doc-default-slim
+    display: "BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index"
+    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2-doc-slim -topics $topics -output $output -hits 1000 -bm25
+    topics:
+      - topic_key: msmarco-v2-doc.dev
+        eval_key: msmarco-v2-doc.dev
+        expected_scores:
+          MRR@100: 0.1572
+        metric_definitions:
+          MRR@100: "-c -M 100 -m recip_rank"
+      - topic_key: msmarco-v2-doc.dev2
+        eval_key: msmarco-v2-doc.dev2
+        expected_scores:
+          MRR@100: 0.1659
+        metric_definitions:
+          MRR@100: "-c -M 100 -m recip_rank"
+      - topic_key: dl21
+        eval_key: dl21-doc
+        expected_scores:
+          MAP@100: 0.2126
+          MRR@100: 0.8367
+          nDCG@10: 0.5116
+          R@100: 0.3195
+          R@1K: 0.6739
+        metric_definitions:
+          MAP@100: "-c -M 100 -m map"
+          MRR@100: "-c -M 100 -m recip_rank"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@100: "-c -m recall.100"
+          R@1K: "-c -m recall.1000"
+      - topic_key: dl22
+        eval_key: dl22-doc
+        expected_scores:
+          MAP@100: 0.0801
+          MRR@100: 0.6514
+          nDCG@10: 0.2993
+          R@100: 0.1756
+          R@1K: 0.4107
+        metric_definitions:
+          MAP@100: "-c -M 100 -m map"
+          MRR@100: "-c -M 100 -m recip_rank"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@100: "-c -m recall.100"
+          R@1K: "-c -m recall.1000"
+      - topic_key: dl23
+        eval_key: dl23-doc
+        expected_scores:
+          MAP@100: 0.1046
+          MRR@100: 0.5669
+          nDCG@10: 0.2946
+          R@100: 0.2422
+          R@1K: 0.5262
+        metric_definitions:
+          MAP@100: "-c -M 100 -m map"
+          MRR@100: "-c -M 100 -m recip_rank"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@100: "-c -m recall.100"
+          R@1K: "-c -m recall.1000"
   - name: bm25-doc-default
-    display: "BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)"
+    display: "BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index"
     command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2-doc -topics $topics -output $output -hits 1000 -bm25
     topics:
       - topic_key: msmarco-v2-doc.dev
@@ -115,8 +173,66 @@ conditions:
           nDCG@10: "-c -m ndcg_cut.10"
           R@100: "-c -m recall.100"
           R@1K: "-c -m recall.1000"
+  - name: bm25-doc-segmented-default-slim
+    display: "BM25 segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index"
+    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2-doc-segmented-slim -topics $topics -output $output -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter \# -selectMaxPassage.hits 1000
+    topics:
+      - topic_key: msmarco-v2-doc.dev
+        eval_key: msmarco-v2-doc.dev
+        expected_scores:
+          MRR@100: 0.1896
+        metric_definitions:
+          MRR@100: "-c -M 100 -m recip_rank"
+      - topic_key: msmarco-v2-doc.dev2
+        eval_key: msmarco-v2-doc.dev2
+        expected_scores:
+          MRR@100: 0.1930
+        metric_definitions:
+          MRR@100: "-c -M 100 -m recip_rank"
+      - topic_key: dl21
+        eval_key: dl21-doc
+        expected_scores:
+          MAP@100: 0.2436
+          MRR@100: 0.8937
+          nDCG@10: 0.5776
+          R@100: 0.3478
+          R@1K: 0.6930
+        metric_definitions:
+          MAP@100: "-c -M 100 -m map"
+          MRR@100: "-c -M 100 -m recip_rank"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@100: "-c -m recall.100"
+          R@1K: "-c -m recall.1000"
+      - topic_key: dl22
+        eval_key: dl22-doc
+        expected_scores:
+          MAP@100: 0.1036
+          MRR@100: 0.7163
+          nDCG@10: 0.3618
+          R@100: 0.2192
+          R@1K: 0.4664
+        metric_definitions:
+          MAP@100: "-c -M 100 -m map"
+          MRR@100: "-c -M 100 -m recip_rank"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@100: "-c -m recall.100"
+          R@1K: "-c -m recall.1000"
+      - topic_key: dl23
+        eval_key: dl23-doc
+        expected_scores:
+          MAP@100: 0.1341
+          MRR@100: 0.6477
+          nDCG@10: 0.3405
+          R@100: 0.2884
+          R@1K: 0.5662
+        metric_definitions:
+          MAP@100: "-c -M 100 -m map"
+          MRR@100: "-c -M 100 -m recip_rank"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@100: "-c -m recall.100"
+          R@1K: "-c -m recall.1000"
   - name: bm25-doc-segmented-default
-    display: "BM25 segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)"
+    display: "BM25 segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index"
     command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2-doc-segmented -topics $topics -output $output -bm25 -hits 10000 -selectMaxPassage -selectMaxPassage.delimiter \# -selectMaxPassage.hits 1000
     topics:
       - topic_key: msmarco-v2-doc.dev

--- a/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-passage.yaml
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2-passage.yaml
@@ -1,6 +1,64 @@
 conditions:
+  - name: bm25-slim
+    display: "BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index"
+    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2-passage-slim -topics $topics -output $output -hits 1000 -bm25
+    topics:
+      - topic_key: msmarco-v2-passage.dev
+        eval_key: msmarco-v2-passage.dev
+        expected_scores:
+          MRR@100: 0.0719
+        metric_definitions:
+          MRR@100: "-c -M 100 -m recip_rank"
+      - topic_key: msmarco-v2-passage.dev2
+        eval_key: msmarco-v2-passage.dev2
+        expected_scores:
+          MRR@100: 0.0802
+        metric_definitions:
+          MRR@100: "-c -M 100 -m recip_rank"
+      - topic_key: dl21
+        eval_key: dl21-passage
+        expected_scores:
+          MAP@100: 0.1357
+          MRR@100: 0.5060
+          nDCG@10: 0.4458
+          R@100: 0.3261
+          R@1K: 0.6149
+        metric_definitions:
+          MAP@100: "-c -M 100 -m map -l 2"
+          MRR@100: "-c -M 100 -m recip_rank -l 2"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@100: "-c -m recall.100 -l 2"
+          R@1K: "-c -m recall.1000 -l 2"
+      - topic_key: dl22
+        eval_key: dl22-passage
+        expected_scores:
+          MAP@100: 0.0325
+          MRR@100: 0.3256
+          nDCG@10: 0.2692
+          R@100: 0.1382
+          R@1K: 0.3321
+        metric_definitions:
+          MAP@100: "-c -M 100 -m map -l 2"
+          MRR@100: "-c -M 100 -m recip_rank -l 2"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@100: "-c -m recall.100 -l 2"
+          R@1K: "-c -m recall.1000 -l 2"
+      - topic_key: dl23
+        eval_key: dl23-passage
+        expected_scores:
+          MAP@100: 0.0793
+          MRR@100: 0.3803
+          nDCG@10: 0.2627
+          R@100: 0.2329
+          R@1K: 0.4346
+        metric_definitions:
+          MAP@100: "-c -M 100 -m map -l 2"
+          MRR@100: "-c -M 100 -m recip_rank -l 2"
+          nDCG@10: "-c -m ndcg_cut.10"
+          R@100: "-c -m recall.100 -l 2"
+          R@1K: "-c -m recall.1000 -l 2"
   - name: bm25
-    display: "BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)"
+    display: "BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index"
     command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2-passage -topics $topics -output $output -hits 1000 -bm25
     topics:
       - topic_key: msmarco-v2-passage.dev
@@ -167,122 +225,6 @@ conditions:
           nDCG@10: 0.3855
           R@100: 0.3293
           R@1K: 0.5541
-        metric_definitions:
-          MAP@100: "-c -M 100 -m map -l 2"
-          MRR@100: "-c -M 100 -m recip_rank -l 2"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@100: "-c -m recall.100 -l 2"
-          R@1K: "-c -m recall.1000 -l 2"
-  - name: bm25-slim
-    display: "BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index"
-    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2-passage-slim -topics $topics -output $output -hits 1000 -bm25
-    topics:
-      - topic_key: msmarco-v2-passage.dev
-        eval_key: msmarco-v2-passage.dev
-        expected_scores:
-          MRR@100: 0.0719
-        metric_definitions:
-          MRR@100: "-c -M 100 -m recip_rank"
-      - topic_key: msmarco-v2-passage.dev2
-        eval_key: msmarco-v2-passage.dev2
-        expected_scores:
-          MRR@100: 0.0802
-        metric_definitions:
-          MRR@100: "-c -M 100 -m recip_rank"
-      - topic_key: dl21
-        eval_key: dl21-passage
-        expected_scores:
-          MAP@100: 0.1357
-          MRR@100: 0.5060
-          nDCG@10: 0.4458
-          R@100: 0.3261
-          R@1K: 0.6149
-        metric_definitions:
-          MAP@100: "-c -M 100 -m map -l 2"
-          MRR@100: "-c -M 100 -m recip_rank -l 2"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@100: "-c -m recall.100 -l 2"
-          R@1K: "-c -m recall.1000 -l 2"
-      - topic_key: dl22
-        eval_key: dl22-passage
-        expected_scores:
-          MAP@100: 0.0325
-          MRR@100: 0.3256
-          nDCG@10: 0.2692
-          R@100: 0.1382
-          R@1K: 0.3321
-        metric_definitions:
-          MAP@100: "-c -M 100 -m map -l 2"
-          MRR@100: "-c -M 100 -m recip_rank -l 2"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@100: "-c -m recall.100 -l 2"
-          R@1K: "-c -m recall.1000 -l 2"
-      - topic_key: dl23
-        eval_key: dl23-passage
-        expected_scores:
-          MAP@100: 0.0793
-          MRR@100: 0.3803
-          nDCG@10: 0.2627
-          R@100: 0.2329
-          R@1K: 0.4346
-        metric_definitions:
-          MAP@100: "-c -M 100 -m map -l 2"
-          MRR@100: "-c -M 100 -m recip_rank -l 2"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@100: "-c -m recall.100 -l 2"
-          R@1K: "-c -m recall.1000 -l 2"
-  - name: bm25-full
-    display: "BM25 (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index"
-    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2-passage-full -topics $topics -output $output -hits 1000 -bm25
-    topics:
-      - topic_key: msmarco-v2-passage.dev
-        eval_key: msmarco-v2-passage.dev
-        expected_scores:
-          MRR@100: 0.0719
-        metric_definitions:
-          MRR@100: "-c -M 100 -m recip_rank"
-      - topic_key: msmarco-v2-passage.dev2
-        eval_key: msmarco-v2-passage.dev2
-        expected_scores:
-          MRR@100: 0.0802
-        metric_definitions:
-          MRR@100: "-c -M 100 -m recip_rank"
-      - topic_key: dl21
-        eval_key: dl21-passage
-        expected_scores:
-          MAP@100: 0.1357
-          MRR@100: 0.5060
-          nDCG@10: 0.4458
-          R@100: 0.3261
-          R@1K: 0.6149
-        metric_definitions:
-          MAP@100: "-c -M 100 -m map -l 2"
-          MRR@100: "-c -M 100 -m recip_rank -l 2"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@100: "-c -m recall.100 -l 2"
-          R@1K: "-c -m recall.1000 -l 2"
-      - topic_key: dl22
-        eval_key: dl22-passage
-        expected_scores:
-          MAP@100: 0.0325
-          MRR@100: 0.3256
-          nDCG@10: 0.2692
-          R@100: 0.1382
-          R@1K: 0.3321
-        metric_definitions:
-          MAP@100: "-c -M 100 -m map -l 2"
-          MRR@100: "-c -M 100 -m recip_rank -l 2"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@100: "-c -m recall.100 -l 2"
-          R@1K: "-c -m recall.1000 -l 2"
-      - topic_key: dl23
-        eval_key: dl23-passage
-        expected_scores:
-          MAP@100: 0.0793
-          MRR@100: 0.3803
-          nDCG@10: 0.2627
-          R@100: 0.2329
-          R@1K: 0.4346
         metric_definitions:
           MAP@100: "-c -M 100 -m map -l 2"
           MRR@100: "-c -M 100 -m recip_rank -l 2"

--- a/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc-segmented.yaml
@@ -1,6 +1,50 @@
 conditions:
+  - name: bm25-slim
+    display: "BM25 doc segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index"
+    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2.1-doc-segmented-slim -topics $topics -output $output -hits 1000 -bm25
+    topics:
+      - topic_key: rag24.test
+        eval_key: rag24.test-umbrela-all
+        expected_scores:
+          nDCG@20: 0.3198
+          nDCG@100: 0.2563
+          R@100: 0.1395
+        metric_definitions:
+          nDCG@20: "-c -m ndcg_cut.20"
+          nDCG@100: "-c -m ndcg_cut.100"
+          R@100: "-c -m recall.100"
+      - topic_key: rag24.test
+        eval_key: rag24.test
+        expected_scores:
+          nDCG@20: 0.2809
+          nDCG@100: 0.2345
+          R@100: 0.1698
+        metric_definitions:
+          nDCG@20: "-c -m ndcg_cut.20"
+          nDCG@100: "-c -m ndcg_cut.100"
+          R@100: "-c -m recall.100"
+      - topic_key: rag25.test
+        eval_key: rag25.test-umbrela2
+        expected_scores:
+          nDCG@30: 0.3250
+          nDCG@100: 0.2835
+          R@100: 0.1167
+        metric_definitions:
+          nDCG@30: "-c -m ndcg_cut.30"
+          nDCG@100: "-c -m ndcg_cut.100"
+          R@100: "-c -m recall.100"
+      - topic_key: rag25.test
+        eval_key: rag25.test
+        expected_scores:
+          nDCG@30: 0.3468
+          nDCG@100: 0.2900
+          R@100: 0.1107
+        metric_definitions:
+          nDCG@30: "-c -m ndcg_cut.30"
+          nDCG@100: "-c -m ndcg_cut.100"
+          R@100: "-c -m recall.100"
   - name: bm25
-    display: "BM25 doc segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)"
+    display: "BM25 doc segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index"
     command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2.1-doc-segmented -topics $topics -output $output -hits 1000 -bm25
     topics:
       - topic_key: rag24.test
@@ -523,94 +567,6 @@ conditions:
           nDCG@30: 0.2182
           nDCG@100: 0.1386
           R@100: 0.0418
-        metric_definitions:
-          nDCG@30: "-c -m ndcg_cut.30"
-          nDCG@100: "-c -m ndcg_cut.100"
-          R@100: "-c -m recall.100"
-  - name: bm25-slim
-    display: "BM25 doc segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index"
-    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2.1-doc-segmented-slim -topics $topics -output $output -hits 1000 -bm25
-    topics:
-      - topic_key: rag24.test
-        eval_key: rag24.test-umbrela-all
-        expected_scores:
-          nDCG@20: 0.3198
-          nDCG@100: 0.2563
-          R@100: 0.1395
-        metric_definitions:
-          nDCG@20: "-c -m ndcg_cut.20"
-          nDCG@100: "-c -m ndcg_cut.100"
-          R@100: "-c -m recall.100"
-      - topic_key: rag24.test
-        eval_key: rag24.test
-        expected_scores:
-          nDCG@20: 0.2809
-          nDCG@100: 0.2345
-          R@100: 0.1698
-        metric_definitions:
-          nDCG@20: "-c -m ndcg_cut.20"
-          nDCG@100: "-c -m ndcg_cut.100"
-          R@100: "-c -m recall.100"
-      - topic_key: rag25.test
-        eval_key: rag25.test-umbrela2
-        expected_scores:
-          nDCG@30: 0.3250
-          nDCG@100: 0.2835
-          R@100: 0.1167
-        metric_definitions:
-          nDCG@30: "-c -m ndcg_cut.30"
-          nDCG@100: "-c -m ndcg_cut.100"
-          R@100: "-c -m recall.100"
-      - topic_key: rag25.test
-        eval_key: rag25.test
-        expected_scores:
-          nDCG@30: 0.3468
-          nDCG@100: 0.2900
-          R@100: 0.1107
-        metric_definitions:
-          nDCG@30: "-c -m ndcg_cut.30"
-          nDCG@100: "-c -m ndcg_cut.100"
-          R@100: "-c -m recall.100"
-  - name: bm25-full
-    display: "BM25 doc segmented (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index"
-    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2.1-doc-segmented-full -topics $topics -output $output -hits 1000 -bm25
-    topics:
-      - topic_key: rag24.test
-        eval_key: rag24.test-umbrela-all
-        expected_scores:
-          nDCG@20: 0.3198
-          nDCG@100: 0.2563
-          R@100: 0.1395
-        metric_definitions:
-          nDCG@20: "-c -m ndcg_cut.20"
-          nDCG@100: "-c -m ndcg_cut.100"
-          R@100: "-c -m recall.100"
-      - topic_key: rag24.test
-        eval_key: rag24.test
-        expected_scores:
-          nDCG@20: 0.2809
-          nDCG@100: 0.2345
-          R@100: 0.1698
-        metric_definitions:
-          nDCG@20: "-c -m ndcg_cut.20"
-          nDCG@100: "-c -m ndcg_cut.100"
-          R@100: "-c -m recall.100"
-      - topic_key: rag25.test
-        eval_key: rag25.test-umbrela2
-        expected_scores:
-          nDCG@30: 0.3250
-          nDCG@100: 0.2835
-          R@100: 0.1167
-        metric_definitions:
-          nDCG@30: "-c -m ndcg_cut.30"
-          nDCG@100: "-c -m ndcg_cut.100"
-          R@100: "-c -m recall.100"
-      - topic_key: rag25.test
-        eval_key: rag25.test
-        expected_scores:
-          nDCG@30: 0.3468
-          nDCG@100: 0.2900
-          R@100: 0.1107
         metric_definitions:
           nDCG@30: "-c -m ndcg_cut.30"
           nDCG@100: "-c -m ndcg_cut.100"

--- a/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc.yaml
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/configs/msmarco-v2.1-doc.yaml
@@ -1,148 +1,4 @@
 conditions:
-  - name: bm25-doc
-    display: "BM25 doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)"
-    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2.1-doc -topics $topics -output $output -hits 1000 -bm25
-    topics:
-      - topic_key: msmarco-v2-doc.dev
-        eval_key: msmarco-v2.1-doc.dev
-        expected_scores:
-          MRR@100: 0.1654
-        metric_definitions:
-          MRR@100: "-c -M 100 -m recip_rank"
-      - topic_key: msmarco-v2-doc.dev2
-        eval_key: msmarco-v2.1-doc.dev2
-        expected_scores:
-          MRR@100: 0.1732
-        metric_definitions:
-          MRR@100: "-c -M 100 -m recip_rank"
-      - topic_key: dl21-doc
-        eval_key: dl21-doc-msmarco-v2.1
-        expected_scores:
-          MAP@100: 0.2281
-          MRR@100: 0.8466
-          nDCG@10: 0.5183
-          R@100: 0.3502
-          R@1K: 0.6915
-        metric_definitions:
-          MAP@100: "-c -M 100 -m map"
-          MRR@100: "-c -M 100 -m recip_rank"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@100: "-c -m recall.100"
-          R@1K: "-c -m recall.1000"
-      - topic_key: dl22-doc
-        eval_key: dl22-doc-msmarco-v2.1
-        expected_scores:
-          MAP@100: 0.0841
-          MRR@100: 0.6623
-          nDCG@10: 0.2991
-          R@100: 0.1866
-          R@1K: 0.4254
-        metric_definitions:
-          MAP@100: "-c -M 100 -m map"
-          MRR@100: "-c -M 100 -m recip_rank"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@100: "-c -m recall.100"
-          R@1K: "-c -m recall.1000"
-      - topic_key: dl23-doc
-        eval_key: dl23-doc-msmarco-v2.1
-        expected_scores:
-          MAP@100: 0.1089
-          MRR@100: 0.5783
-          nDCG@10: 0.2914
-          R@100: 0.2604
-          R@1K: 0.5383
-        metric_definitions:
-          MAP@100: "-c -M 100 -m map"
-          MRR@100: "-c -M 100 -m recip_rank"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@100: "-c -m recall.100"
-          R@1K: "-c -m recall.1000"
-      - topic_key: rag24.raggy-dev
-        eval_key: rag24.raggy-dev
-        expected_scores:
-          MAP@100: 0.1251
-          MRR@100: 0.7060
-          nDCG@10: 0.3631
-          R@100: 0.2433
-          R@1K: 0.5317
-        metric_definitions:
-          MAP@100: "-c -M 100 -m map"
-          MRR@100: "-c -M 100 -m recip_rank"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@100: "-c -m recall.100"
-          R@1K: "-c -m recall.1000"
-  - name: bm25-segmented-doc
-    display: "BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4)"
-    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2.1-doc-segmented -topics $topics -output $output -hits 10000 -bm25 -selectMaxPassage -selectMaxPassage.delimiter \# -selectMaxPassage.hits 1000
-    topics:
-      - topic_key: msmarco-v2-doc.dev
-        eval_key: msmarco-v2.1-doc.dev
-        expected_scores:
-          MRR@100: 0.1973
-        metric_definitions:
-          MRR@100: "-c -M 100 -m recip_rank"
-      - topic_key: msmarco-v2-doc.dev2
-        eval_key: msmarco-v2.1-doc.dev2
-        expected_scores:
-          MRR@100: 0.2000
-        metric_definitions:
-          MRR@100: "-c -M 100 -m recip_rank"
-      - topic_key: dl21-doc
-        eval_key: dl21-doc-msmarco-v2.1
-        expected_scores:
-          MAP@100: 0.2609
-          MRR@100: 0.9026
-          nDCG@10: 0.5778
-          R@100: 0.3811
-          R@1K: 0.7115
-        metric_definitions:
-          MAP@100: "-c -M 100 -m map"
-          MRR@100: "-c -M 100 -m recip_rank"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@100: "-c -m recall.100"
-          R@1K: "-c -m recall.1000"
-      - topic_key: dl22-doc
-        eval_key: dl22-doc-msmarco-v2.1
-        expected_scores:
-          MAP@100: 0.1079
-          MRR@100: 0.7213
-          nDCG@10: 0.3576
-          R@100: 0.2330
-          R@1K: 0.4790
-        metric_definitions:
-          MAP@100: "-c -M 100 -m map"
-          MRR@100: "-c -M 100 -m recip_rank"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@100: "-c -m recall.100"
-          R@1K: "-c -m recall.1000"
-      - topic_key: dl23-doc
-        eval_key: dl23-doc-msmarco-v2.1
-        expected_scores:
-          MAP@100: 0.1391
-          MRR@100: 0.6519
-          nDCG@10: 0.3356
-          R@100: 0.3049
-          R@1K: 0.5852
-        metric_definitions:
-          MAP@100: "-c -M 100 -m map"
-          MRR@100: "-c -M 100 -m recip_rank"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@100: "-c -m recall.100"
-          R@1K: "-c -m recall.1000"
-      - topic_key: rag24.raggy-dev
-        eval_key: rag24.raggy-dev
-        expected_scores:
-          MAP@100: 0.1561
-          MRR@100: 0.7465
-          nDCG@10: 0.4227
-          R@100: 0.2807
-          R@1K: 0.5745
-        metric_definitions:
-          MAP@100: "-c -M 100 -m map"
-          MRR@100: "-c -M 100 -m recip_rank"
-          nDCG@10: "-c -m ndcg_cut.10"
-          R@100: "-c -m recall.100"
-          R@1K: "-c -m recall.1000"
   - name: bm25-doc-slim
     display: "BM25 doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), slim index"
     command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2.1-doc-slim -topics $topics -output $output -hits 1000 -bm25
@@ -215,9 +71,9 @@ conditions:
           nDCG@10: "-c -m ndcg_cut.10"
           R@100: "-c -m recall.100"
           R@1K: "-c -m recall.1000"
-  - name: bm25-doc-full
-    display: "BM25 doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index"
-    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2.1-doc-full -topics $topics -output $output -hits 1000 -bm25
+  - name: bm25-doc
+    display: "BM25 doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index"
+    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2.1-doc -topics $topics -output $output -hits 1000 -bm25
     topics:
       - topic_key: msmarco-v2-doc.dev
         eval_key: msmarco-v2.1-doc.dev
@@ -359,9 +215,9 @@ conditions:
           nDCG@10: "-c -m ndcg_cut.10"
           R@100: "-c -m recall.100"
           R@1K: "-c -m recall.1000"
-  - name: bm25-segmented-doc-full
-    display: "BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), full index"
-    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2.1-doc-segmented-full -topics $topics -output $output -hits 10000 -bm25 -selectMaxPassage -selectMaxPassage.delimiter \# -selectMaxPassage.hits 1000
+  - name: bm25-segmented-doc
+    display: "BM25 segmented doc (<i>k<sub><small>1</small></sub></i>=0.9, <i>b</i>=0.4), regular index"
+    command: io.anserini.search.SearchCollection -threads $threads -index msmarco-v2.1-doc-segmented -topics $topics -output $output -hits 10000 -bm25 -selectMaxPassage -selectMaxPassage.delimiter \# -selectMaxPassage.hits 1000
     topics:
       - topic_key: msmarco-v2-doc.dev
         eval_key: msmarco-v2.1-doc.dev

--- a/src/main/resources/reproduce/from-prebuilt-indexes/docgen/msmarco-v1-doc.template
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/docgen/msmarco-v1-doc.template
@@ -18,6 +18,8 @@ Key:
 
 ${summary}
 
+The BM25 "slim index" does not contain the document texts, whereas the BM25 "regular index" does contain document texts (and hence supports pseudo-relevance feedback with on-the-fly document parsing).
+
 ## Commands
 
 In the commands below:

--- a/src/main/resources/reproduce/from-prebuilt-indexes/docgen/msmarco-v1-passage.template
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/docgen/msmarco-v1-passage.template
@@ -18,6 +18,8 @@ Key:
 
 ${summary}
 
+The BM25 "slim index" does not contain the document texts, whereas the BM25 "regular index" does contain document texts (and hence supports pseudo-relevance feedback with on-the-fly document parsing).
+
 ## Commands
 
 In the commands below:

--- a/src/main/resources/reproduce/from-prebuilt-indexes/docgen/msmarco-v2-doc.template
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/docgen/msmarco-v2-doc.template
@@ -20,6 +20,8 @@ Key:
 
 ${summary}
 
+The BM25 "slim index" does not contain the document texts, whereas the BM25 "regular index" does contain document texts (and hence supports pseudo-relevance feedback with on-the-fly document parsing).
+
 ## Commands
 
 In the commands below:

--- a/src/main/resources/reproduce/from-prebuilt-indexes/docgen/msmarco-v2-passage.template
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/docgen/msmarco-v2-passage.template
@@ -20,6 +20,8 @@ Key:
 
 ${summary}
 
+The BM25 "slim index" does not contain the document texts, whereas the BM25 "regular index" does contain document texts (and hence supports pseudo-relevance feedback with on-the-fly document parsing).
+
 ## Commands
 
 In the commands below:

--- a/src/main/resources/reproduce/from-prebuilt-indexes/docgen/msmarco-v2.1-doc-segmented.template
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/docgen/msmarco-v2.1-doc-segmented.template
@@ -19,6 +19,8 @@ Key:
 
 ${summary}
 
+The BM25 "slim index" does not contain the document texts, whereas the BM25 "regular index" does contain document texts (and hence supports pseudo-relevance feedback with on-the-fly document parsing).
+
 ## Commands
 
 In the commands below:

--- a/src/main/resources/reproduce/from-prebuilt-indexes/docgen/msmarco-v2.1-doc.template
+++ b/src/main/resources/reproduce/from-prebuilt-indexes/docgen/msmarco-v2.1-doc.template
@@ -21,6 +21,8 @@ Key:
 
 ${summary}
 
+The BM25 "slim index" does not contain the document texts, whereas the BM25 "regular index" does contain document texts (and hence supports pseudo-relevance feedback with on-the-fly document parsing).
+
 ## Commands
 
 In the commands below:


### PR DESCRIPTION
## Summary

- Distinguish slim and regular BM25 indexes across MS MARCO v1, v2, and v2.1 reproduction docs.
- Remove stale full-index reproduction conditions in favor of regular-index naming.
- Add Rocchio reproduction conditions and corrected command naming for MS MARCO v1 doc runs.
- Regenerate affected reproduction docs and normalize MS MARCO doc naming in reference tables.

## Validation

- `mvn -Dtest=GenerateReproductionDocsFromPrebuiltIndexesTest test`