### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -680,3 +680,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@Fustigate8933](https://github.com/Fustigate8933) on 2026-07-01 (commit [`77ec7ef`](https://github.com/castorini/anserini/commit/77ec7ef73ae3cec88c41ee0992133f5c751224f8))
 + Results reproduced by [@muhammad-ali-arshad](https://github.com/muhammad-ali-arshad) on 2026-07-02 (commit [`77ec7ef`](https://github.com/castorini/anserini/commit/77ec7ef73ae3cec88c41ee0992133f5c751224f8))
 + Results reproduced by [@yashs33244](https://github.com/yashs33244) on 2026-07-05 (commit [`77ec7ef`](https://github.com/castorini/anserini/commit/77ec7ef73ae3cec88c41ee0992133f5c751224f8))
++ Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-13 (commit [`bd93b89`](https://github.com/castorini/anserini/commit/bd93b899a1f34362b4146153c94a8eab14d9a7da))


### PR DESCRIPTION
Adding my reproduction log entry for `docs/experiments-msmarco-passage.md`.

**Setup:**
- macOS on Apple Silicon (arm64), 16 GB RAM
- Eclipse Temurin OpenJDK 21.0.11, Apache Maven 3.9.16
- Built from commit `bd93b89` with `mvn clean package -DskipTests`

**Results:** everything worked, all numbers match the guide:
- MRR@10 = 0.1874 (official MS MARCO eval script)
- MAP = 0.1957, Recall@1000 = 0.8573 (trec_eval)

**Note:** on a 16 GB machine, indexing with the default `bin/run.sh` heap setting (`-Xmx192G`) got the JVM killed by macOS partway through (`Killed: 9`). Lowering the heap cap to `-Xmx8G` resolved it, consistent with the guide's tip about tweaking `-Xms`/`-Xmx` in `run.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)