### PR TITLE
[codex] Remove stale pre-encoded topic entries

### DIFF
--- a/src/main/java/io/anserini/search/topicreader/Topics.java
+++ b/src/main/java/io/anserini/search/topicreader/Topics.java
@@ -69,9 +69,6 @@ public enum Topics {
   TREC2019_DL_PASSAGE_SPLADE_DISTILL_COCODENSER_MEDIUM(TsvIntTopicReader.class,"topics.dl19-passage.splade_distil_cocodenser_medium.tsv.gz"),
   TREC2019_DL_PASSAGE_SPLADE_PP_ED(TsvIntTopicReader.class,"topics.dl19-passage.splade-pp-ed.tsv.gz"),
   TREC2019_DL_PASSAGE_SPLADE_PP_SD(TsvIntTopicReader.class,"topics.dl19-passage.splade-pp-sd.tsv.gz"),
-  TREC2019_DL_PASSAGE_SPLADE_V3(TsvIntTopicReader.class,"topics.dl19-passage.splade-v3.tsv.gz"),
-  TREC2019_DL_PASSAGE_COSDPR_DISTIL(JsonIntVectorTopicReader.class, "topics.dl19-passage.cosdpr-distil.jsonl.gz"),
-  TREC2019_DL_PASSAGE_BGE_BASE_EN_15(JsonIntVectorTopicReader.class, "topics.dl19-passage.bge-base-en-v1.5.jsonl.gz"),
   TREC2019_DL_PASSAGE_COHERE_EMBED_ENGLISH_30(JsonIntVectorTopicReader.class, "topics.dl19-passage.cohere-embed-english-v3.0.jsonl.gz"),
   TREC2020_DL(TsvIntTopicReader.class,"topics.dl20.txt"),
   TREC2020_DL_WP(TsvIntTopicReader.class,"topics.dl20.wp.tsv.gz"),
@@ -80,9 +77,6 @@ public enum Topics {
   TREC2020_DL_SPLADE_DISTILL_COCODENSER_MEDIUM(TsvIntTopicReader.class,"topics.dl20.splade_distil_cocodenser_medium.tsv.gz"),
   TREC2020_DL_SPLADE_PP_ED(TsvIntTopicReader.class,"topics.dl20.splade-pp-ed.tsv.gz"),
   TREC2020_DL_SPLADE_PP_SD(TsvIntTopicReader.class,"topics.dl20.splade-pp-sd.tsv.gz"),
-  TREC2020_DL_SPLADE_V3(TsvIntTopicReader.class,"topics.dl20.splade-v3.tsv.gz"),
-  TREC2020_DL_COSDPR_DISTIL(JsonIntVectorTopicReader.class, "topics.dl20.cosdpr-distil.jsonl.gz"),
-  TREC2020_DL_BGE_BASE_EN_15(JsonIntVectorTopicReader.class, "topics.dl20.bge-base-en-v1.5.jsonl.gz"),
   TREC2020_DL_COHERE_EMBED_ENGLISH_30(JsonIntVectorTopicReader.class, "topics.dl20.cohere-embed-english-v3.0.jsonl.gz"),
   TREC2021_DL(TsvIntTopicReader.class,"topics.dl21.txt"),
   TREC2021_DL_UNICOIL(TsvIntTopicReader.class,"topics.dl21.unicoil.0shot.tsv.gz"),
@@ -109,9 +103,7 @@ public enum Topics {
   TREC2024_RAG_RESEARCHY_DEV_SNOWFLAKE_ARCTIC_EMBED_L(JsonIntVectorTopicReader.class, "topics.rag24.researchy-dev.snowflake-arctic-embed-l.jsonl.gz"),
   TREC2024_RAG_TEST(TsvStringTopicReader.class, "topics.rag24.test.txt"),
   TREC2024_RAG_TEST_SNOWFLAKE_ARCTIC_EMBED_L(JsonStringVectorTopicReader.class, "topics.rag24.test.snowflake-arctic-embed-l.jsonl.gz"),
-  TREC2024_RAG_TEST_SPLADE_V3(TsvStringTopicReader.class, "topics.rag24.test.splade-v3.tsv.gz"),
   TREC2025_RAG_TEST(JsonStringTopicReader.class, "topics.rag25.test.jsonl"),
-  TREC2025_RAG_TEST_SPLADE_V3(JsonStringTopicReader.class, "topics.rag25.test.splade-v3.jsonl.gz"),
 
   // MS MARCO V1 topics
   MSMARCO_DOC_DEV(TsvIntTopicReader.class,"topics.msmarco-doc.dev.txt"),
@@ -132,9 +124,6 @@ public enum Topics {
   MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_DISTILL_COCODENSER_MEDIUM(TsvIntTopicReader.class, "topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.tsv.gz"),
   MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_ED(TsvIntTopicReader.class, "topics.msmarco-passage.dev-subset.splade-pp-ed.tsv.gz"),
   MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_SD(TsvIntTopicReader.class, "topics.msmarco-passage.dev-subset.splade-pp-sd.tsv.gz"),
-  MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_V3(TsvIntTopicReader.class, "topics.msmarco-passage.dev-subset.splade-v3.tsv.gz"),
-  MSMARCO_PASSAGE_DEV_SUBSET_COSDPR_DISTIL(JsonIntVectorTopicReader.class, "topics.msmarco-passage.dev-subset.cosdpr-distil.jsonl.gz"),
-  MSMARCO_PASSAGE_DEV_SUBSET_BGE_BASE_EN_15(JsonIntVectorTopicReader.class, "topics.msmarco-passage.dev-subset.bge-base-en-v1.5.jsonl.gz"),
   MSMARCO_PASSAGE_DEV_SUBSET_COHERE_EMBED_ENGLISH_30(JsonIntVectorTopicReader.class, "topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.gz"),
   MSMARCO_PASSAGE_TEST_SUBSET(TsvIntTopicReader.class, "topics.msmarco-passage.test-subset.txt"),
 
@@ -458,34 +447,6 @@ public enum Topics {
   BRIGHT_THEOREMQA_THEOREMS_ORIGINAL(JsonStringTopicReader.class, "topics.bright-theoremqa-theorems-original.jsonl.gz"),
   BRIGHT_THEOREMQA_QUESTIONS_ORIGINAL(JsonStringTopicReader.class, "topics.bright-theoremqa-questions-original.jsonl.gz"),
 
-  // BRIGHT: pre-encoded queries for SPLADE-v3
-  BRIGHT_BIOLOGY_SPLADE_V3(TsvStringTopicReader.class, "topics.bright-biology.splade-v3.tsv.gz"),
-  BRIGHT_EARTH_SCIENCE_SPLADE_V3(TsvStringTopicReader.class, "topics.bright-earth-science.splade-v3.tsv.gz"),
-  BRIGHT_ECONOMICS_SPLADE_V3(TsvStringTopicReader.class, "topics.bright-economics.splade-v3.tsv.gz"),
-  BRIGHT_PSYCHOLOGY_SPLADE_V3(TsvStringTopicReader.class, "topics.bright-psychology.splade-v3.tsv.gz"),
-  BRIGHT_ROBOTICS_SPLADE_V3(TsvStringTopicReader.class, "topics.bright-robotics.splade-v3.tsv.gz"),
-  BRIGHT_STACKOVERFLOW_SPLADE_V3(TsvStringTopicReader.class, "topics.bright-stackoverflow.splade-v3.tsv.gz"),
-  BRIGHT_SUSTAINABLE_LIVING_SPLADE_V3(TsvStringTopicReader.class, "topics.bright-sustainable-living.splade-v3.tsv.gz"),
-  BRIGHT_PONY_SPLADE_V3(TsvStringTopicReader.class, "topics.bright-pony.splade-v3.tsv.gz"),
-  BRIGHT_LEETCODE_SPLADE_V3(TsvStringTopicReader.class, "topics.bright-leetcode.splade-v3.tsv.gz"),
-  BRIGHT_AOPS_SPLADE_V3(TsvStringTopicReader.class, "topics.bright-aops.splade-v3.tsv.gz"),
-  BRIGHT_THEOREMQA_THEOREMS_SPLADE_V3(TsvStringTopicReader.class, "topics.bright-theoremqa-theorems.splade-v3.tsv.gz"),
-  BRIGHT_THEOREMQA_QUESTIONS_SPLADE_V3(TsvStringTopicReader.class, "topics.bright-theoremqa-questions.splade-v3.tsv.gz"),
-
-  // BRIGHT: pre-encoded queries for BGE-large-en-v1.5
-  BRIGHT_BIOLOGY_BGE_LARGE_EN_15(JsonStringVectorTopicReader.class, "topics.bright-biology.bge-large-en-v1.5.jsonl.gz"),
-  BRIGHT_EARTH_SCIENCE_BGE_LARGE_EN_15(JsonStringVectorTopicReader.class, "topics.bright-earth-science.bge-large-en-v1.5.jsonl.gz"),
-  BRIGHT_ECONOMICS_BGE_LARGE_EN_15(JsonStringVectorTopicReader.class, "topics.bright-economics.bge-large-en-v1.5.jsonl.gz"),
-  BRIGHT_PSYCHOLOGY_BGE_LARGE_EN_15(JsonStringVectorTopicReader.class, "topics.bright-psychology.bge-large-en-v1.5.jsonl.gz"),
-  BRIGHT_ROBOTICS_BGE_LARGE_EN_15(JsonStringVectorTopicReader.class, "topics.bright-robotics.bge-large-en-v1.5.jsonl.gz"),
-  BRIGHT_STACKOVERFLOW_BGE_LARGE_EN_15(JsonStringVectorTopicReader.class, "topics.bright-stackoverflow.bge-large-en-v1.5.jsonl.gz"),
-  BRIGHT_SUSTAINABLE_LIVING_BGE_LARGE_EN_15(JsonStringVectorTopicReader.class, "topics.bright-sustainable-living.bge-large-en-v1.5.jsonl.gz"),
-  BRIGHT_PONY_BGE_LARGE_EN_15(JsonStringVectorTopicReader.class, "topics.bright-pony.bge-large-en-v1.5.jsonl.gz"),
-  BRIGHT_LEETCODE_BGE_LARGE_EN_15(JsonStringVectorTopicReader.class, "topics.bright-leetcode.bge-large-en-v1.5.jsonl.gz"),
-  BRIGHT_AOPS_BGE_LARGE_EN_15(JsonStringVectorTopicReader.class, "topics.bright-aops.bge-large-en-v1.5.jsonl.gz"),
-  BRIGHT_THEOREMQA_THEOREMS_BGE_LARGE_EN_15(JsonStringVectorTopicReader.class, "topics.bright-theoremqa-theorems.bge-large-en-v1.5.jsonl.gz"),
-  BRIGHT_THEOREMQA_QUESTIONS_BGE_LARGE_EN_15(JsonStringVectorTopicReader.class, "topics.bright-theoremqa-questions.bge-large-en-v1.5.jsonl.gz"),
-
   // M-BEIR original queries
   M_BEIR_CIRR_TASK7_TEST(JsonStringTopicReader.class, "topics.mbeir-cirr_task7.test.jsonl"),
   M_BEIR_EDIS_TASK2_TEST(JsonStringTopicReader.class, "topics.mbeir-edis_task2.test.jsonl"),
@@ -562,47 +523,29 @@ public enum Topics {
     m.put("msmarco-passage-dev", MSMARCO_PASSAGE_DEV_SUBSET);
     m.put("msmarco-passage-dev-splade-pp-ed", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_ED);
     m.put("msmarco-passage-dev-splade-pp-sd", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_SD);
-    m.put("msmarco-passage-dev-splade-v3", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_V3);
-    m.put("msmarco-passage-dev-cosdpr-distil", MSMARCO_PASSAGE_DEV_SUBSET_COSDPR_DISTIL);
-    m.put("msmarco-passage-dev-bge-base-en-v1.5", MSMARCO_PASSAGE_DEV_SUBSET_BGE_BASE_EN_15);
     m.put("msmarco-passage-dev-cohere-embed-english-v3.0", MSMARCO_PASSAGE_DEV_SUBSET_COHERE_EMBED_ENGLISH_30);
 
     m.put("msmarco-passage-dev.splade-pp-ed", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_ED);
     m.put("msmarco-passage-dev.splade-pp-sd", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_SD);
-    m.put("msmarco-passage-dev.splade-v3", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_V3);
-    m.put("msmarco-passage-dev.cosdpr-distil", MSMARCO_PASSAGE_DEV_SUBSET_COSDPR_DISTIL);
-    m.put("msmarco-passage-dev.bge-base-en-v1.5", MSMARCO_PASSAGE_DEV_SUBSET_BGE_BASE_EN_15);
     m.put("msmarco-passage-dev.cohere-embed-english-v3.0", MSMARCO_PASSAGE_DEV_SUBSET_COHERE_EMBED_ENGLISH_30);
 
     m.put("msmarco-passage.dev", MSMARCO_PASSAGE_DEV_SUBSET);
     m.put("msmarco-passage.dev.splade-pp-ed", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_ED);
     m.put("msmarco-passage.dev.splade-pp-sd", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_SD);
-    m.put("msmarco-passage.dev.splade-v3", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_V3);
-    m.put("msmarco-passage.dev.cosdpr-distil", MSMARCO_PASSAGE_DEV_SUBSET_COSDPR_DISTIL);
-    m.put("msmarco-passage.dev.bge-base-en-v1.5", MSMARCO_PASSAGE_DEV_SUBSET_BGE_BASE_EN_15);
     m.put("msmarco-passage.dev.cohere-embed-english-v3.0", MSMARCO_PASSAGE_DEV_SUBSET_COHERE_EMBED_ENGLISH_30);
 
     m.put("msmarco-v1-passage-dev", MSMARCO_PASSAGE_DEV_SUBSET);
     m.put("msmarco-v1-passage-dev-splade-pp-ed", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_ED);
     m.put("msmarco-v1-passage-dev-splade-pp-sd", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_SD);
-    m.put("msmarco-v1-passage-dev-splade-v3", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_V3);
-    m.put("msmarco-v1-passage-dev-cosdpr-distil", MSMARCO_PASSAGE_DEV_SUBSET_COSDPR_DISTIL);
-    m.put("msmarco-v1-passage-dev-bge-base-en-v1.5", MSMARCO_PASSAGE_DEV_SUBSET_BGE_BASE_EN_15);
     m.put("msmarco-v1-passage-dev-cohere-embed-english-v3.0", MSMARCO_PASSAGE_DEV_SUBSET_COHERE_EMBED_ENGLISH_30);
 
     m.put("msmarco-v1-passage-dev.splade-pp-ed", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_ED);
     m.put("msmarco-v1-passage-dev.splade-pp-sd", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_SD);
-    m.put("msmarco-v1-passage-dev.splade-v3", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_V3);
-    m.put("msmarco-v1-passage-dev.cosdpr-distil", MSMARCO_PASSAGE_DEV_SUBSET_COSDPR_DISTIL);
-    m.put("msmarco-v1-passage-dev.bge-base-en-v1.5", MSMARCO_PASSAGE_DEV_SUBSET_BGE_BASE_EN_15);
     m.put("msmarco-v1-passage-dev.cohere-embed-english-v3.0", MSMARCO_PASSAGE_DEV_SUBSET_COHERE_EMBED_ENGLISH_30);
 
     m.put("msmarco-v1-passage.dev", MSMARCO_PASSAGE_DEV_SUBSET);
     m.put("msmarco-v1-passage.dev.splade-pp-ed", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_ED);
     m.put("msmarco-v1-passage.dev.splade-pp-sd", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_SD);
-    m.put("msmarco-v1-passage.dev.splade-v3", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_V3);
-    m.put("msmarco-v1-passage.dev.cosdpr-distil", MSMARCO_PASSAGE_DEV_SUBSET_COSDPR_DISTIL);
-    m.put("msmarco-v1-passage.dev.bge-base-en-v1.5", MSMARCO_PASSAGE_DEV_SUBSET_BGE_BASE_EN_15);
     m.put("msmarco-v1-passage.dev.cohere-embed-english-v3.0", MSMARCO_PASSAGE_DEV_SUBSET_COHERE_EMBED_ENGLISH_30);
 
     m.put("dl20-passage", TREC2020_DL);
@@ -610,18 +553,12 @@ public enum Topics {
 
     m.put("dl20-passage.splade-pp-ed", TREC2020_DL_SPLADE_PP_ED);
     m.put("dl20-passage.splade-pp-sd", TREC2020_DL_SPLADE_PP_SD);
-    m.put("dl20-passage.splade-v3", TREC2020_DL_SPLADE_V3);
-    m.put("dl20-passage.cosdpr-distil", TREC2020_DL_COSDPR_DISTIL);
-    m.put("dl20-passage.bge-base-en-v1.5", TREC2020_DL_BGE_BASE_EN_15);
     m.put("dl20-passage.cohere-embed-english-v3.0", TREC2020_DL_COHERE_EMBED_ENGLISH_30);
     m.put("dl20-passage.unicoil.0shot", TREC2020_DL_UNICOIL);
     m.put("dl20-passage.unicoil-noexp.0shot", TREC2020_DL_UNICOIL_NOEXP);
 
     m.put("dl20-doc.splade-pp-ed", TREC2020_DL_SPLADE_PP_ED);
     m.put("dl20-doc.splade-pp-sd", TREC2020_DL_SPLADE_PP_SD);
-    m.put("dl20-doc.splade-v3", TREC2020_DL_SPLADE_V3);
-    m.put("dl20-doc.cosdpr-distil", TREC2020_DL_COSDPR_DISTIL);
-    m.put("dl20-doc.bge-base-en-v1.5", TREC2020_DL_BGE_BASE_EN_15);
     m.put("dl20-doc.cohere-embed-english-v3.0", TREC2020_DL_COHERE_EMBED_ENGLISH_30);
     m.put("dl20-doc.unicoil.0shot", TREC2020_DL_UNICOIL);
     m.put("dl20-doc.unicoil-noexp.0shot", TREC2020_DL_UNICOIL_NOEXP);

--- a/src/test/java/io/anserini/search/SearchFlatDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchFlatDenseVectorsTest.java
@@ -399,19 +399,6 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
     String runfile = "target/run-" + System.currentTimeMillis();
     String[] searchArgs = new String[] {
         "-index", indexPath,
-        "-topics", "TREC2019_DL_PASSAGE_COSDPR_DISTIL",
-        "-output", runfile,
-        "-hits", "5"};
-    SearchFlatDenseVectors.main(searchArgs);
-
-    // Not checking content, just checking if the topics were loaded successfully.
-    File f = new File(runfile);
-    assertTrue(f.exists());
-    f.delete();
-
-    runfile = "target/run-" + System.currentTimeMillis();
-    searchArgs = new String[] {
-        "-index", indexPath,
         "-topics", "TREC2019_DL_PASSAGE",
         "-encoder", "CosDprDistil",
         "-output", runfile,
@@ -419,7 +406,7 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
     SearchFlatDenseVectors.main(searchArgs);
 
     // Not checking content, just checking if the topics were loaded successfully.
-    f = new File(runfile);
+    File f = new File(runfile);
     assertTrue(f.exists());
     f.delete();
   }

--- a/src/test/java/io/anserini/search/SearchHnswDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchHnswDenseVectorsTest.java
@@ -418,20 +418,6 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
     String runfile = "target/run-" + System.currentTimeMillis();
     String[] searchArgs = new String[] {
         "-index", indexPath,
-        "-topics", "TREC2019_DL_PASSAGE_COSDPR_DISTIL",
-        "-output", runfile,
-        "-efSearch", "1000",
-        "-hits", "5"};
-    SearchHnswDenseVectors.main(searchArgs);
-
-    // Not checking content, just checking if the topics were loaded successfully.
-    File f = new File(runfile);
-    assertTrue(f.exists());
-    f.delete();
-
-    runfile = "target/run-" + System.currentTimeMillis();
-    searchArgs = new String[] {
-        "-index", indexPath,
         "-topics", "TREC2019_DL_PASSAGE",
         "-encoder", "CosDprDistil",
         "-output", runfile,
@@ -440,7 +426,7 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
     SearchHnswDenseVectors.main(searchArgs);
 
     // Not checking content, just checking if the topics were loaded successfully.
-    f = new File(runfile);
+    File f = new File(runfile);
     assertTrue(f.exists());
     f.delete();
   }

--- a/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
@@ -39,7 +39,7 @@ public class TopicReaderTest {
       String path = topic.path;
       assertEquals(topic.readerClass, TopicReader.getTopicReaderClassByFile(path));
     }
-    assertEquals(468, cnt);
+    assertEquals(433, cnt);
   }
 
   @Test
@@ -724,14 +724,6 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(17675, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_PASSAGE_SPLADE_V3);
-    assertNotNull(topics);
-    assertEquals(43, topics.size());
-    assertEquals(19335, (int) topics.firstKey());
-    assertEquals(1080, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1133167, (int) topics.lastKey());
-    assertEquals(749, topics.get(topics.lastKey()).get("title").split(" ").length);
-
     topics = TopicReader.getTopics(Topics.TREC2019_DL_DOC);
     assertNotNull(topics);
     assertEquals(43, topics.size());
@@ -789,22 +781,6 @@ public class TopicReaderTest {
     assertEquals(28936, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(17675, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_PASSAGE_COSDPR_DISTIL);
-    assertNotNull(topics);
-    assertEquals(43, topics.size());
-    assertEquals(19335, (int) topics.firstKey());
-    assertEquals("[0.013790097087621689", topics.get(topics.firstKey()).get("vector").split(",")[0]);
-    assertEquals(1133167, (int) topics.lastKey());
-    assertEquals("[-0.024115752428770065", topics.get(topics.lastKey()).get("vector").split(",")[0]);
-
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_PASSAGE_BGE_BASE_EN_15);
-    assertNotNull(topics);
-    assertEquals(43, topics.size());
-    assertEquals(19335, (int) topics.firstKey());
-    assertEquals("[0.021483641117811203", topics.get(topics.firstKey()).get("vector").split(",")[0]);
-    assertEquals(1133167, (int) topics.lastKey());
-    assertEquals("[0.031006483361124992", topics.get(topics.lastKey()).get("vector").split(",")[0]);
 
     topics = TopicReader.getTopics(Topics.TREC2019_DL_PASSAGE_COHERE_EMBED_ENGLISH_30);
     assertNotNull(topics);
@@ -876,30 +852,6 @@ public class TopicReaderTest {
     assertEquals(35114, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1136962, (int) topics.lastKey());
     assertEquals(30994, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.getTopics(Topics.TREC2020_DL_SPLADE_V3);
-    assertNotNull(topics);
-    assertEquals(200, topics.size());
-    assertEquals(3505, (int) topics.firstKey());
-    assertEquals(1240, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1136962, (int) topics.lastKey());
-    assertEquals(920, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.getTopics(Topics.TREC2020_DL_COSDPR_DISTIL);
-    assertNotNull(topics);
-    assertEquals(200, topics.size());
-    assertEquals(3505, (int) topics.firstKey());
-    assertEquals("[0.0012954670237377286", topics.get(topics.firstKey()).get("vector").split(",")[0]);
-    assertEquals(1136962, (int) topics.lastKey());
-    assertEquals("[0.06602190434932709", topics.get(topics.lastKey()).get("vector").split(",")[0]);
-
-    topics = TopicReader.getTopics(Topics.TREC2020_DL_BGE_BASE_EN_15);
-    assertNotNull(topics);
-    assertEquals(54, topics.size());
-    assertEquals(23849, (int) topics.firstKey());
-    assertEquals("[-0.002988815074786544", topics.get(topics.firstKey()).get("vector").split(",")[0]);
-    assertEquals(1136962, (int) topics.lastKey());
-    assertEquals("[0.008107579313218594", topics.get(topics.lastKey()).get("vector").split(",")[0]);
 
     topics = TopicReader.getTopics(Topics.TREC2020_DL_COHERE_EMBED_ENGLISH_30);
     assertNotNull(topics);
@@ -1150,12 +1102,6 @@ public class TopicReaderTest {
     assertEquals("988", topics.lastKey());
     assertEquals("I'm looking into the complex issue of immigration, particularly the challenges surrounding illegal immigration and the struggles immigrants encounter in the US. I'm also interested in how sanctuary cities add further complications to the overall immigration landscape.", topics.get(topics.lastKey()).get("title"));
     assertEquals("I want to deeply understand the Holocaust: what it was, why and how it transpired, who was responsible, and its profound historical and societal impact, particularly on European Jewry. I'm also curious about its conclusion, lasting effects, and how it aligns with other destructive historical events like Sodom and Gomorrah.", topics.get("200").get("title"));
-
-    topics = TopicReader.getTopics(Topics.TREC2025_RAG_TEST_SPLADE_V3);
-    assertNotNull(topics);
-    assertEquals(105, topics.size());
-    assertEquals("100", topics.firstKey());
-    assertEquals("988", topics.lastKey());
   }
 
   @Test
@@ -1274,29 +1220,6 @@ public class TopicReaderTest {
     assertEquals(25539, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(30718, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.getTopics(Topics.MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_V3);
-    assertNotNull(topics);
-    assertEquals(6980, topics.size());
-    assertEquals(978, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102400, (int) topics.lastKey());
-    assertEquals(966, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.getTopics(Topics.MSMARCO_PASSAGE_DEV_SUBSET_COSDPR_DISTIL);
-    assertNotNull(topics);
-    assertEquals(6980, topics.size());
-    assertEquals(2, (int) topics.firstKey());
-    assertEquals("[-0.007401271723210812", topics.get(topics.firstKey()).get("vector").split(",")[0]);
-    assertEquals(1102400, (int) topics.lastKey());
-    assertEquals("[0.05193052813410759", topics.get(topics.lastKey()).get("vector").split(",")[0]);
-
-    topics = TopicReader.getTopics(Topics.MSMARCO_PASSAGE_DEV_SUBSET_BGE_BASE_EN_15);
-    assertNotNull(topics);
-    assertEquals(6980, topics.size());
-    assertEquals(2, (int) topics.firstKey());
-    assertEquals("[-0.009533700533211231", topics.get(topics.firstKey()).get("vector").split(",")[0]);
-    assertEquals(1102400, (int) topics.lastKey());
-    assertEquals("[0.0019505455857142806", topics.get(topics.lastKey()).get("vector").split(",")[0]);
 
     topics = TopicReader.getTopics(Topics.MSMARCO_PASSAGE_DEV_SUBSET_COHERE_EMBED_ENGLISH_30);
     assertNotNull(topics);
@@ -2039,38 +1962,6 @@ public class TopicReaderTest {
     assertEquals(111, TopicReader.getTopics(Topics.BRIGHT_AOPS_ORIGINAL).keySet().size());
     assertEquals(76, TopicReader.getTopics(Topics.BRIGHT_THEOREMQA_THEOREMS_ORIGINAL).keySet().size());
     assertEquals(194, TopicReader.getTopics(Topics.BRIGHT_THEOREMQA_QUESTIONS_ORIGINAL).keySet().size());
-  }
-
-  @Test
-  public void testBrightSpladeV3Topics() throws IOException {
-    assertEquals(103, TopicReader.getTopics(Topics.BRIGHT_BIOLOGY_SPLADE_V3).keySet().size());
-    assertEquals(116, TopicReader.getTopics(Topics.BRIGHT_EARTH_SCIENCE_SPLADE_V3).keySet().size());
-    assertEquals(103, TopicReader.getTopics(Topics.BRIGHT_ECONOMICS_SPLADE_V3).keySet().size());
-    assertEquals(101, TopicReader.getTopics(Topics.BRIGHT_PSYCHOLOGY_SPLADE_V3).keySet().size());
-    assertEquals(101, TopicReader.getTopics(Topics.BRIGHT_ROBOTICS_SPLADE_V3).keySet().size());
-    assertEquals(117, TopicReader.getTopics(Topics.BRIGHT_STACKOVERFLOW_SPLADE_V3).keySet().size());
-    assertEquals(108, TopicReader.getTopics(Topics.BRIGHT_SUSTAINABLE_LIVING_SPLADE_V3).keySet().size());
-    assertEquals(112, TopicReader.getTopics(Topics.BRIGHT_PONY_SPLADE_V3).keySet().size());
-    assertEquals(142, TopicReader.getTopics(Topics.BRIGHT_LEETCODE_SPLADE_V3).keySet().size());
-    assertEquals(111, TopicReader.getTopics(Topics.BRIGHT_AOPS_SPLADE_V3).keySet().size());
-    assertEquals(76, TopicReader.getTopics(Topics.BRIGHT_THEOREMQA_THEOREMS_SPLADE_V3).keySet().size());
-    assertEquals(194, TopicReader.getTopics(Topics.BRIGHT_THEOREMQA_QUESTIONS_SPLADE_V3).keySet().size());
-  }
-
-  @Test
-  public void testBrightBgeLargeEn15Topics() throws IOException {
-    assertEquals(103, TopicReader.getTopics(Topics.BRIGHT_BIOLOGY_BGE_LARGE_EN_15).keySet().size());
-    assertEquals(116, TopicReader.getTopics(Topics.BRIGHT_EARTH_SCIENCE_BGE_LARGE_EN_15).keySet().size());
-    assertEquals(103, TopicReader.getTopics(Topics.BRIGHT_ECONOMICS_BGE_LARGE_EN_15).keySet().size());
-    assertEquals(101, TopicReader.getTopics(Topics.BRIGHT_PSYCHOLOGY_BGE_LARGE_EN_15).keySet().size());
-    assertEquals(101, TopicReader.getTopics(Topics.BRIGHT_ROBOTICS_BGE_LARGE_EN_15).keySet().size());
-    assertEquals(117, TopicReader.getTopics(Topics.BRIGHT_STACKOVERFLOW_BGE_LARGE_EN_15).keySet().size());
-    assertEquals(108, TopicReader.getTopics(Topics.BRIGHT_SUSTAINABLE_LIVING_BGE_LARGE_EN_15).keySet().size());
-    assertEquals(112, TopicReader.getTopics(Topics.BRIGHT_PONY_BGE_LARGE_EN_15).keySet().size());
-    assertEquals(142, TopicReader.getTopics(Topics.BRIGHT_LEETCODE_BGE_LARGE_EN_15).keySet().size());
-    assertEquals(111, TopicReader.getTopics(Topics.BRIGHT_AOPS_BGE_LARGE_EN_15).keySet().size());
-    assertEquals(76, TopicReader.getTopics(Topics.BRIGHT_THEOREMQA_THEOREMS_BGE_LARGE_EN_15).keySet().size());
-    assertEquals(194, TopicReader.getTopics(Topics.BRIGHT_THEOREMQA_QUESTIONS_BGE_LARGE_EN_15).keySet().size());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Remove stale pre-encoded topic constants and aliases for SPLADE v3, CosDPR Distil, and BGE topic resources.
- Drop tests that load the removed topic resources and update the topic count assertion.

## Validation

- `mvn -Dtest=TopicReaderTest,SearchFlatDenseVectorsTest,SearchHnswDenseVectorsTest test`