### PR TITLE
Add reproduction log entries (Foundations of Retrieval, steps 1-3)

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -679,3 +679,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@sparshshah19](https://github.com/sparshshah19) on 2026-06-25 (commit [`2f3ac67`](https://github.com/castorini/anserini/commit/2f3ac67c9e94f0b184f4fa82927dc1b29c41713b))
 + Results reproduced by [@Fustigate8933](https://github.com/Fustigate8933) on 2026-07-01 (commit [`77ec7ef`](https://github.com/castorini/anserini/commit/77ec7ef73ae3cec88c41ee0992133f5c751224f8))
 + Results reproduced by [@muhammad-ali-arshad](https://github.com/muhammad-ali-arshad) on 2026-07-02 (commit [`77ec7ef`](https://github.com/castorini/anserini/commit/77ec7ef73ae3cec88c41ee0992133f5c751224f8))
++ Results reproduced by [@yashs33244](https://github.com/yashs33244) on 2026-07-05 (commit [`77ec7ef`](https://github.com/castorini/anserini/commit/77ec7ef73ae3cec88c41ee0992133f5c751224f8))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -227,3 +227,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@sparshshah19](https://github.com/sparshshah19) on 2026-06-25 (commit [`e67bf09`](https://github.com/castorini/anserini/commit/e67bf09934dd4d348b2578d1517475dc5defb18b))
 + Results reproduced by [@Fustigate8933](https://github.com/Fustigate8933) on 2026-07-01 (commit [`77ec7ef`](https://github.com/castorini/anserini/commit/77ec7ef73ae3cec88c41ee0992133f5c751224f8))
 + Results reproduced by [@muhammad-ali-arshad](https://github.com/muhammad-ali-arshad) on 2026-07-02 (commit [`77ec7ef`](https://github.com/castorini/anserini/commit/77ec7ef73ae3cec88c41ee0992133f5c751224f8))
++ Results reproduced by [@yashs33244](https://github.com/yashs33244) on 2026-07-05 (commit [`77ec7ef`](https://github.com/castorini/anserini/commit/77ec7ef73ae3cec88c41ee0992133f5c751224f8))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -586,3 +586,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@sparshshah19](https://github.com/sparshshah19) on 2026-06-25 (commit [`77ec7ef`](https://github.com/castorini/anserini/commit/77ec7ef73ae3cec88c41ee0992133f5c751224f8))
 + Results reproduced by [@Fustigate8933](https://github.com/Fustigate8933) on 2026-07-01 (commit [`77ec7ef`](https://github.com/castorini/anserini/commit/77ec7ef73ae3cec88c41ee0992133f5c751224f8))
 + Results reproduced by [@muhammad-ali-arshad](https://github.com/muhammad-ali-arshad) on 2026-07-02 (commit [`77ec7ef`](https://github.com/castorini/anserini/commit/77ec7ef73ae3cec88c41ee0992133f5c751224f8))
++ Results reproduced by [@yashs33244](https://github.com/yashs33244) on 2026-07-05 (commit [`77ec7ef`](https://github.com/castorini/anserini/commit/77ec7ef73ae3cec88c41ee0992133f5c751224f8))


### PR DESCRIPTION
Reproduced the Anserini portion of the Foundations of Retrieval onboarding path (start-here, BM25 MS MARCO passage, dense MS MARCO passage) and added reproduction-log entries to the three docs.

**Environment**
- macOS (Apple Silicon), 16 GB RAM
- OpenJDK 21.0.2, Maven 3.9.16, built with `mvn clean package -Dmaven.test.skip=true`

**Results (all matched the docs exactly)**
- BM25 MS MARCO passage dev: MRR@10 0.18741227770955546, MAP 0.1957, recall@1000 0.8573
- Prebuilt-index BM25: MRR@10 0.1875
- Dense (BGE-base HNSW): MRR@10 0.3521

**One small note for other 16 GB users:** `bin/run.sh` sets `-Xmx192G`, which on a 16 GB machine let the indexing heap grow until the OS killed the JVM (signal 9) partway through. Lowering the heap (invoking `java` directly with `-Xms512M -Xmx8G` and `-threads 4`) fixed it. Might be worth a line in the docs for low-RAM machines, though the existing out-of-memory note already points in the right direction.

Thanks for the clear onboarding path.
