### PR TITLE
[codex] Fix flaky CACM reproduction test assertion

### DIFF
--- a/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
@@ -175,12 +175,13 @@ public class ReproduceFromPrebuiltIndexesTest extends StdOutStdErrRedirectableLu
     String output = out.toString();
     assertTrue(output, output.contains("Run successfully completed!"));
     assertTrue(output, output.contains("Indexes referenced by this run (1 total):"));
-    assertTrue(output, output.contains("Total size across 1 of 1 indexes:"));
+    assertTrue(output, output.matches("(?s).*Total size across [01] of 1 indexes:.*"));
     assertTrue(output, output.contains("MAP: 0.3123"));
     assertTrue(output, output.contains("P30: 0.1942"));
     assertTrue(output, output.matches("(?s).*Duration:\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}.*"));
     assertFalse(output.contains("NumberFormatException"));
     assertTrue(Files.exists(runsDirectory.resolve("run.cacm.bm25.cacm.txt")));
+    assertTrue(Files.size(runsDirectory.resolve("run.cacm.bm25.cacm.txt")) > 0);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Fix a flaky assertion in `ReproduceFromPrebuiltIndexesTest.testCacmEndToEnd`.
- Allow the pre-run index-size summary to report either `0 of 1` or `1 of 1` CACM indexes.
- Assert that the generated CACM run file exists and is non-empty.

## Root Cause

`ReproduceFromPrebuiltIndexes` prints the index-size table before retrieval runs. If CACM is already cached, the table says `Total size across 1 of 1 indexes`; if the cache is cold, it says `0 of 1 indexes`.

That cache state is not the actual end-to-end success condition. The child `SearchCollection` command can lazily fetch/open the CACM prebuilt index after the summary is printed, then produce the expected run and metrics. The old assertion therefore depended on whether the local cache had been warmed by a prior run.

## Validation

- `mvn -Dtest=ReproduceFromPrebuiltIndexesTest#testCacmEndToEnd -Dpyserini.cache=tmp/pyserini-cache-flake-check test`
- `mvn -Dtest=ReproduceFromPrebuiltIndexesTest test`

Both passed.