### PR TITLE
[codex] Pin remote metadata URLs

### DIFF
--- a/src/main/java/io/anserini/eval/Qrels.java
+++ b/src/main/java/io/anserini/eval/Qrels.java
@@ -37,7 +37,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.anserini.util.CacheDirectoryResolver;
 
 public class Qrels {
-  private static final String TOPICS_AND_QRELS_URL = "https://raw.githubusercontent.com/castorini/anserini-tools/master/topics-and-qrels/";
+  private static final String TOPICS_AND_QRELS_COMMIT = "12982126736f2ed7dc45bf30acb2af9fed13c0ef";
+  private static final String TOPICS_AND_QRELS_URL = "https://raw.githubusercontent.com/castorini/anserini-tools/" + TOPICS_AND_QRELS_COMMIT + "/topics-and-qrels/";
   private static final String DEFAULT_METADATA_URL = TOPICS_AND_QRELS_URL + "_metadata_qrels.json";
   private static final String DEFAULT_ALIASES_METADATA_URL = TOPICS_AND_QRELS_URL + "_metadata_qrels_aliases.json";
   private static final String SERVER_PATH = TOPICS_AND_QRELS_URL;

--- a/src/main/java/io/anserini/index/prebuilt/PrebuiltIndex.java
+++ b/src/main/java/io/anserini/index/prebuilt/PrebuiltIndex.java
@@ -37,7 +37,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 
 public class PrebuiltIndex {
-  protected static final String DEFAULT_METADATA_URL = "https://api.github.com/repos/castorini/prebuilt-indexes/contents/lucene?ref=main";
+  protected static final String METADATA_COMMIT = "eb2a94de2029b3e9234ffd7445ab74991b6b0137";
+  protected static final String DEFAULT_METADATA_URL = "https://api.github.com/repos/castorini/prebuilt-indexes/contents/lucene?ref=" + METADATA_COMMIT;
   protected static final String METADATA_SUFFIX = ".json";
   private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(60);
   private static final String USER_AGENT = "anserini-prebuilt-index-loader";


### PR DESCRIPTION
## Summary

- Pin prebuilt-index metadata lookup to a specific `castorini/prebuilt-indexes` commit.
- Pin qrels metadata lookup to a specific `castorini/anserini-tools` commit.

## Validation

- `mvn -Dtest=PrebuiltIndexTest test`
- `mvn -Dtest=QrelsTest clean test`
