### PR TITLE
Fix sharded indexing dropping segments with negative hashCode

### DIFF
--- a/src/main/java/io/anserini/collection/C4Collection.java
+++ b/src/main/java/io/anserini/collection/C4Collection.java
@@ -82,7 +82,7 @@ public class C4Collection extends DocumentCollection<C4Collection.Document> {
   @Override
   public List<Path> getSegmentPaths(int shardCount, int currShard) {
     List<Path> segments = super.getSegmentPaths();
-    return segments.stream().filter(x -> getFileNumber(x.toString()) % shardCount == currShard).collect(Collectors.toList());
+    return segments.stream().filter(x -> Math.floorMod(getFileNumber(x.toString()), shardCount) == currShard).collect(Collectors.toList());
   }
 
   public static class Segment extends FileSegment<C4Collection.Document> {

--- a/src/main/java/io/anserini/collection/DocumentCollection.java
+++ b/src/main/java/io/anserini/collection/DocumentCollection.java
@@ -172,7 +172,7 @@ public abstract class DocumentCollection<T extends SourceDocument> implements It
    */
   public List<Path> getSegmentPaths(int shardCount, int currShard) {
     List<Path> segments = discover(this.path);
-    return segments.stream().filter(x -> x.toString().hashCode() % shardCount == currShard).collect(Collectors.toList());
+    return segments.stream().filter(x -> Math.floorMod(x.toString().hashCode(), shardCount) == currShard).collect(Collectors.toList());
   }
 
   // Private method for walking a path.

--- a/src/test/java/io/anserini/collection/DocumentCollectionTest.java
+++ b/src/test/java/io/anserini/collection/DocumentCollectionTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -147,6 +148,28 @@ public abstract class DocumentCollectionTest<T extends SourceDocument> extends S
 
     assertEquals(totalSegments, segmentCnt.get());
     assertEquals(totalDocs, docCnt.get());
+  }
+
+  @Test
+  // Sharded getSegmentPaths must partition the collection: every segment lands in exactly one shard.
+  public void testShardedPartition() {
+    if (collection == null)
+      return;
+
+    Set<Path> all = new HashSet<>(collection.getSegmentPaths());
+    int shardCount = 3;
+    Set<Path> union = new HashSet<>();
+    int assigned = 0;
+    for (int i = 0; i < shardCount; i++) {
+      List<Path> shard = collection.getSegmentPaths(shardCount, i);
+      assigned += shard.size();
+      union.addAll(shard);
+    }
+
+    // Completeness: every segment is assigned to some shard (nothing silently dropped).
+    assertEquals(all, union);
+    // Disjointness: no segment is assigned to more than one shard.
+    assertEquals(all.size(), assigned);
   }
 
   abstract void checkDocument(SourceDocument doc, Map<String, String> expected);


### PR DESCRIPTION
`getSegmentPaths(shardCount, currShard)` filtered with `x.toString().hashCode() % shardCount == currShard`. Java `%` keeps the dividend's sign and `String.hashCode()` is negative for roughly half of inputs, so the result can be negative and match no `currShard` in `[0, shardCount-1]`. Those segments are then indexed by no shard and silently dropped (a quick check drops ~half of segments on a random set).

Switched to `Math.floorMod(...)` in `DocumentCollection` and in the `C4Collection` override (whose `NumberFormatException` fallback also returns a raw `hashCode()`). Added a `testShardedPartition` regression test asserting the shards partition the collection: every segment lands in exactly one shard (complete and disjoint). It runs for all collection subclasses.
