### PR TITLE
Add reproduction log entry for prebuilt and dense retrieval guide

### DIFF
--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -227,3 +227,4 @@ If you think this guide can be improved in any way (e.g., you caught a typo or t
 + Results reproduced by [@sparshshah19](https://github.com/sparshshah19) on 2026-06-25 (commit [`e67bf09`](https://github.com/castorini/anserini/commit/e67bf09934dd4d348b2578d1517475dc5defb18b))
 + Results reproduced by [@Fustigate8933](https://github.com/Fustigate8933) on 2026-07-01 (commit [`77ec7ef`](https://github.com/castorini/anserini/commit/77ec7ef73ae3cec88c41ee0992133f5c751224f8))
 + Results reproduced by [@muhammad-ali-arshad](https://github.com/muhammad-ali-arshad) on 2026-07-02 (commit [`77ec7ef`](https://github.com/castorini/anserini/commit/77ec7ef73ae3cec88c41ee0992133f5c751224f8))
++ Results reproduced by [@abubinfahd](https://github.com/abubinfahd) on 2026-07-10 (commit [`b98b8fb7`](https://github.com/castorini/anserini/commit/b98b8fb7c874cfda814daddbaa429dc2b8d6f982))


### PR DESCRIPTION
## Environment

- OS: Ubuntu 24.04 LTS
- Java: OpenJDK 21
- Maven: 3.8.7

## Results

Successfully reproduced the guide.

- Repeated BM25 retrieval using the prebuilt Lucene index.
- Successfully ran dense retrieval using the prebuilt HNSW index.
- Verified the reported evaluation metrics.

## Notes

Initially encountered a corrupted cached HNSW archive (`Unexpected EOF in archive`). Removing the cached archive and downloading it again resolved the issue.