### PR TITLE
Fix TweetGenerator swapping friends_count and followers_count

### DIFF
--- a/src/main/java/io/anserini/index/generator/TweetGenerator.java
+++ b/src/main/java/io/anserini/index/generator/TweetGenerator.java
@@ -157,8 +157,8 @@ public class TweetGenerator implements LuceneDocumentGenerator<TweetCollection.D
 
     tweetDoc.getEpoch().ifPresent(epoch -> doc.add(new LongPoint(TweetField.EPOCH.name, epoch)));
     doc.add(new StringField(TweetField.SCREEN_NAME.name, tweetDoc.getScreenName(), Field.Store.NO));
-    doc.add(new IntPoint(TweetField.FRIENDS_COUNT.name, tweetDoc.getFollowersCount()));
-    doc.add(new IntPoint(TweetField.FOLLOWERS_COUNT.name, tweetDoc.getFriendsCount()));
+    doc.add(new IntPoint(TweetField.FRIENDS_COUNT.name, tweetDoc.getFriendsCount()));
+    doc.add(new IntPoint(TweetField.FOLLOWERS_COUNT.name, tweetDoc.getFollowersCount()));
     doc.add(new IntPoint(TweetField.STATUSES_COUNT.name, tweetDoc.getStatusesCount()));
 
     tweetDoc.getInReplyToStatusId().ifPresent(rid -> {


### PR DESCRIPTION
`TweetGenerator` indexed the `friends_count` field with `getFollowersCount()` and the `followers_count` field with `getFriendsCount()`, so the two values were swapped. The field names and the `TweetCollection` getters are otherwise correct (JSON `followers_count` -> `getFollowersCount()`, `friends_count` -> `getFriendsCount()`).

Swapped the two calls so each field is indexed with its own value.
