### PR TITLE
Add MS MARCO onboarding reproduction log entries

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -673,3 +673,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-11 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))
 + Results reproduced by [@nayanananto](https://github.com/nayanananto) on 2026-06-12 (commit [`6caf7e8`](https://github.com/castorini/anserini/commit/6caf7e863b6d5758e96d326ca69c45e16ec2decb))
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-18 (commit [`420530f`](https://github.com/castorini/anserini/commit/420530fd8e2163e86e12c909930995d8b1259329))
++ Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`70faa6e`](https://github.com/castorini/anserini/commit/70faa6e69d7faaf307b99a235b1f44f8614b88d5))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -221,3 +221,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-11 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))
 + Results reproduced by [@nayanananto](https://github.com/nayanananto) on 2026-06-12 (commit [`6caf7e8`](https://github.com/castorini/anserini/commit/6caf7e863b6d5758e96d326ca69c45e16ec2decb))
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-19 (commit [`420530f`](https://github.com/castorini/anserini/commit/420530fd8e2163e86e12c909930995d8b1259329))
++ Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`70faa6e`](https://github.com/castorini/anserini/commit/70faa6e69d7faaf307b99a235b1f44f8614b88d5))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -580,3 +580,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@nayanananto](https://github.com/nayanananto) on 2026-06-07 (commit [`cc9d3cd`](https://github.com/castorini/anserini/commit/cc9d3cd76ef0bf1cffbd15547546bd85398b2437))
 + Results reproduced by [@kenoi1](https://github.com/kenoi1) on 2026-06-11 (commit [`6663a15`](https://github.com/castorini/anserini/commit/6663a15bffe0242e927c53744e5b140ce1a0bcba))
 + Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-06-18 (commit [`420530f`](https://github.com/castorini/anserini/commit/420530fd8e2163e86e12c909930995d8b1259329))
++ Results reproduced by [@MasrurAjhor](https://github.com/MasrurAjhor) on 2026-06-21 (commit [`70faa6e`](https://github.com/castorini/anserini/commit/70faa6e69d7faaf307b99a235b1f44f8614b88d5))


### PR DESCRIPTION
## Summary

This PR adds my reproduction log entries for:

- `docs/start-here.md`
- `docs/experiments-msmarco-passage.md`
- `docs/experiments-msmarco-passage2.md`

These were reproduced against the Anserini main-trunk commit `70faa6e69d7faaf307b99a235b1f44f8614b88d5`.

## Environment

- macOS
- Java 21 via Homebrew
- Maven 3.9.16
- Anserini built locally with `mvn -U -q -DskipTests package`
- Dense HNSW index and encoder cache stored on an external SSD via `-Dpyserini.cache`

## Reproduction Notes

For `docs/start-here.md`, I completed the MS MARCO passage data walkthrough:

- Downloaded `collectionandqueries.tar.gz`
- Verified MD5: `31644046b18952c1386cd4564ba2ae69`
- Converted the collection to JSONL
- Verified `8,841,823` passages across 9 JSONL files
- Filtered dev queries and verified `6,980` queries
- Traced query `1048585` to relevant passage `7187158`

For `docs/experiments-msmarco-passage.md`, I built the Lucene index and reproduced the BM25 run:

- Indexed `8,841,823` documents
- Official 1000-hit run output: `6,974,598` lines
- Evaluation:

```text
MRR @10: 0.18741227770955546
QueriesRanked: 6980
```

For `docs/experiments-msmarco-passage2.md`, I reproduced the dense BGE HNSW retrieval run:

- Verified the BGE HNSW archive size: `25,993,352,262` bytes
- Verified archive MD5: `00a577f689d90f95e6c5611438b0af3d`
- Used `SearchHnswDenseVectors` with `BgeBaseEn15`, `4` threads, and controlled heap on an 8 GB Mac
- Anserini confirmed the extracted prebuilt index existed and skipped downloading
- Retrieval output: `698,000` lines
- Evaluation:

```text
recip_rank            	all	0.3521
```

## Issues Encountered

On my local setup, the MS MARCO v1 output-ordering branch produced a zero-line BM25 run file unless I set:

```bash
-Dpyserini.cache=tools
```

This allowed the special writer branch to read the repository's `tools/topics-and-qrels` topic file. After setting this property, the expected MRR reproduced exactly.

For the dense HNSW run, I manually verified and extracted the prebuilt index into Anserini's expected MD5-suffixed cache directory before running retrieval. This avoided redownloading the 24 GB archive and ensured the prebuilt-index handler reused the local SSD cache.

## Checks

- Verified Anserini build succeeded.
- Verified the MS MARCO BM25 evaluation matched the expected `MRR @10`.
- Verified the MS MARCO dense BGE evaluation matched the expected `recip_rank all 0.3521`.