### PR TITLE
[codex] Add local metadata for registered topics

### DIFF
--- a/src/main/java/io/anserini/cli/ExtractQueriesAndDocumentsFromTrecRun.java
+++ b/src/main/java/io/anserini/cli/ExtractQueriesAndDocumentsFromTrecRun.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -42,6 +43,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.anserini.index.IndexReaderUtils;
+import io.anserini.search.topicreader.TopicReader;
 import io.anserini.search.topicreader.Topics;
 import io.anserini.util.LoggingBootstrap;
 
@@ -177,12 +179,13 @@ public final class ExtractQueriesAndDocumentsFromTrecRun {
   }
 
   private static SortedMap<String, Map<String, String>> getTopics(String topics, String topicsReader) throws IOException {
-    SortedMap<?, Map<String, String>> resolvedTopics = Topics.resolve(topics, topicsReader);
+    Path topicsPath = Paths.get(topics);
+    SortedMap<?, Map<String, String>> resolvedTopics =
+        Files.exists(topicsPath) && Files.isRegularFile(topicsPath) && Files.isReadable(topicsPath) ?
+        TopicReader.load(topics, topicsReader) : Topics.load(topics);
     SortedMap<String, Map<String, String>> convertedTopics = new TreeMap<>();
-    for (Map.Entry<?, Map<String, String>> entry : resolvedTopics.entrySet()) {
-      convertedTopics.put(String.valueOf(entry.getKey()), entry.getValue());
-    }
-    LOG.info("Successfully loaded topics: " + topics);
+    resolvedTopics.forEach((key, value) -> convertedTopics.put(String.valueOf(key), value));
+    LOG.info("Successfully loaded topics: {}", topics);
 
     return convertedTopics;
   }

--- a/src/main/java/io/anserini/cli/TopicsRegistry.java
+++ b/src/main/java/io/anserini/cli/TopicsRegistry.java
@@ -130,7 +130,7 @@ public final class TopicsRegistry {
     }
 
     try {
-      return TopicReader.getTopics(topic);
+      return TopicReader.load(topic);
     } catch (Exception e) {
       System.err.printf("Error: unable to read topics \"%s\": %s%n", topicName, e.getMessage());
       return null;

--- a/src/main/java/io/anserini/cli/TopicsRegistry.java
+++ b/src/main/java/io/anserini/cli/TopicsRegistry.java
@@ -92,10 +92,7 @@ public final class TopicsRegistry {
   private static void run(Args args) {
     try {
       if (args.list) {
-        TreeSet<String> names = new TreeSet<>(Topics.getSymbolDictionaryKeys());
-        for (Topics topic : Topics.values()) {
-          names.add(topic.name());
-        }
+        TreeSet<String> names = new TreeSet<>(Topics.names());
 
         if (args.filter != null) {
           Pattern pattern;
@@ -113,7 +110,7 @@ public final class TopicsRegistry {
       } else {
         SortedMap<?, Map<String, String>> queries = getAllQueriesForTopic(args.get);
         if (queries == null) {
-          if (Topics.getByName(args.get) == null) {
+          if (Topics.get(args.get) == null) {
             System.err.printf("Error: unknown topics \"%s\"%n", args.get);
           }
           return;
@@ -127,7 +124,7 @@ public final class TopicsRegistry {
   }
 
   private static SortedMap<?, Map<String, String>> getAllQueriesForTopic(String topicName) {
-    Topics topic = Topics.getByName(topicName);
+    Topics topic = Topics.get(topicName);
     if (topic == null) {
       return null;
     }

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -957,8 +957,8 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
 
         if (isMSMARCOv1_passage || isMAMARCOv1_doc) {
           try (InputStream inputStream = isMSMARCOv1_passage ?
-                Files.newInputStream(TopicReader.getTopicPath(Path.of(Topics.MSMARCO_PASSAGE_DEV_SUBSET.path)), StandardOpenOption.READ):
-                Files.newInputStream(TopicReader.getTopicPath(Path.of(Topics.MSMARCO_DOC_DEV.path)), StandardOpenOption.READ) ) {
+                Files.newInputStream(TopicReader.getTopicPath(Path.of(Topics.get("msmarco-passage.dev-subset").path)), StandardOpenOption.READ):
+                Files.newInputStream(TopicReader.getTopicPath(Path.of(Topics.get("msmarco-doc.dev").path)), StandardOpenOption.READ) ) {
             BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
             String line;
             while ((line = reader.readLine()) != null) {

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -1044,7 +1045,15 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
       loadQrels(args.rf_qrels);
     }
 
-    topics = Topics.resolve(args.topics, args.topicReader);
+    topics = new TreeMap<>();
+    for (String topicsFile : args.topics) {
+      Path topicsPath = Paths.get(topicsFile);
+      if (Files.exists(topicsPath) && Files.isRegularFile(topicsPath) && Files.isReadable(topicsPath)) {
+        topics.putAll(TopicReader.load(topicsFile, args.topicReader));
+      } else {
+        topics.putAll(Topics.load(topicsFile));
+      }
+    }
   }
 
   @Override

--- a/src/main/java/io/anserini/search/SearchCollection.java
+++ b/src/main/java/io/anserini/search/SearchCollection.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -1045,15 +1044,7 @@ public final class SearchCollection<K extends Comparable<K>> implements Runnable
       loadQrels(args.rf_qrels);
     }
 
-    topics = new TreeMap<>();
-    for (String topicsFile : args.topics) {
-      Path topicsPath = Paths.get(topicsFile);
-      if (Files.exists(topicsPath) && Files.isRegularFile(topicsPath) && Files.isReadable(topicsPath)) {
-        topics.putAll(TopicReader.load(topicsFile, args.topicReader));
-      } else {
-        topics.putAll(Topics.load(topicsFile));
-      }
-    }
+    topics = TopicReader.load(args.topics, args.topicReader);
   }
 
   @Override

--- a/src/main/java/io/anserini/search/SearchFlatDenseVectors.java
+++ b/src/main/java/io/anserini/search/SearchFlatDenseVectors.java
@@ -18,15 +18,11 @@ package io.anserini.search;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
-import java.util.TreeMap;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -38,7 +34,6 @@ import org.kohsuke.args4j.spi.StringArrayOptionHandler;
 
 import io.anserini.eval.ExcludeDocs;
 import io.anserini.search.topicreader.TopicReader;
-import io.anserini.search.topicreader.Topics;
 import io.anserini.util.LoggingBootstrap;
 
 /**
@@ -91,15 +86,7 @@ public final class SearchFlatDenseVectors<K extends Comparable<K>> implements Ru
 
     // We might not be able to successfully read topics for a variety of reasons. Gather all possible
     // exceptions together as an unchecked exception to make initialization and error reporting clearer.
-    SortedMap<K, Map<String, String>> topics = new TreeMap<>();
-    for (String topicsFile : args.topics) {
-      Path topicsPath = Paths.get(topicsFile);
-      if (Files.exists(topicsPath) && Files.isRegularFile(topicsPath) && Files.isReadable(topicsPath)) {
-        topics.putAll(TopicReader.load(topicsFile, args.topicReader));
-      } else {
-        topics.putAll(Topics.load(topicsFile));
-      }
-    }
+    SortedMap<K, Map<String, String>> topics = TopicReader.load(args.topics, args.topicReader);
 
     // Now iterate through all the topics to pick out the right field with proper exception handling.
     try {

--- a/src/main/java/io/anserini/search/SearchFlatDenseVectors.java
+++ b/src/main/java/io/anserini/search/SearchFlatDenseVectors.java
@@ -95,7 +95,7 @@ public final class SearchFlatDenseVectors<K extends Comparable<K>> implements Ru
     for (String topicsFile : args.topics) {
       Path topicsFilePath = Paths.get(topicsFile);
       if (!Files.exists(topicsFilePath) || !Files.isRegularFile(topicsFilePath) || !Files.isReadable(topicsFilePath)) {
-        Topics ref = Topics.getByName(topicsFile);
+        Topics ref = Topics.get(topicsFile);
         if (ref==null) {
           throw new IllegalArgumentException(String.format("\"%s\" does not refer to valid topics.", topicsFilePath));
         } else {

--- a/src/main/java/io/anserini/search/SearchFlatDenseVectors.java
+++ b/src/main/java/io/anserini/search/SearchFlatDenseVectors.java
@@ -93,25 +93,11 @@ public final class SearchFlatDenseVectors<K extends Comparable<K>> implements Ru
     // exceptions together as an unchecked exception to make initialization and error reporting clearer.
     SortedMap<K, Map<String, String>> topics = new TreeMap<>();
     for (String topicsFile : args.topics) {
-      Path topicsFilePath = Paths.get(topicsFile);
-      if (!Files.exists(topicsFilePath) || !Files.isRegularFile(topicsFilePath) || !Files.isReadable(topicsFilePath)) {
-        Topics ref = Topics.get(topicsFile);
-        if (ref==null) {
-          throw new IllegalArgumentException(String.format("\"%s\" does not refer to valid topics.", topicsFilePath));
-        } else {
-          topics.putAll(TopicReader.load(ref));
-        }
+      Path topicsPath = Paths.get(topicsFile);
+      if (Files.exists(topicsPath) && Files.isRegularFile(topicsPath) && Files.isReadable(topicsPath)) {
+        topics.putAll(TopicReader.load(topicsFile, args.topicReader));
       } else {
-        try {
-          @SuppressWarnings("unchecked")
-          TopicReader<K> tr = (TopicReader<K>) Class
-              .forName(String.format("io.anserini.search.topicreader.%sTopicReader", args.topicReader))
-              .getConstructor(Path.class).newInstance(topicsFilePath);
-
-          topics.putAll(tr.read());
-        } catch (Exception e) {
-          throw new IllegalArgumentException(String.format("Unable to load topic reader \"%s\".", args.topicReader));
-        }
+        topics.putAll(Topics.load(topicsFile));
       }
     }
 

--- a/src/main/java/io/anserini/search/SearchFlatDenseVectors.java
+++ b/src/main/java/io/anserini/search/SearchFlatDenseVectors.java
@@ -99,7 +99,7 @@ public final class SearchFlatDenseVectors<K extends Comparable<K>> implements Ru
         if (ref==null) {
           throw new IllegalArgumentException(String.format("\"%s\" does not refer to valid topics.", topicsFilePath));
         } else {
-          topics.putAll(TopicReader.getTopics(ref));
+          topics.putAll(TopicReader.load(ref));
         }
       } else {
         try {

--- a/src/main/java/io/anserini/search/SearchHnswDenseVectors.java
+++ b/src/main/java/io/anserini/search/SearchHnswDenseVectors.java
@@ -97,7 +97,7 @@ public final class SearchHnswDenseVectors<K extends Comparable<K>> implements Ru
         if (ref==null) {
           throw new IllegalArgumentException(String.format("\"%s\" does not refer to valid topics.", topicsFilePath));
         } else {
-          topics.putAll(TopicReader.getTopics(ref));
+          topics.putAll(TopicReader.load(ref));
         }
       } else {
         try {

--- a/src/main/java/io/anserini/search/SearchHnswDenseVectors.java
+++ b/src/main/java/io/anserini/search/SearchHnswDenseVectors.java
@@ -93,7 +93,7 @@ public final class SearchHnswDenseVectors<K extends Comparable<K>> implements Ru
     for (String topicsFile : args.topics) {
       Path topicsFilePath = Paths.get(topicsFile);
       if (!Files.exists(topicsFilePath) || !Files.isRegularFile(topicsFilePath) || !Files.isReadable(topicsFilePath)) {
-        Topics ref = Topics.getByName(topicsFile);
+        Topics ref = Topics.get(topicsFile);
         if (ref==null) {
           throw new IllegalArgumentException(String.format("\"%s\" does not refer to valid topics.", topicsFilePath));
         } else {

--- a/src/main/java/io/anserini/search/SearchHnswDenseVectors.java
+++ b/src/main/java/io/anserini/search/SearchHnswDenseVectors.java
@@ -91,25 +91,11 @@ public final class SearchHnswDenseVectors<K extends Comparable<K>> implements Ru
     // exceptions together as an unchecked exception to make initialization and error reporting clearer.
     SortedMap<K, Map<String, String>> topics = new TreeMap<>();
     for (String topicsFile : args.topics) {
-      Path topicsFilePath = Paths.get(topicsFile);
-      if (!Files.exists(topicsFilePath) || !Files.isRegularFile(topicsFilePath) || !Files.isReadable(topicsFilePath)) {
-        Topics ref = Topics.get(topicsFile);
-        if (ref==null) {
-          throw new IllegalArgumentException(String.format("\"%s\" does not refer to valid topics.", topicsFilePath));
-        } else {
-          topics.putAll(TopicReader.load(ref));
-        }
+      Path topicsPath = Paths.get(topicsFile);
+      if (Files.exists(topicsPath) && Files.isRegularFile(topicsPath) && Files.isReadable(topicsPath)) {
+        topics.putAll(TopicReader.load(topicsFile, args.topicReader));
       } else {
-        try {
-          @SuppressWarnings("unchecked")
-          TopicReader<K> tr = (TopicReader<K>) Class
-              .forName(String.format("io.anserini.search.topicreader.%sTopicReader", args.topicReader))
-              .getConstructor(Path.class).newInstance(topicsFilePath);
-
-          topics.putAll(tr.read());
-        } catch (Exception e) {
-          throw new IllegalArgumentException(String.format("Unable to load topic reader \"%s\".", args.topicReader));
-        }
+        topics.putAll(Topics.load(topicsFile));
       }
     }
 

--- a/src/main/java/io/anserini/search/SearchHnswDenseVectors.java
+++ b/src/main/java/io/anserini/search/SearchHnswDenseVectors.java
@@ -17,15 +17,11 @@
 package io.anserini.search;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
-import java.util.TreeMap;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -36,7 +32,6 @@ import org.kohsuke.args4j.ParserProperties;
 import org.kohsuke.args4j.spi.StringArrayOptionHandler;
 
 import io.anserini.search.topicreader.TopicReader;
-import io.anserini.search.topicreader.Topics;
 import io.anserini.util.LoggingBootstrap;
 
 /**
@@ -89,15 +84,7 @@ public final class SearchHnswDenseVectors<K extends Comparable<K>> implements Ru
 
     // We might not be able to successfully read topics for a variety of reasons. Gather all possible
     // exceptions together as an unchecked exception to make initialization and error reporting clearer.
-    SortedMap<K, Map<String, String>> topics = new TreeMap<>();
-    for (String topicsFile : args.topics) {
-      Path topicsPath = Paths.get(topicsFile);
-      if (Files.exists(topicsPath) && Files.isRegularFile(topicsPath) && Files.isReadable(topicsPath)) {
-        topics.putAll(TopicReader.load(topicsFile, args.topicReader));
-      } else {
-        topics.putAll(Topics.load(topicsFile));
-      }
-    }
+    SortedMap<K, Map<String, String>> topics = TopicReader.load(args.topics, args.topicReader);
 
     // Now iterate through all the topics to pick out the right field with proper exception handling.
     try {

--- a/src/main/java/io/anserini/search/topicreader/TopicReader.java
+++ b/src/main/java/io/anserini/search/topicreader/TopicReader.java
@@ -51,7 +51,7 @@ public abstract class TopicReader<K> {
 
   static {
     // Inverts the "Topic" enum to populate the lookup table that maps topics filename to reader class.
-    for (Topics topic : Topics.registry().values()) {
+    for (Topics topic : Topics.entries().values()) {
       String path = topic.path;
       TOPIC_FILE_TO_TYPE.put(path, topic.readerClass);
     }
@@ -114,15 +114,15 @@ public abstract class TopicReader<K> {
   abstract public SortedMap<K, Map<String, String>> read(BufferedReader bRdr) throws IOException;
 
   /**
-   * Returns a standard set of evaluation topics.
+   * Loads topics from a registered {@link Topics} entry.
    *
-   * @param topics topics
+   * @param topics registered topics entry
    * @param <K> type of topic id
-   * @throws IOException if error encountered reading topics
    * @return evaluation topics
+   * @throws IOException if error encountered reading topics
    */
   @SuppressWarnings("unchecked")
-  public static <K> SortedMap<K, Map<String, String>> getTopics(Topics topics) throws IOException {
+  public static <K> SortedMap<K, Map<String, String>> load(Topics topics) throws IOException {
     Path topicPath = getTopicPath(Path.of(topics.path));
 
     try(InputStream inputStream = topicPath.toString().endsWith(".gz") ?
@@ -135,6 +135,32 @@ public abstract class TopicReader<K> {
       return reader.read(new BufferedReader(new InputStreamReader(inputStream)));
     } catch (Exception e) {
       throw new IOException("Unable to read topics: " + topics);
+    }
+  }
+
+  /**
+   * Loads topics from a local file using a caller-specified {@code TopicReader} class name.
+   *
+   * @param file topics file
+   * @param topicReader {@code TopicReader} class name without the {@code TopicReader} suffix
+   * @param <K> type of topic id
+   * @return evaluation topics
+   * @throws IllegalArgumentException if the topic reader is missing or cannot be loaded
+   */
+  @SuppressWarnings("unchecked")
+  public static <K> SortedMap<K, Map<String, String>> load(String file, String topicReader) {
+    if (topicReader == null) {
+      throw new IllegalArgumentException("Must specify the topic reader using -topicReader.");
+    }
+
+    try {
+      TopicReader<K> tr = (TopicReader<K>) Class
+          .forName(String.format("io.anserini.search.topicreader.%sTopicReader", topicReader))
+          .getConstructor(Path.class).newInstance(Paths.get(file));
+      return tr.read();
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+        String.format("Unable to load topic reader \"%s\" as fully-qualified class io.anserini.search.topicreader.%sTopicReader.", topicReader, topicReader));
     }
   }
 
@@ -167,7 +193,7 @@ public abstract class TopicReader<K> {
    * @throws IOException if error encountered reading topics
    */
   public static Map<String, Map<String, String>> getTopicsWithStringIds(Topics topics) throws IOException {
-    SortedMap<?, Map<String, String>> originalTopics = getTopics(topics);
+    SortedMap<?, Map<String, String>> originalTopics = load(topics);
     if (originalTopics == null)
       return null;
 
@@ -187,8 +213,7 @@ public abstract class TopicReader<K> {
    * @param file topics file
    * @return evaluation topics, with strings as topic ids
    */
-  public static Map<String, Map<String, String>> getTopicsWithStringIdsFromFileWithTopicReaderClass(String className,
-                                                                                                    String file) {
+  public static Map<String, Map<String, String>> getTopicsWithStringIdsFromFileWithTopicReaderClass(String className, String file) {
     try {
       Class<?> clazz = Class.forName(className);
       Constructor<?>[] ctors = clazz.getDeclaredConstructors();
@@ -210,7 +235,8 @@ public abstract class TopicReader<K> {
   }
 
   /**
-   * Downloads the topics from the cloud and returns the path to the local copy
+   * Downloads the topics from server and returns the path to the local copy.
+   *
    * @param topicPath Path to the topics
    * @return Path to the local copy of the topics
    * @throws IOException if error encountered downloading topics
@@ -227,12 +253,9 @@ public abstract class TopicReader<K> {
     return localTopicPath;
   }
 
-  public static Path getNewTopicsAbsPath(Path topicPath){
-    return CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve(topicPath.getFileName());
-  }
-
   /**
    * Returns the path to the topic file. If the topic file is not in the list of known topics, we assume it is a local file.
+   *
    * @param topicPath Path to the topic file
    * @return Path to the topic file
    * @throws IOException if error encountered reading topics
@@ -245,14 +268,14 @@ public abstract class TopicReader<K> {
         // If the topic file is not in the list of known topics, we assume it is a local file.
         Path tempPath = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve(topicPath.getFileName());
         if (Files.exists(tempPath)) {
-          // if it is an unregistred topic, but it is in the cache, we use it
+          // if it is an unregistered topic, but it is in the cache, we use it
           return tempPath;
         }
         return topicPath;
       }
     }
     
-    Path resultPath = getNewTopicsAbsPath(topicPath);
+    Path resultPath = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve(topicPath.getFileName());
     if (!Files.exists(resultPath)) {
       resultPath = downloadTopics(topicPath);
     }

--- a/src/main/java/io/anserini/search/topicreader/TopicReader.java
+++ b/src/main/java/io/anserini/search/topicreader/TopicReader.java
@@ -31,6 +31,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.zip.GZIPInputStream;
 
 import io.anserini.util.CacheDirectoryResolver;
@@ -132,6 +133,28 @@ public abstract class TopicReader<K> {
       throw new IllegalArgumentException(
         String.format("Unable to load topic reader \"%s\" as fully-qualified class io.anserini.search.topicreader.%sTopicReader.", topicReader, topicReader));
     }
+  }
+
+  /**
+   * Loads and merges topics from registered topic names or local files. Local files are read using the
+   * caller-specified {@code TopicReader}; registered topics use the reader in the topics registry.
+   *
+   * @param topics registered topic names or local topic files
+   * @param topicReader {@code TopicReader} class name without the {@code TopicReader} suffix for local files
+   * @param <K> type of topic id
+   * @return merged evaluation topics
+   */
+  public static <K> SortedMap<K, Map<String, String>> load(String[] topics, String topicReader) {
+    SortedMap<K, Map<String, String>> mergedTopics = new TreeMap<>();
+    for (String topic : topics) {
+      Path topicPath = Paths.get(topic);
+      if (Files.exists(topicPath) && Files.isRegularFile(topicPath) && Files.isReadable(topicPath)) {
+        mergedTopics.putAll(load(topic, topicReader));
+      } else {
+        mergedTopics.putAll(Topics.load(topic));
+      }
+    }
+    return mergedTopics;
   }
 
   /**

--- a/src/main/java/io/anserini/search/topicreader/TopicReader.java
+++ b/src/main/java/io/anserini/search/topicreader/TopicReader.java
@@ -51,7 +51,7 @@ public abstract class TopicReader<K> {
 
   static {
     // Inverts the "Topic" enum to populate the lookup table that maps topics filename to reader class.
-    for (Topics topic : Topics.values()) {
+    for (Topics topic : Topics.registry().values()) {
       String path = topic.path;
       TOPIC_FILE_TO_TYPE.put(path, topic.readerClass);
     }

--- a/src/main/java/io/anserini/search/topicreader/TopicReader.java
+++ b/src/main/java/io/anserini/search/topicreader/TopicReader.java
@@ -34,7 +34,6 @@ import java.util.SortedMap;
 import java.util.zip.GZIPInputStream;
 
 import io.anserini.util.CacheDirectoryResolver;
-import io.anserini.search.SearchCollection;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -45,40 +44,11 @@ import org.apache.logging.log4j.Logger;
  * @param <K> type of the topic id
  */
 public abstract class TopicReader<K> {
-  private static final Logger LOG = LogManager.getLogger(SearchCollection.class);
+  private static final Logger LOG = LogManager.getLogger(TopicReader.class);
   private static final String SERVER_PATH = "https://raw.githubusercontent.com/castorini/anserini-tools/master/topics-and-qrels/";
-  private static final Map<String, Class<? extends TopicReader<?>>> TOPIC_FILE_TO_TYPE = new HashMap<>();
-
-  static {
-    // Inverts the "Topic" enum to populate the lookup table that maps topics filename to reader class.
-    for (Topics topic : Topics.entries().values()) {
-      String path = topic.path;
-      TOPIC_FILE_TO_TYPE.put(path, topic.readerClass);
-    }
-  }
 
   protected final int BUFFER_SIZE = 1 << 16; // 64K
   protected Path topicFile;
-
-  /**
-   * Returns the {@link TopicReader} class corresponding to a known topics file, or <code>null</code> if unknown.
-   *
-   * @param file topics file
-   * @return the {@link TopicReader} class corresponding to a known topics file, or <code>null</code> if unknown.
-   */
-  public static Class<? extends TopicReader<?>> getTopicReaderClassByFile(String file) {
-    // If we're given something that looks like a path with directories, pull out only the file name at the end.
-    if (file.contains("/")) {
-      String[] parts = file.split("/");
-      file = parts[parts.length-1];
-    }
-
-    if (TOPIC_FILE_TO_TYPE.containsKey(file)) {
-      return TOPIC_FILE_TO_TYPE.get(file);
-    }
-
-    return null;
-  }
 
   public TopicReader(Path topicFile) throws IOException {
     this.topicFile = getTopicPath(topicFile);
@@ -175,7 +145,7 @@ public abstract class TopicReader<K> {
   public static <K> SortedMap<K, Map<String, String>> getTopicsByFile(String file) {
     try {
       // Get the constructor
-      Constructor<?>[] ctors = getTopicReaderClassByFile(file).getDeclaredConstructors();
+      Constructor<?>[] ctors = Topics.getTopicReaderClassForPath(file).getDeclaredConstructors();
       // The one we want is always the zero-th one; pass in a dummy Path.
       TopicReader<K> reader = (TopicReader<K>) ctors[0].newInstance(Paths.get(file));
       return reader.read();
@@ -264,7 +234,7 @@ public abstract class TopicReader<K> {
     if (Files.exists(topicPath)) {
       return topicPath;
     } else {
-      if (!TOPIC_FILE_TO_TYPE.containsKey(topicPath.getFileName().toString())) {
+      if (Topics.getTopicReaderClassForPath(topicPath.getFileName().toString()) == null) {
         // If the topic file is not in the list of known topics, we assume it is a local file.
         Path tempPath = CacheDirectoryResolver.getTopicsAndQrelsCachePath().resolve(topicPath.getFileName());
         if (Files.exists(tempPath)) {

--- a/src/main/java/io/anserini/search/topicreader/Topics.java
+++ b/src/main/java/io/anserini/search/topicreader/Topics.java
@@ -17,16 +17,13 @@
 package io.anserini.search.topicreader;
 
 import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.TreeMap;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -56,68 +53,34 @@ public final class Topics {
   }
 
   public static Topics get(String name) {
-    return registryData().get(name);
+    return registry().get(name);
   }
 
-  public static Map<String, Topics> registry() {
-    return registryData().canonical;
+  public static Map<String, Topics> entries() {
+    return registry().canonical;
   }
 
   public static Set<String> names() {
-    return Collections.unmodifiableSet(registryData().lookup.keySet());
+    return Collections.unmodifiableSet(registry().lookup.keySet());
   }
 
-  public static Topics getBaseTopics(String name) {
-    name = name.replaceFirst("^topics\\.", "");
-    String regex = "^(.*?)(?:[.-](bge|cohere|splade|unicoil|cosdpr|txt|tsv|v\\d+|v\\d+\\.\\d+)).*";
-    return Topics.get(name.replaceAll(regex, "$1"));
-  }
-
-  public static <K> SortedMap<K, Map<String, String>> resolve(String topics) {
-    return resolve(topics, null);
-  }
-
-  @SuppressWarnings("unchecked")
-  public static <K> SortedMap<K, Map<String, String>> resolve(String topics, String topicReader) {
-    Path topicsPath = Paths.get(topics);
-    if (!Files.exists(topicsPath) || !Files.isRegularFile(topicsPath) || !Files.isReadable(topicsPath)) {
-      Topics ref = Topics.get(topics);
-      if (ref == null) {
-        throw new IllegalArgumentException(String.format("\"%s\" does not refer to valid topics.", topicsPath));
-      }
-
-      try {
-        return TopicReader.getTopics(ref);
-      } catch (Exception e) {
-        throw new IllegalArgumentException(String.format("Unable to read topics \"%s\".", topics), e);
-      }
+  public static <K> SortedMap<K, Map<String, String>> load(String topics) {
+    Topics ref = Topics.get(topics);
+    if (ref == null) {
+      throw new IllegalArgumentException(String.format("\"%s\" does not refer to valid topics.", topics));
     }
+    return load(ref);
+  }
 
-    if (topicReader == null) {
-      throw new IllegalArgumentException("Must specify the topic reader using -topicReader.");
-    }
-
+  public static <K> SortedMap<K, Map<String, String>> load(Topics topics) {
     try {
-      TopicReader<K> tr = (TopicReader<K>) Class
-          .forName(String.format("io.anserini.search.topicreader.%sTopicReader", topicReader))
-          .getConstructor(Path.class).newInstance(topicsPath);
-      return tr.read();
+      return TopicReader.load(topics);
     } catch (Exception e) {
-      throw new IllegalArgumentException(String.format("Unable to load topic reader \"%s\".", topicReader));
+      throw new IllegalArgumentException(String.format("Unable to read topics \"%s\".", topics.name()), e);
     }
   }
 
-  public static <K> SortedMap<K, Map<String, String>> resolve(String[] topicsArray, String topicReader) {
-    SortedMap<K, Map<String, String>> topics = new TreeMap<>();
-
-    for (String topicsFile : topicsArray) {
-      topics.putAll(resolve(topicsFile, topicReader));
-    }
-
-    return topics;
-  }
-
-  private static Registry registryData() {
+  private static Registry registry() {
     Registry registry = registryCache;
     if (registry == null) {
       synchronized (Topics.class) {
@@ -149,9 +112,9 @@ public final class Topics {
 
       Topics topic = new Topics(name, loadReaderClass(value.reader_class), value.path);
       canonical.put(name, topic);
-      addLookup(lookup, name, topic);
-      addLookup(lookup, value.path, topic);
-      addLookup(lookup, Path.of(value.path).getFileName().toString(), topic);
+      addLookupEntry(lookup, name, topic);
+      addLookupEntry(lookup, value.path, topic);
+      addLookupEntry(lookup, Path.of(value.path).getFileName().toString(), topic);
     }
 
     for (Map.Entry<String, List<String>> entry : aliases.entrySet()) {
@@ -160,7 +123,7 @@ public final class Topics {
         throw new IllegalStateException("Topic alias canonical name is not registered: " + entry.getKey());
       }
       for (String alias : entry.getValue()) {
-        addLookup(lookup, alias, topic);
+        addLookupEntry(lookup, alias, topic);
       }
     }
 
@@ -202,7 +165,7 @@ public final class Topics {
     }
   }
 
-  private static void addLookup(Map<String, Topics> lookup, String name, Topics topic) {
+  private static void addLookupEntry(Map<String, Topics> lookup, String name, Topics topic) {
     Topics existing = lookup.get(name);
     if (existing != null && existing != topic) {
       throw new IllegalStateException("Topic name maps to conflicting topics: " + name);

--- a/src/main/java/io/anserini/search/topicreader/Topics.java
+++ b/src/main/java/io/anserini/search/topicreader/Topics.java
@@ -16,613 +16,61 @@
 
 package io.anserini.search.topicreader;
 
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.SortedMap;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.TreeMap;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
- * An enumeration comprising standard sets of topics from various evaluations.
+ * A registry entry for a standard set of topics from various evaluations.
  */
-public enum Topics {
-  TREC1_ADHOC(TrecTopicReader.class, "topics.adhoc.51-100.txt"),
-  TREC2_ADHOC(TrecTopicReader.class, "topics.adhoc.101-150.txt"),
-  TREC3_ADHOC(TrecTopicReader.class, "topics.adhoc.151-200.txt"),
-  ROBUST04(TrecTopicReader.class, "topics.robust04.txt"),
-  ROBUST05(TrecTopicReader.class, "topics.robust05.txt"),
-  CORE17(TrecTopicReader.class, "topics.core17.txt"),
-  CORE18(TrecTopicReader.class, "topics.core18.txt"),
-  WT10G(TrecTopicReader.class, "topics.adhoc.451-550.txt"),
-  TREC2004_TERABYTE(TrecTopicReader.class, "topics.terabyte04.701-750.txt"),
-  TREC2005_TERABYTE(TrecTopicReader.class, "topics.terabyte05.751-800.txt"),
-  TREC2006_TERABYTE(TrecTopicReader.class, "topics.terabyte06.801-850.txt"),
-  TREC2007_MILLION_QUERY(WebTopicReader.class, "topics.mq.1-10000.txt"),
-  TREC2008_MILLION_QUERY(WebTopicReader.class, "topics.mq.10001-20000.txt"),
-  TREC2009_MILLION_QUERY(PrioritizedWebTopicReader.class, "topics.mq.20001-60000.txt"),
-  TREC2009_WEB(WebxmlTopicReader.class, "topics.web.1-50.txt"),
-  TREC2010_WEB(WebxmlTopicReader.class, "topics.web.51-100.txt"),
-  TREC2011_WEB(WebxmlTopicReader.class, "topics.web.101-150.txt"),
-  TREC2012_WEB(WebxmlTopicReader.class, "topics.web.151-200.txt"),
-  TREC2013_WEB(WebxmlTopicReader.class, "topics.web.201-250.txt"),
-  TREC2014_WEB(WebxmlTopicReader.class, "topics.web.251-300.txt"),
-  MB11(MicroblogTopicReader.class, "topics.microblog2011.txt"),
-  MB12(MicroblogTopicReader.class, "topics.microblog2012.txt"),
-  MB13(MicroblogTopicReader.class, "topics.microblog2013.txt"),
-  MB14(MicroblogTopicReader.class, "topics.microblog2014.txt"),
-  CAR17V15_BENCHMARK_Y1_TEST(CarTopicReader.class, "topics.car17v1.5.benchmarkY1test.txt"),
-  CAR17V20_BENCHMARK_Y1_TEST(CarTopicReader.class, "topics.car17v2.0.benchmarkY1test.txt"),
-
-  // TREC DL topics
-  TREC2019_DL_DOC(TsvIntTopicReader.class,"topics.dl19-doc.txt"),
-  TREC2019_DL_DOC_WP(TsvIntTopicReader.class,"topics.dl19-doc.wp.tsv.gz"),
-  TREC2019_DL_DOC_UNICOIL(TsvIntTopicReader.class,"topics.dl19-doc.unicoil.0shot.tsv.gz"),
-  TREC2019_DL_DOC_UNICOIL_NOEXP(TsvIntTopicReader.class,"topics.dl19-doc.unicoil-noexp.0shot.tsv.gz"),
-  TREC2019_DL_PASSAGE(TsvIntTopicReader.class,"topics.dl19-passage.txt"),
-  TREC2019_DL_PASSAGE_WP(TsvIntTopicReader.class,"topics.dl19-passage.wp.tsv.gz"),
-  TREC2019_DL_PASSAGE_UNICOIL(TsvIntTopicReader.class,"topics.dl19-passage.unicoil.0shot.tsv.gz"),
-  TREC2019_DL_PASSAGE_UNICOIL_NOEXP(TsvIntTopicReader.class,"topics.dl19-passage.unicoil-noexp.0shot.tsv.gz"),
-  TREC2019_DL_PASSAGE_SPLADE_DISTILL_COCODENSER_MEDIUM(TsvIntTopicReader.class,"topics.dl19-passage.splade_distil_cocodenser_medium.tsv.gz"),
-  TREC2019_DL_PASSAGE_SPLADE_PP_ED(TsvIntTopicReader.class,"topics.dl19-passage.splade-pp-ed.tsv.gz"),
-  TREC2019_DL_PASSAGE_SPLADE_PP_SD(TsvIntTopicReader.class,"topics.dl19-passage.splade-pp-sd.tsv.gz"),
-  TREC2019_DL_PASSAGE_COHERE_EMBED_ENGLISH_30(JsonIntVectorTopicReader.class, "topics.dl19-passage.cohere-embed-english-v3.0.jsonl.gz"),
-  TREC2020_DL(TsvIntTopicReader.class,"topics.dl20.txt"),
-  TREC2020_DL_WP(TsvIntTopicReader.class,"topics.dl20.wp.tsv.gz"),
-  TREC2020_DL_UNICOIL(TsvIntTopicReader.class,"topics.dl20.unicoil.0shot.tsv.gz"),
-  TREC2020_DL_UNICOIL_NOEXP(TsvIntTopicReader.class,"topics.dl20.unicoil-noexp.0shot.tsv.gz"),
-  TREC2020_DL_SPLADE_DISTILL_COCODENSER_MEDIUM(TsvIntTopicReader.class,"topics.dl20.splade_distil_cocodenser_medium.tsv.gz"),
-  TREC2020_DL_SPLADE_PP_ED(TsvIntTopicReader.class,"topics.dl20.splade-pp-ed.tsv.gz"),
-  TREC2020_DL_SPLADE_PP_SD(TsvIntTopicReader.class,"topics.dl20.splade-pp-sd.tsv.gz"),
-  TREC2020_DL_COHERE_EMBED_ENGLISH_30(JsonIntVectorTopicReader.class, "topics.dl20.cohere-embed-english-v3.0.jsonl.gz"),
-  TREC2021_DL(TsvIntTopicReader.class,"topics.dl21.txt"),
-  TREC2021_DL_UNICOIL(TsvIntTopicReader.class,"topics.dl21.unicoil.0shot.tsv.gz"),
-  TREC2021_DL_UNICOIL_NOEXP(TsvIntTopicReader.class,"topics.dl21.unicoil-noexp.0shot.tsv.gz"),
-  TREC2021_DL_SPLADE_PP_ED(TsvIntTopicReader.class,"topics.dl21.splade-pp-ed.tsv.gz"),
-  TREC2021_DL_SPLADE_PP_SD(TsvIntTopicReader.class,"topics.dl21.splade-pp-sd.tsv.gz"),
-  TREC2021_DL_SNOWFLAKE_ARCTIC_EMBED_L(JsonIntVectorTopicReader.class, "topics.dl21.snowflake-arctic-embed-l.jsonl.gz"),
-  TREC2022_DL(TsvIntTopicReader.class,"topics.dl22.txt"),
-  TREC2022_DL_UNICOIL(TsvIntTopicReader.class,"topics.dl22.unicoil.0shot.tsv.gz"),
-  TREC2022_DL_UNICOIL_NOEXP(TsvIntTopicReader.class,"topics.dl22.unicoil-noexp.0shot.tsv.gz"),
-  TREC2022_DL_SPLADE_PP_ED(TsvIntTopicReader.class,"topics.dl22.splade-pp-ed.tsv.gz"),
-  TREC2022_DL_SPLADE_PP_SD(TsvIntTopicReader.class,"topics.dl22.splade-pp-sd.tsv.gz"),
-  TREC2022_DL_SNOWFLAKE_ARCTIC_EMBED_L(JsonIntVectorTopicReader.class, "topics.dl22.snowflake-arctic-embed-l.jsonl.gz"),
-  TREC2023_DL(TsvIntTopicReader.class, "topics.dl23.txt"),
-  TREC2023_DL_UNICOIL(TsvIntTopicReader.class,"topics.dl23.unicoil.0shot.tsv.gz"),
-  TREC2023_DL_UNICOIL_NOEXP(TsvIntTopicReader.class,"topics.dl23.unicoil-noexp.0shot.tsv.gz"),
-  TREC2023_DL_SPLADE_PP_ED(TsvIntTopicReader.class,"topics.dl23.splade-pp-ed.tsv.gz"),
-  TREC2023_DL_SPLADE_PP_SD(TsvIntTopicReader.class,"topics.dl23.splade-pp-sd.tsv.gz"),
-  TREC2023_DL_SNOWFLAKE_ARCTIC_EMBED_L(JsonIntVectorTopicReader.class, "topics.dl23.snowflake-arctic-embed-l.jsonl.gz"),
-
-  TREC2024_RAG_RAGGY_DEV(TsvIntTopicReader.class, "topics.rag24.raggy-dev.txt"),
-  TREC2024_RAG_RAGGY_DEV_SNOWFLAKE_ARCTIC_EMBED_L(JsonIntVectorTopicReader.class, "topics.rag24.raggy-dev.snowflake-arctic-embed-l.jsonl.gz"),
-  TREC2024_RAG_RESEARCHY_DEV(TsvIntTopicReader.class, "topics.rag24.researchy-dev.txt"),
-  TREC2024_RAG_RESEARCHY_DEV_SNOWFLAKE_ARCTIC_EMBED_L(JsonIntVectorTopicReader.class, "topics.rag24.researchy-dev.snowflake-arctic-embed-l.jsonl.gz"),
-  TREC2024_RAG_TEST(TsvStringTopicReader.class, "topics.rag24.test.txt"),
-  TREC2024_RAG_TEST_SNOWFLAKE_ARCTIC_EMBED_L(JsonStringVectorTopicReader.class, "topics.rag24.test.snowflake-arctic-embed-l.jsonl.gz"),
-  TREC2025_RAG_TEST(JsonStringTopicReader.class, "topics.rag25.test.jsonl"),
-
-  // MS MARCO V1 topics
-  MSMARCO_DOC_DEV(TsvIntTopicReader.class,"topics.msmarco-doc.dev.txt"),
-  MSMARCO_DOC_DEV_WP(TsvIntTopicReader.class,"topics.msmarco-doc.dev.wp.tsv.gz"),
-  MSMARCO_DOC_DEV_UNICOIL(TsvIntTopicReader.class,"topics.msmarco-doc.dev.unicoil.tsv.gz"),
-  MSMARCO_DOC_DEV_UNICOIL_NOEXP(TsvIntTopicReader.class,"topics.msmarco-doc.dev.unicoil-noexp.tsv.gz"),
-  MSMARCO_DOC_TEST(TsvIntTopicReader.class,"topics.msmarco-doc.test.txt"),
-  MSMARCO_PASSAGE_DEV_SUBSET(TsvIntTopicReader.class, "topics.msmarco-passage.dev-subset.txt"),
-  MSMARCO_PASSAGE_DEV_SUBSET_WP(TsvIntTopicReader.class, "topics.msmarco-passage.dev-subset.wp.tsv.gz"),
-  MSMARCO_PASSAGE_DEV_SUBSET_DEEPIMPACT(TsvIntTopicReader.class, "topics.msmarco-passage.dev-subset.deepimpact.tsv.gz"),
-  MSMARCO_PASSAGE_DEV_SUBSET_UNICOIL(TsvIntTopicReader.class, "topics.msmarco-passage.dev-subset.unicoil.tsv.gz"),
-  MSMARCO_PASSAGE_DEV_SUBSET_UNICOIL_NOEXP(TsvIntTopicReader.class, "topics.msmarco-passage.dev-subset.unicoil-noexp.tsv.gz"),
-  MSMARCO_PASSAGE_DEV_SUBSET_UNICOIL_TILDE(TsvIntTopicReader.class, "topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.tsv.gz"),
-  MSMARCO_PASSAGE_DEV_SUBSET_DISTILL_SPLADE_MAX(TsvIntTopicReader.class, "topics.msmarco-passage.dev-subset.distill-splade-max.tsv.gz"),
-  // DSE topics
-  SLIDEVQA_TEST(TsvIntTopicReader.class, "topics.slidevqa.test.tsv"),
-  WIKI_SS_NQ_TEST(TsvIntTopicReader.class, "topics.wiki-ss-nq.test.tsv"),
-  MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_DISTILL_COCODENSER_MEDIUM(TsvIntTopicReader.class, "topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.tsv.gz"),
-  MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_ED(TsvIntTopicReader.class, "topics.msmarco-passage.dev-subset.splade-pp-ed.tsv.gz"),
-  MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_SD(TsvIntTopicReader.class, "topics.msmarco-passage.dev-subset.splade-pp-sd.tsv.gz"),
-  MSMARCO_PASSAGE_DEV_SUBSET_COHERE_EMBED_ENGLISH_30(JsonIntVectorTopicReader.class, "topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.gz"),
-  MSMARCO_PASSAGE_TEST_SUBSET(TsvIntTopicReader.class, "topics.msmarco-passage.test-subset.txt"),
-
-  // MS MARCO V2 topics
-  MSMARCO_V2_DOC_DEV(TsvIntTopicReader.class,"topics.msmarco-v2-doc.dev.txt"),
-  MSMARCO_V2_DOC_DEV_UNICOIL(TsvIntTopicReader.class,"topics.msmarco-v2-doc.dev.unicoil.0shot.tsv.gz"),
-  MSMARCO_V2_DOC_DEV_UNICOIL_NOEXP(TsvIntTopicReader.class,"topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.tsv.gz"),
-  MSMARCO_V2_DOC_DEV_SNOWFLAKE_ARCTIC_EMBED_L(JsonIntVectorTopicReader.class, "topics.msmarco-v2-doc.dev.snowflake-arctic-embed-l.jsonl.gz"),
-  MSMARCO_V2_DOC_DEV2(TsvIntTopicReader.class,"topics.msmarco-v2-doc.dev2.txt"),
-  MSMARCO_V2_DOC_DEV2_UNICOIL(TsvIntTopicReader.class,"topics.msmarco-v2-doc.dev2.unicoil.0shot.tsv.gz"),
-  MSMARCO_V2_DOC_DEV2_UNICOIL_NOEXP(TsvIntTopicReader.class,"topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.tsv.gz"),
-  MSMARCO_V2_DOC_DEV2_SNOWFLAKE_ARCTIC_EMBED_L(JsonIntVectorTopicReader.class, "topics.msmarco-v2-doc.dev2.snowflake-arctic-embed-l.jsonl.gz"),
-  MSMARCO_V2_PASSAGE_DEV(TsvIntTopicReader.class, "topics.msmarco-v2-passage.dev.txt"),
-  MSMARCO_V2_PASSAGE_DEV_UNICOIL(TsvIntTopicReader.class, "topics.msmarco-v2-passage.dev.unicoil.0shot.tsv.gz"),
-  MSMARCO_V2_PASSAGE_DEV_UNICOIL_NOEXP(TsvIntTopicReader.class, "topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.tsv.gz"),
-  MSMARCO_V2_PASSAGE_DEV_SPLADE_PP_ED(TsvIntTopicReader.class, "topics.msmarco-v2-passage.dev.splade-pp-ed.tsv.gz"),
-  MSMARCO_V2_PASSAGE_DEV_SPLADE_PP_SD(TsvIntTopicReader.class, "topics.msmarco-v2-passage.dev.splade-pp-sd.tsv.gz"),
-  MSMARCO_V2_PASSAGE_DEV2(TsvIntTopicReader.class, "topics.msmarco-v2-passage.dev2.txt"),
-  MSMARCO_V2_PASSAGE_DEV2_UNICOIL(TsvIntTopicReader.class, "topics.msmarco-v2-passage.dev2.unicoil.0shot.tsv.gz"),
-  MSMARCO_V2_PASSAGE_DEV2_UNICOIL_NOEXP(TsvIntTopicReader.class, "topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.tsv.gz"),
-  MSMARCO_V2_PASSAGE_DEV2_SPLADE_PP_ED(TsvIntTopicReader.class, "topics.msmarco-v2-passage.dev2.splade-pp-ed.tsv.gz"),
-  MSMARCO_V2_PASSAGE_DEV2_SPLADE_PP_SD(TsvIntTopicReader.class, "topics.msmarco-v2-passage.dev2.splade-pp-sd.tsv.gz"),
-
-  NTCIR8_ZH(TsvStringTopicReader.class, "topics.ntcir8zh.eval.txt"),
-  CLEF2006_FR(TsvStringTopicReader.class, "topics.clef06fr.mono.fr.txt"),
-  TREC2002_AR(TrecTopicReader.class, "topics.trec02ar-ar.txt"),
-  FIRE2012_BN(TrecTopicReader.class, "topics.fire12bn.176-225.txt"),
-  FIRE2012_HI(TrecTopicReader.class, "topics.fire12hi.176-225.txt"),
-  FIRE2012_EN(TrecTopicReader.class, "topics.fire12en.176-225.txt"),
-  COVID_ROUND1(CovidTopicReader.class, "topics.covid-round1.xml"),
-  COVID_ROUND1_UDEL(CovidTopicReader.class, "topics.covid-round1-udel.xml"),
-  COVID_ROUND2(CovidTopicReader.class, "topics.covid-round2.xml"),
-  COVID_ROUND2_UDEL(CovidTopicReader.class, "topics.covid-round2-udel.xml"),
-  COVID_ROUND3(CovidTopicReader.class, "topics.covid-round3.xml"),
-  COVID_ROUND3_UDEL(CovidTopicReader.class, "topics.covid-round3-udel.xml"),
-  COVID_ROUND4(CovidTopicReader.class, "topics.covid-round4.xml"),
-  COVID_ROUND4_UDEL(CovidTopicReader.class, "topics.covid-round4-udel.xml"),
-  COVID_ROUND5(CovidTopicReader.class, "topics.covid-round5.xml"),
-  COVID_ROUND5_UDEL(CovidTopicReader.class, "topics.covid-round5-udel.xml"),
-  TREC2018_BL(BackgroundLinkingTopicReader.class, "topics.backgroundlinking18.txt"),
-  TREC2019_BL(BackgroundLinkingTopicReader.class, "topics.backgroundlinking19.txt"),
-  TREC2020_BL(BackgroundLinkingTopicReader.class, "topics.backgroundlinking20.txt"),
-  EPIDEMIC_QA_EXPERT_PRELIM(EpidemicQATopicReader.class, "topics.epidemic-qa.expert.prelim.json"),
-  EPIDEMIC_QA_CONSUMER_PRELIM(EpidemicQATopicReader.class, "topics.epidemic-qa.consumer.prelim.json"),
-  DPR_NQ_DEV(DprNqTopicReader.class, "topics.dpr.nq.dev.txt"),
-  DPR_NQ_TEST(DprNqTopicReader.class, "topics.dpr.nq.test.txt"),
-  DPR_TRIVIA_DEV(DprNqTopicReader.class, "topics.dpr.trivia.dev.txt"),
-  DPR_TRIVIA_TEST(DprNqTopicReader.class, "topics.dpr.trivia.test.txt"),
-  DPR_WQ_TEST(DprJsonlTopicReader.class, "topics.dpr.wq.test.txt"),
-  DPR_CURATED_TEST(DprJsonlTopicReader.class, "topics.dpr.curated.test.txt"),
-  DPR_SQUAD_TEST(DprJsonlTopicReader.class, "topics.dpr.squad.test.txt"),
-  NQ_DEV(DprNqTopicReader.class, "topics.nq.dev.txt"),
-  NQ_TEST(DprNqTopicReader.class, "topics.nq.test.txt"),
-  NQ_TEST_GART5_ANSWERS(TsvIntTopicReader.class, "topics.nq.test.gar-t5.answers.tsv"),
-  NQ_TEST_GART5_TITLES(TsvIntTopicReader.class, "topics.nq.test.gar-t5.titles.tsv"),
-  NQ_TEST_GART5_SENTENCES(TsvIntTopicReader.class, "topics.nq.test.gar-t5.sentences.tsv"),
-  NQ_TEST_GART5_ALL(TsvIntTopicReader.class, "topics.nq.test.gar-t5.all.tsv"),
-  DPR_TRIVIA_TEST_GART5_ANSWERS(TsvIntTopicReader.class, "topics.dpr.trivia.test.gar-t5.answers.tsv"),
-  DPR_TRIVIA_TEST_GART5_TITLES(TsvIntTopicReader.class, "topics.dpr.trivia.test.gar-t5.titles.tsv"),
-  DPR_TRIVIA_TEST_GART5_SENTENCES(TsvIntTopicReader.class, "topics.dpr.trivia.test.gar-t5.sentences.tsv"),
-  DPR_TRIVIA_TEST_GART5_ALL(TsvIntTopicReader.class, "topics.dpr.trivia.test.gar-t5.all.tsv"),
-
-  // Mr.TyDi queries
-  MRTYDI_V11_AR_TRAIN(TsvIntTopicReader.class, "topics.mrtydi-v1.1-ar.train.txt.gz"),
-  MRTYDI_V11_AR_DEV(TsvIntTopicReader.class, "topics.mrtydi-v1.1-ar.dev.txt.gz"),
-  MRTYDI_V11_AR_TEST(TsvIntTopicReader.class, "topics.mrtydi-v1.1-ar.test.txt.gz"),
-  MRTYDI_V11_BN_TRAIN(TsvIntTopicReader.class, "topics.mrtydi-v1.1-bn.train.txt.gz"),
-  MRTYDI_V11_BN_DEV(TsvIntTopicReader.class, "topics.mrtydi-v1.1-bn.dev.txt.gz"),
-  MRTYDI_V11_BN_TEST(TsvIntTopicReader.class, "topics.mrtydi-v1.1-bn.test.txt.gz"),
-  MRTYDI_V11_EN_TRAIN(TsvIntTopicReader.class, "topics.mrtydi-v1.1-en.train.txt.gz"),
-  MRTYDI_V11_EN_DEV(TsvIntTopicReader.class, "topics.mrtydi-v1.1-en.dev.txt.gz"),
-  MRTYDI_V11_EN_TEST(TsvIntTopicReader.class, "topics.mrtydi-v1.1-en.test.txt.gz"),
-  MRTYDI_V11_FI_TRAIN(TsvIntTopicReader.class, "topics.mrtydi-v1.1-fi.train.txt.gz"),
-  MRTYDI_V11_FI_DEV(TsvIntTopicReader.class, "topics.mrtydi-v1.1-fi.dev.txt.gz"),
-  MRTYDI_V11_FI_TEST(TsvIntTopicReader.class, "topics.mrtydi-v1.1-fi.test.txt.gz"),
-  MRTYDI_V11_ID_TRAIN(TsvIntTopicReader.class, "topics.mrtydi-v1.1-id.train.txt.gz"),
-  MRTYDI_V11_ID_DEV(TsvIntTopicReader.class, "topics.mrtydi-v1.1-id.dev.txt.gz"),
-  MRTYDI_V11_ID_TEST(TsvIntTopicReader.class, "topics.mrtydi-v1.1-id.test.txt.gz"),
-  MRTYDI_V11_JA_TRAIN(TsvIntTopicReader.class, "topics.mrtydi-v1.1-ja.train.txt.gz"),
-  MRTYDI_V11_JA_DEV(TsvIntTopicReader.class, "topics.mrtydi-v1.1-ja.dev.txt.gz"),
-  MRTYDI_V11_JA_TEST(TsvIntTopicReader.class, "topics.mrtydi-v1.1-ja.test.txt.gz"),
-  MRTYDI_V11_KO_TRAIN(TsvIntTopicReader.class, "topics.mrtydi-v1.1-ko.train.txt.gz"),
-  MRTYDI_V11_KO_DEV(TsvIntTopicReader.class, "topics.mrtydi-v1.1-ko.dev.txt.gz"),
-  MRTYDI_V11_KO_TEST(TsvIntTopicReader.class, "topics.mrtydi-v1.1-ko.test.txt.gz"),
-  MRTYDI_V11_RU_TRAIN(TsvIntTopicReader.class, "topics.mrtydi-v1.1-ru.train.txt.gz"),
-  MRTYDI_V11_RU_DEV(TsvIntTopicReader.class, "topics.mrtydi-v1.1-ru.dev.txt.gz"),
-  MRTYDI_V11_RU_TEST(TsvIntTopicReader.class, "topics.mrtydi-v1.1-ru.test.txt.gz"),
-  MRTYDI_V11_SW_TRAIN(TsvIntTopicReader.class, "topics.mrtydi-v1.1-sw.train.txt.gz"),
-  MRTYDI_V11_SW_DEV(TsvIntTopicReader.class, "topics.mrtydi-v1.1-sw.dev.txt.gz"),
-  MRTYDI_V11_SW_TEST(TsvIntTopicReader.class, "topics.mrtydi-v1.1-sw.test.txt.gz"),
-  MRTYDI_V11_TE_TRAIN(TsvIntTopicReader.class, "topics.mrtydi-v1.1-te.train.txt.gz"),
-  MRTYDI_V11_TE_DEV(TsvIntTopicReader.class, "topics.mrtydi-v1.1-te.dev.txt.gz"),
-  MRTYDI_V11_TE_TEST(TsvIntTopicReader.class, "topics.mrtydi-v1.1-te.test.txt.gz"),
-  MRTYDI_V11_TH_TRAIN(TsvIntTopicReader.class, "topics.mrtydi-v1.1-th.train.txt.gz"),
-  MRTYDI_V11_TH_DEV(TsvIntTopicReader.class, "topics.mrtydi-v1.1-th.dev.txt.gz"),
-  MRTYDI_V11_TH_TEST(TsvIntTopicReader.class, "topics.mrtydi-v1.1-th.test.txt.gz"),
-
-  // BEIR (v1.0.0): original queries
-  BEIR_V1_0_0_TREC_COVID_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-trec-covid.test.tsv.gz"),
-  BEIR_V1_0_0_BIOASQ_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-bioasq.test.tsv.gz"),
-  BEIR_V1_0_0_NFCORPUS_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-nfcorpus.test.tsv.gz"),
-  BEIR_V1_0_0_NQ_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-nq.test.tsv.gz"),
-  BEIR_V1_0_0_HOTPOTQA_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-hotpotqa.test.tsv.gz"),
-  BEIR_V1_0_0_FIQA_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-fiqa.test.tsv.gz"),
-  BEIR_V1_0_0_SIGNAL1M_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-signal1m.test.tsv.gz"),
-  BEIR_V1_0_0_TREC_NEWS_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-trec-news.test.tsv.gz"),
-  BEIR_V1_0_0_ROBUST04_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-robust04.test.tsv.gz"),
-  BEIR_V1_0_0_ARGUANA_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-arguana.test.tsv.gz"),
-  BEIR_V1_0_0_WEBIS_TOUCHE2020_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-webis-touche2020.test.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_ANDROID_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-android.test.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_ENGLISH_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-english.test.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_GAMING_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-gaming.test.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_GIS_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-gis.test.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_MATHEMATICA_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-mathematica.test.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_PHYSICS_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-physics.test.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_PROGRAMMERS_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-programmers.test.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_STATS_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-stats.test.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_TEX_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-tex.test.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_UNIX_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-unix.test.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_WEBMASTERS_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-webmasters.test.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_WORDPRESS_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-wordpress.test.tsv.gz"),
-  BEIR_V1_0_0_QUORA_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-quora.test.tsv.gz"),
-  BEIR_V1_0_0_DBPEDIA_ENTITY_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-dbpedia-entity.test.tsv.gz"),
-  BEIR_V1_0_0_SCIDOCS_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-scidocs.test.tsv.gz"),
-  BEIR_V1_0_0_FEVER_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-fever.test.tsv.gz"),
-  BEIR_V1_0_0_CLIMATE_FEVER_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-climate-fever.test.tsv.gz"),
-  BEIR_V1_0_0_SCIFACT_TEST(TsvStringTopicReader.class, "topics.beir-v1.0.0-scifact.test.tsv.gz"),
-
-  // BEIR (v1.0.0): word piece queries
-  BEIR_V1_0_0_TREC_COVID_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-trec-covid.test.wp.tsv.gz"),
-  BEIR_V1_0_0_BIOASQ_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-bioasq.test.wp.tsv.gz"),
-  BEIR_V1_0_0_NFCORPUS_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-nfcorpus.test.wp.tsv.gz"),
-  BEIR_V1_0_0_NQ_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-nq.test.wp.tsv.gz"),
-  BEIR_V1_0_0_HOTPOTQA_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-hotpotqa.test.wp.tsv.gz"),
-  BEIR_V1_0_0_FIQA_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-fiqa.test.wp.tsv.gz"),
-  BEIR_V1_0_0_SIGNAL1M_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-signal1m.test.wp.tsv.gz"),
-  BEIR_V1_0_0_TREC_NEWS_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-trec-news.test.wp.tsv.gz"),
-  BEIR_V1_0_0_ROBUST04_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-robust04.test.wp.tsv.gz"),
-  BEIR_V1_0_0_ARGUANA_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-arguana.test.wp.tsv.gz"),
-  BEIR_V1_0_0_WEBIS_TOUCHE2020_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-webis-touche2020.test.wp.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_ANDROID_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-android.test.wp.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_ENGLISH_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-english.test.wp.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_GAMING_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-gaming.test.wp.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_GIS_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-gis.test.wp.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_MATHEMATICA_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-mathematica.test.wp.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_PHYSICS_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-physics.test.wp.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_PROGRAMMERS_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-programmers.test.wp.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_STATS_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-stats.test.wp.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_TEX_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-tex.test.wp.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_UNIX_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-unix.test.wp.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_WEBMASTERS_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-webmasters.test.wp.tsv.gz"),
-  BEIR_V1_0_0_CQADUPSTACK_WORDPRESS_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-cqadupstack-wordpress.test.wp.tsv.gz"),
-  BEIR_V1_0_0_QUORA_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-quora.test.wp.tsv.gz"),
-  BEIR_V1_0_0_DBPEDIA_ENTITY_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-dbpedia-entity.test.wp.tsv.gz"),
-  BEIR_V1_0_0_SCIDOCS_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-scidocs.test.wp.tsv.gz"),
-  BEIR_V1_0_0_FEVER_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-fever.test.wp.tsv.gz"),
-  BEIR_V1_0_0_CLIMATE_FEVER_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-climate-fever.test.wp.tsv.gz"),
-  BEIR_V1_0_0_SCIFACT_TEST_WP(TsvStringTopicReader.class, "topics.beir-v1.0.0-scifact.test.wp.tsv.gz"),
-
-  // HC4 V1.0 Topics
-  HC4_V1_0_FA_DEV_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-fa.dev.title.tsv"),
-  HC4_V1_0_FA_DEV_DESC(TsvIntTopicReader.class, "topics.hc4-v1.0-fa.dev.desc.tsv"),
-  HC4_V1_0_FA_DEV_DESC_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-fa.dev.desc.title.tsv"),
-  HC4_V1_0_FA_TEST_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-fa.test.title.tsv"),
-  HC4_V1_0_FA_TEST_DESC(TsvIntTopicReader.class, "topics.hc4-v1.0-fa.test.desc.tsv"),
-  HC4_V1_0_FA_TEST_DESC_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-fa.test.desc.title.tsv"),
-  HC4_V1_0_FA_EN_TEST_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-fa.en.test.title.tsv"),
-  HC4_V1_0_FA_EN_TEST_DESC(TsvIntTopicReader.class, "topics.hc4-v1.0-fa.en.test.desc.tsv"),
-  HC4_V1_0_FA_EN_TEST_DESC_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-fa.en.test.desc.title.tsv"),
-  HC4_V1_0_RU_DEV_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-ru.dev.title.tsv"),
-  HC4_V1_0_RU_DEV_DESC(TsvIntTopicReader.class, "topics.hc4-v1.0-ru.dev.desc.tsv"),
-  HC4_V1_0_RU_DEV_DESC_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-ru.dev.desc.title.tsv"),
-  HC4_V1_0_RU_TEST_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-ru.test.title.tsv"),
-  HC4_V1_0_RU_TEST_DESC(TsvIntTopicReader.class, "topics.hc4-v1.0-ru.test.desc.tsv"),
-  HC4_V1_0_RU_TEST_DESC_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-ru.test.desc.title.tsv"),
-  HC4_V1_0_RU_EN_TEST_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-ru.en.test.title.tsv"),
-  HC4_V1_0_RU_EN_TEST_DESC(TsvIntTopicReader.class, "topics.hc4-v1.0-ru.en.test.desc.tsv"),
-  HC4_V1_0_RU_EN_TEST_DESC_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-ru.en.test.desc.title.tsv"),
-  HC4_V1_0_ZH_DEV_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-zh.dev.title.tsv"),
-  HC4_V1_0_ZH_DEV_DESC(TsvIntTopicReader.class, "topics.hc4-v1.0-zh.dev.desc.tsv"),
-  HC4_V1_0_ZH_DEV_DESC_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-zh.dev.desc.title.tsv"),
-  HC4_V1_0_ZH_TEST_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-zh.test.title.tsv"),
-  HC4_V1_0_ZH_TEST_DESC(TsvIntTopicReader.class, "topics.hc4-v1.0-zh.test.desc.tsv"),
-  HC4_V1_0_ZH_TEST_DESC_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-zh.test.desc.title.tsv"),
-  HC4_V1_0_ZH_EN_TEST_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-zh.en.test.title.tsv"),
-  HC4_V1_0_ZH_EN_TEST_DESC(TsvIntTopicReader.class, "topics.hc4-v1.0-zh.en.test.desc.tsv"),
-  HC4_V1_0_ZH_EN_TEST_DESC_TITLE(TsvIntTopicReader.class, "topics.hc4-v1.0-zh.en.test.desc.title.tsv"),
-
-  // TREC NeuCLIR 2022 Topics
-  NEUCLIR22_EN_TITLE(TsvIntTopicReader.class,         "topics.neuclir22-en.original-title.txt"),
-  NEUCLIR22_EN_DESC(TsvIntTopicReader.class,          "topics.neuclir22-en.original-desc.txt"),
-  NEUCLIR22_EN_DESC_TITLE(TsvIntTopicReader.class,    "topics.neuclir22-en.original-desc_title.txt"),
-  NEUCLIR22_FA_HT_TITLE(TsvIntTopicReader.class,      "topics.neuclir22-fa.ht-title.txt"),
-  NEUCLIR22_FA_HT_DESC(TsvIntTopicReader.class,       "topics.neuclir22-fa.ht-desc.txt"),
-  NEUCLIR22_FA_HT_DESC_TITLE(TsvIntTopicReader.class, "topics.neuclir22-fa.ht-desc_title.txt"),
-  NEUCLIR22_FA_MT_TITLE(TsvIntTopicReader.class,      "topics.neuclir22-fa.mt-title.txt"),
-  NEUCLIR22_FA_MT_DESC(TsvIntTopicReader.class,       "topics.neuclir22-fa.mt-desc.txt"),
-  NEUCLIR22_FA_MT_DESC_TITLE(TsvIntTopicReader.class, "topics.neuclir22-fa.mt-desc_title.txt"),
-  NEUCLIR22_RU_HT_TITLE(TsvIntTopicReader.class,      "topics.neuclir22-ru.ht-title.txt"),
-  NEUCLIR22_RU_HT_DESC(TsvIntTopicReader.class,       "topics.neuclir22-ru.ht-desc.txt"),
-  NEUCLIR22_RU_HT_DESC_TITLE(TsvIntTopicReader.class, "topics.neuclir22-ru.ht-desc_title.txt"),
-  NEUCLIR22_RU_MT_TITLE(TsvIntTopicReader.class,      "topics.neuclir22-ru.mt-title.txt"),
-  NEUCLIR22_RU_MT_DESC(TsvIntTopicReader.class,       "topics.neuclir22-ru.mt-desc.txt"),
-  NEUCLIR22_RU_MT_DESC_TITLE(TsvIntTopicReader.class, "topics.neuclir22-ru.mt-desc_title.txt"),
-  NEUCLIR22_ZH_HT_TITLE(TsvIntTopicReader.class,      "topics.neuclir22-zh.ht-title.txt"),
-  NEUCLIR22_ZH_HT_DESC(TsvIntTopicReader.class,       "topics.neuclir22-zh.ht-desc.txt"),
-  NEUCLIR22_ZH_HT_DESC_TITLE(TsvIntTopicReader.class, "topics.neuclir22-zh.ht-desc_title.txt"),
-  NEUCLIR22_ZH_MT_TITLE(TsvIntTopicReader.class,      "topics.neuclir22-zh.mt-title.txt"),
-  NEUCLIR22_ZH_MT_DESC(TsvIntTopicReader.class,       "topics.neuclir22-zh.mt-desc.txt"),
-  NEUCLIR22_ZH_MT_DESC_TITLE(TsvIntTopicReader.class, "topics.neuclir22-zh.mt-desc_title.txt"),
-
-  // TREC NeuCLIR 2022 Topics, SPLADE
-  NEUCLIR22_FA_SPLADE_HT_TITLE(TsvIntTopicReader.class,      "topics.neuclir22-fa.splade.ht-title.txt.gz"),
-  NEUCLIR22_FA_SPLADE_HT_DESC(TsvIntTopicReader.class,       "topics.neuclir22-fa.splade.ht-desc.txt.gz"),
-  NEUCLIR22_FA_SPLADE_HT_DESC_TITLE(TsvIntTopicReader.class, "topics.neuclir22-fa.splade.ht-desc_title.txt.gz"),
-  NEUCLIR22_FA_SPLADE_MT_TITLE(TsvIntTopicReader.class,      "topics.neuclir22-fa.splade.mt-title.txt.gz"),
-  NEUCLIR22_FA_SPLADE_MT_DESC(TsvIntTopicReader.class,       "topics.neuclir22-fa.splade.mt-desc.txt.gz"),
-  NEUCLIR22_FA_SPLADE_MT_DESC_TITLE(TsvIntTopicReader.class, "topics.neuclir22-fa.splade.mt-desc_title.txt.gz"),
-  NEUCLIR22_RU_SPLADE_HT_TITLE(TsvIntTopicReader.class,      "topics.neuclir22-ru.splade.ht-title.txt.gz"),
-  NEUCLIR22_RU_SPLADE_HT_DESC(TsvIntTopicReader.class,       "topics.neuclir22-ru.splade.ht-desc.txt.gz"),
-  NEUCLIR22_RU_SPLADE_HT_DESC_TITLE(TsvIntTopicReader.class, "topics.neuclir22-ru.splade.ht-desc_title.txt.gz"),
-  NEUCLIR22_RU_SPLADE_MT_TITLE(TsvIntTopicReader.class,      "topics.neuclir22-ru.splade.mt-title.txt.gz"),
-  NEUCLIR22_RU_SPLADE_MT_DESC(TsvIntTopicReader.class,       "topics.neuclir22-ru.splade.mt-desc.txt.gz"),
-  NEUCLIR22_RU_SPLADE_MT_DESC_TITLE(TsvIntTopicReader.class, "topics.neuclir22-ru.splade.mt-desc_title.txt.gz"),
-  NEUCLIR22_ZH_SPLADE_HT_TITLE(TsvIntTopicReader.class,      "topics.neuclir22-zh.splade.ht-title.txt.gz"),
-  NEUCLIR22_ZH_SPLADE_HT_DESC(TsvIntTopicReader.class,       "topics.neuclir22-zh.splade.ht-desc.txt.gz"),
-  NEUCLIR22_ZH_SPLADE_HT_DESC_TITLE(TsvIntTopicReader.class, "topics.neuclir22-zh.splade.ht-desc_title.txt.gz"),
-  NEUCLIR22_ZH_SPLADE_MT_TITLE(TsvIntTopicReader.class,      "topics.neuclir22-zh.splade.mt-title.txt.gz"),
-  NEUCLIR22_ZH_SPLADE_MT_DESC(TsvIntTopicReader.class,       "topics.neuclir22-zh.splade.mt-desc.txt.gz"),
-  NEUCLIR22_ZH_SPLADE_MT_DESC_TITLE(TsvIntTopicReader.class, "topics.neuclir22-zh.splade.mt-desc_title.txt.gz"),
-
-  // MIRACL (v1.0.0): original queries
-  MIRACL_V10_AR_DEV(TsvIntTopicReader.class, "topics.miracl-v1.0-ar-dev.tsv"),
-  MIRACL_V10_BN_DEV(TsvIntTopicReader.class, "topics.miracl-v1.0-bn-dev.tsv"),
-  MIRACL_V10_EN_DEV(TsvIntTopicReader.class, "topics.miracl-v1.0-en-dev.tsv"),
-  MIRACL_V10_ES_DEV(TsvStringTopicReader.class, "topics.miracl-v1.0-es-dev.tsv"),
-  MIRACL_V10_FA_DEV(TsvStringTopicReader.class, "topics.miracl-v1.0-fa-dev.tsv"),
-  MIRACL_V10_FI_DEV(TsvIntTopicReader.class, "topics.miracl-v1.0-fi-dev.tsv"),
-  MIRACL_V10_FR_DEV(TsvStringTopicReader.class, "topics.miracl-v1.0-fr-dev.tsv"),
-  MIRACL_V10_HI_DEV(TsvStringTopicReader.class, "topics.miracl-v1.0-hi-dev.tsv"),
-  MIRACL_V10_ID_DEV(TsvIntTopicReader.class, "topics.miracl-v1.0-id-dev.tsv"),
-  MIRACL_V10_JA_DEV(TsvIntTopicReader.class, "topics.miracl-v1.0-ja-dev.tsv"),
-  MIRACL_V10_KO_DEV(TsvIntTopicReader.class, "topics.miracl-v1.0-ko-dev.tsv"),
-  MIRACL_V10_RU_DEV(TsvIntTopicReader.class, "topics.miracl-v1.0-ru-dev.tsv"),
-  MIRACL_V10_SW_DEV(TsvIntTopicReader.class, "topics.miracl-v1.0-sw-dev.tsv"),
-  MIRACL_V10_TE_DEV(TsvIntTopicReader.class, "topics.miracl-v1.0-te-dev.tsv"),
-  MIRACL_V10_TH_DEV(TsvIntTopicReader.class, "topics.miracl-v1.0-th-dev.tsv"),
-  MIRACL_V10_ZH_DEV(TsvStringTopicReader.class,"topics.miracl-v1.0-zh-dev.tsv"),
-  MIRACL_V10_DE_DEV(TsvStringTopicReader.class, "topics.miracl-v1.0-de-dev.tsv"),
-  MIRACL_V10_YO_DEV(TsvStringTopicReader.class, "topics.miracl-v1.0-yo-dev.tsv"),
-
-  // AToMiC topics
-  ATOMIC_V021_VIT_L_14_LAION2B_S32B_B82K_TEXT_VAL(JsonStringTopicReader.class, "topics.atomic.validation.text.ViT-L-14.laion2b_s32b_b82k.jsonl"),
-  ATOMIC_V021_VIT_L_14_LAION2B_S32B_B82K_IMAGE_VAL(JsonStringTopicReader.class, "topics.atomic.validation.image.ViT-L-14.laion2b_s32b_b82k.jsonl"),
-  ATOMIC_V021_VIT_B_32_LAION2B_E16_TEXT_VAL(JsonStringTopicReader.class, "topics.atomic.validation.text.ViT-B-32.laion2b_e16.jsonl"),
-  ATOMIC_V021_VIT_B_32_LAION2B_E16_IMAGE_VAL(JsonStringTopicReader.class, "topics.atomic.validation.image.ViT-B-32.laion2b_e16.jsonl"),
-  ATOMIC_V021_VIT_BIGG_14_LAION2B_S39B_B160K_TEXT_VAL(JsonStringTopicReader.class, "topics.atomic.validation.text.ViT-bigG-14.laion2b_s39b_b160k.jsonl"),
-  ATOMIC_V021_VIT_BIGG_14_LAION2B_S39B_B160K_IMAGE_VAL(JsonStringTopicReader.class, "topics.atomic.validation.image.ViT-bigG-14.laion2b_s39b_b160k.jsonl"),
-  ATOMIC_V021_VIT_H_14_LAION2B_S32B_B79K_TEXT_VAL(JsonStringTopicReader.class, "topics.atomic.validation.text.ViT-H-14.laion2b_s32b_b79k.jsonl"),
-  ATOMIC_V021_VIT_H_14_LAION2B_S32B_B79K_IMAGE_VAL(JsonStringTopicReader.class, "topics.atomic.validation.image.ViT-H-14.laion2b_s32b_b79k.jsonl"),
-  ATOMIC_V021_VIT_B_32_LAION400M_E32_TEXT_VAL(JsonStringTopicReader.class, "topics.atomic.validation.text.ViT-B-32.laion400m_e32.jsonl"),
-  ATOMIC_V021_VIT_B_32_LAION400M_E32_IMAGE_VAL(JsonStringTopicReader.class, "topics.atomic.validation.image.ViT-B-32.laion400m_e32.jsonl"),
-  ATOMIC_V021_SALESFORCE_BLIP_ITM_LARGE_COCO_TEXT_VAL(JsonStringTopicReader.class, "topics.atomic.validation.text.Salesforce.blip-itm-large-coco.jsonl"),
-  ATOMIC_V021_SALESFORCE_BLIP_ITM_LARGE_COCO_IMAGE_VAL(JsonStringTopicReader.class, "topics.atomic.validation.image.Salesforce.blip-itm-large-coco.jsonl"),
-  ATOMIC_V021_SALESFORCE_BLIP_ITM_BASE_COCO_TEXT_VAL(JsonStringTopicReader.class, "topics.atomic.validation.text.Salesforce.blip-itm-base-coco.jsonl"),
-  ATOMIC_V021_SALESFORCE_BLIP_ITM_BASE_COCO_IMAGE_VAL(JsonStringTopicReader.class, "topics.atomic.validation.image.Salesforce.blip-itm-base-coco.jsonl"),
-  ATOMIC_V021_OPENAI_CLIP_VIT_BASE_PATCH32_TEXT_VAL(JsonStringTopicReader.class, "topics.atomic.validation.text.openai.clip-vit-base-patch32.jsonl"),
-  ATOMIC_V021_OPENAI_CLIP_VIT_BASE_PATCH32_IMAGE_VAL(JsonStringTopicReader.class, "topics.atomic.validation.image.openai.clip-vit-base-patch32.jsonl"),
-  ATOMIC_V021_OPENAI_CLIP_VIT_LARGE_PATCH14_TEXT_VAL(JsonStringTopicReader.class, "topics.atomic.validation.text.openai.clip-vit-large-patch14.jsonl"),
-  ATOMIC_V021_OPENAI_CLIP_VIT_LARGE_PATCH14_IMAGE_VAL(JsonStringTopicReader.class, "topics.atomic.validation.image.openai.clip-vit-large-patch14.jsonl"),
-  ATOMIC_V021_FACEBOOK_FLAVA_FULL_TEXT_VAL(JsonStringTopicReader.class, "topics.atomic.validation.text.facebook.flava-full.jsonl"),
-  ATOMIC_V021_FACEBOOK_FLAVA_FULL_IMAGE_VAL(JsonStringTopicReader.class, "topics.atomic.validation.image.facebook.flava-full.jsonl"),
-
-  // CIRAL Queries
-  CIRAL_V10_HA_TEST_A(TsvIntTopicReader.class, "topics.ciral-v1.0-ha-test-a.tsv"),
-  CIRAL_V10_SO_TEST_A(TsvIntTopicReader.class, "topics.ciral-v1.0-so-test-a.tsv"),
-  CIRAL_V10_SW_TEST_A(TsvIntTopicReader.class, "topics.ciral-v1.0-sw-test-a.tsv"),
-  CIRAL_V10_YO_TEST_A(TsvIntTopicReader.class, "topics.ciral-v1.0-yo-test-a.tsv"),
-  CIRAL_V10_HA_TEST_B(TsvIntTopicReader.class, "topics.ciral-v1.0-ha-test-b.tsv"),
-  CIRAL_V10_SO_TEST_B(TsvIntTopicReader.class, "topics.ciral-v1.0-so-test-b.tsv"),
-  CIRAL_V10_SW_TEST_B(TsvIntTopicReader.class, "topics.ciral-v1.0-sw-test-b.tsv"),
-  CIRAL_V10_YO_TEST_B(TsvIntTopicReader.class, "topics.ciral-v1.0-yo-test-b.tsv"),
-  CIRAL_V10_HA_TEST_A_NATIVE(TsvIntTopicReader.class, "topics.ciral-v1.0-ha-test-a-native.tsv"),
-  CIRAL_V10_SO_TEST_A_NATIVE(TsvIntTopicReader.class, "topics.ciral-v1.0-so-test-a-native.tsv"),
-  CIRAL_V10_SW_TEST_A_NATIVE(TsvIntTopicReader.class, "topics.ciral-v1.0-sw-test-a-native.tsv"),
-  CIRAL_V10_YO_TEST_A_NATIVE(TsvIntTopicReader.class, "topics.ciral-v1.0-yo-test-a-native.tsv"),
-  CIRAL_V10_HA_TEST_B_NATIVE(TsvIntTopicReader.class, "topics.ciral-v1.0-ha-test-b-native.tsv"),
-  CIRAL_V10_SO_TEST_B_NATIVE(TsvIntTopicReader.class, "topics.ciral-v1.0-so-test-b-native.tsv"),
-  CIRAL_V10_SW_TEST_B_NATIVE(TsvIntTopicReader.class, "topics.ciral-v1.0-sw-test-b-native.tsv"),
-  CIRAL_V10_YO_TEST_B_NATIVE(TsvIntTopicReader.class, "topics.ciral-v1.0-yo-test-b-native.tsv"),
-  CIRAL_V10_HA_DEV_MONO(TsvIntTopicReader.class, "topics.ciral-v1.0-ha-dev-native.tsv"),
-  CIRAL_V10_SO_DEV_MONO(TsvIntTopicReader.class, "topics.ciral-v1.0-so-dev-native.tsv"),
-  CIRAL_V10_SW_DEV_MONO(TsvIntTopicReader.class, "topics.ciral-v1.0-sw-dev-native.tsv"),
-  CIRAL_V10_YO_DEV_MONO(TsvIntTopicReader.class, "topics.ciral-v1.0-yo-dev-native.tsv"),
-
-  // BRIGHT queries converted to tsv format (some spacing changes were made to the original queries)
-  BRIGHT_BIOLOGY(TsvStringTopicReader.class, "topics.bright-biology.tsv.gz"),
-  BRIGHT_EARTH_SCIENCE(TsvStringTopicReader.class, "topics.bright-earth-science.tsv.gz"),
-  BRIGHT_ECONOMICS(TsvStringTopicReader.class, "topics.bright-economics.tsv.gz"),
-  BRIGHT_PSYCHOLOGY(TsvStringTopicReader.class, "topics.bright-psychology.tsv.gz"),
-  BRIGHT_ROBOTICS(TsvStringTopicReader.class, "topics.bright-robotics.tsv.gz"),
-  BRIGHT_STACKOVERFLOW(TsvStringTopicReader.class, "topics.bright-stackoverflow.tsv.gz"),
-  BRIGHT_SUSTAINABLE_LIVING(TsvStringTopicReader.class, "topics.bright-sustainable-living.tsv.gz"),
-  BRIGHT_PONY(TsvStringTopicReader.class, "topics.bright-pony.tsv.gz"),
-  BRIGHT_LEETCODE(TsvStringTopicReader.class, "topics.bright-leetcode.tsv.gz"),
-  BRIGHT_AOPS(TsvStringTopicReader.class, "topics.bright-aops.tsv.gz"),
-  BRIGHT_THEOREMQA_THEOREMS(TsvStringTopicReader.class, "topics.bright-theoremqa-theorems.tsv.gz"),
-  BRIGHT_THEOREMQA_QUESTIONS(TsvStringTopicReader.class, "topics.bright-theoremqa-questions.tsv.gz"),
-
-  // BRIGHT queries original jsonl format
-  BRIGHT_BIOLOGY_ORIGINAL(JsonStringTopicReader.class, "topics.bright-biology-original.jsonl.gz"),
-  BRIGHT_EARTH_SCIENCE_ORIGINAL(JsonStringTopicReader.class, "topics.bright-earth-science-original.jsonl.gz"),
-  BRIGHT_ECONOMICS_ORIGINAL(JsonStringTopicReader.class, "topics.bright-economics-original.jsonl.gz"),
-  BRIGHT_PSYCHOLOGY_ORIGINAL(JsonStringTopicReader.class, "topics.bright-psychology-original.jsonl.gz"),
-  BRIGHT_ROBOTICS_ORIGINAL(JsonStringTopicReader.class, "topics.bright-robotics-original.jsonl.gz"),
-  BRIGHT_STACKOVERFLOW_ORIGINAL(JsonStringTopicReader.class, "topics.bright-stackoverflow-original.jsonl.gz"),
-  BRIGHT_SUSTAINABLE_LIVING_ORIGINAL(JsonStringTopicReader.class, "topics.bright-sustainable-living-original.jsonl.gz"),
-  BRIGHT_PONY_ORIGINAL(JsonStringTopicReader.class, "topics.bright-pony-original.jsonl.gz"),
-  BRIGHT_LEETCODE_ORIGINAL(JsonStringTopicReader.class, "topics.bright-leetcode-original.jsonl.gz"),
-  BRIGHT_AOPS_ORIGINAL(JsonStringTopicReader.class, "topics.bright-aops-original.jsonl.gz"),
-  BRIGHT_THEOREMQA_THEOREMS_ORIGINAL(JsonStringTopicReader.class, "topics.bright-theoremqa-theorems-original.jsonl.gz"),
-  BRIGHT_THEOREMQA_QUESTIONS_ORIGINAL(JsonStringTopicReader.class, "topics.bright-theoremqa-questions-original.jsonl.gz"),
-
-  // M-BEIR original queries
-  M_BEIR_CIRR_TASK7_TEST(JsonStringTopicReader.class, "topics.mbeir-cirr_task7.test.jsonl"),
-  M_BEIR_EDIS_TASK2_TEST(JsonStringTopicReader.class, "topics.mbeir-edis_task2.test.jsonl"),
-  M_BEIR_FASHION200K_TASK0_TEST(JsonStringTopicReader.class, "topics.mbeir-fashion200k_task0.test.jsonl"),
-  M_BEIR_FASHION200K_TASK3_TEST(JsonStringTopicReader.class, "topics.mbeir-fashion200k_task3.test.jsonl"),
-  M_BEIR_FASHIONIQ_TASK7_TEST(JsonStringTopicReader.class, "topics.mbeir-fashioniq_task7.test.jsonl"),
-  M_BEIR_INFOSEEK_TASK6_TEST(JsonStringTopicReader.class, "topics.mbeir-infoseek_task6.test.jsonl"),
-  M_BEIR_INFOSEEK_TASK8_TEST(JsonStringTopicReader.class, "topics.mbeir-infoseek_task8.test.jsonl"),
-  M_BEIR_MSCOCO_TASK0_TEST(JsonStringTopicReader.class, "topics.mbeir-mscoco_task0.test.jsonl"),
-  M_BEIR_MSCOCO_TASK3_TEST(JsonStringTopicReader.class, "topics.mbeir-mscoco_task3.test.jsonl"),
-  M_BEIR_NIGHTS_TASK4_TEST(JsonStringTopicReader.class, "topics.mbeir-nights_task4.test.jsonl"),
-  M_BEIR_OVEN_TASK6_TEST(JsonStringTopicReader.class, "topics.mbeir-oven_task6.test.jsonl"),
-  M_BEIR_OVEN_TASK8_TEST(JsonStringTopicReader.class, "topics.mbeir-oven_task8.test.jsonl"),
-  M_BEIR_VISUALNEWS_TASK0_TEST(JsonStringTopicReader.class, "topics.mbeir-visualnews_task0.test.jsonl"),
-  M_BEIR_VISUALNEWS_TASK3_TEST(JsonStringTopicReader.class, "topics.mbeir-visualnews_task3.test.jsonl"),
-  M_BEIR_WEBQA_TASK1_TEST(JsonStringTopicReader.class, "topics.mbeir-webqa_task1.test.jsonl"),
-  M_BEIR_WEBQA_TASK2_TEST(JsonStringTopicReader.class, "topics.mbeir-webqa_task2.test.jsonl"),
-
-  // MMEB-VisDoc queries
-  MMEB_VISDOC_VIDORE_ARXIVQA_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_arxivqa.test.jsonl"),
-  MMEB_VISDOC_VIDORE_DOCVQA_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_docvqa.test.jsonl"),
-  MMEB_VISDOC_VIDORE_INFOVQA_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_infovqa.test.jsonl"),
-  MMEB_VISDOC_VIDORE_SHIFTPROJECT_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_shiftproject.test.jsonl"),
-  MMEB_VISDOC_VIDORE_SYNTHETIC_DOCQA_ARTIFICIAL_INTELLIGENCE_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_syntheticDocQA_artificial_intelligence.test.jsonl"),
-  MMEB_VISDOC_VIDORE_SYNTHETIC_DOCQA_ENERGY_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_syntheticDocQA_energy.test.jsonl"),
-  MMEB_VISDOC_VIDORE_SYNTHETIC_DOCQA_GOVERNMENT_REPORTS_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_syntheticDocQA_government_reports.test.jsonl"),
-  MMEB_VISDOC_VIDORE_SYNTHETIC_DOCQA_HEALTHCARE_INDUSTRY_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_syntheticDocQA_healthcare_industry.test.jsonl"),
-  MMEB_VISDOC_VIDORE_TABFQUAD_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_tabfquad.test.jsonl"),
-  MMEB_VISDOC_VIDORE_TATDQA_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_tatdqa.test.jsonl"),
-  MMEB_VISDOC_VIDORE_BIOMEDICAL_LECTURES_V2_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_biomedical_lectures_v2.test.jsonl"),
-  MMEB_VISDOC_VIDORE_BIOMEDICAL_LECTURES_V2_MULTILINGUAL_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_biomedical_lectures_v2_multilingual.test.jsonl"),
-  MMEB_VISDOC_VIDORE_ECONOMICS_REPORTS_V2_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_economics_reports_v2.test.jsonl"),
-  MMEB_VISDOC_VIDORE_ECONOMICS_REPORTS_V2_MULTILINGUAL_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_economics_reports_v2_multilingual.test.jsonl"),
-  MMEB_VISDOC_VIDORE_ESG_REPORTS_HUMAN_LABELED_V2_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_esg_reports_human_labeled_v2.test.jsonl"),
-  MMEB_VISDOC_VIDORE_ESG_REPORTS_V2_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_esg_reports_v2.test.jsonl"),
-  MMEB_VISDOC_VIDORE_ESG_REPORTS_V2_MULTILINGUAL_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoRe_esg_reports_v2_multilingual.test.jsonl"),
-  MMEB_VISDOC_VISRAG_ARXIVQA_TRAIN(JsonStringTopicReader.class, "topics.mmeb-visdoc-VisRAG_ArxivQA.train.jsonl"),
-  MMEB_VISDOC_VISRAG_CHARTQA_TRAIN(JsonStringTopicReader.class, "topics.mmeb-visdoc-VisRAG_ChartQA.train.jsonl"),
-  MMEB_VISDOC_VISRAG_INFOVQA_TRAIN(JsonStringTopicReader.class, "topics.mmeb-visdoc-VisRAG_InfoVQA.train.jsonl"),
-  MMEB_VISDOC_VISRAG_MP_DOCVQA_TRAIN(JsonStringTopicReader.class, "topics.mmeb-visdoc-VisRAG_MP-DocVQA.train.jsonl"),
-  MMEB_VISDOC_VISRAG_PLOTQA_TRAIN(JsonStringTopicReader.class, "topics.mmeb-visdoc-VisRAG_PlotQA.train.jsonl"),
-  MMEB_VISDOC_VISRAG_SLIDEVQA_TRAIN(JsonStringTopicReader.class, "topics.mmeb-visdoc-VisRAG_SlideVQA.train.jsonl"),
-  MMEB_VISDOC_VIDOSEEK_DOC_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoSeek-doc.test.jsonl"),
-  MMEB_VISDOC_VIDOSEEK_PAGE_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-ViDoSeek-page.test.jsonl"),
-  MMEB_VISDOC_MMLONGBENCH_DOC_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-MMLongBench-doc.test.jsonl"),
-  MMEB_VISDOC_MMLONGBENCH_PAGE_TEST(JsonStringTopicReader.class, "topics.mmeb-visdoc-MMLongBench-page.test.jsonl"),
-
-  // unused topics
-  CACM(CacmTopicReader.class,                   "topics.cacm.txt"),
-  NTCIR_EN_1(NtcirTopicReader.class,            "topics.www1.english.txt"),
-  NTCIR_EN_2(NtcirTopicReader.class,            "topics.www2.english.txt"),
-  TERABYTE_05_EFFICIENCY(WebTopicReader.class,  "topics.terabyte05.efficiency.txt"),
-  NTCIR_8_EN_EVAL(TsvStringTopicReader.class,   "topics.ntcir8en.eval.txt");
+public final class Topics {
+  private static final String LOCAL_METADATA_RESOURCE = "topics-and-qrels/_local_metadata_topics.json";
+  private static final String LOCAL_ALIASES_METADATA_RESOURCE = "topics-and-qrels/_local_metadata_topics_aliases.json";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static volatile Registry registryCache;
 
   public final String path;
   public final Class<? extends TopicReader<?>> readerClass;
 
-  Topics(Class<? extends TopicReader<?>> c, String path) {
-    this.readerClass = c;
+  private final String name;
+
+  private Topics(String name, Class<? extends TopicReader<?>> readerClass, String path) {
+    this.name = name;
+    this.readerClass = readerClass;
     this.path = path;
   }
 
-  private static final Map<String, Topics> SYMBOL_DICTIONARY = generateSymbolDictionary();
-
-  private static Map<String, Topics> generateSymbolDictionary() {
-    Map<String, Topics> m = new HashMap<>();
-    for (Topics t : Topics.values()) {
-      String sym = t.path.replaceFirst("^topics\\.", "");
-      sym = sym.replaceFirst("(\\.tsv|\\.txt|\\.txt\\.gz|\\.jsonl|\\.jsonl\\.gz|\\.tsv\\.gz)$", "");
-      m.put(sym, t);
-    }
-
-    // Additional aliases
-    m.put("msmarco-passage-dev", MSMARCO_PASSAGE_DEV_SUBSET);
-    m.put("msmarco-passage-dev-splade-pp-ed", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_ED);
-    m.put("msmarco-passage-dev-splade-pp-sd", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_SD);
-    m.put("msmarco-passage-dev-cohere-embed-english-v3.0", MSMARCO_PASSAGE_DEV_SUBSET_COHERE_EMBED_ENGLISH_30);
-
-    m.put("msmarco-passage-dev.splade-pp-ed", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_ED);
-    m.put("msmarco-passage-dev.splade-pp-sd", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_SD);
-    m.put("msmarco-passage-dev.cohere-embed-english-v3.0", MSMARCO_PASSAGE_DEV_SUBSET_COHERE_EMBED_ENGLISH_30);
-
-    m.put("msmarco-passage.dev", MSMARCO_PASSAGE_DEV_SUBSET);
-    m.put("msmarco-passage.dev.splade-pp-ed", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_ED);
-    m.put("msmarco-passage.dev.splade-pp-sd", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_SD);
-    m.put("msmarco-passage.dev.cohere-embed-english-v3.0", MSMARCO_PASSAGE_DEV_SUBSET_COHERE_EMBED_ENGLISH_30);
-
-    m.put("msmarco-v1-passage-dev", MSMARCO_PASSAGE_DEV_SUBSET);
-    m.put("msmarco-v1-passage-dev-splade-pp-ed", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_ED);
-    m.put("msmarco-v1-passage-dev-splade-pp-sd", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_SD);
-    m.put("msmarco-v1-passage-dev-cohere-embed-english-v3.0", MSMARCO_PASSAGE_DEV_SUBSET_COHERE_EMBED_ENGLISH_30);
-
-    m.put("msmarco-v1-passage-dev.splade-pp-ed", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_ED);
-    m.put("msmarco-v1-passage-dev.splade-pp-sd", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_SD);
-    m.put("msmarco-v1-passage-dev.cohere-embed-english-v3.0", MSMARCO_PASSAGE_DEV_SUBSET_COHERE_EMBED_ENGLISH_30);
-
-    m.put("msmarco-v1-passage.dev", MSMARCO_PASSAGE_DEV_SUBSET);
-    m.put("msmarco-v1-passage.dev.splade-pp-ed", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_ED);
-    m.put("msmarco-v1-passage.dev.splade-pp-sd", MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_SD);
-    m.put("msmarco-v1-passage.dev.cohere-embed-english-v3.0", MSMARCO_PASSAGE_DEV_SUBSET_COHERE_EMBED_ENGLISH_30);
-
-    m.put("dl20-passage", TREC2020_DL);
-    m.put("dl20-doc", TREC2020_DL);
-
-    m.put("dl20-passage.splade-pp-ed", TREC2020_DL_SPLADE_PP_ED);
-    m.put("dl20-passage.splade-pp-sd", TREC2020_DL_SPLADE_PP_SD);
-    m.put("dl20-passage.cohere-embed-english-v3.0", TREC2020_DL_COHERE_EMBED_ENGLISH_30);
-    m.put("dl20-passage.unicoil.0shot", TREC2020_DL_UNICOIL);
-    m.put("dl20-passage.unicoil-noexp.0shot", TREC2020_DL_UNICOIL_NOEXP);
-
-    m.put("dl20-doc.splade-pp-ed", TREC2020_DL_SPLADE_PP_ED);
-    m.put("dl20-doc.splade-pp-sd", TREC2020_DL_SPLADE_PP_SD);
-    m.put("dl20-doc.cohere-embed-english-v3.0", TREC2020_DL_COHERE_EMBED_ENGLISH_30);
-    m.put("dl20-doc.unicoil.0shot", TREC2020_DL_UNICOIL);
-    m.put("dl20-doc.unicoil-noexp.0shot", TREC2020_DL_UNICOIL_NOEXP);
-
-    m.put("dl21-passage", TREC2021_DL);
-    m.put("dl21-doc", TREC2021_DL);
-    m.put("dl22-passage", TREC2022_DL);
-    m.put("dl22-doc", TREC2022_DL);
-    m.put("dl23-passage", TREC2023_DL);
-    m.put("dl23-doc", TREC2023_DL);
-
-    m.put("beir-trec-covid", BEIR_V1_0_0_TREC_COVID_TEST);
-    m.put("beir-bioasq", BEIR_V1_0_0_BIOASQ_TEST);
-    m.put("beir-nfcorpus", BEIR_V1_0_0_NFCORPUS_TEST);
-    m.put("beir-nq", BEIR_V1_0_0_NQ_TEST);
-    m.put("beir-hotpotqa", BEIR_V1_0_0_HOTPOTQA_TEST);
-    m.put("beir-fiqa", BEIR_V1_0_0_FIQA_TEST);
-    m.put("beir-signal1m", BEIR_V1_0_0_SIGNAL1M_TEST);
-    m.put("beir-trec-news", BEIR_V1_0_0_TREC_NEWS_TEST);
-    m.put("beir-robust04", BEIR_V1_0_0_ROBUST04_TEST);
-    m.put("beir-arguana", BEIR_V1_0_0_ARGUANA_TEST);
-    m.put("beir-webis-touche2020", BEIR_V1_0_0_WEBIS_TOUCHE2020_TEST);
-    m.put("beir-cqadupstack-android", BEIR_V1_0_0_CQADUPSTACK_ANDROID_TEST);
-    m.put("beir-cqadupstack-english", BEIR_V1_0_0_CQADUPSTACK_ENGLISH_TEST);
-    m.put("beir-cqadupstack-gaming", BEIR_V1_0_0_CQADUPSTACK_GAMING_TEST);
-    m.put("beir-cqadupstack-gis", BEIR_V1_0_0_CQADUPSTACK_GIS_TEST);
-    m.put("beir-cqadupstack-mathematica", BEIR_V1_0_0_CQADUPSTACK_MATHEMATICA_TEST);
-    m.put("beir-cqadupstack-physics", BEIR_V1_0_0_CQADUPSTACK_PHYSICS_TEST);
-    m.put("beir-cqadupstack-programmers", BEIR_V1_0_0_CQADUPSTACK_PROGRAMMERS_TEST);
-    m.put("beir-cqadupstack-stats", BEIR_V1_0_0_CQADUPSTACK_STATS_TEST);
-    m.put("beir-cqadupstack-tex", BEIR_V1_0_0_CQADUPSTACK_TEX_TEST);
-    m.put("beir-cqadupstack-unix", BEIR_V1_0_0_CQADUPSTACK_UNIX_TEST);
-    m.put("beir-cqadupstack-webmasters", BEIR_V1_0_0_CQADUPSTACK_WEBMASTERS_TEST);
-    m.put("beir-cqadupstack-wordpress", BEIR_V1_0_0_CQADUPSTACK_WORDPRESS_TEST);
-    m.put("beir-quora", BEIR_V1_0_0_QUORA_TEST);
-    m.put("beir-dbpedia-entity", BEIR_V1_0_0_DBPEDIA_ENTITY_TEST);
-    m.put("beir-scidocs", BEIR_V1_0_0_SCIDOCS_TEST);
-    m.put("beir-fever", BEIR_V1_0_0_FEVER_TEST);
-    m.put("beir-climate-fever", BEIR_V1_0_0_CLIMATE_FEVER_TEST);
-    m.put("beir-scifact", BEIR_V1_0_0_SCIFACT_TEST);
-
-    return m;
+  public String name() {
+    return name;
   }
 
-  public static Topics getByName(String name) {
-    try {
-      return Topics.valueOf(name);
-    } catch (IllegalArgumentException e) {
-      if (SYMBOL_DICTIONARY.containsKey(name)) {
-        return SYMBOL_DICTIONARY.get(name);
-      }
-
-      return null;
-    }
+  public static Topics get(String name) {
+    return registryData().get(name);
   }
 
-  public static Set<String> getSymbolDictionaryKeys() {
-    return Collections.unmodifiableSet(SYMBOL_DICTIONARY.keySet());
+  public static Map<String, Topics> registry() {
+    return registryData().canonical;
+  }
+
+  public static Set<String> names() {
+    return Collections.unmodifiableSet(registryData().lookup.keySet());
   }
 
   public static Topics getBaseTopics(String name) {
-    name = name.replaceFirst("^topics\\.", ""); // Remove "topics." prefix if present
-    String regex = "^(.*?)(?:[.-](bge|cohere|splade|unicoil|cosdpr|txt|tsv|v\\d+|v\\d+\\.\\d+)).*"; // Regex to remove model suffixes to get base topi name
-    return Topics.getByName(name.replaceAll(regex, "$1"));
+    name = name.replaceFirst("^topics\\.", "");
+    String regex = "^(.*?)(?:[.-](bge|cohere|splade|unicoil|cosdpr|txt|tsv|v\\d+|v\\d+\\.\\d+)).*";
+    return Topics.get(name.replaceAll(regex, "$1"));
   }
 
   public static <K> SortedMap<K, Map<String, String>> resolve(String topics) {
@@ -633,7 +81,7 @@ public enum Topics {
   public static <K> SortedMap<K, Map<String, String>> resolve(String topics, String topicReader) {
     Path topicsPath = Paths.get(topics);
     if (!Files.exists(topicsPath) || !Files.isRegularFile(topicsPath) || !Files.isReadable(topicsPath)) {
-      Topics ref = Topics.getByName(topics);
+      Topics ref = Topics.get(topics);
       if (ref == null) {
         throw new IllegalArgumentException(String.format("\"%s\" does not refer to valid topics.", topicsPath));
       }
@@ -667,5 +115,117 @@ public enum Topics {
     }
 
     return topics;
+  }
+
+  private static Registry registryData() {
+    Registry registry = registryCache;
+    if (registry == null) {
+      synchronized (Topics.class) {
+        registry = registryCache;
+        if (registry == null) {
+          registry = loadRegistry();
+          registryCache = registry;
+        }
+      }
+    }
+    return registry;
+  }
+
+  private static Registry loadRegistry() {
+    Map<String, TopicMetadata> metadata = loadMetadata();
+    Map<String, List<String>> aliases = loadAliasesMetadata();
+    Map<String, Topics> canonical = new LinkedHashMap<>();
+    Map<String, Topics> lookup = new LinkedHashMap<>();
+
+    for (Map.Entry<String, TopicMetadata> entry : metadata.entrySet()) {
+      String name = entry.getKey();
+      TopicMetadata value = entry.getValue();
+      if (value.path == null || value.path.isBlank()) {
+        throw new IllegalStateException("Topic metadata path is missing: " + name);
+      }
+      if (value.reader_class == null || value.reader_class.isBlank()) {
+        throw new IllegalStateException("Topic metadata reader_class is missing: " + name);
+      }
+
+      Topics topic = new Topics(name, loadReaderClass(value.reader_class), value.path);
+      canonical.put(name, topic);
+      addLookup(lookup, name, topic);
+      addLookup(lookup, value.path, topic);
+      addLookup(lookup, Path.of(value.path).getFileName().toString(), topic);
+    }
+
+    for (Map.Entry<String, List<String>> entry : aliases.entrySet()) {
+      Topics topic = canonical.get(entry.getKey());
+      if (topic == null) {
+        throw new IllegalStateException("Topic alias canonical name is not registered: " + entry.getKey());
+      }
+      for (String alias : entry.getValue()) {
+        addLookup(lookup, alias, topic);
+      }
+    }
+
+    return new Registry(Collections.unmodifiableMap(canonical), Collections.unmodifiableMap(lookup));
+  }
+
+  private static Map<String, TopicMetadata> loadMetadata() {
+    try (InputStream inputStream = Topics.class.getClassLoader().getResourceAsStream(LOCAL_METADATA_RESOURCE)) {
+      if (inputStream == null) {
+        throw new IllegalStateException("Topic metadata resource not found: " + LOCAL_METADATA_RESOURCE);
+      }
+      return MAPPER.readValue(inputStream, new TypeReference<>() {});
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to load topic metadata from " + LOCAL_METADATA_RESOURCE, e);
+    }
+  }
+
+  private static Map<String, List<String>> loadAliasesMetadata() {
+    try (InputStream inputStream = Topics.class.getClassLoader().getResourceAsStream(LOCAL_ALIASES_METADATA_RESOURCE)) {
+      if (inputStream == null) {
+        return Map.of();
+      }
+      return MAPPER.readValue(inputStream, new TypeReference<>() {});
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to load topic aliases metadata from " + LOCAL_ALIASES_METADATA_RESOURCE, e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Class<? extends TopicReader<?>> loadReaderClass(String className) {
+    try {
+      Class<?> clazz = Class.forName(className);
+      if (!TopicReader.class.isAssignableFrom(clazz)) {
+        throw new IllegalStateException("Topic reader class does not extend TopicReader: " + className);
+      }
+      return (Class<? extends TopicReader<?>>) clazz;
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException("Topic reader class not found: " + className, e);
+    }
+  }
+
+  private static void addLookup(Map<String, Topics> lookup, String name, Topics topic) {
+    Topics existing = lookup.get(name);
+    if (existing != null && existing != topic) {
+      throw new IllegalStateException("Topic name maps to conflicting topics: " + name);
+    }
+    lookup.put(name, topic);
+  }
+
+  private static final class Registry {
+    private final Map<String, Topics> canonical;
+    private final Map<String, Topics> lookup;
+
+    private Registry(Map<String, Topics> canonical, Map<String, Topics> lookup) {
+      this.canonical = canonical;
+      this.lookup = lookup;
+    }
+
+    private Topics get(String name) {
+      return lookup.get(name);
+    }
+  }
+
+  private static class TopicMetadata {
+    public String path;
+    public String reader_class;
   }
 }

--- a/src/main/java/io/anserini/search/topicreader/Topics.java
+++ b/src/main/java/io/anserini/search/topicreader/Topics.java
@@ -61,7 +61,15 @@ public final class Topics {
   }
 
   public static Set<String> names() {
-    return Collections.unmodifiableSet(registry().lookup.keySet());
+    return Collections.unmodifiableSet(registry().canonical.keySet());
+  }
+
+  public static Class<? extends TopicReader<?>> getTopicReaderClassForPath(String path) {
+    Topics topic = Topics.get(path);
+    if (topic == null) {
+      topic = Topics.get(Path.of(path).getFileName().toString());
+    }
+    return topic == null ? null : topic.readerClass;
   }
 
   public static <K> SortedMap<K, Map<String, String>> load(String topics) {

--- a/src/main/java/io/anserini/util/DumpAnalyzedQueries.java
+++ b/src/main/java/io/anserini/util/DumpAnalyzedQueries.java
@@ -20,6 +20,7 @@ import io.anserini.analysis.AnalyzerUtils;
 import io.anserini.analysis.AnalyzerMap;
 import io.anserini.index.IndexCollection;
 import io.anserini.search.topicreader.TopicReader;
+import io.anserini.search.topicreader.Topics;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.apache.commons.lang3.StringUtils;
@@ -96,7 +97,7 @@ public class DumpAnalyzedQueries {
 
     TopicReader<?> tr;
     try {
-      Class<? extends TopicReader<?>> clazz = (Class<? extends TopicReader<?>>) TopicReader.getTopicReaderClassByFile(args.topicsFile.toString());
+      Class<? extends TopicReader<?>> clazz = (Class<? extends TopicReader<?>>) Topics.getTopicReaderClassForPath(args.topicsFile.toString());
       if (clazz != null) {
         LOG.warn(String.format("Inferring %s has TopicReader class %s.", args.topicsFile, clazz));
       } else {
@@ -108,8 +109,7 @@ public class DumpAnalyzedQueries {
           System.exit(-1);
         }
 
-        clazz = (Class<? extends TopicReader<?>>) Class.forName(
-            "io.anserini.search.topicreader." + args.topicReader + "TopicReader");
+        clazz = (Class<? extends TopicReader<?>>) Class.forName("io.anserini.search.topicreader." + args.topicReader + "TopicReader");
       }
 
       tr = (TopicReader<?>) clazz.getConstructor(Path.class).newInstance(args.topicsFile);

--- a/src/main/resources/topics-and-qrels/_local_metadata_topics.json
+++ b/src/main/resources/topics-and-qrels/_local_metadata_topics.json
@@ -347,14 +347,6 @@
     "path": "topics.bright-aops-original.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
   },
-  "bright-aops.bge-large-en-v1.5": {
-    "path": "topics.bright-aops.bge-large-en-v1.5.jsonl.gz",
-    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
-  },
-  "bright-aops.splade-v3": {
-    "path": "topics.bright-aops.splade-v3.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
-  },
   "bright-biology": {
     "path": "topics.bright-biology.tsv.gz",
     "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
@@ -362,14 +354,6 @@
   "bright-biology-original": {
     "path": "topics.bright-biology-original.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
-  },
-  "bright-biology.bge-large-en-v1.5": {
-    "path": "topics.bright-biology.bge-large-en-v1.5.jsonl.gz",
-    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
-  },
-  "bright-biology.splade-v3": {
-    "path": "topics.bright-biology.splade-v3.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
   },
   "bright-earth-science": {
     "path": "topics.bright-earth-science.tsv.gz",
@@ -379,14 +363,6 @@
     "path": "topics.bright-earth-science-original.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
   },
-  "bright-earth-science.bge-large-en-v1.5": {
-    "path": "topics.bright-earth-science.bge-large-en-v1.5.jsonl.gz",
-    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
-  },
-  "bright-earth-science.splade-v3": {
-    "path": "topics.bright-earth-science.splade-v3.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
-  },
   "bright-economics": {
     "path": "topics.bright-economics.tsv.gz",
     "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
@@ -394,14 +370,6 @@
   "bright-economics-original": {
     "path": "topics.bright-economics-original.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
-  },
-  "bright-economics.bge-large-en-v1.5": {
-    "path": "topics.bright-economics.bge-large-en-v1.5.jsonl.gz",
-    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
-  },
-  "bright-economics.splade-v3": {
-    "path": "topics.bright-economics.splade-v3.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
   },
   "bright-leetcode": {
     "path": "topics.bright-leetcode.tsv.gz",
@@ -411,14 +379,6 @@
     "path": "topics.bright-leetcode-original.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
   },
-  "bright-leetcode.bge-large-en-v1.5": {
-    "path": "topics.bright-leetcode.bge-large-en-v1.5.jsonl.gz",
-    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
-  },
-  "bright-leetcode.splade-v3": {
-    "path": "topics.bright-leetcode.splade-v3.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
-  },
   "bright-pony": {
     "path": "topics.bright-pony.tsv.gz",
     "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
@@ -426,14 +386,6 @@
   "bright-pony-original": {
     "path": "topics.bright-pony-original.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
-  },
-  "bright-pony.bge-large-en-v1.5": {
-    "path": "topics.bright-pony.bge-large-en-v1.5.jsonl.gz",
-    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
-  },
-  "bright-pony.splade-v3": {
-    "path": "topics.bright-pony.splade-v3.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
   },
   "bright-psychology": {
     "path": "topics.bright-psychology.tsv.gz",
@@ -443,14 +395,6 @@
     "path": "topics.bright-psychology-original.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
   },
-  "bright-psychology.bge-large-en-v1.5": {
-    "path": "topics.bright-psychology.bge-large-en-v1.5.jsonl.gz",
-    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
-  },
-  "bright-psychology.splade-v3": {
-    "path": "topics.bright-psychology.splade-v3.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
-  },
   "bright-robotics": {
     "path": "topics.bright-robotics.tsv.gz",
     "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
@@ -458,14 +402,6 @@
   "bright-robotics-original": {
     "path": "topics.bright-robotics-original.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
-  },
-  "bright-robotics.bge-large-en-v1.5": {
-    "path": "topics.bright-robotics.bge-large-en-v1.5.jsonl.gz",
-    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
-  },
-  "bright-robotics.splade-v3": {
-    "path": "topics.bright-robotics.splade-v3.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
   },
   "bright-stackoverflow": {
     "path": "topics.bright-stackoverflow.tsv.gz",
@@ -475,14 +411,6 @@
     "path": "topics.bright-stackoverflow-original.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
   },
-  "bright-stackoverflow.bge-large-en-v1.5": {
-    "path": "topics.bright-stackoverflow.bge-large-en-v1.5.jsonl.gz",
-    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
-  },
-  "bright-stackoverflow.splade-v3": {
-    "path": "topics.bright-stackoverflow.splade-v3.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
-  },
   "bright-sustainable-living": {
     "path": "topics.bright-sustainable-living.tsv.gz",
     "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
@@ -490,14 +418,6 @@
   "bright-sustainable-living-original": {
     "path": "topics.bright-sustainable-living-original.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
-  },
-  "bright-sustainable-living.bge-large-en-v1.5": {
-    "path": "topics.bright-sustainable-living.bge-large-en-v1.5.jsonl.gz",
-    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
-  },
-  "bright-sustainable-living.splade-v3": {
-    "path": "topics.bright-sustainable-living.splade-v3.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
   },
   "bright-theoremqa-questions": {
     "path": "topics.bright-theoremqa-questions.tsv.gz",
@@ -507,14 +427,6 @@
     "path": "topics.bright-theoremqa-questions-original.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
   },
-  "bright-theoremqa-questions.bge-large-en-v1.5": {
-    "path": "topics.bright-theoremqa-questions.bge-large-en-v1.5.jsonl.gz",
-    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
-  },
-  "bright-theoremqa-questions.splade-v3": {
-    "path": "topics.bright-theoremqa-questions.splade-v3.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
-  },
   "bright-theoremqa-theorems": {
     "path": "topics.bright-theoremqa-theorems.tsv.gz",
     "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
@@ -522,14 +434,6 @@
   "bright-theoremqa-theorems-original": {
     "path": "topics.bright-theoremqa-theorems-original.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
-  },
-  "bright-theoremqa-theorems.bge-large-en-v1.5": {
-    "path": "topics.bright-theoremqa-theorems.bge-large-en-v1.5.jsonl.gz",
-    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
-  },
-  "bright-theoremqa-theorems.splade-v3": {
-    "path": "topics.bright-theoremqa-theorems.splade-v3.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
   },
   "cacm": {
     "path": "topics.cacm.txt",
@@ -679,14 +583,6 @@
     "path": "topics.dl19-doc.txt",
     "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
   },
-  "dl19-doc.unicoil-noexp.0shot": {
-    "path": "topics.dl19-doc.unicoil-noexp.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl19-doc.unicoil.0shot": {
-    "path": "topics.dl19-doc.unicoil.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
   "dl19-doc.wp": {
     "path": "topics.dl19-doc.wp.tsv.gz",
     "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
@@ -698,30 +594,6 @@
   "dl19-passage.cohere-embed-english-v3.0": {
     "path": "topics.dl19-passage.cohere-embed-english-v3.0.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
-  },
-  "dl19-passage.splade-pp-ed": {
-    "path": "topics.dl19-passage.splade-pp-ed.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl19-passage.splade-pp-sd": {
-    "path": "topics.dl19-passage.splade-pp-sd.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl19-passage.splade-v3": {
-    "path": "topics.dl19-passage.splade-v3.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl19-passage.splade_distil_cocodenser_medium": {
-    "path": "topics.dl19-passage.splade_distil_cocodenser_medium.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl19-passage.unicoil-noexp.0shot": {
-    "path": "topics.dl19-passage.unicoil-noexp.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl19-passage.unicoil.0shot": {
-    "path": "topics.dl19-passage.unicoil.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
   },
   "dl19-passage.wp": {
     "path": "topics.dl19-passage.wp.tsv.gz",
@@ -735,30 +607,6 @@
     "path": "topics.dl20.cohere-embed-english-v3.0.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
   },
-  "dl20.splade-pp-ed": {
-    "path": "topics.dl20.splade-pp-ed.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl20.splade-pp-sd": {
-    "path": "topics.dl20.splade-pp-sd.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl20.splade-v3": {
-    "path": "topics.dl20.splade-v3.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl20.splade_distil_cocodenser_medium": {
-    "path": "topics.dl20.splade_distil_cocodenser_medium.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl20.unicoil-noexp.0shot": {
-    "path": "topics.dl20.unicoil-noexp.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl20.unicoil.0shot": {
-    "path": "topics.dl20.unicoil.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
   "dl20.wp": {
     "path": "topics.dl20.wp.tsv.gz",
     "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
@@ -771,22 +619,6 @@
     "path": "topics.dl21.snowflake-arctic-embed-l.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
   },
-  "dl21.splade-pp-ed": {
-    "path": "topics.dl21.splade-pp-ed.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl21.splade-pp-sd": {
-    "path": "topics.dl21.splade-pp-sd.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl21.unicoil-noexp.0shot": {
-    "path": "topics.dl21.unicoil-noexp.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl21.unicoil.0shot": {
-    "path": "topics.dl21.unicoil.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
   "dl22": {
     "path": "topics.dl22.txt",
     "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
@@ -795,22 +627,6 @@
     "path": "topics.dl22.snowflake-arctic-embed-l.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
   },
-  "dl22.splade-pp-ed": {
-    "path": "topics.dl22.splade-pp-ed.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl22.splade-pp-sd": {
-    "path": "topics.dl22.splade-pp-sd.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl22.unicoil-noexp.0shot": {
-    "path": "topics.dl22.unicoil-noexp.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl22.unicoil.0shot": {
-    "path": "topics.dl22.unicoil.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
   "dl23": {
     "path": "topics.dl23.txt",
     "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
@@ -818,22 +634,6 @@
   "dl23.snowflake-arctic-embed-l": {
     "path": "topics.dl23.snowflake-arctic-embed-l.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
-  },
-  "dl23.splade-pp-ed": {
-    "path": "topics.dl23.splade-pp-ed.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl23.splade-pp-sd": {
-    "path": "topics.dl23.splade-pp-sd.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl23.unicoil-noexp.0shot": {
-    "path": "topics.dl23.unicoil-noexp.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "dl23.unicoil.0shot": {
-    "path": "topics.dl23.unicoil.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
   },
   "dpr.curated.test": {
     "path": "topics.dpr.curated.test.txt",
@@ -1415,14 +1215,6 @@
     "path": "topics.msmarco-doc.dev.txt",
     "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
   },
-  "msmarco-doc.dev.unicoil": {
-    "path": "topics.msmarco-doc.dev.unicoil.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-doc.dev.unicoil-noexp": {
-    "path": "topics.msmarco-doc.dev.unicoil-noexp.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
   "msmarco-doc.dev.wp": {
     "path": "topics.msmarco-doc.dev.wp.tsv.gz",
     "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
@@ -1443,38 +1235,6 @@
     "path": "topics.msmarco-passage.dev-subset.deepimpact.tsv.gz",
     "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
   },
-  "msmarco-passage.dev-subset.distill-splade-max": {
-    "path": "topics.msmarco-passage.dev-subset.distill-splade-max.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-passage.dev-subset.splade-pp-ed": {
-    "path": "topics.msmarco-passage.dev-subset.splade-pp-ed.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-passage.dev-subset.splade-pp-sd": {
-    "path": "topics.msmarco-passage.dev-subset.splade-pp-sd.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-passage.dev-subset.splade-v3": {
-    "path": "topics.msmarco-passage.dev-subset.splade-v3.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-passage.dev-subset.splade_distil_cocodenser_medium": {
-    "path": "topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-passage.dev-subset.unicoil": {
-    "path": "topics.msmarco-passage.dev-subset.unicoil.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-passage.dev-subset.unicoil-noexp": {
-    "path": "topics.msmarco-passage.dev-subset.unicoil-noexp.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-passage.dev-subset.unicoil-tilde-expansion": {
-    "path": "topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
   "msmarco-passage.dev-subset.wp": {
     "path": "topics.msmarco-passage.dev-subset.wp.tsv.gz",
     "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
@@ -1491,14 +1251,6 @@
     "path": "topics.msmarco-v2-doc.dev.snowflake-arctic-embed-l.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
   },
-  "msmarco-v2-doc.dev.unicoil-noexp.0shot": {
-    "path": "topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-v2-doc.dev.unicoil.0shot": {
-    "path": "topics.msmarco-v2-doc.dev.unicoil.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
   "msmarco-v2-doc.dev2": {
     "path": "topics.msmarco-v2-doc.dev2.txt",
     "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
@@ -1507,52 +1259,12 @@
     "path": "topics.msmarco-v2-doc.dev2.snowflake-arctic-embed-l.jsonl.gz",
     "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
   },
-  "msmarco-v2-doc.dev2.unicoil-noexp.0shot": {
-    "path": "topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-v2-doc.dev2.unicoil.0shot": {
-    "path": "topics.msmarco-v2-doc.dev2.unicoil.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
   "msmarco-v2-passage.dev": {
     "path": "topics.msmarco-v2-passage.dev.txt",
     "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
   },
-  "msmarco-v2-passage.dev.splade-pp-ed": {
-    "path": "topics.msmarco-v2-passage.dev.splade-pp-ed.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-v2-passage.dev.splade-pp-sd": {
-    "path": "topics.msmarco-v2-passage.dev.splade-pp-sd.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-v2-passage.dev.unicoil-noexp.0shot": {
-    "path": "topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-v2-passage.dev.unicoil.0shot": {
-    "path": "topics.msmarco-v2-passage.dev.unicoil.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
   "msmarco-v2-passage.dev2": {
     "path": "topics.msmarco-v2-passage.dev2.txt",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-v2-passage.dev2.splade-pp-ed": {
-    "path": "topics.msmarco-v2-passage.dev2.splade-pp-ed.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-v2-passage.dev2.splade-pp-sd": {
-    "path": "topics.msmarco-v2-passage.dev2.splade-pp-sd.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-v2-passage.dev2.unicoil-noexp.0shot": {
-    "path": "topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.tsv.gz",
-    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
-  },
-  "msmarco-v2-passage.dev2.unicoil.0shot": {
-    "path": "topics.msmarco-v2-passage.dev2.unicoil.0shot.tsv.gz",
     "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
   },
   "neuclir22-en.original-desc": {

--- a/src/main/resources/topics-and-qrels/_local_metadata_topics.json
+++ b/src/main/resources/topics-and-qrels/_local_metadata_topics.json
@@ -1,0 +1,1842 @@
+{
+  "adhoc.101-150": {
+    "path": "topics.adhoc.101-150.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
+  "adhoc.151-200": {
+    "path": "topics.adhoc.151-200.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
+  "adhoc.451-550": {
+    "path": "topics.adhoc.451-550.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
+  "adhoc.51-100": {
+    "path": "topics.adhoc.51-100.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
+  "atomic.validation.image.Salesforce.blip-itm-base-coco": {
+    "path": "topics.atomic.validation.image.Salesforce.blip-itm-base-coco.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.image.Salesforce.blip-itm-large-coco": {
+    "path": "topics.atomic.validation.image.Salesforce.blip-itm-large-coco.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.image.ViT-B-32.laion2b_e16": {
+    "path": "topics.atomic.validation.image.ViT-B-32.laion2b_e16.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.image.ViT-B-32.laion400m_e32": {
+    "path": "topics.atomic.validation.image.ViT-B-32.laion400m_e32.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.image.ViT-H-14.laion2b_s32b_b79k": {
+    "path": "topics.atomic.validation.image.ViT-H-14.laion2b_s32b_b79k.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.image.ViT-L-14.laion2b_s32b_b82k": {
+    "path": "topics.atomic.validation.image.ViT-L-14.laion2b_s32b_b82k.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.image.ViT-bigG-14.laion2b_s39b_b160k": {
+    "path": "topics.atomic.validation.image.ViT-bigG-14.laion2b_s39b_b160k.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.image.facebook.flava-full": {
+    "path": "topics.atomic.validation.image.facebook.flava-full.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.image.openai.clip-vit-base-patch32": {
+    "path": "topics.atomic.validation.image.openai.clip-vit-base-patch32.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.image.openai.clip-vit-large-patch14": {
+    "path": "topics.atomic.validation.image.openai.clip-vit-large-patch14.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.text.Salesforce.blip-itm-base-coco": {
+    "path": "topics.atomic.validation.text.Salesforce.blip-itm-base-coco.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.text.Salesforce.blip-itm-large-coco": {
+    "path": "topics.atomic.validation.text.Salesforce.blip-itm-large-coco.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.text.ViT-B-32.laion2b_e16": {
+    "path": "topics.atomic.validation.text.ViT-B-32.laion2b_e16.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.text.ViT-B-32.laion400m_e32": {
+    "path": "topics.atomic.validation.text.ViT-B-32.laion400m_e32.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.text.ViT-H-14.laion2b_s32b_b79k": {
+    "path": "topics.atomic.validation.text.ViT-H-14.laion2b_s32b_b79k.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.text.ViT-L-14.laion2b_s32b_b82k": {
+    "path": "topics.atomic.validation.text.ViT-L-14.laion2b_s32b_b82k.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.text.ViT-bigG-14.laion2b_s39b_b160k": {
+    "path": "topics.atomic.validation.text.ViT-bigG-14.laion2b_s39b_b160k.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.text.facebook.flava-full": {
+    "path": "topics.atomic.validation.text.facebook.flava-full.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.text.openai.clip-vit-base-patch32": {
+    "path": "topics.atomic.validation.text.openai.clip-vit-base-patch32.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "atomic.validation.text.openai.clip-vit-large-patch14": {
+    "path": "topics.atomic.validation.text.openai.clip-vit-large-patch14.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "backgroundlinking18": {
+    "path": "topics.backgroundlinking18.txt",
+    "reader_class": "io.anserini.search.topicreader.BackgroundLinkingTopicReader"
+  },
+  "backgroundlinking19": {
+    "path": "topics.backgroundlinking19.txt",
+    "reader_class": "io.anserini.search.topicreader.BackgroundLinkingTopicReader"
+  },
+  "backgroundlinking20": {
+    "path": "topics.backgroundlinking20.txt",
+    "reader_class": "io.anserini.search.topicreader.BackgroundLinkingTopicReader"
+  },
+  "beir-v1.0.0-arguana.test": {
+    "path": "topics.beir-v1.0.0-arguana.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-arguana.test.wp": {
+    "path": "topics.beir-v1.0.0-arguana.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-bioasq.test": {
+    "path": "topics.beir-v1.0.0-bioasq.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-bioasq.test.wp": {
+    "path": "topics.beir-v1.0.0-bioasq.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-climate-fever.test": {
+    "path": "topics.beir-v1.0.0-climate-fever.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-climate-fever.test.wp": {
+    "path": "topics.beir-v1.0.0-climate-fever.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-android.test": {
+    "path": "topics.beir-v1.0.0-cqadupstack-android.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-android.test.wp": {
+    "path": "topics.beir-v1.0.0-cqadupstack-android.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-english.test": {
+    "path": "topics.beir-v1.0.0-cqadupstack-english.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-english.test.wp": {
+    "path": "topics.beir-v1.0.0-cqadupstack-english.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-gaming.test": {
+    "path": "topics.beir-v1.0.0-cqadupstack-gaming.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-gaming.test.wp": {
+    "path": "topics.beir-v1.0.0-cqadupstack-gaming.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-gis.test": {
+    "path": "topics.beir-v1.0.0-cqadupstack-gis.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-gis.test.wp": {
+    "path": "topics.beir-v1.0.0-cqadupstack-gis.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-mathematica.test": {
+    "path": "topics.beir-v1.0.0-cqadupstack-mathematica.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-mathematica.test.wp": {
+    "path": "topics.beir-v1.0.0-cqadupstack-mathematica.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-physics.test": {
+    "path": "topics.beir-v1.0.0-cqadupstack-physics.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-physics.test.wp": {
+    "path": "topics.beir-v1.0.0-cqadupstack-physics.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-programmers.test": {
+    "path": "topics.beir-v1.0.0-cqadupstack-programmers.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-programmers.test.wp": {
+    "path": "topics.beir-v1.0.0-cqadupstack-programmers.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-stats.test": {
+    "path": "topics.beir-v1.0.0-cqadupstack-stats.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-stats.test.wp": {
+    "path": "topics.beir-v1.0.0-cqadupstack-stats.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-tex.test": {
+    "path": "topics.beir-v1.0.0-cqadupstack-tex.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-tex.test.wp": {
+    "path": "topics.beir-v1.0.0-cqadupstack-tex.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-unix.test": {
+    "path": "topics.beir-v1.0.0-cqadupstack-unix.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-unix.test.wp": {
+    "path": "topics.beir-v1.0.0-cqadupstack-unix.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-webmasters.test": {
+    "path": "topics.beir-v1.0.0-cqadupstack-webmasters.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-webmasters.test.wp": {
+    "path": "topics.beir-v1.0.0-cqadupstack-webmasters.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-wordpress.test": {
+    "path": "topics.beir-v1.0.0-cqadupstack-wordpress.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-cqadupstack-wordpress.test.wp": {
+    "path": "topics.beir-v1.0.0-cqadupstack-wordpress.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-dbpedia-entity.test": {
+    "path": "topics.beir-v1.0.0-dbpedia-entity.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-dbpedia-entity.test.wp": {
+    "path": "topics.beir-v1.0.0-dbpedia-entity.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-fever.test": {
+    "path": "topics.beir-v1.0.0-fever.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-fever.test.wp": {
+    "path": "topics.beir-v1.0.0-fever.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-fiqa.test": {
+    "path": "topics.beir-v1.0.0-fiqa.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-fiqa.test.wp": {
+    "path": "topics.beir-v1.0.0-fiqa.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-hotpotqa.test": {
+    "path": "topics.beir-v1.0.0-hotpotqa.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-hotpotqa.test.wp": {
+    "path": "topics.beir-v1.0.0-hotpotqa.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-nfcorpus.test": {
+    "path": "topics.beir-v1.0.0-nfcorpus.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-nfcorpus.test.wp": {
+    "path": "topics.beir-v1.0.0-nfcorpus.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-nq.test": {
+    "path": "topics.beir-v1.0.0-nq.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-nq.test.wp": {
+    "path": "topics.beir-v1.0.0-nq.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-quora.test": {
+    "path": "topics.beir-v1.0.0-quora.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-quora.test.wp": {
+    "path": "topics.beir-v1.0.0-quora.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-robust04.test": {
+    "path": "topics.beir-v1.0.0-robust04.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-robust04.test.wp": {
+    "path": "topics.beir-v1.0.0-robust04.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-scidocs.test": {
+    "path": "topics.beir-v1.0.0-scidocs.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-scidocs.test.wp": {
+    "path": "topics.beir-v1.0.0-scidocs.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-scifact.test": {
+    "path": "topics.beir-v1.0.0-scifact.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-scifact.test.wp": {
+    "path": "topics.beir-v1.0.0-scifact.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-signal1m.test": {
+    "path": "topics.beir-v1.0.0-signal1m.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-signal1m.test.wp": {
+    "path": "topics.beir-v1.0.0-signal1m.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-trec-covid.test": {
+    "path": "topics.beir-v1.0.0-trec-covid.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-trec-covid.test.wp": {
+    "path": "topics.beir-v1.0.0-trec-covid.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-trec-news.test": {
+    "path": "topics.beir-v1.0.0-trec-news.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-trec-news.test.wp": {
+    "path": "topics.beir-v1.0.0-trec-news.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-webis-touche2020.test": {
+    "path": "topics.beir-v1.0.0-webis-touche2020.test.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "beir-v1.0.0-webis-touche2020.test.wp": {
+    "path": "topics.beir-v1.0.0-webis-touche2020.test.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-aops": {
+    "path": "topics.bright-aops.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-aops-original": {
+    "path": "topics.bright-aops-original.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "bright-aops.bge-large-en-v1.5": {
+    "path": "topics.bright-aops.bge-large-en-v1.5.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
+  },
+  "bright-aops.splade-v3": {
+    "path": "topics.bright-aops.splade-v3.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-biology": {
+    "path": "topics.bright-biology.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-biology-original": {
+    "path": "topics.bright-biology-original.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "bright-biology.bge-large-en-v1.5": {
+    "path": "topics.bright-biology.bge-large-en-v1.5.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
+  },
+  "bright-biology.splade-v3": {
+    "path": "topics.bright-biology.splade-v3.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-earth-science": {
+    "path": "topics.bright-earth-science.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-earth-science-original": {
+    "path": "topics.bright-earth-science-original.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "bright-earth-science.bge-large-en-v1.5": {
+    "path": "topics.bright-earth-science.bge-large-en-v1.5.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
+  },
+  "bright-earth-science.splade-v3": {
+    "path": "topics.bright-earth-science.splade-v3.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-economics": {
+    "path": "topics.bright-economics.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-economics-original": {
+    "path": "topics.bright-economics-original.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "bright-economics.bge-large-en-v1.5": {
+    "path": "topics.bright-economics.bge-large-en-v1.5.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
+  },
+  "bright-economics.splade-v3": {
+    "path": "topics.bright-economics.splade-v3.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-leetcode": {
+    "path": "topics.bright-leetcode.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-leetcode-original": {
+    "path": "topics.bright-leetcode-original.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "bright-leetcode.bge-large-en-v1.5": {
+    "path": "topics.bright-leetcode.bge-large-en-v1.5.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
+  },
+  "bright-leetcode.splade-v3": {
+    "path": "topics.bright-leetcode.splade-v3.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-pony": {
+    "path": "topics.bright-pony.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-pony-original": {
+    "path": "topics.bright-pony-original.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "bright-pony.bge-large-en-v1.5": {
+    "path": "topics.bright-pony.bge-large-en-v1.5.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
+  },
+  "bright-pony.splade-v3": {
+    "path": "topics.bright-pony.splade-v3.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-psychology": {
+    "path": "topics.bright-psychology.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-psychology-original": {
+    "path": "topics.bright-psychology-original.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "bright-psychology.bge-large-en-v1.5": {
+    "path": "topics.bright-psychology.bge-large-en-v1.5.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
+  },
+  "bright-psychology.splade-v3": {
+    "path": "topics.bright-psychology.splade-v3.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-robotics": {
+    "path": "topics.bright-robotics.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-robotics-original": {
+    "path": "topics.bright-robotics-original.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "bright-robotics.bge-large-en-v1.5": {
+    "path": "topics.bright-robotics.bge-large-en-v1.5.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
+  },
+  "bright-robotics.splade-v3": {
+    "path": "topics.bright-robotics.splade-v3.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-stackoverflow": {
+    "path": "topics.bright-stackoverflow.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-stackoverflow-original": {
+    "path": "topics.bright-stackoverflow-original.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "bright-stackoverflow.bge-large-en-v1.5": {
+    "path": "topics.bright-stackoverflow.bge-large-en-v1.5.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
+  },
+  "bright-stackoverflow.splade-v3": {
+    "path": "topics.bright-stackoverflow.splade-v3.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-sustainable-living": {
+    "path": "topics.bright-sustainable-living.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-sustainable-living-original": {
+    "path": "topics.bright-sustainable-living-original.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "bright-sustainable-living.bge-large-en-v1.5": {
+    "path": "topics.bright-sustainable-living.bge-large-en-v1.5.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
+  },
+  "bright-sustainable-living.splade-v3": {
+    "path": "topics.bright-sustainable-living.splade-v3.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-theoremqa-questions": {
+    "path": "topics.bright-theoremqa-questions.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-theoremqa-questions-original": {
+    "path": "topics.bright-theoremqa-questions-original.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "bright-theoremqa-questions.bge-large-en-v1.5": {
+    "path": "topics.bright-theoremqa-questions.bge-large-en-v1.5.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
+  },
+  "bright-theoremqa-questions.splade-v3": {
+    "path": "topics.bright-theoremqa-questions.splade-v3.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-theoremqa-theorems": {
+    "path": "topics.bright-theoremqa-theorems.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "bright-theoremqa-theorems-original": {
+    "path": "topics.bright-theoremqa-theorems-original.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "bright-theoremqa-theorems.bge-large-en-v1.5": {
+    "path": "topics.bright-theoremqa-theorems.bge-large-en-v1.5.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
+  },
+  "bright-theoremqa-theorems.splade-v3": {
+    "path": "topics.bright-theoremqa-theorems.splade-v3.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "cacm": {
+    "path": "topics.cacm.txt",
+    "reader_class": "io.anserini.search.topicreader.CacmTopicReader"
+  },
+  "car17v1.5.benchmarkY1test": {
+    "path": "topics.car17v1.5.benchmarkY1test.txt",
+    "reader_class": "io.anserini.search.topicreader.CarTopicReader"
+  },
+  "car17v2.0.benchmarkY1test": {
+    "path": "topics.car17v2.0.benchmarkY1test.txt",
+    "reader_class": "io.anserini.search.topicreader.CarTopicReader"
+  },
+  "ciral-v1.0-ha-dev-native": {
+    "path": "topics.ciral-v1.0-ha-dev-native.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-ha-test-a": {
+    "path": "topics.ciral-v1.0-ha-test-a.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-ha-test-a-native": {
+    "path": "topics.ciral-v1.0-ha-test-a-native.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-ha-test-b": {
+    "path": "topics.ciral-v1.0-ha-test-b.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-ha-test-b-native": {
+    "path": "topics.ciral-v1.0-ha-test-b-native.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-so-dev-native": {
+    "path": "topics.ciral-v1.0-so-dev-native.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-so-test-a": {
+    "path": "topics.ciral-v1.0-so-test-a.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-so-test-a-native": {
+    "path": "topics.ciral-v1.0-so-test-a-native.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-so-test-b": {
+    "path": "topics.ciral-v1.0-so-test-b.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-so-test-b-native": {
+    "path": "topics.ciral-v1.0-so-test-b-native.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-sw-dev-native": {
+    "path": "topics.ciral-v1.0-sw-dev-native.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-sw-test-a": {
+    "path": "topics.ciral-v1.0-sw-test-a.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-sw-test-a-native": {
+    "path": "topics.ciral-v1.0-sw-test-a-native.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-sw-test-b": {
+    "path": "topics.ciral-v1.0-sw-test-b.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-sw-test-b-native": {
+    "path": "topics.ciral-v1.0-sw-test-b-native.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-yo-dev-native": {
+    "path": "topics.ciral-v1.0-yo-dev-native.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-yo-test-a": {
+    "path": "topics.ciral-v1.0-yo-test-a.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-yo-test-a-native": {
+    "path": "topics.ciral-v1.0-yo-test-a-native.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-yo-test-b": {
+    "path": "topics.ciral-v1.0-yo-test-b.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ciral-v1.0-yo-test-b-native": {
+    "path": "topics.ciral-v1.0-yo-test-b-native.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "clef06fr.mono.fr": {
+    "path": "topics.clef06fr.mono.fr.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "core17": {
+    "path": "topics.core17.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
+  "core18": {
+    "path": "topics.core18.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
+  "covid-round1": {
+    "path": "topics.covid-round1.xml",
+    "reader_class": "io.anserini.search.topicreader.CovidTopicReader"
+  },
+  "covid-round1-udel": {
+    "path": "topics.covid-round1-udel.xml",
+    "reader_class": "io.anserini.search.topicreader.CovidTopicReader"
+  },
+  "covid-round2": {
+    "path": "topics.covid-round2.xml",
+    "reader_class": "io.anserini.search.topicreader.CovidTopicReader"
+  },
+  "covid-round2-udel": {
+    "path": "topics.covid-round2-udel.xml",
+    "reader_class": "io.anserini.search.topicreader.CovidTopicReader"
+  },
+  "covid-round3": {
+    "path": "topics.covid-round3.xml",
+    "reader_class": "io.anserini.search.topicreader.CovidTopicReader"
+  },
+  "covid-round3-udel": {
+    "path": "topics.covid-round3-udel.xml",
+    "reader_class": "io.anserini.search.topicreader.CovidTopicReader"
+  },
+  "covid-round4": {
+    "path": "topics.covid-round4.xml",
+    "reader_class": "io.anserini.search.topicreader.CovidTopicReader"
+  },
+  "covid-round4-udel": {
+    "path": "topics.covid-round4-udel.xml",
+    "reader_class": "io.anserini.search.topicreader.CovidTopicReader"
+  },
+  "covid-round5": {
+    "path": "topics.covid-round5.xml",
+    "reader_class": "io.anserini.search.topicreader.CovidTopicReader"
+  },
+  "covid-round5-udel": {
+    "path": "topics.covid-round5-udel.xml",
+    "reader_class": "io.anserini.search.topicreader.CovidTopicReader"
+  },
+  "dl19-doc": {
+    "path": "topics.dl19-doc.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl19-doc.unicoil-noexp.0shot": {
+    "path": "topics.dl19-doc.unicoil-noexp.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl19-doc.unicoil.0shot": {
+    "path": "topics.dl19-doc.unicoil.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl19-doc.wp": {
+    "path": "topics.dl19-doc.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl19-passage": {
+    "path": "topics.dl19-passage.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl19-passage.cohere-embed-english-v3.0": {
+    "path": "topics.dl19-passage.cohere-embed-english-v3.0.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
+  },
+  "dl19-passage.splade-pp-ed": {
+    "path": "topics.dl19-passage.splade-pp-ed.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl19-passage.splade-pp-sd": {
+    "path": "topics.dl19-passage.splade-pp-sd.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl19-passage.splade-v3": {
+    "path": "topics.dl19-passage.splade-v3.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl19-passage.splade_distil_cocodenser_medium": {
+    "path": "topics.dl19-passage.splade_distil_cocodenser_medium.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl19-passage.unicoil-noexp.0shot": {
+    "path": "topics.dl19-passage.unicoil-noexp.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl19-passage.unicoil.0shot": {
+    "path": "topics.dl19-passage.unicoil.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl19-passage.wp": {
+    "path": "topics.dl19-passage.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl20": {
+    "path": "topics.dl20.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl20.cohere-embed-english-v3.0": {
+    "path": "topics.dl20.cohere-embed-english-v3.0.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
+  },
+  "dl20.splade-pp-ed": {
+    "path": "topics.dl20.splade-pp-ed.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl20.splade-pp-sd": {
+    "path": "topics.dl20.splade-pp-sd.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl20.splade-v3": {
+    "path": "topics.dl20.splade-v3.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl20.splade_distil_cocodenser_medium": {
+    "path": "topics.dl20.splade_distil_cocodenser_medium.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl20.unicoil-noexp.0shot": {
+    "path": "topics.dl20.unicoil-noexp.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl20.unicoil.0shot": {
+    "path": "topics.dl20.unicoil.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl20.wp": {
+    "path": "topics.dl20.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl21": {
+    "path": "topics.dl21.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl21.snowflake-arctic-embed-l": {
+    "path": "topics.dl21.snowflake-arctic-embed-l.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
+  },
+  "dl21.splade-pp-ed": {
+    "path": "topics.dl21.splade-pp-ed.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl21.splade-pp-sd": {
+    "path": "topics.dl21.splade-pp-sd.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl21.unicoil-noexp.0shot": {
+    "path": "topics.dl21.unicoil-noexp.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl21.unicoil.0shot": {
+    "path": "topics.dl21.unicoil.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl22": {
+    "path": "topics.dl22.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl22.snowflake-arctic-embed-l": {
+    "path": "topics.dl22.snowflake-arctic-embed-l.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
+  },
+  "dl22.splade-pp-ed": {
+    "path": "topics.dl22.splade-pp-ed.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl22.splade-pp-sd": {
+    "path": "topics.dl22.splade-pp-sd.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl22.unicoil-noexp.0shot": {
+    "path": "topics.dl22.unicoil-noexp.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl22.unicoil.0shot": {
+    "path": "topics.dl22.unicoil.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl23": {
+    "path": "topics.dl23.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl23.snowflake-arctic-embed-l": {
+    "path": "topics.dl23.snowflake-arctic-embed-l.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
+  },
+  "dl23.splade-pp-ed": {
+    "path": "topics.dl23.splade-pp-ed.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl23.splade-pp-sd": {
+    "path": "topics.dl23.splade-pp-sd.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl23.unicoil-noexp.0shot": {
+    "path": "topics.dl23.unicoil-noexp.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dl23.unicoil.0shot": {
+    "path": "topics.dl23.unicoil.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dpr.curated.test": {
+    "path": "topics.dpr.curated.test.txt",
+    "reader_class": "io.anserini.search.topicreader.DprJsonlTopicReader"
+  },
+  "dpr.nq.dev": {
+    "path": "topics.dpr.nq.dev.txt",
+    "reader_class": "io.anserini.search.topicreader.DprNqTopicReader"
+  },
+  "dpr.nq.test": {
+    "path": "topics.dpr.nq.test.txt",
+    "reader_class": "io.anserini.search.topicreader.DprNqTopicReader"
+  },
+  "dpr.squad.test": {
+    "path": "topics.dpr.squad.test.txt",
+    "reader_class": "io.anserini.search.topicreader.DprJsonlTopicReader"
+  },
+  "dpr.trivia.dev": {
+    "path": "topics.dpr.trivia.dev.txt",
+    "reader_class": "io.anserini.search.topicreader.DprNqTopicReader"
+  },
+  "dpr.trivia.test": {
+    "path": "topics.dpr.trivia.test.txt",
+    "reader_class": "io.anserini.search.topicreader.DprNqTopicReader"
+  },
+  "dpr.trivia.test.gar-t5.all": {
+    "path": "topics.dpr.trivia.test.gar-t5.all.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dpr.trivia.test.gar-t5.answers": {
+    "path": "topics.dpr.trivia.test.gar-t5.answers.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dpr.trivia.test.gar-t5.sentences": {
+    "path": "topics.dpr.trivia.test.gar-t5.sentences.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dpr.trivia.test.gar-t5.titles": {
+    "path": "topics.dpr.trivia.test.gar-t5.titles.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "dpr.wq.test": {
+    "path": "topics.dpr.wq.test.txt",
+    "reader_class": "io.anserini.search.topicreader.DprJsonlTopicReader"
+  },
+  "epidemic-qa.consumer.prelim": {
+    "path": "topics.epidemic-qa.consumer.prelim.json",
+    "reader_class": "io.anserini.search.topicreader.EpidemicQATopicReader"
+  },
+  "epidemic-qa.expert.prelim": {
+    "path": "topics.epidemic-qa.expert.prelim.json",
+    "reader_class": "io.anserini.search.topicreader.EpidemicQATopicReader"
+  },
+  "fire12bn.176-225": {
+    "path": "topics.fire12bn.176-225.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
+  "fire12en.176-225": {
+    "path": "topics.fire12en.176-225.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
+  "fire12hi.176-225": {
+    "path": "topics.fire12hi.176-225.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
+  "hc4-v1.0-fa.dev.desc": {
+    "path": "topics.hc4-v1.0-fa.dev.desc.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-fa.dev.desc.title": {
+    "path": "topics.hc4-v1.0-fa.dev.desc.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-fa.dev.title": {
+    "path": "topics.hc4-v1.0-fa.dev.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-fa.en.test.desc": {
+    "path": "topics.hc4-v1.0-fa.en.test.desc.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-fa.en.test.desc.title": {
+    "path": "topics.hc4-v1.0-fa.en.test.desc.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-fa.en.test.title": {
+    "path": "topics.hc4-v1.0-fa.en.test.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-fa.test.desc": {
+    "path": "topics.hc4-v1.0-fa.test.desc.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-fa.test.desc.title": {
+    "path": "topics.hc4-v1.0-fa.test.desc.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-fa.test.title": {
+    "path": "topics.hc4-v1.0-fa.test.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-ru.dev.desc": {
+    "path": "topics.hc4-v1.0-ru.dev.desc.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-ru.dev.desc.title": {
+    "path": "topics.hc4-v1.0-ru.dev.desc.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-ru.dev.title": {
+    "path": "topics.hc4-v1.0-ru.dev.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-ru.en.test.desc": {
+    "path": "topics.hc4-v1.0-ru.en.test.desc.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-ru.en.test.desc.title": {
+    "path": "topics.hc4-v1.0-ru.en.test.desc.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-ru.en.test.title": {
+    "path": "topics.hc4-v1.0-ru.en.test.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-ru.test.desc": {
+    "path": "topics.hc4-v1.0-ru.test.desc.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-ru.test.desc.title": {
+    "path": "topics.hc4-v1.0-ru.test.desc.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-ru.test.title": {
+    "path": "topics.hc4-v1.0-ru.test.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-zh.dev.desc": {
+    "path": "topics.hc4-v1.0-zh.dev.desc.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-zh.dev.desc.title": {
+    "path": "topics.hc4-v1.0-zh.dev.desc.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-zh.dev.title": {
+    "path": "topics.hc4-v1.0-zh.dev.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-zh.en.test.desc": {
+    "path": "topics.hc4-v1.0-zh.en.test.desc.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-zh.en.test.desc.title": {
+    "path": "topics.hc4-v1.0-zh.en.test.desc.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-zh.en.test.title": {
+    "path": "topics.hc4-v1.0-zh.en.test.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-zh.test.desc": {
+    "path": "topics.hc4-v1.0-zh.test.desc.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-zh.test.desc.title": {
+    "path": "topics.hc4-v1.0-zh.test.desc.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "hc4-v1.0-zh.test.title": {
+    "path": "topics.hc4-v1.0-zh.test.title.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mbeir-cirr_task7.test": {
+    "path": "topics.mbeir-cirr_task7.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mbeir-edis_task2.test": {
+    "path": "topics.mbeir-edis_task2.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mbeir-fashion200k_task0.test": {
+    "path": "topics.mbeir-fashion200k_task0.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mbeir-fashion200k_task3.test": {
+    "path": "topics.mbeir-fashion200k_task3.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mbeir-fashioniq_task7.test": {
+    "path": "topics.mbeir-fashioniq_task7.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mbeir-infoseek_task6.test": {
+    "path": "topics.mbeir-infoseek_task6.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mbeir-infoseek_task8.test": {
+    "path": "topics.mbeir-infoseek_task8.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mbeir-mscoco_task0.test": {
+    "path": "topics.mbeir-mscoco_task0.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mbeir-mscoco_task3.test": {
+    "path": "topics.mbeir-mscoco_task3.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mbeir-nights_task4.test": {
+    "path": "topics.mbeir-nights_task4.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mbeir-oven_task6.test": {
+    "path": "topics.mbeir-oven_task6.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mbeir-oven_task8.test": {
+    "path": "topics.mbeir-oven_task8.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mbeir-visualnews_task0.test": {
+    "path": "topics.mbeir-visualnews_task0.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mbeir-visualnews_task3.test": {
+    "path": "topics.mbeir-visualnews_task3.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mbeir-webqa_task1.test": {
+    "path": "topics.mbeir-webqa_task1.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mbeir-webqa_task2.test": {
+    "path": "topics.mbeir-webqa_task2.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "microblog2011": {
+    "path": "topics.microblog2011.txt",
+    "reader_class": "io.anserini.search.topicreader.MicroblogTopicReader"
+  },
+  "microblog2012": {
+    "path": "topics.microblog2012.txt",
+    "reader_class": "io.anserini.search.topicreader.MicroblogTopicReader"
+  },
+  "microblog2013": {
+    "path": "topics.microblog2013.txt",
+    "reader_class": "io.anserini.search.topicreader.MicroblogTopicReader"
+  },
+  "microblog2014": {
+    "path": "topics.microblog2014.txt",
+    "reader_class": "io.anserini.search.topicreader.MicroblogTopicReader"
+  },
+  "miracl-v1.0-ar-dev": {
+    "path": "topics.miracl-v1.0-ar-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "miracl-v1.0-bn-dev": {
+    "path": "topics.miracl-v1.0-bn-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "miracl-v1.0-de-dev": {
+    "path": "topics.miracl-v1.0-de-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "miracl-v1.0-en-dev": {
+    "path": "topics.miracl-v1.0-en-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "miracl-v1.0-es-dev": {
+    "path": "topics.miracl-v1.0-es-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "miracl-v1.0-fa-dev": {
+    "path": "topics.miracl-v1.0-fa-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "miracl-v1.0-fi-dev": {
+    "path": "topics.miracl-v1.0-fi-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "miracl-v1.0-fr-dev": {
+    "path": "topics.miracl-v1.0-fr-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "miracl-v1.0-hi-dev": {
+    "path": "topics.miracl-v1.0-hi-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "miracl-v1.0-id-dev": {
+    "path": "topics.miracl-v1.0-id-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "miracl-v1.0-ja-dev": {
+    "path": "topics.miracl-v1.0-ja-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "miracl-v1.0-ko-dev": {
+    "path": "topics.miracl-v1.0-ko-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "miracl-v1.0-ru-dev": {
+    "path": "topics.miracl-v1.0-ru-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "miracl-v1.0-sw-dev": {
+    "path": "topics.miracl-v1.0-sw-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "miracl-v1.0-te-dev": {
+    "path": "topics.miracl-v1.0-te-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "miracl-v1.0-th-dev": {
+    "path": "topics.miracl-v1.0-th-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "miracl-v1.0-yo-dev": {
+    "path": "topics.miracl-v1.0-yo-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "miracl-v1.0-zh-dev": {
+    "path": "topics.miracl-v1.0-zh-dev.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "mmeb-visdoc-MMLongBench-doc.test": {
+    "path": "topics.mmeb-visdoc-MMLongBench-doc.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-MMLongBench-page.test": {
+    "path": "topics.mmeb-visdoc-MMLongBench-page.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_arxivqa.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_arxivqa.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_biomedical_lectures_v2.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_biomedical_lectures_v2.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_biomedical_lectures_v2_multilingual.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_biomedical_lectures_v2_multilingual.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_docvqa.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_docvqa.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_economics_reports_v2.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_economics_reports_v2.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_economics_reports_v2_multilingual.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_economics_reports_v2_multilingual.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_esg_reports_human_labeled_v2.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_esg_reports_human_labeled_v2.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_esg_reports_v2.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_esg_reports_v2.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_esg_reports_v2_multilingual.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_esg_reports_v2_multilingual.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_infovqa.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_infovqa.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_shiftproject.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_shiftproject.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_syntheticDocQA_artificial_intelligence.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_syntheticDocQA_artificial_intelligence.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_syntheticDocQA_energy.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_syntheticDocQA_energy.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_syntheticDocQA_government_reports.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_syntheticDocQA_government_reports.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_syntheticDocQA_healthcare_industry.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_syntheticDocQA_healthcare_industry.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_tabfquad.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_tabfquad.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoRe_tatdqa.test": {
+    "path": "topics.mmeb-visdoc-ViDoRe_tatdqa.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoSeek-doc.test": {
+    "path": "topics.mmeb-visdoc-ViDoSeek-doc.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-ViDoSeek-page.test": {
+    "path": "topics.mmeb-visdoc-ViDoSeek-page.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-VisRAG_ArxivQA.train": {
+    "path": "topics.mmeb-visdoc-VisRAG_ArxivQA.train.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-VisRAG_ChartQA.train": {
+    "path": "topics.mmeb-visdoc-VisRAG_ChartQA.train.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-VisRAG_InfoVQA.train": {
+    "path": "topics.mmeb-visdoc-VisRAG_InfoVQA.train.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-VisRAG_MP-DocVQA.train": {
+    "path": "topics.mmeb-visdoc-VisRAG_MP-DocVQA.train.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-VisRAG_PlotQA.train": {
+    "path": "topics.mmeb-visdoc-VisRAG_PlotQA.train.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mmeb-visdoc-VisRAG_SlideVQA.train": {
+    "path": "topics.mmeb-visdoc-VisRAG_SlideVQA.train.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "mq.1-10000": {
+    "path": "topics.mq.1-10000.txt",
+    "reader_class": "io.anserini.search.topicreader.WebTopicReader"
+  },
+  "mq.10001-20000": {
+    "path": "topics.mq.10001-20000.txt",
+    "reader_class": "io.anserini.search.topicreader.WebTopicReader"
+  },
+  "mq.20001-60000": {
+    "path": "topics.mq.20001-60000.txt",
+    "reader_class": "io.anserini.search.topicreader.PrioritizedWebTopicReader"
+  },
+  "mrtydi-v1.1-ar.dev": {
+    "path": "topics.mrtydi-v1.1-ar.dev.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-ar.test": {
+    "path": "topics.mrtydi-v1.1-ar.test.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-ar.train": {
+    "path": "topics.mrtydi-v1.1-ar.train.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-bn.dev": {
+    "path": "topics.mrtydi-v1.1-bn.dev.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-bn.test": {
+    "path": "topics.mrtydi-v1.1-bn.test.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-bn.train": {
+    "path": "topics.mrtydi-v1.1-bn.train.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-en.dev": {
+    "path": "topics.mrtydi-v1.1-en.dev.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-en.test": {
+    "path": "topics.mrtydi-v1.1-en.test.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-en.train": {
+    "path": "topics.mrtydi-v1.1-en.train.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-fi.dev": {
+    "path": "topics.mrtydi-v1.1-fi.dev.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-fi.test": {
+    "path": "topics.mrtydi-v1.1-fi.test.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-fi.train": {
+    "path": "topics.mrtydi-v1.1-fi.train.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-id.dev": {
+    "path": "topics.mrtydi-v1.1-id.dev.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-id.test": {
+    "path": "topics.mrtydi-v1.1-id.test.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-id.train": {
+    "path": "topics.mrtydi-v1.1-id.train.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-ja.dev": {
+    "path": "topics.mrtydi-v1.1-ja.dev.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-ja.test": {
+    "path": "topics.mrtydi-v1.1-ja.test.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-ja.train": {
+    "path": "topics.mrtydi-v1.1-ja.train.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-ko.dev": {
+    "path": "topics.mrtydi-v1.1-ko.dev.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-ko.test": {
+    "path": "topics.mrtydi-v1.1-ko.test.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-ko.train": {
+    "path": "topics.mrtydi-v1.1-ko.train.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-ru.dev": {
+    "path": "topics.mrtydi-v1.1-ru.dev.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-ru.test": {
+    "path": "topics.mrtydi-v1.1-ru.test.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-ru.train": {
+    "path": "topics.mrtydi-v1.1-ru.train.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-sw.dev": {
+    "path": "topics.mrtydi-v1.1-sw.dev.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-sw.test": {
+    "path": "topics.mrtydi-v1.1-sw.test.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-sw.train": {
+    "path": "topics.mrtydi-v1.1-sw.train.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-te.dev": {
+    "path": "topics.mrtydi-v1.1-te.dev.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-te.test": {
+    "path": "topics.mrtydi-v1.1-te.test.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-te.train": {
+    "path": "topics.mrtydi-v1.1-te.train.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-th.dev": {
+    "path": "topics.mrtydi-v1.1-th.dev.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-th.test": {
+    "path": "topics.mrtydi-v1.1-th.test.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "mrtydi-v1.1-th.train": {
+    "path": "topics.mrtydi-v1.1-th.train.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-doc.dev": {
+    "path": "topics.msmarco-doc.dev.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-doc.dev.unicoil": {
+    "path": "topics.msmarco-doc.dev.unicoil.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-doc.dev.unicoil-noexp": {
+    "path": "topics.msmarco-doc.dev.unicoil-noexp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-doc.dev.wp": {
+    "path": "topics.msmarco-doc.dev.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-doc.test": {
+    "path": "topics.msmarco-doc.test.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-passage.dev-subset": {
+    "path": "topics.msmarco-passage.dev-subset.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-passage.dev-subset.cohere-embed-english-v3.0": {
+    "path": "topics.msmarco-passage.dev-subset.cohere-embed-english-v3.0.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
+  },
+  "msmarco-passage.dev-subset.deepimpact": {
+    "path": "topics.msmarco-passage.dev-subset.deepimpact.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-passage.dev-subset.distill-splade-max": {
+    "path": "topics.msmarco-passage.dev-subset.distill-splade-max.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-passage.dev-subset.splade-pp-ed": {
+    "path": "topics.msmarco-passage.dev-subset.splade-pp-ed.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-passage.dev-subset.splade-pp-sd": {
+    "path": "topics.msmarco-passage.dev-subset.splade-pp-sd.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-passage.dev-subset.splade-v3": {
+    "path": "topics.msmarco-passage.dev-subset.splade-v3.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-passage.dev-subset.splade_distil_cocodenser_medium": {
+    "path": "topics.msmarco-passage.dev-subset.splade_distil_cocodenser_medium.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-passage.dev-subset.unicoil": {
+    "path": "topics.msmarco-passage.dev-subset.unicoil.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-passage.dev-subset.unicoil-noexp": {
+    "path": "topics.msmarco-passage.dev-subset.unicoil-noexp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-passage.dev-subset.unicoil-tilde-expansion": {
+    "path": "topics.msmarco-passage.dev-subset.unicoil-tilde-expansion.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-passage.dev-subset.wp": {
+    "path": "topics.msmarco-passage.dev-subset.wp.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-passage.test-subset": {
+    "path": "topics.msmarco-passage.test-subset.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-v2-doc.dev": {
+    "path": "topics.msmarco-v2-doc.dev.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-v2-doc.dev.snowflake-arctic-embed-l": {
+    "path": "topics.msmarco-v2-doc.dev.snowflake-arctic-embed-l.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
+  },
+  "msmarco-v2-doc.dev.unicoil-noexp.0shot": {
+    "path": "topics.msmarco-v2-doc.dev.unicoil-noexp.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-v2-doc.dev.unicoil.0shot": {
+    "path": "topics.msmarco-v2-doc.dev.unicoil.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-v2-doc.dev2": {
+    "path": "topics.msmarco-v2-doc.dev2.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-v2-doc.dev2.snowflake-arctic-embed-l": {
+    "path": "topics.msmarco-v2-doc.dev2.snowflake-arctic-embed-l.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
+  },
+  "msmarco-v2-doc.dev2.unicoil-noexp.0shot": {
+    "path": "topics.msmarco-v2-doc.dev2.unicoil-noexp.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-v2-doc.dev2.unicoil.0shot": {
+    "path": "topics.msmarco-v2-doc.dev2.unicoil.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-v2-passage.dev": {
+    "path": "topics.msmarco-v2-passage.dev.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-v2-passage.dev.splade-pp-ed": {
+    "path": "topics.msmarco-v2-passage.dev.splade-pp-ed.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-v2-passage.dev.splade-pp-sd": {
+    "path": "topics.msmarco-v2-passage.dev.splade-pp-sd.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-v2-passage.dev.unicoil-noexp.0shot": {
+    "path": "topics.msmarco-v2-passage.dev.unicoil-noexp.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-v2-passage.dev.unicoil.0shot": {
+    "path": "topics.msmarco-v2-passage.dev.unicoil.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-v2-passage.dev2": {
+    "path": "topics.msmarco-v2-passage.dev2.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-v2-passage.dev2.splade-pp-ed": {
+    "path": "topics.msmarco-v2-passage.dev2.splade-pp-ed.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-v2-passage.dev2.splade-pp-sd": {
+    "path": "topics.msmarco-v2-passage.dev2.splade-pp-sd.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-v2-passage.dev2.unicoil-noexp.0shot": {
+    "path": "topics.msmarco-v2-passage.dev2.unicoil-noexp.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "msmarco-v2-passage.dev2.unicoil.0shot": {
+    "path": "topics.msmarco-v2-passage.dev2.unicoil.0shot.tsv.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-en.original-desc": {
+    "path": "topics.neuclir22-en.original-desc.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-en.original-desc_title": {
+    "path": "topics.neuclir22-en.original-desc_title.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-en.original-title": {
+    "path": "topics.neuclir22-en.original-title.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-fa.ht-desc": {
+    "path": "topics.neuclir22-fa.ht-desc.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-fa.ht-desc_title": {
+    "path": "topics.neuclir22-fa.ht-desc_title.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-fa.ht-title": {
+    "path": "topics.neuclir22-fa.ht-title.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-fa.mt-desc": {
+    "path": "topics.neuclir22-fa.mt-desc.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-fa.mt-desc_title": {
+    "path": "topics.neuclir22-fa.mt-desc_title.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-fa.mt-title": {
+    "path": "topics.neuclir22-fa.mt-title.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-fa.splade.ht-desc": {
+    "path": "topics.neuclir22-fa.splade.ht-desc.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-fa.splade.ht-desc_title": {
+    "path": "topics.neuclir22-fa.splade.ht-desc_title.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-fa.splade.ht-title": {
+    "path": "topics.neuclir22-fa.splade.ht-title.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-fa.splade.mt-desc": {
+    "path": "topics.neuclir22-fa.splade.mt-desc.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-fa.splade.mt-desc_title": {
+    "path": "topics.neuclir22-fa.splade.mt-desc_title.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-fa.splade.mt-title": {
+    "path": "topics.neuclir22-fa.splade.mt-title.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-ru.ht-desc": {
+    "path": "topics.neuclir22-ru.ht-desc.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-ru.ht-desc_title": {
+    "path": "topics.neuclir22-ru.ht-desc_title.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-ru.ht-title": {
+    "path": "topics.neuclir22-ru.ht-title.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-ru.mt-desc": {
+    "path": "topics.neuclir22-ru.mt-desc.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-ru.mt-desc_title": {
+    "path": "topics.neuclir22-ru.mt-desc_title.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-ru.mt-title": {
+    "path": "topics.neuclir22-ru.mt-title.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-ru.splade.ht-desc": {
+    "path": "topics.neuclir22-ru.splade.ht-desc.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-ru.splade.ht-desc_title": {
+    "path": "topics.neuclir22-ru.splade.ht-desc_title.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-ru.splade.ht-title": {
+    "path": "topics.neuclir22-ru.splade.ht-title.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-ru.splade.mt-desc": {
+    "path": "topics.neuclir22-ru.splade.mt-desc.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-ru.splade.mt-desc_title": {
+    "path": "topics.neuclir22-ru.splade.mt-desc_title.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-ru.splade.mt-title": {
+    "path": "topics.neuclir22-ru.splade.mt-title.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-zh.ht-desc": {
+    "path": "topics.neuclir22-zh.ht-desc.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-zh.ht-desc_title": {
+    "path": "topics.neuclir22-zh.ht-desc_title.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-zh.ht-title": {
+    "path": "topics.neuclir22-zh.ht-title.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-zh.mt-desc": {
+    "path": "topics.neuclir22-zh.mt-desc.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-zh.mt-desc_title": {
+    "path": "topics.neuclir22-zh.mt-desc_title.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-zh.mt-title": {
+    "path": "topics.neuclir22-zh.mt-title.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-zh.splade.ht-desc": {
+    "path": "topics.neuclir22-zh.splade.ht-desc.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-zh.splade.ht-desc_title": {
+    "path": "topics.neuclir22-zh.splade.ht-desc_title.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-zh.splade.ht-title": {
+    "path": "topics.neuclir22-zh.splade.ht-title.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-zh.splade.mt-desc": {
+    "path": "topics.neuclir22-zh.splade.mt-desc.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-zh.splade.mt-desc_title": {
+    "path": "topics.neuclir22-zh.splade.mt-desc_title.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "neuclir22-zh.splade.mt-title": {
+    "path": "topics.neuclir22-zh.splade.mt-title.txt.gz",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "nq.dev": {
+    "path": "topics.nq.dev.txt",
+    "reader_class": "io.anserini.search.topicreader.DprNqTopicReader"
+  },
+  "nq.test": {
+    "path": "topics.nq.test.txt",
+    "reader_class": "io.anserini.search.topicreader.DprNqTopicReader"
+  },
+  "nq.test.gar-t5.all": {
+    "path": "topics.nq.test.gar-t5.all.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "nq.test.gar-t5.answers": {
+    "path": "topics.nq.test.gar-t5.answers.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "nq.test.gar-t5.sentences": {
+    "path": "topics.nq.test.gar-t5.sentences.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "nq.test.gar-t5.titles": {
+    "path": "topics.nq.test.gar-t5.titles.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "ntcir8en.eval": {
+    "path": "topics.ntcir8en.eval.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "ntcir8zh.eval": {
+    "path": "topics.ntcir8zh.eval.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "rag24.raggy-dev": {
+    "path": "topics.rag24.raggy-dev.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "rag24.raggy-dev.snowflake-arctic-embed-l": {
+    "path": "topics.rag24.raggy-dev.snowflake-arctic-embed-l.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
+  },
+  "rag24.researchy-dev": {
+    "path": "topics.rag24.researchy-dev.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "rag24.researchy-dev.snowflake-arctic-embed-l": {
+    "path": "topics.rag24.researchy-dev.snowflake-arctic-embed-l.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonIntVectorTopicReader"
+  },
+  "rag24.test": {
+    "path": "topics.rag24.test.txt",
+    "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
+  },
+  "rag24.test.snowflake-arctic-embed-l": {
+    "path": "topics.rag24.test.snowflake-arctic-embed-l.jsonl.gz",
+    "reader_class": "io.anserini.search.topicreader.JsonStringVectorTopicReader"
+  },
+  "rag25.test": {
+    "path": "topics.rag25.test.jsonl",
+    "reader_class": "io.anserini.search.topicreader.JsonStringTopicReader"
+  },
+  "robust04": {
+    "path": "topics.robust04.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
+  "robust05": {
+    "path": "topics.robust05.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
+  "slidevqa.test": {
+    "path": "topics.slidevqa.test.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "terabyte04.701-750": {
+    "path": "topics.terabyte04.701-750.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
+  "terabyte05.751-800": {
+    "path": "topics.terabyte05.751-800.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
+  "terabyte05.efficiency": {
+    "path": "topics.terabyte05.efficiency.txt",
+    "reader_class": "io.anserini.search.topicreader.WebTopicReader"
+  },
+  "terabyte06.801-850": {
+    "path": "topics.terabyte06.801-850.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
+  "trec02ar-ar": {
+    "path": "topics.trec02ar-ar.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
+  "web.1-50": {
+    "path": "topics.web.1-50.txt",
+    "reader_class": "io.anserini.search.topicreader.WebxmlTopicReader"
+  },
+  "web.101-150": {
+    "path": "topics.web.101-150.txt",
+    "reader_class": "io.anserini.search.topicreader.WebxmlTopicReader"
+  },
+  "web.151-200": {
+    "path": "topics.web.151-200.txt",
+    "reader_class": "io.anserini.search.topicreader.WebxmlTopicReader"
+  },
+  "web.201-250": {
+    "path": "topics.web.201-250.txt",
+    "reader_class": "io.anserini.search.topicreader.WebxmlTopicReader"
+  },
+  "web.251-300": {
+    "path": "topics.web.251-300.txt",
+    "reader_class": "io.anserini.search.topicreader.WebxmlTopicReader"
+  },
+  "web.51-100": {
+    "path": "topics.web.51-100.txt",
+    "reader_class": "io.anserini.search.topicreader.WebxmlTopicReader"
+  },
+  "wiki-ss-nq.test": {
+    "path": "topics.wiki-ss-nq.test.tsv",
+    "reader_class": "io.anserini.search.topicreader.TsvIntTopicReader"
+  },
+  "www1.english": {
+    "path": "topics.www1.english.txt",
+    "reader_class": "io.anserini.search.topicreader.NtcirTopicReader"
+  },
+  "www2.english": {
+    "path": "topics.www2.english.txt",
+    "reader_class": "io.anserini.search.topicreader.NtcirTopicReader"
+  }
+}

--- a/src/main/resources/topics-and-qrels/_local_metadata_topics_aliases.json
+++ b/src/main/resources/topics-and-qrels/_local_metadata_topics_aliases.json
@@ -71,15 +71,6 @@
   "atomic.validation.text.openai.clip-vit-large-patch14": [
     "atomic-v0.2.1-openai.clip-vit-large-patch14-text-validation"
   ],
-  "backgroundlinking18": [
-    "trec2018-bl"
-  ],
-  "backgroundlinking19": [
-    "trec2019-bl"
-  ],
-  "backgroundlinking20": [
-    "trec2020-bl"
-  ],
   "beir-v1.0.0-arguana.test": [
     "beir-v1.0.0-arguana",
     "beir-v1.0.0-arguana-test",
@@ -225,42 +216,6 @@
     "beir-v1.0.0-webis-touche2020-test",
     "beir-webis-touche2020"
   ],
-  "bright-aops.bge-large-en-v1.5": [
-    "bright-aops.bge-large-en-v1.5.flat"
-  ],
-  "bright-biology.bge-large-en-v1.5": [
-    "bright-biology.bge-large-en-v1.5.flat"
-  ],
-  "bright-earth-science.bge-large-en-v1.5": [
-    "bright-earth-science.bge-large-en-v1.5.flat"
-  ],
-  "bright-economics.bge-large-en-v1.5": [
-    "bright-economics.bge-large-en-v1.5.flat"
-  ],
-  "bright-leetcode.bge-large-en-v1.5": [
-    "bright-leetcode.bge-large-en-v1.5.flat"
-  ],
-  "bright-pony.bge-large-en-v1.5": [
-    "bright-pony.bge-large-en-v1.5.flat"
-  ],
-  "bright-psychology.bge-large-en-v1.5": [
-    "bright-psychology.bge-large-en-v1.5.flat"
-  ],
-  "bright-robotics.bge-large-en-v1.5": [
-    "bright-robotics.bge-large-en-v1.5.flat"
-  ],
-  "bright-stackoverflow.bge-large-en-v1.5": [
-    "bright-stackoverflow.bge-large-en-v1.5.flat"
-  ],
-  "bright-sustainable-living.bge-large-en-v1.5": [
-    "bright-sustainable-living.bge-large-en-v1.5.flat"
-  ],
-  "bright-theoremqa-questions.bge-large-en-v1.5": [
-    "bright-theoremqa-questions.bge-large-en-v1.5.flat"
-  ],
-  "bright-theoremqa-theorems.bge-large-en-v1.5": [
-    "bright-theoremqa-theorems.bge-large-en-v1.5.flat"
-  ],
   "car17v1.5.benchmarkY1test": [
     "car17v1.5-benchmarkY1test"
   ],
@@ -270,109 +225,26 @@
   "clef06fr.mono.fr": [
     "clef2006-fr"
   ],
-  "dl19-doc.unicoil-noexp.0shot": [
-    "dl19-doc-unicoil-noexp"
-  ],
-  "dl19-doc.unicoil.0shot": [
-    "dl19-doc-unicoil"
-  ],
-  "dl19-passage.splade-pp-ed": [
-    "dl19-passage-splade-pp-ed"
-  ],
-  "dl19-passage.splade-pp-sd": [
-    "dl19-passage-splade-pp-sd"
-  ],
-  "dl19-passage.splade-v3": [
-    "dl19-passage-splade-v3"
-  ],
-  "dl19-passage.splade_distil_cocodenser_medium": [
-    "dl19-passage-splade-distil-cocodenser-medium",
-    "dl19-passage.splade-distil-cocodenser-medium"
-  ],
-  "dl19-passage.unicoil-noexp.0shot": [
-    "dl19-passage-unicoil-noexp",
-    "dl19-passage.unicoil-noexp"
-  ],
-  "dl19-passage.unicoil.0shot": [
-    "dl19-passage-unicoil",
-    "dl19-passage.unicoil"
-  ],
   "dl20": [
-    "dl20-doc",
-    "dl20-passage"
+    "dl20-passage",
+    "dl20-doc"
   ],
   "dl20.cohere-embed-english-v3.0": [
     "dl20-cohere-embed-english-v3.0",
     "dl20-passage.cohere-embed-english-v3.0",
     "dl20-doc.cohere-embed-english-v3.0"
   ],
-  "dl20.splade-pp-ed": [
-    "dl20-passage-splade-pp-ed",
-    "dl20-splade-pp-ed",
-    "dl20-passage.splade-pp-ed",
-    "dl20-doc.splade-pp-ed"
-  ],
-  "dl20.splade-pp-sd": [
-    "dl20-passage-splade-pp-sd",
-    "dl20-splade-pp-sd",
-    "dl20-passage.splade-pp-sd",
-    "dl20-doc.splade-pp-sd"
-  ],
-  "dl20.splade-v3": [
-    "dl20-passage-splade-v3",
-    "dl20-splade-v3",
-    "dl20-passage.splade-v3"
-  ],
-  "dl20.splade_distil_cocodenser_medium": [
-    "dl20-passage-splade-distil-cocodenser-medium",
-    "dl20-splade-distil-cocodenser-medium",
-    "dl20-passage.splade-distil-cocodenser-medium"
-  ],
-  "dl20.unicoil-noexp.0shot": [
-    "dl20-doc-unicoil-noexp",
-    "dl20-passage-unicoil-noexp",
-    "dl20-unicoil-noexp",
-    "dl20-passage.unicoil-noexp",
-    "dl20-passage.unicoil-noexp.0shot",
-    "dl20-doc.unicoil-noexp.0shot"
-  ],
-  "dl20.unicoil.0shot": [
-    "dl20-doc-unicoil",
-    "dl20-passage-unicoil",
-    "dl20-unicoil",
-    "dl20-passage.unicoil",
-    "dl20-passage.unicoil.0shot",
-    "dl20-doc.unicoil.0shot"
-  ],
   "dl21": [
     "dl21-doc",
     "dl21-passage"
-  ],
-  "dl21.unicoil-noexp.0shot": [
-    "dl21-unicoil-noexp"
-  ],
-  "dl21.unicoil.0shot": [
-    "dl21-unicoil"
   ],
   "dl22": [
     "dl22-doc",
     "dl22-passage"
   ],
-  "dl22.unicoil-noexp.0shot": [
-    "dl22-unicoil-noexp"
-  ],
-  "dl22.unicoil.0shot": [
-    "dl22-unicoil"
-  ],
   "dl23": [
     "dl23-doc",
     "dl23-passage"
-  ],
-  "dl23.unicoil-noexp.0shot": [
-    "dl23-unicoil-noexp"
-  ],
-  "dl23.unicoil.0shot": [
-    "dl23-unicoil"
   ],
   "dpr.curated.test": [
     "dpr-curated-test"
@@ -755,12 +627,6 @@
   "msmarco-doc.dev": [
     "msmarco-doc-dev"
   ],
-  "msmarco-doc.dev.unicoil": [
-    "msmarco-doc-dev-unicoil"
-  ],
-  "msmarco-doc.dev.unicoil-noexp": [
-    "msmarco-doc-dev-unicoil-noexp"
-  ],
   "msmarco-doc.test": [
     "msmarco-doc-test"
   ],
@@ -784,77 +650,10 @@
     "msmarco-passage-dev-subset-deepimpact",
     "msmarco-passage-dev-subset.deepimpact",
     "msmarco-passage-dev.deepimpact",
-    "msmarco-v1-passage-dev.deepimpact",
     "msmarco-passage.dev.deepimpact",
+    "msmarco-v1-passage-dev-deepimpact",
+    "msmarco-v1-passage-dev.deepimpact",
     "msmarco-v1-passage.dev.deepimpact"
-  ],
-  "msmarco-passage.dev-subset.distill-splade-max": [
-    "msmarco-passage-dev-subset-distill-splade-max",
-    "msmarco-passage-dev-subset.distill-splade-max",
-    "msmarco-passage-dev.distill-splade-max",
-    "msmarco-v1-passage-dev.distill-splade-max",
-    "msmarco-passage.dev.distill-splade-max",
-    "msmarco-v1-passage.dev.distill-splade-max"
-  ],
-  "msmarco-passage.dev-subset.splade-pp-ed": [
-    "msmarco-passage-dev-subset-splade-pp-ed",
-    "msmarco-passage-dev-splade-pp-ed",
-    "msmarco-passage-dev.splade-pp-ed",
-    "msmarco-passage.dev.splade-pp-ed",
-    "msmarco-v1-passage-dev-splade-pp-ed",
-    "msmarco-v1-passage-dev.splade-pp-ed",
-    "msmarco-v1-passage.dev.splade-pp-ed",
-    "msmarco-passage-dev-subset.splade-pp-ed"
-  ],
-  "msmarco-passage.dev-subset.splade-pp-sd": [
-    "msmarco-passage-dev-subset-splade-pp-sd",
-    "msmarco-passage-dev-splade-pp-sd",
-    "msmarco-passage-dev.splade-pp-sd",
-    "msmarco-passage.dev.splade-pp-sd",
-    "msmarco-v1-passage-dev-splade-pp-sd",
-    "msmarco-v1-passage-dev.splade-pp-sd",
-    "msmarco-v1-passage.dev.splade-pp-sd",
-    "msmarco-passage-dev-subset.splade-pp-sd"
-  ],
-  "msmarco-passage.dev-subset.splade-v3": [
-    "msmarco-passage-dev-subset-splade-v3",
-    "msmarco-passage-dev-subset.splade-v3",
-    "msmarco-passage-dev.splade-v3",
-    "msmarco-v1-passage-dev.splade-v3",
-    "msmarco-passage.dev.splade-v3",
-    "msmarco-v1-passage.dev.splade-v3"
-  ],
-  "msmarco-passage.dev-subset.splade_distil_cocodenser_medium": [
-    "msmarco-passage-dev-subset-splade-distil-cocodenser-medium",
-    "msmarco-passage-dev-subset.splade-distil-cocodenser-medium",
-    "msmarco-passage-dev.splade-distil-cocodenser-medium",
-    "msmarco-v1-passage-dev.splade-distil-cocodenser-medium",
-    "msmarco-passage.dev.splade-distil-cocodenser-medium",
-    "msmarco-v1-passage.dev.splade-distil-cocodenser-medium"
-  ],
-  "msmarco-passage.dev-subset.unicoil": [
-    "msmarco-passage-dev-subset-unicoil",
-    "msmarco-passage-dev-subset.unicoil",
-    "msmarco-passage-dev.unicoil",
-    "msmarco-v1-passage-dev.unicoil",
-    "msmarco-passage.dev.unicoil",
-    "msmarco-v1-passage.dev.unicoil"
-  ],
-  "msmarco-passage.dev-subset.unicoil-noexp": [
-    "msmarco-passage-dev-subset-unicoil-noexp",
-    "msmarco-passage-dev-subset.unicoil-noexp",
-    "msmarco-passage-dev.unicoil-noexp",
-    "msmarco-v1-passage-dev.unicoil-noexp",
-    "msmarco-passage.dev.unicoil-noexp",
-    "msmarco-v1-passage.dev.unicoil-noexp"
-  ],
-  "msmarco-passage.dev-subset.unicoil-tilde-expansion": [
-    "msmarco-passage-dev-subset-unicoil-tilde",
-    "msmarco-passage-dev-subset.unicoil-tilde",
-    "msmarco-passage-dev.unicoil-tilde",
-    "msmarco-v1-passage-dev.unicoil-tilde",
-    "msmarco-passage.dev.unicoil-tilde",
-    "msmarco-v1-passage.dev.unicoil-tilde"
   ],
   "msmarco-passage.test-subset": [
     "msmarco-passage-test-subset"
@@ -862,38 +661,14 @@
   "msmarco-v2-doc.dev": [
     "msmarco-v2-doc-dev"
   ],
-  "msmarco-v2-doc.dev.unicoil-noexp.0shot": [
-    "msmarco-v2-doc-dev-unicoil-noexp"
-  ],
-  "msmarco-v2-doc.dev.unicoil.0shot": [
-    "msmarco-v2-doc-dev-unicoil"
-  ],
   "msmarco-v2-doc.dev2": [
     "msmarco-v2-doc-dev2"
-  ],
-  "msmarco-v2-doc.dev2.unicoil-noexp.0shot": [
-    "msmarco-v2-doc-dev2-unicoil-noexp"
-  ],
-  "msmarco-v2-doc.dev2.unicoil.0shot": [
-    "msmarco-v2-doc-dev2-unicoil"
   ],
   "msmarco-v2-passage.dev": [
     "msmarco-v2-passage-dev"
   ],
-  "msmarco-v2-passage.dev.unicoil-noexp.0shot": [
-    "msmarco-v2-passage-dev-unicoil-noexp"
-  ],
-  "msmarco-v2-passage.dev.unicoil.0shot": [
-    "msmarco-v2-passage-dev-unicoil"
-  ],
   "msmarco-v2-passage.dev2": [
     "msmarco-v2-passage-dev2"
-  ],
-  "msmarco-v2-passage.dev2.unicoil-noexp.0shot": [
-    "msmarco-v2-passage-dev2-unicoil-noexp"
-  ],
-  "msmarco-v2-passage.dev2.unicoil.0shot": [
-    "msmarco-v2-passage-dev2-unicoil"
   ],
   "neuclir22-en.original-desc": [
     "neuclir22-en-desc"

--- a/src/main/resources/topics-and-qrels/_local_metadata_topics_aliases.json
+++ b/src/main/resources/topics-and-qrels/_local_metadata_topics_aliases.json
@@ -1,0 +1,1015 @@
+{
+  "adhoc.101-150": [
+    "trec2-adhoc"
+  ],
+  "adhoc.151-200": [
+    "trec3-adhoc"
+  ],
+  "adhoc.451-550": [
+    "wt10g"
+  ],
+  "adhoc.51-100": [
+    "trec1-adhoc"
+  ],
+  "atomic.validation.image.Salesforce.blip-itm-base-coco": [
+    "atomic-v0.2-Salesforce.blip-itm-base-coco-image-validation"
+  ],
+  "atomic.validation.image.Salesforce.blip-itm-large-coco": [
+    "atomic-v0.2-Salesforce.blip-itm-large-coco-image-validation"
+  ],
+  "atomic.validation.image.ViT-B-32.laion2b_e16": [
+    "atomic-v0.2-ViT-B-32.laion2b_e16-image-validation"
+  ],
+  "atomic.validation.image.ViT-B-32.laion400m_e32": [
+    "atomic-v0.2-ViT-B-32.laion400m_e32-image-validation"
+  ],
+  "atomic.validation.image.ViT-H-14.laion2b_s32b_b79k": [
+    "atomic-v0.2-ViT-H-14.laion2b_s32b_b79k-image-validation"
+  ],
+  "atomic.validation.image.ViT-L-14.laion2b_s32b_b82k": [
+    "atomic-v0.2-ViT-L-14.laion2b_s32b_b82k-image-validation"
+  ],
+  "atomic.validation.image.ViT-bigG-14.laion2b_s39b_b160k": [
+    "atomic-v0.2-ViT-bigG-14.laion2b_s39b_b160k-image-validation"
+  ],
+  "atomic.validation.image.facebook.flava-full": [
+    "atomic-v0.2-facebook.flava-full-image-validation"
+  ],
+  "atomic.validation.image.openai.clip-vit-base-patch32": [
+    "atomic-v0.2-openai.clip-vit-base-patch32-image-validation"
+  ],
+  "atomic.validation.image.openai.clip-vit-large-patch14": [
+    "atomic-v0.2-openai.clip-vit-large-patch14-image-validation"
+  ],
+  "atomic.validation.text.Salesforce.blip-itm-base-coco": [
+    "atomic-v0.2.1-Salesforce.blip-itm-base-coco-text-validation"
+  ],
+  "atomic.validation.text.Salesforce.blip-itm-large-coco": [
+    "atomic-v0.2.1-Salesforce.blip-itm-large-coco-text-validation"
+  ],
+  "atomic.validation.text.ViT-B-32.laion2b_e16": [
+    "atomic-v0.2.1-ViT-B-32.laion2b_e16-text-validation"
+  ],
+  "atomic.validation.text.ViT-B-32.laion400m_e32": [
+    "atomic-v0.2.1-ViT-B-32.laion400m_e32-text-validation"
+  ],
+  "atomic.validation.text.ViT-H-14.laion2b_s32b_b79k": [
+    "atomic-v0.2.1-ViT-H-14.laion2b_s32b_b79k-text-validation"
+  ],
+  "atomic.validation.text.ViT-L-14.laion2b_s32b_b82k": [
+    "atomic-v0.2.1-ViT-L-14.laion2b_s32b_b82k-text-validation"
+  ],
+  "atomic.validation.text.ViT-bigG-14.laion2b_s39b_b160k": [
+    "atomic-v0.2.1-ViT-bigG-14.laion2b_s39b_b160k-text-validation"
+  ],
+  "atomic.validation.text.facebook.flava-full": [
+    "atomic-v0.2.1-facebook.flava-full-text-validation"
+  ],
+  "atomic.validation.text.openai.clip-vit-base-patch32": [
+    "atomic-v0.2.1-openai.clip-vit-base-patch32-text-validation"
+  ],
+  "atomic.validation.text.openai.clip-vit-large-patch14": [
+    "atomic-v0.2.1-openai.clip-vit-large-patch14-text-validation"
+  ],
+  "backgroundlinking18": [
+    "trec2018-bl"
+  ],
+  "backgroundlinking19": [
+    "trec2019-bl"
+  ],
+  "backgroundlinking20": [
+    "trec2020-bl"
+  ],
+  "beir-v1.0.0-arguana.test": [
+    "beir-v1.0.0-arguana",
+    "beir-v1.0.0-arguana-test",
+    "beir-arguana"
+  ],
+  "beir-v1.0.0-bioasq.test": [
+    "beir-v1.0.0-bioasq",
+    "beir-v1.0.0-bioasq-test",
+    "beir-bioasq"
+  ],
+  "beir-v1.0.0-climate-fever.test": [
+    "beir-v1.0.0-climate-fever",
+    "beir-v1.0.0-climate-fever-test",
+    "beir-climate-fever"
+  ],
+  "beir-v1.0.0-cqadupstack-android.test": [
+    "beir-v1.0.0-cqadupstack-android",
+    "beir-v1.0.0-cqadupstack-android-test",
+    "beir-cqadupstack-android"
+  ],
+  "beir-v1.0.0-cqadupstack-english.test": [
+    "beir-v1.0.0-cqadupstack-english",
+    "beir-v1.0.0-cqadupstack-english-test",
+    "beir-cqadupstack-english"
+  ],
+  "beir-v1.0.0-cqadupstack-gaming.test": [
+    "beir-v1.0.0-cqadupstack-gaming",
+    "beir-v1.0.0-cqadupstack-gaming-test",
+    "beir-cqadupstack-gaming"
+  ],
+  "beir-v1.0.0-cqadupstack-gis.test": [
+    "beir-v1.0.0-cqadupstack-gis",
+    "beir-v1.0.0-cqadupstack-gis-test",
+    "beir-cqadupstack-gis"
+  ],
+  "beir-v1.0.0-cqadupstack-mathematica.test": [
+    "beir-v1.0.0-cqadupstack-mathematica",
+    "beir-v1.0.0-cqadupstack-mathematica-test",
+    "beir-cqadupstack-mathematica"
+  ],
+  "beir-v1.0.0-cqadupstack-physics.test": [
+    "beir-v1.0.0-cqadupstack-physics",
+    "beir-v1.0.0-cqadupstack-physics-test",
+    "beir-cqadupstack-physics"
+  ],
+  "beir-v1.0.0-cqadupstack-programmers.test": [
+    "beir-v1.0.0-cqadupstack-programmers",
+    "beir-v1.0.0-cqadupstack-programmers-test",
+    "beir-cqadupstack-programmers"
+  ],
+  "beir-v1.0.0-cqadupstack-stats.test": [
+    "beir-v1.0.0-cqadupstack-stats",
+    "beir-v1.0.0-cqadupstack-stats-test",
+    "beir-cqadupstack-stats"
+  ],
+  "beir-v1.0.0-cqadupstack-tex.test": [
+    "beir-v1.0.0-cqadupstack-tex",
+    "beir-v1.0.0-cqadupstack-tex-test",
+    "beir-cqadupstack-tex"
+  ],
+  "beir-v1.0.0-cqadupstack-unix.test": [
+    "beir-v1.0.0-cqadupstack-unix",
+    "beir-v1.0.0-cqadupstack-unix-test",
+    "beir-cqadupstack-unix"
+  ],
+  "beir-v1.0.0-cqadupstack-webmasters.test": [
+    "beir-v1.0.0-cqadupstack-webmasters",
+    "beir-v1.0.0-cqadupstack-webmasters-test",
+    "beir-cqadupstack-webmasters"
+  ],
+  "beir-v1.0.0-cqadupstack-wordpress.test": [
+    "beir-v1.0.0-cqadupstack-wordpress",
+    "beir-v1.0.0-cqadupstack-wordpress-test",
+    "beir-cqadupstack-wordpress"
+  ],
+  "beir-v1.0.0-dbpedia-entity.test": [
+    "beir-v1.0.0-dbpedia-entity",
+    "beir-v1.0.0-dbpedia-entity-test",
+    "beir-dbpedia-entity"
+  ],
+  "beir-v1.0.0-fever.test": [
+    "beir-v1.0.0-fever",
+    "beir-v1.0.0-fever-test",
+    "beir-fever"
+  ],
+  "beir-v1.0.0-fiqa.test": [
+    "beir-v1.0.0-fiqa",
+    "beir-v1.0.0-fiqa-test",
+    "beir-fiqa"
+  ],
+  "beir-v1.0.0-hotpotqa.test": [
+    "beir-v1.0.0-hotpotqa",
+    "beir-v1.0.0-hotpotqa-test",
+    "beir-hotpotqa"
+  ],
+  "beir-v1.0.0-nfcorpus.test": [
+    "beir-v1.0.0-nfcorpus",
+    "beir-v1.0.0-nfcorpus-test",
+    "beir-nfcorpus"
+  ],
+  "beir-v1.0.0-nq.test": [
+    "beir-v1.0.0-nq",
+    "beir-v1.0.0-nq-test",
+    "beir-nq"
+  ],
+  "beir-v1.0.0-quora.test": [
+    "beir-v1.0.0-quora",
+    "beir-v1.0.0-quora-test",
+    "beir-quora"
+  ],
+  "beir-v1.0.0-robust04.test": [
+    "beir-v1.0.0-robust04",
+    "beir-v1.0.0-robust04-test",
+    "beir-robust04"
+  ],
+  "beir-v1.0.0-scidocs.test": [
+    "beir-v1.0.0-scidocs",
+    "beir-v1.0.0-scidocs-test",
+    "beir-scidocs"
+  ],
+  "beir-v1.0.0-scifact.test": [
+    "beir-v1.0.0-scifact",
+    "beir-v1.0.0-scifact-test",
+    "beir-scifact"
+  ],
+  "beir-v1.0.0-signal1m.test": [
+    "beir-v1.0.0-signal1m",
+    "beir-v1.0.0-signal1m-test",
+    "beir-signal1m"
+  ],
+  "beir-v1.0.0-trec-covid.test": [
+    "beir-v1.0.0-trec-covid",
+    "beir-v1.0.0-trec-covid-test",
+    "beir-trec-covid"
+  ],
+  "beir-v1.0.0-trec-news.test": [
+    "beir-v1.0.0-trec-news",
+    "beir-v1.0.0-trec-news-test",
+    "beir-trec-news"
+  ],
+  "beir-v1.0.0-webis-touche2020.test": [
+    "beir-v1.0.0-webis-touche2020",
+    "beir-v1.0.0-webis-touche2020-test",
+    "beir-webis-touche2020"
+  ],
+  "bright-aops.bge-large-en-v1.5": [
+    "bright-aops.bge-large-en-v1.5.flat"
+  ],
+  "bright-biology.bge-large-en-v1.5": [
+    "bright-biology.bge-large-en-v1.5.flat"
+  ],
+  "bright-earth-science.bge-large-en-v1.5": [
+    "bright-earth-science.bge-large-en-v1.5.flat"
+  ],
+  "bright-economics.bge-large-en-v1.5": [
+    "bright-economics.bge-large-en-v1.5.flat"
+  ],
+  "bright-leetcode.bge-large-en-v1.5": [
+    "bright-leetcode.bge-large-en-v1.5.flat"
+  ],
+  "bright-pony.bge-large-en-v1.5": [
+    "bright-pony.bge-large-en-v1.5.flat"
+  ],
+  "bright-psychology.bge-large-en-v1.5": [
+    "bright-psychology.bge-large-en-v1.5.flat"
+  ],
+  "bright-robotics.bge-large-en-v1.5": [
+    "bright-robotics.bge-large-en-v1.5.flat"
+  ],
+  "bright-stackoverflow.bge-large-en-v1.5": [
+    "bright-stackoverflow.bge-large-en-v1.5.flat"
+  ],
+  "bright-sustainable-living.bge-large-en-v1.5": [
+    "bright-sustainable-living.bge-large-en-v1.5.flat"
+  ],
+  "bright-theoremqa-questions.bge-large-en-v1.5": [
+    "bright-theoremqa-questions.bge-large-en-v1.5.flat"
+  ],
+  "bright-theoremqa-theorems.bge-large-en-v1.5": [
+    "bright-theoremqa-theorems.bge-large-en-v1.5.flat"
+  ],
+  "car17v1.5.benchmarkY1test": [
+    "car17v1.5-benchmarkY1test"
+  ],
+  "car17v2.0.benchmarkY1test": [
+    "car17v2.0-benchmarkY1test"
+  ],
+  "clef06fr.mono.fr": [
+    "clef2006-fr"
+  ],
+  "dl19-doc.unicoil-noexp.0shot": [
+    "dl19-doc-unicoil-noexp"
+  ],
+  "dl19-doc.unicoil.0shot": [
+    "dl19-doc-unicoil"
+  ],
+  "dl19-passage.splade-pp-ed": [
+    "dl19-passage-splade-pp-ed"
+  ],
+  "dl19-passage.splade-pp-sd": [
+    "dl19-passage-splade-pp-sd"
+  ],
+  "dl19-passage.splade-v3": [
+    "dl19-passage-splade-v3"
+  ],
+  "dl19-passage.splade_distil_cocodenser_medium": [
+    "dl19-passage-splade-distil-cocodenser-medium",
+    "dl19-passage.splade-distil-cocodenser-medium"
+  ],
+  "dl19-passage.unicoil-noexp.0shot": [
+    "dl19-passage-unicoil-noexp",
+    "dl19-passage.unicoil-noexp"
+  ],
+  "dl19-passage.unicoil.0shot": [
+    "dl19-passage-unicoil",
+    "dl19-passage.unicoil"
+  ],
+  "dl20": [
+    "dl20-doc",
+    "dl20-passage"
+  ],
+  "dl20.cohere-embed-english-v3.0": [
+    "dl20-cohere-embed-english-v3.0",
+    "dl20-passage.cohere-embed-english-v3.0",
+    "dl20-doc.cohere-embed-english-v3.0"
+  ],
+  "dl20.splade-pp-ed": [
+    "dl20-passage-splade-pp-ed",
+    "dl20-splade-pp-ed",
+    "dl20-passage.splade-pp-ed",
+    "dl20-doc.splade-pp-ed"
+  ],
+  "dl20.splade-pp-sd": [
+    "dl20-passage-splade-pp-sd",
+    "dl20-splade-pp-sd",
+    "dl20-passage.splade-pp-sd",
+    "dl20-doc.splade-pp-sd"
+  ],
+  "dl20.splade-v3": [
+    "dl20-passage-splade-v3",
+    "dl20-splade-v3",
+    "dl20-passage.splade-v3"
+  ],
+  "dl20.splade_distil_cocodenser_medium": [
+    "dl20-passage-splade-distil-cocodenser-medium",
+    "dl20-splade-distil-cocodenser-medium",
+    "dl20-passage.splade-distil-cocodenser-medium"
+  ],
+  "dl20.unicoil-noexp.0shot": [
+    "dl20-doc-unicoil-noexp",
+    "dl20-passage-unicoil-noexp",
+    "dl20-unicoil-noexp",
+    "dl20-passage.unicoil-noexp",
+    "dl20-passage.unicoil-noexp.0shot",
+    "dl20-doc.unicoil-noexp.0shot"
+  ],
+  "dl20.unicoil.0shot": [
+    "dl20-doc-unicoil",
+    "dl20-passage-unicoil",
+    "dl20-unicoil",
+    "dl20-passage.unicoil",
+    "dl20-passage.unicoil.0shot",
+    "dl20-doc.unicoil.0shot"
+  ],
+  "dl21": [
+    "dl21-doc",
+    "dl21-passage"
+  ],
+  "dl21.unicoil-noexp.0shot": [
+    "dl21-unicoil-noexp"
+  ],
+  "dl21.unicoil.0shot": [
+    "dl21-unicoil"
+  ],
+  "dl22": [
+    "dl22-doc",
+    "dl22-passage"
+  ],
+  "dl22.unicoil-noexp.0shot": [
+    "dl22-unicoil-noexp"
+  ],
+  "dl22.unicoil.0shot": [
+    "dl22-unicoil"
+  ],
+  "dl23": [
+    "dl23-doc",
+    "dl23-passage"
+  ],
+  "dl23.unicoil-noexp.0shot": [
+    "dl23-unicoil-noexp"
+  ],
+  "dl23.unicoil.0shot": [
+    "dl23-unicoil"
+  ],
+  "dpr.curated.test": [
+    "dpr-curated-test"
+  ],
+  "dpr.nq.dev": [
+    "dpr-nq-dev"
+  ],
+  "dpr.nq.test": [
+    "dpr-nq-test"
+  ],
+  "dpr.squad.test": [
+    "dpr-squad-test"
+  ],
+  "dpr.trivia.dev": [
+    "dpr-trivia-dev"
+  ],
+  "dpr.trivia.test": [
+    "dpr-trivia-test"
+  ],
+  "dpr.trivia.test.gar-t5.all": [
+    "dpr-trivia-test-gar-t5-all"
+  ],
+  "dpr.trivia.test.gar-t5.answers": [
+    "dpr-trivia-test-gar-t5-answers"
+  ],
+  "dpr.trivia.test.gar-t5.sentences": [
+    "dpr-trivia-test-gar-t5-sentences"
+  ],
+  "dpr.trivia.test.gar-t5.titles": [
+    "dpr-trivia-test-gar-t5-titles"
+  ],
+  "dpr.wq.test": [
+    "dpr-wq-test"
+  ],
+  "epidemic-qa.consumer.prelim": [
+    "epidemic-qa-consumer-prelim"
+  ],
+  "epidemic-qa.expert.prelim": [
+    "epidemic-qa-expert-prelim"
+  ],
+  "fire12bn.176-225": [
+    "fire2012-bn"
+  ],
+  "fire12en.176-225": [
+    "fire2012-en"
+  ],
+  "fire12hi.176-225": [
+    "fire2012-hi"
+  ],
+  "hc4-v1.0-fa.dev.desc": [
+    "hc4-v1.0-fa-dev-desc"
+  ],
+  "hc4-v1.0-fa.dev.desc.title": [
+    "hc4-v1.0-fa-dev-desc-title"
+  ],
+  "hc4-v1.0-fa.dev.title": [
+    "hc4-v1.0-fa-dev-title"
+  ],
+  "hc4-v1.0-fa.en.test.desc": [
+    "hc4-v1.0-fa-en-test-desc"
+  ],
+  "hc4-v1.0-fa.en.test.desc.title": [
+    "hc4-v1.0-fa-en-test-desc-title"
+  ],
+  "hc4-v1.0-fa.en.test.title": [
+    "hc4-v1.0-fa-en-test-title"
+  ],
+  "hc4-v1.0-fa.test.desc": [
+    "hc4-v1.0-fa-test-desc"
+  ],
+  "hc4-v1.0-fa.test.desc.title": [
+    "hc4-v1.0-fa-test-desc-title"
+  ],
+  "hc4-v1.0-fa.test.title": [
+    "hc4-v1.0-fa-test-title"
+  ],
+  "hc4-v1.0-ru.dev.desc": [
+    "hc4-v1.0-ru-dev-desc"
+  ],
+  "hc4-v1.0-ru.dev.desc.title": [
+    "hc4-v1.0-ru-dev-desc-title"
+  ],
+  "hc4-v1.0-ru.dev.title": [
+    "hc4-v1.0-ru-dev-title"
+  ],
+  "hc4-v1.0-ru.en.test.desc": [
+    "hc4-v1.0-ru-en-test-desc"
+  ],
+  "hc4-v1.0-ru.en.test.desc.title": [
+    "hc4-v1.0-ru-en-test-desc-title"
+  ],
+  "hc4-v1.0-ru.en.test.title": [
+    "hc4-v1.0-ru-en-test-title"
+  ],
+  "hc4-v1.0-ru.test.desc": [
+    "hc4-v1.0-ru-test-desc"
+  ],
+  "hc4-v1.0-ru.test.desc.title": [
+    "hc4-v1.0-ru-test-desc-title"
+  ],
+  "hc4-v1.0-ru.test.title": [
+    "hc4-v1.0-ru-test-title"
+  ],
+  "hc4-v1.0-zh.dev.desc": [
+    "hc4-v1.0-zh-dev-desc"
+  ],
+  "hc4-v1.0-zh.dev.desc.title": [
+    "hc4-v1.0-zh-dev-desc-title"
+  ],
+  "hc4-v1.0-zh.dev.title": [
+    "hc4-v1.0-zh-dev-title"
+  ],
+  "hc4-v1.0-zh.en.test.desc": [
+    "hc4-v1.0-zh-en-test-desc"
+  ],
+  "hc4-v1.0-zh.en.test.desc.title": [
+    "hc4-v1.0-zh-en-test-desc-title"
+  ],
+  "hc4-v1.0-zh.en.test.title": [
+    "hc4-v1.0-zh-en-test-title"
+  ],
+  "hc4-v1.0-zh.test.desc": [
+    "hc4-v1.0-zh-test-desc"
+  ],
+  "hc4-v1.0-zh.test.desc.title": [
+    "hc4-v1.0-zh-test-desc-title"
+  ],
+  "hc4-v1.0-zh.test.title": [
+    "hc4-v1.0-zh-test-title"
+  ],
+  "mbeir-cirr_task7.test": [
+    "m-beir-cirr_task7-test"
+  ],
+  "mbeir-edis_task2.test": [
+    "m-beir-edis_task2-test"
+  ],
+  "mbeir-fashion200k_task0.test": [
+    "m-beir-fashion200k_task0-test"
+  ],
+  "mbeir-fashion200k_task3.test": [
+    "m-beir-fashion200k_task3-test"
+  ],
+  "mbeir-fashioniq_task7.test": [
+    "m-beir-fashioniq_task7-test"
+  ],
+  "mbeir-infoseek_task6.test": [
+    "m-beir-infoseek_task6-test"
+  ],
+  "mbeir-infoseek_task8.test": [
+    "m-beir-infoseek_task8-test"
+  ],
+  "mbeir-mscoco_task0.test": [
+    "m-beir-mscoco_task0-test"
+  ],
+  "mbeir-mscoco_task3.test": [
+    "m-beir-mscoco_task3-test"
+  ],
+  "mbeir-nights_task4.test": [
+    "m-beir-nights_task4-test"
+  ],
+  "mbeir-oven_task6.test": [
+    "m-beir-oven_task6-test"
+  ],
+  "mbeir-oven_task8.test": [
+    "m-beir-oven_task8-test"
+  ],
+  "mbeir-visualnews_task0.test": [
+    "m-beir-visualnews_task0-test"
+  ],
+  "mbeir-visualnews_task3.test": [
+    "m-beir-visualnews_task3-test"
+  ],
+  "mbeir-webqa_task1.test": [
+    "m-beir-webqa_task1-test"
+  ],
+  "mbeir-webqa_task2.test": [
+    "m-beir-webqa_task2-test"
+  ],
+  "microblog2011": [
+    "mb11"
+  ],
+  "microblog2012": [
+    "mb12"
+  ],
+  "microblog2013": [
+    "mb13"
+  ],
+  "microblog2014": [
+    "mb14"
+  ],
+  "mmeb-visdoc-MMLongBench-doc.test": [
+    "mmeb-visdoc-MMLongBench-doc-test"
+  ],
+  "mmeb-visdoc-MMLongBench-page.test": [
+    "mmeb-visdoc-MMLongBench-page-test"
+  ],
+  "mmeb-visdoc-ViDoRe_arxivqa.test": [
+    "mmeb-visdoc-ViDoRe_arxivqa-test"
+  ],
+  "mmeb-visdoc-ViDoRe_biomedical_lectures_v2.test": [
+    "mmeb-visdoc-ViDoRe_biomedical_lectures_v2-test"
+  ],
+  "mmeb-visdoc-ViDoRe_biomedical_lectures_v2_multilingual.test": [
+    "mmeb-visdoc-ViDoRe_biomedical_lectures_v2_multilingual-test"
+  ],
+  "mmeb-visdoc-ViDoRe_docvqa.test": [
+    "mmeb-visdoc-ViDoRe_docvqa-test"
+  ],
+  "mmeb-visdoc-ViDoRe_economics_reports_v2.test": [
+    "mmeb-visdoc-ViDoRe_economics_reports_v2_test"
+  ],
+  "mmeb-visdoc-ViDoRe_economics_reports_v2_multilingual.test": [
+    "mmeb-visdoc-ViDoRe_economics_reports_v2_multilingual-test"
+  ],
+  "mmeb-visdoc-ViDoRe_esg_reports_human_labeled_v2.test": [
+    "mmeb-visdoc-ViDoRe_esg_reports_human_labeled_v2-test"
+  ],
+  "mmeb-visdoc-ViDoRe_esg_reports_v2.test": [
+    "mmeb-visdoc-ViDoRe_esg_reports_v2-test"
+  ],
+  "mmeb-visdoc-ViDoRe_esg_reports_v2_multilingual.test": [
+    "mmeb-visdoc-ViDoRe_esg_reports_v2_multilingual-test"
+  ],
+  "mmeb-visdoc-ViDoRe_infovqa.test": [
+    "mmeb-visdoc-ViDoRe_infovqa-test"
+  ],
+  "mmeb-visdoc-ViDoRe_shiftproject.test": [
+    "mmeb-visdoc-ViDoRe_shiftproject-test"
+  ],
+  "mmeb-visdoc-ViDoRe_syntheticDocQA_artificial_intelligence.test": [
+    "mmeb-visdoc-ViDoRe_syntheticDocQA_artificial_intelligence-test"
+  ],
+  "mmeb-visdoc-ViDoRe_syntheticDocQA_energy.test": [
+    "mmeb-visdoc-ViDoRe_syntheticDocQA_energy-test"
+  ],
+  "mmeb-visdoc-ViDoRe_syntheticDocQA_government_reports.test": [
+    "mmeb-visdoc-ViDoRe_syntheticDocQA_government_reports-test"
+  ],
+  "mmeb-visdoc-ViDoRe_syntheticDocQA_healthcare_industry.test": [
+    "mmeb-visdoc-ViDoRe_syntheticDocQA_healthcare_industry-test"
+  ],
+  "mmeb-visdoc-ViDoRe_tabfquad.test": [
+    "mmeb-visdoc-ViDoRe_tabfquad-test"
+  ],
+  "mmeb-visdoc-ViDoRe_tatdqa.test": [
+    "mmeb-visdoc-ViDoRe_tatdqa-test"
+  ],
+  "mmeb-visdoc-ViDoSeek-doc.test": [
+    "mmeb-visdoc-ViDoSeek-doc-test"
+  ],
+  "mmeb-visdoc-ViDoSeek-page.test": [
+    "mmeb-visdoc-ViDoSeek-page-test"
+  ],
+  "mmeb-visdoc-VisRAG_ArxivQA.train": [
+    "mmeb-visdoc-VisRAG_ArxivQA-train"
+  ],
+  "mmeb-visdoc-VisRAG_ChartQA.train": [
+    "mmeb-visdoc-VisRAG_ChartQA-train"
+  ],
+  "mmeb-visdoc-VisRAG_InfoVQA.train": [
+    "mmeb-visdoc-VisRAG_InfoVQA-train"
+  ],
+  "mmeb-visdoc-VisRAG_MP-DocVQA.train": [
+    "mmeb-visdoc-VisRAG_MP-DocVQA-train"
+  ],
+  "mmeb-visdoc-VisRAG_PlotQA.train": [
+    "mmeb-visdoc-VisRAG_PlotQA-train"
+  ],
+  "mmeb-visdoc-VisRAG_SlideVQA.train": [
+    "mmeb-visdoc-VisRAG_SlideVQA-train"
+  ],
+  "mq.1-10000": [
+    "trec2007-million-query"
+  ],
+  "mq.10001-20000": [
+    "trec2008-million-query"
+  ],
+  "mq.20001-60000": [
+    "trec2009-million-query"
+  ],
+  "mrtydi-v1.1-ar.dev": [
+    "mrtydi-v1.1-arabic-dev"
+  ],
+  "mrtydi-v1.1-ar.test": [
+    "mrtydi-v1.1-arabic-test"
+  ],
+  "mrtydi-v1.1-ar.train": [
+    "mrtydi-v1.1-arabic-train"
+  ],
+  "mrtydi-v1.1-bn.dev": [
+    "mrtydi-v1.1-bengali-dev"
+  ],
+  "mrtydi-v1.1-bn.test": [
+    "mrtydi-v1.1-bengali-test"
+  ],
+  "mrtydi-v1.1-bn.train": [
+    "mrtydi-v1.1-bengali-train"
+  ],
+  "mrtydi-v1.1-en.dev": [
+    "mrtydi-v1.1-english-dev"
+  ],
+  "mrtydi-v1.1-en.test": [
+    "mrtydi-v1.1-english-test"
+  ],
+  "mrtydi-v1.1-en.train": [
+    "mrtydi-v1.1-english-train"
+  ],
+  "mrtydi-v1.1-fi.dev": [
+    "mrtydi-v1.1-finnish-dev"
+  ],
+  "mrtydi-v1.1-fi.test": [
+    "mrtydi-v1.1-finnish-test"
+  ],
+  "mrtydi-v1.1-fi.train": [
+    "mrtydi-v1.1-finnish-train"
+  ],
+  "mrtydi-v1.1-id.dev": [
+    "mrtydi-v1.1-indonesian-dev"
+  ],
+  "mrtydi-v1.1-id.test": [
+    "mrtydi-v1.1-indonesian-test"
+  ],
+  "mrtydi-v1.1-id.train": [
+    "mrtydi-v1.1-indonesian-train"
+  ],
+  "mrtydi-v1.1-ja.dev": [
+    "mrtydi-v1.1-japanese-dev"
+  ],
+  "mrtydi-v1.1-ja.test": [
+    "mrtydi-v1.1-japanese-test"
+  ],
+  "mrtydi-v1.1-ja.train": [
+    "mrtydi-v1.1-japanese-train"
+  ],
+  "mrtydi-v1.1-ko.dev": [
+    "mrtydi-v1.1-korean-dev"
+  ],
+  "mrtydi-v1.1-ko.test": [
+    "mrtydi-v1.1-korean-test"
+  ],
+  "mrtydi-v1.1-ko.train": [
+    "mrtydi-v1.1-korean-train"
+  ],
+  "mrtydi-v1.1-ru.dev": [
+    "mrtydi-v1.1-russian-dev"
+  ],
+  "mrtydi-v1.1-ru.test": [
+    "mrtydi-v1.1-russian-test"
+  ],
+  "mrtydi-v1.1-ru.train": [
+    "mrtydi-v1.1-russian-train"
+  ],
+  "mrtydi-v1.1-sw.dev": [
+    "mrtydi-v1.1-swahili-dev"
+  ],
+  "mrtydi-v1.1-sw.test": [
+    "mrtydi-v1.1-swahili-test"
+  ],
+  "mrtydi-v1.1-sw.train": [
+    "mrtydi-v1.1-swahili-train"
+  ],
+  "mrtydi-v1.1-te.dev": [
+    "mrtydi-v1.1-telugu-dev"
+  ],
+  "mrtydi-v1.1-te.test": [
+    "mrtydi-v1.1-telugu-test"
+  ],
+  "mrtydi-v1.1-te.train": [
+    "mrtydi-v1.1-telugu-train"
+  ],
+  "mrtydi-v1.1-th.dev": [
+    "mrtydi-v1.1-thai-dev"
+  ],
+  "mrtydi-v1.1-th.test": [
+    "mrtydi-v1.1-thai-test"
+  ],
+  "mrtydi-v1.1-th.train": [
+    "mrtydi-v1.1-thai-train"
+  ],
+  "msmarco-doc.dev": [
+    "msmarco-doc-dev"
+  ],
+  "msmarco-doc.dev.unicoil": [
+    "msmarco-doc-dev-unicoil"
+  ],
+  "msmarco-doc.dev.unicoil-noexp": [
+    "msmarco-doc-dev-unicoil-noexp"
+  ],
+  "msmarco-doc.test": [
+    "msmarco-doc-test"
+  ],
+  "msmarco-passage.dev-subset": [
+    "msmarco-passage-dev-subset",
+    "msmarco-passage-dev",
+    "msmarco-passage.dev",
+    "msmarco-v1-passage-dev",
+    "msmarco-v1-passage.dev"
+  ],
+  "msmarco-passage.dev-subset.cohere-embed-english-v3.0": [
+    "msmarco-passage-dev-subset-cohere-embed-english-v3.0",
+    "msmarco-passage-dev-cohere-embed-english-v3.0",
+    "msmarco-passage-dev.cohere-embed-english-v3.0",
+    "msmarco-passage.dev.cohere-embed-english-v3.0",
+    "msmarco-v1-passage-dev-cohere-embed-english-v3.0",
+    "msmarco-v1-passage-dev.cohere-embed-english-v3.0",
+    "msmarco-v1-passage.dev.cohere-embed-english-v3.0"
+  ],
+  "msmarco-passage.dev-subset.deepimpact": [
+    "msmarco-passage-dev-subset-deepimpact",
+    "msmarco-passage-dev-subset.deepimpact",
+    "msmarco-passage-dev.deepimpact",
+    "msmarco-v1-passage-dev.deepimpact",
+    "msmarco-passage.dev.deepimpact",
+    "msmarco-v1-passage.dev.deepimpact"
+  ],
+  "msmarco-passage.dev-subset.distill-splade-max": [
+    "msmarco-passage-dev-subset-distill-splade-max",
+    "msmarco-passage-dev-subset.distill-splade-max",
+    "msmarco-passage-dev.distill-splade-max",
+    "msmarco-v1-passage-dev.distill-splade-max",
+    "msmarco-passage.dev.distill-splade-max",
+    "msmarco-v1-passage.dev.distill-splade-max"
+  ],
+  "msmarco-passage.dev-subset.splade-pp-ed": [
+    "msmarco-passage-dev-subset-splade-pp-ed",
+    "msmarco-passage-dev-splade-pp-ed",
+    "msmarco-passage-dev.splade-pp-ed",
+    "msmarco-passage.dev.splade-pp-ed",
+    "msmarco-v1-passage-dev-splade-pp-ed",
+    "msmarco-v1-passage-dev.splade-pp-ed",
+    "msmarco-v1-passage.dev.splade-pp-ed",
+    "msmarco-passage-dev-subset.splade-pp-ed"
+  ],
+  "msmarco-passage.dev-subset.splade-pp-sd": [
+    "msmarco-passage-dev-subset-splade-pp-sd",
+    "msmarco-passage-dev-splade-pp-sd",
+    "msmarco-passage-dev.splade-pp-sd",
+    "msmarco-passage.dev.splade-pp-sd",
+    "msmarco-v1-passage-dev-splade-pp-sd",
+    "msmarco-v1-passage-dev.splade-pp-sd",
+    "msmarco-v1-passage.dev.splade-pp-sd",
+    "msmarco-passage-dev-subset.splade-pp-sd"
+  ],
+  "msmarco-passage.dev-subset.splade-v3": [
+    "msmarco-passage-dev-subset-splade-v3",
+    "msmarco-passage-dev-subset.splade-v3",
+    "msmarco-passage-dev.splade-v3",
+    "msmarco-v1-passage-dev.splade-v3",
+    "msmarco-passage.dev.splade-v3",
+    "msmarco-v1-passage.dev.splade-v3"
+  ],
+  "msmarco-passage.dev-subset.splade_distil_cocodenser_medium": [
+    "msmarco-passage-dev-subset-splade-distil-cocodenser-medium",
+    "msmarco-passage-dev-subset.splade-distil-cocodenser-medium",
+    "msmarco-passage-dev.splade-distil-cocodenser-medium",
+    "msmarco-v1-passage-dev.splade-distil-cocodenser-medium",
+    "msmarco-passage.dev.splade-distil-cocodenser-medium",
+    "msmarco-v1-passage.dev.splade-distil-cocodenser-medium"
+  ],
+  "msmarco-passage.dev-subset.unicoil": [
+    "msmarco-passage-dev-subset-unicoil",
+    "msmarco-passage-dev-subset.unicoil",
+    "msmarco-passage-dev.unicoil",
+    "msmarco-v1-passage-dev.unicoil",
+    "msmarco-passage.dev.unicoil",
+    "msmarco-v1-passage.dev.unicoil"
+  ],
+  "msmarco-passage.dev-subset.unicoil-noexp": [
+    "msmarco-passage-dev-subset-unicoil-noexp",
+    "msmarco-passage-dev-subset.unicoil-noexp",
+    "msmarco-passage-dev.unicoil-noexp",
+    "msmarco-v1-passage-dev.unicoil-noexp",
+    "msmarco-passage.dev.unicoil-noexp",
+    "msmarco-v1-passage.dev.unicoil-noexp"
+  ],
+  "msmarco-passage.dev-subset.unicoil-tilde-expansion": [
+    "msmarco-passage-dev-subset-unicoil-tilde",
+    "msmarco-passage-dev-subset.unicoil-tilde",
+    "msmarco-passage-dev.unicoil-tilde",
+    "msmarco-v1-passage-dev.unicoil-tilde",
+    "msmarco-passage.dev.unicoil-tilde",
+    "msmarco-v1-passage.dev.unicoil-tilde"
+  ],
+  "msmarco-passage.test-subset": [
+    "msmarco-passage-test-subset"
+  ],
+  "msmarco-v2-doc.dev": [
+    "msmarco-v2-doc-dev"
+  ],
+  "msmarco-v2-doc.dev.unicoil-noexp.0shot": [
+    "msmarco-v2-doc-dev-unicoil-noexp"
+  ],
+  "msmarco-v2-doc.dev.unicoil.0shot": [
+    "msmarco-v2-doc-dev-unicoil"
+  ],
+  "msmarco-v2-doc.dev2": [
+    "msmarco-v2-doc-dev2"
+  ],
+  "msmarco-v2-doc.dev2.unicoil-noexp.0shot": [
+    "msmarco-v2-doc-dev2-unicoil-noexp"
+  ],
+  "msmarco-v2-doc.dev2.unicoil.0shot": [
+    "msmarco-v2-doc-dev2-unicoil"
+  ],
+  "msmarco-v2-passage.dev": [
+    "msmarco-v2-passage-dev"
+  ],
+  "msmarco-v2-passage.dev.unicoil-noexp.0shot": [
+    "msmarco-v2-passage-dev-unicoil-noexp"
+  ],
+  "msmarco-v2-passage.dev.unicoil.0shot": [
+    "msmarco-v2-passage-dev-unicoil"
+  ],
+  "msmarco-v2-passage.dev2": [
+    "msmarco-v2-passage-dev2"
+  ],
+  "msmarco-v2-passage.dev2.unicoil-noexp.0shot": [
+    "msmarco-v2-passage-dev2-unicoil-noexp"
+  ],
+  "msmarco-v2-passage.dev2.unicoil.0shot": [
+    "msmarco-v2-passage-dev2-unicoil"
+  ],
+  "neuclir22-en.original-desc": [
+    "neuclir22-en-desc"
+  ],
+  "neuclir22-en.original-desc_title": [
+    "neuclir22-en-desc-title"
+  ],
+  "neuclir22-en.original-title": [
+    "neuclir22-en-title"
+  ],
+  "neuclir22-fa.ht-desc": [
+    "neuclir22-fa-ht-desc"
+  ],
+  "neuclir22-fa.ht-desc_title": [
+    "neuclir22-fa-ht-desc-title"
+  ],
+  "neuclir22-fa.ht-title": [
+    "neuclir22-fa-ht-title"
+  ],
+  "neuclir22-fa.mt-desc": [
+    "neuclir22-fa-mt-desc"
+  ],
+  "neuclir22-fa.mt-desc_title": [
+    "neuclir22-fa-mt-desc-title"
+  ],
+  "neuclir22-fa.mt-title": [
+    "neuclir22-fa-mt-title"
+  ],
+  "neuclir22-ru.ht-desc": [
+    "neuclir22-ru-ht-desc"
+  ],
+  "neuclir22-ru.ht-desc_title": [
+    "neuclir22-ru-ht-desc-title"
+  ],
+  "neuclir22-ru.ht-title": [
+    "neuclir22-ru-ht-title"
+  ],
+  "neuclir22-ru.mt-desc": [
+    "neuclir22-ru-mt-desc"
+  ],
+  "neuclir22-ru.mt-desc_title": [
+    "neuclir22-ru-mt-desc-title"
+  ],
+  "neuclir22-ru.mt-title": [
+    "neuclir22-ru-mt-title"
+  ],
+  "neuclir22-zh.ht-desc": [
+    "neuclir22-zh-ht-desc"
+  ],
+  "neuclir22-zh.ht-desc_title": [
+    "neuclir22-zh-ht-desc-title"
+  ],
+  "neuclir22-zh.ht-title": [
+    "neuclir22-zh-ht-title"
+  ],
+  "neuclir22-zh.mt-desc": [
+    "neuclir22-zh-mt-desc"
+  ],
+  "neuclir22-zh.mt-desc_title": [
+    "neuclir22-zh-mt-desc-title"
+  ],
+  "neuclir22-zh.mt-title": [
+    "neuclir22-zh-mt-title"
+  ],
+  "nq.dev": [
+    "nq-dev"
+  ],
+  "nq.test": [
+    "nq-test"
+  ],
+  "nq.test.gar-t5.all": [
+    "nq-test-gar-t5-all"
+  ],
+  "nq.test.gar-t5.answers": [
+    "nq-test-gar-t5-answers"
+  ],
+  "nq.test.gar-t5.sentences": [
+    "nq-test-gar-t5-sentences"
+  ],
+  "nq.test.gar-t5.titles": [
+    "nq-test-gar-t5-titles"
+  ],
+  "ntcir8zh.eval": [
+    "ntcir8-zh"
+  ],
+  "slidevqa.test": [
+    "slidevqa"
+  ],
+  "terabyte04.701-750": [
+    "trec2004-terabyte"
+  ],
+  "terabyte05.751-800": [
+    "trec2005-terabyte"
+  ],
+  "terabyte06.801-850": [
+    "trec2006-terabyte"
+  ],
+  "trec02ar-ar": [
+    "trec2002-ar"
+  ],
+  "web.101-150": [
+    "trec2011-web"
+  ],
+  "web.151-200": [
+    "trec2012-web"
+  ],
+  "web.201-250": [
+    "trec2013-web"
+  ],
+  "web.251-300": [
+    "trec2014-web"
+  ],
+  "web.51-100": [
+    "trec2010-web"
+  ],
+  "wiki-ss-nq.test": [
+    "wiki-ss-nq"
+  ]
+}

--- a/src/test/java/io/anserini/cli/TopicsRegistryTest.java
+++ b/src/test/java/io/anserini/cli/TopicsRegistryTest.java
@@ -83,10 +83,7 @@ public class TopicsRegistryTest extends StdOutStdErrRedirectableLuceneTestCase {
 
     List<String> names = MAPPER.readValue(out.toString(), NAME_LIST_TYPE);
 
-    Set<String> expectedNames = new TreeSet<>(Topics.getSymbolDictionaryKeys());
-    for (Topics topic : Topics.values()) {
-      expectedNames.add(topic.name());
-    }
+    Set<String> expectedNames = new TreeSet<>(Topics.names());
     expectedNames.removeIf(name -> !name.contains("msmarco"));
 
     assertEquals(expectedNames.size(), names.size());
@@ -112,10 +109,7 @@ public class TopicsRegistryTest extends StdOutStdErrRedirectableLuceneTestCase {
 
     List<String> names = MAPPER.readValue(out.toString(), NAME_LIST_TYPE);
 
-    Set<String> expectedNames = new TreeSet<>(Topics.getSymbolDictionaryKeys());
-    for (Topics topic : Topics.values()) {
-      expectedNames.add(topic.name());
-    }
+    Set<String> expectedNames = new TreeSet<>(Topics.names());
 
     assertEquals(expectedNames.size(), names.size());
     assertEquals(expectedNames, new TreeSet<>(names));
@@ -127,7 +121,7 @@ public class TopicsRegistryTest extends StdOutStdErrRedirectableLuceneTestCase {
     Files.writeString(topicFile, "1\tquery one\n2\tquery two\n", StandardCharsets.UTF_8);
 
     try {
-      TopicsRegistry.main(new String[] {"--get", "TREC2019_DL_PASSAGE"});
+      TopicsRegistry.main(new String[] {"--get", "dl19-passage"});
 
       Map<String, Map<String, String>> queries = MAPPER.readValue(out.toString(), QUERY_MAP_TYPE);
 

--- a/src/test/java/io/anserini/cli/TopicsRegistryTest.java
+++ b/src/test/java/io/anserini/cli/TopicsRegistryTest.java
@@ -88,6 +88,8 @@ public class TopicsRegistryTest extends StdOutStdErrRedirectableLuceneTestCase {
 
     assertEquals(expectedNames.size(), names.size());
     assertEquals(expectedNames, new TreeSet<>(names));
+    assertTrue(names.contains("msmarco-passage.dev-subset"));
+    assertFalse(names.contains("topics.msmarco-passage.dev-subset.txt"));
   }
 
   @Test
@@ -113,6 +115,8 @@ public class TopicsRegistryTest extends StdOutStdErrRedirectableLuceneTestCase {
 
     assertEquals(expectedNames.size(), names.size());
     assertEquals(expectedNames, new TreeSet<>(names));
+    assertTrue(names.contains("dl19-passage"));
+    assertFalse(names.contains("topics.dl19-passage.txt"));
   }
 
   @Test

--- a/src/test/java/io/anserini/reproduce/ReproduceFromDocumentCollectionTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromDocumentCollectionTest.java
@@ -162,7 +162,7 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
 
   @Test
   public void testCacmRegressionDryRun() throws Exception {
-    SortedMap<Integer, Map<String, String>> topics = TopicReader.getTopics(Topics.CACM);
+    SortedMap<Integer, Map<String, String>> topics = TopicReader.getTopics(Topics.get("cacm"));
     assertNotNull(topics);
 
     ReproduceFromDocumentCollection.main(new String[] {"--config", "cacm", "--index", "--search", "--dry-run"});
@@ -170,7 +170,7 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
 
   @Test
   public void testCacmRegressionInRepo() throws Exception {
-    SortedMap<Integer, Map<String, String>> topics = TopicReader.getTopics(Topics.CACM);
+    SortedMap<Integer, Map<String, String>> topics = TopicReader.getTopics(Topics.get("cacm"));
     assertNotNull(topics);
 
     ReproduceFromDocumentCollection.main(new String[] {"--config", "cacm", "--index", "--search"});
@@ -186,7 +186,7 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
   public void testCacmRegressionFromDownload() throws Exception {
     assumeGithubReachable();
 
-    SortedMap<Integer, Map<String, String>> topics = TopicReader.getTopics(Topics.CACM);
+    SortedMap<Integer, Map<String, String>> topics = TopicReader.getTopics(Topics.get("cacm"));
     assertNotNull(topics);
 
     ReproduceFromDocumentCollection.main(new String[] {"--config", "cacm-download", "--download", "--index", "--search"});
@@ -242,7 +242,7 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
 
   @Test
   public void testCacmRegressionFromFatjar() throws Exception {
-    SortedMap<Integer, Map<String, String>> topics = TopicReader.getTopics(Topics.CACM);
+    SortedMap<Integer, Map<String, String>> topics = TopicReader.getTopics(Topics.get("cacm"));
     assertNotNull(topics);
 
     Path classesDir = Paths.get("target/classes");

--- a/src/test/java/io/anserini/reproduce/ReproduceFromDocumentCollectionTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromDocumentCollectionTest.java
@@ -162,7 +162,7 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
 
   @Test
   public void testCacmRegressionDryRun() throws Exception {
-    SortedMap<Integer, Map<String, String>> topics = TopicReader.getTopics(Topics.get("cacm"));
+    SortedMap<Integer, Map<String, String>> topics = TopicReader.load(Topics.get("cacm"));
     assertNotNull(topics);
 
     ReproduceFromDocumentCollection.main(new String[] {"--config", "cacm", "--index", "--search", "--dry-run"});
@@ -170,7 +170,7 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
 
   @Test
   public void testCacmRegressionInRepo() throws Exception {
-    SortedMap<Integer, Map<String, String>> topics = TopicReader.getTopics(Topics.get("cacm"));
+    SortedMap<Integer, Map<String, String>> topics = TopicReader.load(Topics.get("cacm"));
     assertNotNull(topics);
 
     ReproduceFromDocumentCollection.main(new String[] {"--config", "cacm", "--index", "--search"});
@@ -186,7 +186,7 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
   public void testCacmRegressionFromDownload() throws Exception {
     assumeGithubReachable();
 
-    SortedMap<Integer, Map<String, String>> topics = TopicReader.getTopics(Topics.get("cacm"));
+    SortedMap<Integer, Map<String, String>> topics = TopicReader.load(Topics.get("cacm"));
     assertNotNull(topics);
 
     ReproduceFromDocumentCollection.main(new String[] {"--config", "cacm-download", "--download", "--index", "--search"});
@@ -242,7 +242,7 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
 
   @Test
   public void testCacmRegressionFromFatjar() throws Exception {
-    SortedMap<Integer, Map<String, String>> topics = TopicReader.getTopics(Topics.get("cacm"));
+    SortedMap<Integer, Map<String, String>> topics = TopicReader.load(Topics.get("cacm"));
     assertNotNull(topics);
 
     Path classesDir = Paths.get("target/classes");

--- a/src/test/java/io/anserini/search/SearchCollectionTest.java
+++ b/src/test/java/io/anserini/search/SearchCollectionTest.java
@@ -161,7 +161,7 @@ public class SearchCollectionTest extends StdOutStdErrRedirectableLuceneTestCase
   public void testSpecifyTopicsAsSymbol() throws Exception {
     SearchCollection.main(new String[] {
         "-index", "src/test/resources/prebuilt_indexes/lucene9-index.sample_docs_trec_collection2/",
-        "-topics", "TREC2019_DL_PASSAGE",
+        "-topics", "dl19-passage",
         "-output", RUN_TEST, "-bm25"});
 
     // Not checking content, just checking if the topics were loaded successfully.

--- a/src/test/java/io/anserini/search/SearchFlatDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchFlatDenseVectorsTest.java
@@ -171,7 +171,7 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
 
     SearchFlatDenseVectors.main(searchArgs);
 
-    assertTrue(err.toString().contains("Error: Unable to load topic reader \"FakeJsonIntVector\"."));
+    assertTrue(err.toString().contains("Error: Unable to load topic reader \"FakeJsonIntVector\""));
   }
 
   @Test

--- a/src/test/java/io/anserini/search/SearchFlatDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchFlatDenseVectorsTest.java
@@ -399,7 +399,7 @@ public class SearchFlatDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
     String runfile = "target/run-" + System.currentTimeMillis();
     String[] searchArgs = new String[] {
         "-index", indexPath,
-        "-topics", "TREC2019_DL_PASSAGE",
+        "-topics", "dl19-passage",
         "-encoder", "CosDprDistil",
         "-output", runfile,
         "-hits", "5"};

--- a/src/test/java/io/anserini/search/SearchHnswDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchHnswDenseVectorsTest.java
@@ -177,7 +177,7 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
 
     SearchHnswDenseVectors.main(searchArgs);
 
-    assertEquals("Error: Unable to load topic reader \"FakeJsonIntVector\".\n", err.toString());
+    assertTrue(err.toString().contains("Error: Unable to load topic reader \"FakeJsonIntVector\""));
   }
 
   @Test

--- a/src/test/java/io/anserini/search/SearchHnswDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchHnswDenseVectorsTest.java
@@ -418,7 +418,7 @@ public class SearchHnswDenseVectorsTest extends StdOutStdErrRedirectableLuceneTe
     String runfile = "target/run-" + System.currentTimeMillis();
     String[] searchArgs = new String[] {
         "-index", indexPath,
-        "-topics", "TREC2019_DL_PASSAGE",
+        "-topics", "dl19-passage",
         "-encoder", "CosDprDistil",
         "-output", runfile,
         "-efSearch", "1000",

--- a/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
@@ -20,8 +20,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 
@@ -30,9 +34,9 @@ import org.junit.Test;
 public class TopicReaderTest {
 
   @Test
-  public void testIterateThroughAllEnums() {
+  public void testIterateThroughAllTopics() {
     int cnt = 0;
-    for (Topics topic : Topics.registry().values()) {
+    for (Topics topic : Topics.entries().values()) {
       cnt++; 
 
       // Verify that we can fetch the TopicReader class given the name of the topic file.
@@ -55,14 +59,42 @@ public class TopicReaderTest {
   }
 
   @Test(expected = NullPointerException.class)
-  public void testGetTopicsInvalid() throws IOException {
-    TopicReader.getTopics(null);
+  public void testLoadTopicsInvalid() throws IOException {
+    TopicReader.load(null);
+  }
+
+  @Test
+  public void testLoadFileWithTopicReader() throws IOException {
+    Path topicsFile = Files.createTempFile("topics", ".tsv");
+    Files.write(topicsFile, List.of("1\ttest query"));
+
+    try {
+      SortedMap<Integer, Map<String, String>> topics = TopicReader.load(topicsFile.toString(), "TsvInt");
+      assertEquals(1, topics.size());
+      assertEquals(Integer.valueOf(1), topics.firstKey());
+      assertEquals("test query", topics.get(topics.firstKey()).get("title"));
+    } finally {
+      Files.deleteIfExists(topicsFile);
+    }
+  }
+
+  @Test
+  public void testLoadFileWithoutTopicReader() throws IOException {
+    Path topicsFile = Files.createTempFile("topics", ".txt");
+
+    try {
+      TopicReader.load(topicsFile.toString(), null);
+      fail("Expected IllegalArgumentException to be thrown");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Must specify the topic reader using -topicReader.", e.getMessage());
+    } finally {
+      Files.deleteIfExists(topicsFile);
+    }
   }
 
   @Test
   public void testGetTopicsByFile() {
-    SortedMap<Object, Map<String, String>> topics =
-        TopicReader.getTopicsByFile("tools/topics-and-qrels/topics.robust04.txt");
+    SortedMap<Object, Map<String, String>> topics = TopicReader.getTopicsByFile("tools/topics-and-qrels/topics.robust04.txt");
 
     assertNotNull(topics);
     assertEquals(250, topics.size());
@@ -76,7 +108,17 @@ public class TopicReaderTest {
   public void testCacmTopics() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("cacm"));
+    topics = TopicReader.load(Topics.get("cacm"));
+    assertNotNull(topics);
+    assertEquals(64, topics.size());
+    assertEquals(1, (int) topics.firstKey());
+    assertTrue(topics.get(topics.firstKey()).get("title").contains("What articles exist which deal with TSS"));
+    assertEquals(64, (int) topics.lastKey());
+    assertTrue(topics.get(topics.lastKey()).get("title").contains("List all articles on EL1 and ECL"));
+
+    // Test that TopicReader.load(Topics.get("cacm")) and Topics.load("cacm")) give the same thing.
+    // No need to check for all topics, just this one is sufficient.
+    topics = Topics.load("cacm");
     assertNotNull(topics);
     assertEquals(64, topics.size());
     assertEquals(1, (int) topics.firstKey());
@@ -86,10 +128,30 @@ public class TopicReaderTest {
   }
 
   @Test
+  public void testLoadTopicsByPath() throws IOException {
+    SortedMap<Integer, Map<String, String>> topics;
+
+    Path path = TopicReader.getTopicPath(Path.of(Topics.get("cacm").path));
+    topics = TopicReader.load(path.toString(), "Cacm");
+    assertNotNull(topics);
+    assertEquals(64, topics.size());
+    assertEquals(1, (int) topics.firstKey());
+    assertTrue(topics.get(topics.firstKey()).get("title").contains("What articles exist which deal with TSS"));
+    assertEquals(64, (int) topics.lastKey());
+    assertTrue(topics.get(topics.lastKey()).get("title").contains("List all articles on EL1 and ECL"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testLoadTopicsByPathInvalidTopicReader() throws IOException {
+    Path path = TopicReader.getTopicPath(Path.of(Topics.get("cacm").path));
+    TopicReader.load(path.toString(), "xxx");
+  }
+
+  @Test
   public void testNewswireTopics() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("adhoc.51-100"));
+    topics = TopicReader.load(Topics.get("adhoc.51-100"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(51, (int) topics.firstKey());
@@ -97,7 +159,7 @@ public class TopicReaderTest {
     assertEquals(100, (int) topics.lastKey());
     assertEquals("Controlling the Transfer of High Technology", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("adhoc.101-150"));
+    topics = TopicReader.load(Topics.get("adhoc.101-150"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(101, (int) topics.firstKey());
@@ -105,7 +167,7 @@ public class TopicReaderTest {
     assertEquals(150, (int) topics.lastKey());
     assertEquals("U.S. Political Campaign Financing", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("adhoc.151-200"));
+    topics = TopicReader.load(Topics.get("adhoc.151-200"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(151, (int) topics.firstKey());
@@ -113,7 +175,7 @@ public class TopicReaderTest {
     assertEquals(200, (int) topics.lastKey());
     assertEquals("Impact of foreign textile imports on U.S. textile industry", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("robust04"));
+    topics = TopicReader.load(Topics.get("robust04"));
     assertNotNull(topics);
     assertEquals(250, topics.size());
     assertEquals(301, (int) topics.firstKey());
@@ -121,7 +183,7 @@ public class TopicReaderTest {
     assertEquals(700, (int) topics.lastKey());
     assertEquals("gasoline tax U.S.", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("robust05"));
+    topics = TopicReader.load(Topics.get("robust05"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(303, (int) topics.firstKey());
@@ -129,7 +191,7 @@ public class TopicReaderTest {
     assertEquals(689, (int) topics.lastKey());
     assertEquals("family-planning aid", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("core17"));
+    topics = TopicReader.load(Topics.get("core17"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(307, (int) topics.firstKey());
@@ -137,7 +199,7 @@ public class TopicReaderTest {
     assertEquals(690, (int) topics.lastKey());
     assertEquals("college education advantage", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("core18"));
+    topics = TopicReader.load(Topics.get("core18"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(321, (int) topics.firstKey());
@@ -150,11 +212,11 @@ public class TopicReaderTest {
   public void testDseTopics() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("slidevqa.test"));
+    topics = TopicReader.load(Topics.get("slidevqa.test"));
     assertNotNull(topics);
     assertEquals(2214, topics.size());
 
-    topics = TopicReader.getTopics(Topics.get("wiki-ss-nq.test"));
+    topics = TopicReader.load(Topics.get("wiki-ss-nq.test"));
     assertNotNull(topics);
     assertEquals(3610, topics.size());
   }
@@ -163,7 +225,7 @@ public class TopicReaderTest {
   public void testTrecTitleParsing() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("adhoc.51-100"));
+    topics = TopicReader.load(Topics.get("adhoc.51-100"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
 
@@ -176,7 +238,7 @@ public class TopicReaderTest {
     assertEquals("Criminal Actions Against Officers of Failed Financial Institutions", topics.get(87).get("title"));
     assertEquals("What Backing Does the National Rifle Association Have?", topics.get(93).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("adhoc.101-150"));
+    topics = TopicReader.load(Topics.get("adhoc.101-150"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
 
@@ -237,7 +299,7 @@ public class TopicReaderTest {
   public void testWebTopics() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("adhoc.451-550"));
+    topics = TopicReader.load(Topics.get("adhoc.451-550"));
     assertNotNull(topics);
     assertEquals(100, topics.size());
     assertEquals(451, (int) topics.firstKey());
@@ -245,7 +307,7 @@ public class TopicReaderTest {
     assertEquals(550, (int) topics.lastKey());
     assertEquals("how are the volcanoes made?", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("terabyte04.701-750"));
+    topics = TopicReader.load(Topics.get("terabyte04.701-750"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(701, (int) topics.firstKey());
@@ -253,7 +315,7 @@ public class TopicReaderTest {
     assertEquals(750, (int) topics.lastKey());
     assertEquals("John Edwards womens issues", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("terabyte05.751-800"));
+    topics = TopicReader.load(Topics.get("terabyte05.751-800"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(751, (int) topics.firstKey());
@@ -261,7 +323,7 @@ public class TopicReaderTest {
     assertEquals(800, (int) topics.lastKey());
     assertEquals("Ovarian Cancer Treatment", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("terabyte06.801-850"));
+    topics = TopicReader.load(Topics.get("terabyte06.801-850"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(801, (int) topics.firstKey());
@@ -269,7 +331,7 @@ public class TopicReaderTest {
     assertEquals(850, (int) topics.lastKey());
     assertEquals("Mississippi River flood", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("mq.1-10000"));
+    topics = TopicReader.load(Topics.get("mq.1-10000"));
     assertNotNull(topics);
     assertEquals(10000, topics.keySet().size());
     assertEquals(1, (int) topics.firstKey());
@@ -277,7 +339,7 @@ public class TopicReaderTest {
     assertEquals(10000, (int) topics.lastKey());
     assertEquals("californa mission", topics.get(topics.lastKey()).get("title").trim());
 
-    topics = TopicReader.getTopics(Topics.get("mq.10001-20000"));
+    topics = TopicReader.load(Topics.get("mq.10001-20000"));
     assertNotNull(topics);
     assertEquals(10000, topics.keySet().size());
     assertEquals(10001, (int) topics.firstKey());
@@ -285,7 +347,7 @@ public class TopicReaderTest {
     assertEquals(20000, (int) topics.lastKey());
     assertEquals("manchester city hall", topics.get(topics.lastKey()).get("title").trim());
 
-    topics = TopicReader.getTopics(Topics.get("mq.20001-60000"));
+    topics = TopicReader.load(Topics.get("mq.20001-60000"));
     assertNotNull(topics);
     assertEquals(40000, topics.keySet().size());
     assertEquals(20001, (int) topics.firstKey());
@@ -295,7 +357,7 @@ public class TopicReaderTest {
     assertEquals("bird shingles", topics.get(topics.lastKey()).get("title").trim());
     assertEquals("4", topics.get(topics.lastKey()).get("priority").trim());
 
-    topics = TopicReader.getTopics(Topics.get("web.51-100"));
+    topics = TopicReader.load(Topics.get("web.51-100"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(51, (int) topics.firstKey());
@@ -303,7 +365,7 @@ public class TopicReaderTest {
     assertEquals(100, (int) topics.lastKey());
     assertEquals("rincon puerto rico", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("web.101-150"));
+    topics = TopicReader.load(Topics.get("web.101-150"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(101, (int) topics.firstKey());
@@ -311,7 +373,7 @@ public class TopicReaderTest {
     assertEquals(150, (int) topics.lastKey());
     assertEquals("tn highway patrol", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("web.151-200"));
+    topics = TopicReader.load(Topics.get("web.151-200"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(151, (int) topics.firstKey());
@@ -319,7 +381,7 @@ public class TopicReaderTest {
     assertEquals(200, (int) topics.lastKey());
     assertEquals("ontario california airport", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("web.201-250"));
+    topics = TopicReader.load(Topics.get("web.201-250"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(201, (int) topics.firstKey());
@@ -327,7 +389,7 @@ public class TopicReaderTest {
     assertEquals(250, (int) topics.lastKey());
     assertEquals("ford edge problems", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("web.251-300"));
+    topics = TopicReader.load(Topics.get("web.251-300"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(251, (int) topics.firstKey());
@@ -419,7 +481,7 @@ public class TopicReaderTest {
   public void testMicoblogTopics() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("microblog2011"));
+    topics = TopicReader.load(Topics.get("microblog2011"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(1, (int) topics.firstKey());
@@ -427,7 +489,7 @@ public class TopicReaderTest {
     assertEquals(50, (int) topics.lastKey());
     assertEquals("war prisoners, Hatch Act", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("microblog2012"));
+    topics = TopicReader.load(Topics.get("microblog2012"));
     assertNotNull(topics);
     assertEquals(60, topics.size());
     assertEquals(51, (int) topics.firstKey());
@@ -435,7 +497,7 @@ public class TopicReaderTest {
     assertEquals(110, (int) topics.lastKey());
     assertEquals("economic trade sanctions", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("microblog2013"));
+    topics = TopicReader.load(Topics.get("microblog2013"));
     assertNotNull(topics);
     assertEquals(60, topics.size());
     assertEquals(111, (int) topics.firstKey());
@@ -443,7 +505,7 @@ public class TopicReaderTest {
     assertEquals(170, (int) topics.lastKey());
     assertEquals("Tony Mendez", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("microblog2014"));
+    topics = TopicReader.load(Topics.get("microblog2014"));
     assertNotNull(topics);
     assertEquals(55, topics.size());
     assertEquals(171, (int) topics.firstKey());
@@ -485,7 +547,7 @@ public class TopicReaderTest {
   public void testCAR() throws IOException {
     SortedMap<String, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("car17v1.5.benchmarkY1test"));
+    topics = TopicReader.load(Topics.get("car17v1.5.benchmarkY1test"));
     assertNotNull(topics);
     assertEquals(2125, topics.size());
     assertEquals("Aftertaste/Aftertaste%20processing%20in%20the%20cerebral%20cortex", topics.firstKey());
@@ -493,7 +555,7 @@ public class TopicReaderTest {
     assertEquals("Yellowstone%20National%20Park/Recreation", topics.lastKey());
     assertEquals("Yellowstone National Park/Recreation", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("car17v2.0.benchmarkY1test"));
+    topics = TopicReader.load(Topics.get("car17v2.0.benchmarkY1test"));
     assertNotNull(topics);
     assertEquals(2254, topics.size());
     assertEquals("enwiki:Aftertaste", topics.firstKey());
@@ -526,7 +588,7 @@ public class TopicReaderTest {
   public void testDprNq() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("dpr.nq.dev"));
+    topics = TopicReader.load(Topics.get("dpr.nq.dev"));
     assertNotNull(topics);
     assertEquals(8757, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -537,7 +599,7 @@ public class TopicReaderTest {
     assertEquals("['2010']", topics.get(topics.lastKey()).get("answers"));
     assertEquals("who did the artwork for pink floyd 's wall", topics.get(1726).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("dpr.nq.test"));
+    topics = TopicReader.load(Topics.get("dpr.nq.test"));
     assertNotNull(topics);
     assertEquals(3610, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -553,7 +615,7 @@ public class TopicReaderTest {
   public void testDprTrivia() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("dpr.trivia.dev"));
+    topics = TopicReader.load(Topics.get("dpr.trivia.dev"));
     assertNotNull(topics);
     assertEquals(8837, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -563,7 +625,7 @@ public class TopicReaderTest {
     assertEquals("Name the artist and the title of this 1978 classic that remains popular today: We were at the beach Everybody had matching towels Somebody went under a dock And there they saw a rock It wasnt a rock", topics.get(topics.lastKey()).get("title"));
     assertEquals("['Rock Lobster by the B-52s']", topics.get(topics.lastKey()).get("answers"));
 
-    topics = TopicReader.getTopics(Topics.get("dpr.trivia.test"));
+    topics = TopicReader.load(Topics.get("dpr.trivia.test"));
     assertNotNull(topics);
     assertEquals(11313, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -578,7 +640,7 @@ public class TopicReaderTest {
   public void testDprWq() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("dpr.wq.test"));
+    topics = TopicReader.load(Topics.get("dpr.wq.test"));
     assertNotNull(topics);
     assertEquals(2032, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -593,7 +655,7 @@ public class TopicReaderTest {
   public void testDprCurated() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("dpr.curated.test"));
+    topics = TopicReader.load(Topics.get("dpr.curated.test"));
     assertNotNull(topics);
     assertEquals(694, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -608,7 +670,7 @@ public class TopicReaderTest {
   public void testDprSquad() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("dpr.squad.test"));
+    topics = TopicReader.load(Topics.get("dpr.squad.test"));
     assertNotNull(topics);
     assertEquals(10570, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -623,7 +685,7 @@ public class TopicReaderTest {
   public void testNq() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("nq.dev"));
+    topics = TopicReader.load(Topics.get("nq.dev"));
     assertNotNull(topics);
     assertEquals(8757, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -634,7 +696,7 @@ public class TopicReaderTest {
     assertEquals("['2010']", topics.get(topics.lastKey()).get("answers"));
     assertEquals("who did the artwork for pink floyd's wall", topics.get(1726).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("nq.test"));
+    topics = TopicReader.load(Topics.get("nq.test"));
     assertNotNull(topics);
     assertEquals(3610, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -648,25 +710,25 @@ public class TopicReaderTest {
 
   @Test
   public void testGarT5Nq() throws IOException {
-    assertEquals(3610, TopicReader.getTopics(Topics.get("nq.test.gar-t5.answers")).keySet().size());
-    assertEquals(3610, TopicReader.getTopics(Topics.get("nq.test.gar-t5.titles")).keySet().size());
-    assertEquals(3610, TopicReader.getTopics(Topics.get("nq.test.gar-t5.sentences")).keySet().size());
-    assertEquals(3610, TopicReader.getTopics(Topics.get("nq.test.gar-t5.all")).keySet().size());
+    assertEquals(3610, TopicReader.load(Topics.get("nq.test.gar-t5.answers")).keySet().size());
+    assertEquals(3610, TopicReader.load(Topics.get("nq.test.gar-t5.titles")).keySet().size());
+    assertEquals(3610, TopicReader.load(Topics.get("nq.test.gar-t5.sentences")).keySet().size());
+    assertEquals(3610, TopicReader.load(Topics.get("nq.test.gar-t5.all")).keySet().size());
   }
 
   @Test
   public void testGarT5Trivia() throws IOException {
-    assertEquals(11313, TopicReader.getTopics(Topics.get("dpr.trivia.test.gar-t5.answers")).keySet().size());
-    assertEquals(11313, TopicReader.getTopics(Topics.get("dpr.trivia.test.gar-t5.titles")).keySet().size());
-    assertEquals(11313, TopicReader.getTopics(Topics.get("dpr.trivia.test.gar-t5.sentences")).keySet().size());
-    assertEquals(11313, TopicReader.getTopics(Topics.get("dpr.trivia.test.gar-t5.all")).keySet().size());
+    assertEquals(11313, TopicReader.load(Topics.get("dpr.trivia.test.gar-t5.answers")).keySet().size());
+    assertEquals(11313, TopicReader.load(Topics.get("dpr.trivia.test.gar-t5.titles")).keySet().size());
+    assertEquals(11313, TopicReader.load(Topics.get("dpr.trivia.test.gar-t5.sentences")).keySet().size());
+    assertEquals(11313, TopicReader.load(Topics.get("dpr.trivia.test.gar-t5.all")).keySet().size());
   }
 
   @Test
   public void testTREC19DL() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("dl19-passage"));
+    topics = TopicReader.load(Topics.get("dl19-passage"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -675,7 +737,7 @@ public class TopicReaderTest {
     assertEquals("how is the weather in jamaica", topics.get(topics.lastKey()).get("title"));
     assertEquals("does legionella pneumophila cause pneumonia", topics.get(168216).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("dl19-passage.wp"));
+    topics = TopicReader.load(Topics.get("dl19-passage.wp"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -684,7 +746,7 @@ public class TopicReaderTest {
     assertEquals("how is the weather in jamaica", topics.get(topics.lastKey()).get("title"));
     assertEquals("does legion ##ella p ##ne ##um ##op ##hila cause pneumonia", topics.get(168216).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("dl19-passage.unicoil.0shot"));
+    topics = TopicReader.load(Topics.get("dl19-passage.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -692,7 +754,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(595, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl19-passage.unicoil-noexp.0shot"));
+    topics = TopicReader.load(Topics.get("dl19-passage.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -700,7 +762,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(586, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl19-passage.splade_distil_cocodenser_medium"));
+    topics = TopicReader.load(Topics.get("dl19-passage.splade_distil_cocodenser_medium"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -708,7 +770,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(1382, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl19-passage.splade-pp-ed"));
+    topics = TopicReader.load(Topics.get("dl19-passage.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -716,7 +778,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(18791, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl19-passage.splade-pp-sd"));
+    topics = TopicReader.load(Topics.get("dl19-passage.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -724,7 +786,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(17675, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl19-doc"));
+    topics = TopicReader.load(Topics.get("dl19-doc"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -733,7 +795,7 @@ public class TopicReaderTest {
     assertEquals("how is the weather in jamaica", topics.get(topics.lastKey()).get("title"));
     assertEquals("how long to hold bow in yoga", topics.get(1132213).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("dl19-doc.wp"));
+    topics = TopicReader.load(Topics.get("dl19-doc.wp"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -742,7 +804,7 @@ public class TopicReaderTest {
     assertEquals("how is the weather in jamaica", topics.get(topics.lastKey()).get("title"));
     assertEquals("how long to hold bow in yoga", topics.get(1132213).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("dl19-doc.unicoil.0shot"));
+    topics = TopicReader.load(Topics.get("dl19-doc.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -750,7 +812,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(595, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl19-doc.unicoil-noexp.0shot"));
+    topics = TopicReader.load(Topics.get("dl19-doc.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -758,7 +820,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(586, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl19-passage.splade_distil_cocodenser_medium"));
+    topics = TopicReader.load(Topics.get("dl19-passage.splade_distil_cocodenser_medium"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -766,7 +828,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(1382, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl19-passage.splade-pp-ed"));
+    topics = TopicReader.load(Topics.get("dl19-passage.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -774,7 +836,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(18791, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl19-passage.splade-pp-sd"));
+    topics = TopicReader.load(Topics.get("dl19-passage.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -782,7 +844,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(17675, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl19-passage.cohere-embed-english-v3.0"));
+    topics = TopicReader.load(Topics.get("dl19-passage.cohere-embed-english-v3.0"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -795,7 +857,7 @@ public class TopicReaderTest {
   public void testTREC20DL() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("dl20"));
+    topics = TopicReader.load(Topics.get("dl20"));
     assertNotNull(topics);
     assertEquals(200, topics.size());
     assertEquals(3505, (int) topics.firstKey());
@@ -804,7 +866,7 @@ public class TopicReaderTest {
     assertEquals("why did the ancient egyptians call their land kemet, or black land?", topics.get(topics.lastKey()).get("title"));
     assertEquals("who is aziz hashim", topics.get(1030303).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("dl20.wp"));
+    topics = TopicReader.load(Topics.get("dl20.wp"));
     assertNotNull(topics);
     assertEquals(200, topics.size());
     assertEquals(3505, (int) topics.firstKey());
@@ -813,7 +875,7 @@ public class TopicReaderTest {
     assertEquals("why did the ancient egyptians call their land ke ##met , or black land ?", topics.get(topics.lastKey()).get("title"));
     assertEquals("who is aziz hash ##im", topics.get(1030303).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("dl20.unicoil.0shot"));
+    topics = TopicReader.load(Topics.get("dl20.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(200, topics.size());
     assertEquals(3505, (int) topics.firstKey());
@@ -821,7 +883,7 @@ public class TopicReaderTest {
     assertEquals(1136962, (int) topics.lastKey());
     assertEquals(1169, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl20.unicoil-noexp.0shot"));
+    topics = TopicReader.load(Topics.get("dl20.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(200, topics.size());
     assertEquals(3505, (int) topics.firstKey());
@@ -829,7 +891,7 @@ public class TopicReaderTest {
     assertEquals(1136962, (int) topics.lastKey());
     assertEquals(1164, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl20.splade_distil_cocodenser_medium"));
+    topics = TopicReader.load(Topics.get("dl20.splade_distil_cocodenser_medium"));
     assertNotNull(topics);
     assertEquals(54, topics.size());
     assertEquals(23849, (int) topics.firstKey());
@@ -837,7 +899,7 @@ public class TopicReaderTest {
     assertEquals(1136962, (int) topics.lastKey());
     assertEquals(2075, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl20.splade-pp-ed"));
+    topics = TopicReader.load(Topics.get("dl20.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(200, topics.size());
     assertEquals(3505, (int) topics.firstKey());
@@ -845,7 +907,7 @@ public class TopicReaderTest {
     assertEquals(1136962, (int) topics.lastKey());
     assertEquals(25909, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl20.splade-pp-sd"));
+    topics = TopicReader.load(Topics.get("dl20.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(200, topics.size());
     assertEquals(3505, (int) topics.firstKey());
@@ -853,7 +915,7 @@ public class TopicReaderTest {
     assertEquals(1136962, (int) topics.lastKey());
     assertEquals(30994, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl20.cohere-embed-english-v3.0"));
+    topics = TopicReader.load(Topics.get("dl20.cohere-embed-english-v3.0"));
     assertNotNull(topics);
     assertEquals(200, topics.size());
     assertEquals(3505, (int) topics.firstKey());
@@ -866,7 +928,7 @@ public class TopicReaderTest {
   public void testTREC21DL() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("dl21"));
+    topics = TopicReader.load(Topics.get("dl21"));
     assertNotNull(topics);
     assertEquals(477, topics.size());
     assertEquals(2082, (int) topics.firstKey());
@@ -875,7 +937,7 @@ public class TopicReaderTest {
     assertEquals("why does lacquered brass tarnish", topics.get(topics.lastKey()).get("title"));
     assertEquals("who killed nicholas ii of russia", topics.get(1043135).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("dl21.unicoil.0shot"));
+    topics = TopicReader.load(Topics.get("dl21.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(477, topics.size());
     assertEquals(2082, (int) topics.firstKey());
@@ -883,7 +945,7 @@ public class TopicReaderTest {
     assertEquals(1136769, (int) topics.lastKey());
     assertEquals(712, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl21.unicoil-noexp.0shot"));
+    topics = TopicReader.load(Topics.get("dl21.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(477, topics.size());
     assertEquals(2082, (int) topics.firstKey());
@@ -891,7 +953,7 @@ public class TopicReaderTest {
     assertEquals(1136769, (int) topics.lastKey());
     assertEquals(633, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl21.splade-pp-ed"));
+    topics = TopicReader.load(Topics.get("dl21.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(477, topics.size());
     assertEquals(2082, (int) topics.firstKey());
@@ -899,7 +961,7 @@ public class TopicReaderTest {
     assertEquals(1136769, (int) topics.lastKey());
     assertEquals(25398, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl21.splade-pp-sd"));
+    topics = TopicReader.load(Topics.get("dl21.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(477, topics.size());
     assertEquals(2082, (int) topics.firstKey());
@@ -907,7 +969,7 @@ public class TopicReaderTest {
     assertEquals(1136769, (int) topics.lastKey());
     assertEquals(27149, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl21.snowflake-arctic-embed-l"));
+    topics = TopicReader.load(Topics.get("dl21.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(477, topics.size());
     assertEquals(2082, (int) topics.firstKey());
@@ -920,7 +982,7 @@ public class TopicReaderTest {
   public void testTREC22DL() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("dl22"));
+    topics = TopicReader.load(Topics.get("dl22"));
     assertNotNull(topics);
     assertEquals(500, topics.size());
     assertEquals(588, (int) topics.firstKey());
@@ -929,7 +991,7 @@ public class TopicReaderTest {
     assertEquals("is a dairy farm considered as an agriculture", topics.get(topics.lastKey()).get("title"));
     assertEquals("how does magic leap optics work", topics.get(2056323).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("dl22.unicoil.0shot"));
+    topics = TopicReader.load(Topics.get("dl22.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(500, topics.size());
     assertEquals(588, (int) topics.firstKey());
@@ -937,7 +999,7 @@ public class TopicReaderTest {
     assertEquals(2056473, (int) topics.lastKey());
     assertEquals(720, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl22.unicoil-noexp.0shot"));
+    topics = TopicReader.load(Topics.get("dl22.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(500, topics.size());
     assertEquals(588, (int) topics.firstKey());
@@ -945,7 +1007,7 @@ public class TopicReaderTest {
     assertEquals(2056473, (int) topics.lastKey());
     assertEquals(726, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl22.splade-pp-ed"));
+    topics = TopicReader.load(Topics.get("dl22.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(500, topics.size());
     assertEquals(588, (int) topics.firstKey());
@@ -953,7 +1015,7 @@ public class TopicReaderTest {
     assertEquals(2056473, (int) topics.lastKey());
     assertEquals(28012, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl22.splade-pp-sd"));
+    topics = TopicReader.load(Topics.get("dl22.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(500, topics.size());
     assertEquals(588, (int) topics.firstKey());
@@ -961,7 +1023,7 @@ public class TopicReaderTest {
     assertEquals(2056473, (int) topics.lastKey());
     assertEquals(33891, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl22.snowflake-arctic-embed-l"));
+    topics = TopicReader.load(Topics.get("dl22.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(500, topics.size());
     assertEquals(588, (int) topics.firstKey());
@@ -974,7 +1036,7 @@ public class TopicReaderTest {
   public void testTREC23DL() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("dl23"));
+    topics = TopicReader.load(Topics.get("dl23"));
     assertNotNull(topics);
     assertEquals(700, topics.size());
     assertEquals(2000138, (int) topics.firstKey());
@@ -983,7 +1045,7 @@ public class TopicReaderTest {
     assertEquals("How do birth control and hormone levels affect menstrual cycle variations?", topics.get(topics.lastKey()).get("title"));
     assertEquals("How do birth control and hormone levels affect menstrual cycle variations?", topics.get(3100949).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("dl23.unicoil.0shot"));
+    topics = TopicReader.load(Topics.get("dl23.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(700, topics.size());
     assertEquals(2000138, (int) topics.firstKey());
@@ -991,7 +1053,7 @@ public class TopicReaderTest {
     assertEquals(3100949, (int) topics.lastKey());
     assertEquals(31334, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl23.unicoil-noexp.0shot"));
+    topics = TopicReader.load(Topics.get("dl23.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(700, topics.size());
     assertEquals(2000138, (int) topics.firstKey());
@@ -999,7 +1061,7 @@ public class TopicReaderTest {
     assertEquals(3100949, (int) topics.lastKey());
     assertEquals(31283, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl23.splade-pp-ed"));
+    topics = TopicReader.load(Topics.get("dl23.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(700, topics.size());
     assertEquals(2000138, (int) topics.firstKey());
@@ -1007,7 +1069,7 @@ public class TopicReaderTest {
     assertEquals(3100949, (int) topics.lastKey());
     assertEquals(139500, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl23.splade-pp-sd"));
+    topics = TopicReader.load(Topics.get("dl23.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(700, topics.size());
     assertEquals(2000138, (int) topics.firstKey());
@@ -1015,7 +1077,7 @@ public class TopicReaderTest {
     assertEquals(3100949, (int) topics.lastKey());
     assertEquals(181700, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("dl23.snowflake-arctic-embed-l"));
+    topics = TopicReader.load(Topics.get("dl23.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(700, topics.size());
     assertEquals(2000138, (int) topics.firstKey());
@@ -1028,7 +1090,7 @@ public class TopicReaderTest {
   public void testTREC24_RAG_RAGGY_DEV() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("rag24.raggy-dev"));
+    topics = TopicReader.load(Topics.get("rag24.raggy-dev"));
     assertNotNull(topics);
     assertEquals(120, topics.size());
     assertEquals(23287, (int) topics.firstKey());
@@ -1037,7 +1099,7 @@ public class TopicReaderTest {
     assertEquals("Can older adults gain strength by training once per week?", topics.get(topics.lastKey()).get("title"));
     assertEquals("Can older adults gain strength by training once per week?", topics.get(3100918).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("rag24.raggy-dev.snowflake-arctic-embed-l"));
+    topics = TopicReader.load(Topics.get("rag24.raggy-dev.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(120, topics.size());
     assertEquals(23287, (int) topics.firstKey());
@@ -1050,7 +1112,7 @@ public class TopicReaderTest {
   public void testTREC24_RAG_RESEARCHY_DEV() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("rag24.researchy-dev"));
+    topics = TopicReader.load(Topics.get("rag24.researchy-dev"));
     assertNotNull(topics);
     assertEquals(600, topics.size());
     assertEquals(429, (int) topics.firstKey());
@@ -1059,7 +1121,7 @@ public class TopicReaderTest {
     assertEquals("how do video games improve problem solving", topics.get(topics.lastKey()).get("title"));
     assertEquals("how do video games improve problem solving", topics.get(1009569).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("rag24.researchy-dev.snowflake-arctic-embed-l"));
+    topics = TopicReader.load(Topics.get("rag24.researchy-dev.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(600, topics.size());
     assertEquals(429, (int) topics.firstKey());
@@ -1072,7 +1134,7 @@ public class TopicReaderTest {
   public void testTREC24_RAG_TEST() throws IOException {
     SortedMap<String, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("rag24.test"));
+    topics = TopicReader.load(Topics.get("rag24.test"));
     assertNotNull(topics);
     assertEquals(301, topics.size());
     assertEquals("2024-105741", topics.firstKey());
@@ -1081,7 +1143,7 @@ public class TopicReaderTest {
     assertEquals("how would advance electronics course impact students", topics.get(topics.lastKey()).get("title"));
     assertEquals("how the solar eclipse can affect mental health", topics.get("2024-79154").get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("rag24.test.snowflake-arctic-embed-l"));
+    topics = TopicReader.load(Topics.get("rag24.test.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(301, topics.size());
     assertEquals("2024-105741", topics.firstKey());
@@ -1094,7 +1156,7 @@ public class TopicReaderTest {
   public void testTREC25_RAG_TEST() throws IOException {
     SortedMap<String, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("rag25.test"));
+    topics = TopicReader.load(Topics.get("rag25.test"));
     assertNotNull(topics);
     assertEquals(105, topics.size());
     assertEquals("100", topics.firstKey());
@@ -1108,7 +1170,7 @@ public class TopicReaderTest {
   public void testMSMARCO_V1() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-doc.dev"));
+    topics = TopicReader.load(Topics.get("msmarco-doc.dev"));
     assertNotNull(topics);
     assertEquals(5193, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1116,7 +1178,7 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals("why do bears hibernate", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-doc.dev.wp"));
+    topics = TopicReader.load(Topics.get("msmarco-doc.dev.wp"));
     assertNotNull(topics);
     assertEquals(5193, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1124,7 +1186,7 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals("why do bears hi ##ber ##nate", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-doc.dev.unicoil"));
+    topics = TopicReader.load(Topics.get("msmarco-doc.dev.unicoil"));
     assertNotNull(topics);
     assertEquals(5193, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1132,7 +1194,7 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(682, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-doc.dev.unicoil-noexp"));
+    topics = TopicReader.load(Topics.get("msmarco-doc.dev.unicoil-noexp"));
     assertNotNull(topics);
     assertEquals(5193, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1140,7 +1202,7 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(577, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-doc.test"));
+    topics = TopicReader.load(Topics.get("msmarco-doc.test"));
     assertNotNull(topics);
     assertEquals(5793, topics.size());
     assertEquals(57, (int) topics.firstKey());
@@ -1148,7 +1210,7 @@ public class TopicReaderTest {
     assertEquals(1136966, (int) topics.lastKey());
     assertEquals("#ffffff color code", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset"));
+    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1156,7 +1218,7 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals("why do bears hibernate", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.wp"));
+    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.wp"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1164,7 +1226,7 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals("why do bears hi ##ber ##nate", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.deepimpact"));
+    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.deepimpact"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1172,56 +1234,56 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals("why hibernate bears", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.unicoil"));
+    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.unicoil"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(619, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(686, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.unicoil-noexp"));
+    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.unicoil-noexp"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(609, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(577, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.unicoil-tilde-expansion"));
+    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.unicoil-tilde-expansion"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(584, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(610, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.distill-splade-max"));
+    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.distill-splade-max"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(1991, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(2409, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.splade_distil_cocodenser_medium"));
+    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.splade_distil_cocodenser_medium"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(1695, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(1682, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.splade-pp-ed"));
+    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(21944, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(24271, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.splade-pp-sd"));
+    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(25539, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(30718, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.cohere-embed-english-v3.0"));
+    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.cohere-embed-english-v3.0"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1229,7 +1291,7 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals("[0.0107421875", topics.get(topics.lastKey()).get("vector").split(",")[0]);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-passage.test-subset"));
+    topics = TopicReader.load(Topics.get("msmarco-passage.test-subset"));
     assertNotNull(topics);
     assertEquals(6837, topics.size());
     assertEquals(57, (int) topics.firstKey());
@@ -1242,7 +1304,7 @@ public class TopicReaderTest {
   public void testMSMARCO_V2() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-doc.dev"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-doc.dev"));
     assertNotNull(topics);
     assertEquals(4552, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1250,7 +1312,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals("why do children get aggressive", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-doc.dev.unicoil.0shot"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-doc.dev.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(4552, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1258,7 +1320,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals(608, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-doc.dev.unicoil-noexp.0shot"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-doc.dev.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(4552, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1266,7 +1328,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals(533, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-doc.dev.snowflake-arctic-embed-l"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-doc.dev.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(4552, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1274,7 +1336,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals("[-0.04409797489643097", topics.get(topics.lastKey()).get("vector").split(",")[0]);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-doc.dev2"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-doc.dev2"));
     assertNotNull(topics);
     assertEquals(5000, topics.size());
     assertEquals(361, (int) topics.firstKey());
@@ -1282,7 +1344,7 @@ public class TopicReaderTest {
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals("why do a ferritin level", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-doc.dev2.unicoil.0shot"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-doc.dev2.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(5000, topics.size());
     assertEquals(361, (int) topics.firstKey());
@@ -1290,7 +1352,7 @@ public class TopicReaderTest {
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals(664, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-doc.dev2.unicoil-noexp.0shot"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-doc.dev2.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(5000, topics.size());
     assertEquals(361, (int) topics.firstKey());
@@ -1298,7 +1360,7 @@ public class TopicReaderTest {
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals(537, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-doc.dev2.snowflake-arctic-embed-l"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-doc.dev2.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(5000, topics.size());
     assertEquals(361, (int) topics.firstKey());
@@ -1306,7 +1368,7 @@ public class TopicReaderTest {
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals("[0.006848456338047981", topics.get(topics.lastKey()).get("vector").split(",")[0]);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev"));
     assertNotNull(topics);
     assertEquals(3903, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1314,7 +1376,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals("why do children get aggressive", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev.unicoil.0shot"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(3903, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1322,7 +1384,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals(608, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev.unicoil-noexp.0shot"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(3903, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1330,7 +1392,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals(533, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev.splade-pp-ed"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(3903, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1338,7 +1400,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals(30978, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev.splade-pp-sd"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(3903, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1346,7 +1408,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals(35354, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev2"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev2"));
     assertNotNull(topics);
     assertEquals(4281, topics.size());
     assertEquals(1325, (int) topics.firstKey());
@@ -1354,7 +1416,7 @@ public class TopicReaderTest {
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals("why do a ferritin level", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev2.unicoil.0shot"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev2.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(4281, topics.size());
     assertEquals(1325, (int) topics.firstKey());
@@ -1362,7 +1424,7 @@ public class TopicReaderTest {
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals(664, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev2.unicoil-noexp.0shot"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev2.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(4281, topics.size());
     assertEquals(1325, (int) topics.firstKey());
@@ -1370,7 +1432,7 @@ public class TopicReaderTest {
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals(537, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev2.splade-pp-ed"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev2.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(4281, topics.size());
     assertEquals(1325, (int) topics.firstKey());
@@ -1378,7 +1440,7 @@ public class TopicReaderTest {
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals(18984, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev2.splade-pp-sd"));
+    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev2.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(4281, topics.size());
     assertEquals(1325, (int) topics.firstKey());
@@ -1444,7 +1506,7 @@ public class TopicReaderTest {
   public void testNonEnglishTopics1() throws IOException {
     SortedMap<String, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("ntcir8zh.eval"));
+    topics = TopicReader.load(Topics.get("ntcir8zh.eval"));
     assertNotNull(topics);
     assertEquals(73, topics.size());
     assertEquals("ACLIA2-CS-0002", topics.firstKey());
@@ -1452,7 +1514,7 @@ public class TopicReaderTest {
     assertEquals("ACLIA2-CS-0100", topics.lastKey());
     assertEquals("为什么美军占领了巴格达？", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("clef06fr.mono.fr"));
+    topics = TopicReader.load(Topics.get("clef06fr.mono.fr"));
     assertNotNull(topics);
     assertEquals(49, topics.size());
     assertEquals("301-AH", topics.firstKey());
@@ -1465,7 +1527,7 @@ public class TopicReaderTest {
   public void testNonEnglishTopics2() throws IOException {
       SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("trec02ar-ar"));
+    topics = TopicReader.load(Topics.get("trec02ar-ar"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(26, (int) topics.firstKey());
@@ -1473,7 +1535,7 @@ public class TopicReaderTest {
     assertEquals(75, (int) topics.lastKey());
     assertEquals("فيروسات الكمبيوتر في الوطن العربي", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("fire12bn.176-225"));
+    topics = TopicReader.load(Topics.get("fire12bn.176-225"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(176, (int) topics.firstKey());
@@ -1481,7 +1543,7 @@ public class TopicReaderTest {
     assertEquals(225, (int) topics.lastKey());
     assertEquals("স্যাটানিক ভার্সেস বিতর্ক", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("fire12hi.176-225"));
+    topics = TopicReader.load(Topics.get("fire12hi.176-225"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(176, (int) topics.firstKey());
@@ -1489,7 +1551,7 @@ public class TopicReaderTest {
     assertEquals(225, (int) topics.lastKey());
     assertEquals("सेटेनिक वर्सेज विवाद", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.get("fire12en.176-225"));
+    topics = TopicReader.load(Topics.get("fire12en.176-225"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(176, (int) topics.firstKey());
@@ -1550,7 +1612,7 @@ public class TopicReaderTest {
     Map<Integer, Map<String, String>> topics;
 
     // Round 1
-    topics = TopicReader.getTopics(Topics.get("covid-round1"));
+    topics = TopicReader.load(Topics.get("covid-round1"));
     assertEquals(30, topics.keySet().size());
 
     assertEquals("coronavirus origin", topics.get(1).get("query"));
@@ -1566,25 +1628,25 @@ public class TopicReaderTest {
         topics.get(30).get("narrative"));
 
     // Round 2
-    topics = TopicReader.getTopics(Topics.get("covid-round2"));
+    topics = TopicReader.load(Topics.get("covid-round2"));
     assertEquals(35, topics.keySet().size());
 
     assertEquals("coronavirus public datasets", topics.get(35).get("query"));
 
     // Round 3
-    topics = TopicReader.getTopics(Topics.get("covid-round3"));
+    topics = TopicReader.load(Topics.get("covid-round3"));
     assertEquals(40, topics.keySet().size());
 
     assertEquals("coronavirus mutations", topics.get(40).get("query"));
 
     // Round 4
-    topics = TopicReader.getTopics(Topics.get("covid-round4"));
+    topics = TopicReader.load(Topics.get("covid-round4"));
     assertEquals(45, topics.keySet().size());
 
     assertEquals("coronavirus mental health impact", topics.get(45).get("query"));
 
     // Round 5
-    topics = TopicReader.getTopics(Topics.get("covid-round5"));
+    topics = TopicReader.load(Topics.get("covid-round5"));
     assertEquals(50, topics.keySet().size());
 
     assertEquals("mRNA vaccine coronavirus", topics.get(50).get("query"));
@@ -1595,35 +1657,35 @@ public class TopicReaderTest {
     Map<Integer, Map<String, String>> topics;
 
     // Round 1
-    topics = TopicReader.getTopics(Topics.get("covid-round1-udel"));
+    topics = TopicReader.load(Topics.get("covid-round1-udel"));
     assertEquals(30, topics.keySet().size());
 
     assertEquals("coronavirus remdesivir remdesivir effective treatment COVID-19",
         topics.get(30).get("query"));
 
     // Round 2
-    topics = TopicReader.getTopics(Topics.get("covid-round2-udel"));
+    topics = TopicReader.load(Topics.get("covid-round2-udel"));
     assertEquals(35, topics.keySet().size());
 
     assertEquals("coronavirus public datasets public datasets COVID-19",
         topics.get(35).get("query"));
 
     // Round 3
-    topics = TopicReader.getTopics(Topics.get("covid-round3-udel"));
+    topics = TopicReader.load(Topics.get("covid-round3-udel"));
     assertEquals(40, topics.keySet().size());
 
     assertEquals("coronavirus mutations observed mutations SARS-CoV-2 genome mutations",
         topics.get(40).get("query"));
 
     // Round 4
-    topics = TopicReader.getTopics(Topics.get("covid-round4-udel"));
+    topics = TopicReader.load(Topics.get("covid-round4-udel"));
     assertEquals(45, topics.keySet().size());
 
     assertEquals("coronavirus mental health impact COVID-19 pandemic impacted mental health",
         topics.get(45).get("query"));
 
     // Round 5
-    topics = TopicReader.getTopics(Topics.get("covid-round5-udel"));
+    topics = TopicReader.load(Topics.get("covid-round5-udel"));
     assertEquals(50, topics.keySet().size());
 
     assertEquals("mRNA vaccine coronavirus mRNA vaccine SARS-CoV-2 virus",
@@ -1720,7 +1782,7 @@ public class TopicReaderTest {
   public void testBackgroundLinkingTopics() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.get("backgroundlinking18"));
+    topics = TopicReader.load(Topics.get("backgroundlinking18"));
 
     assertEquals(50, topics.keySet().size());
     assertEquals(321, (int) topics.firstKey());
@@ -1735,7 +1797,7 @@ public class TopicReaderTest {
         "cellulosic-ethanol-once-the-way-of-the-future-is-off-to-a-delayed-boisterous-start/" +
         "2013/11/08/a1c41a70-35c7-11e3-8a0e-4e2cf80831fc_story.html", topics.get(topics.lastKey()).get("url"));
 
-    topics = TopicReader.getTopics(Topics.get("backgroundlinking19"));
+    topics = TopicReader.load(Topics.get("backgroundlinking19"));
     
     assertEquals(60, topics.keySet().size());
     assertEquals(826, (int) topics.firstKey());
@@ -1750,7 +1812,7 @@ public class TopicReaderTest {
         "sun-erupts-to-mark-another-bastille-day-aurora-possible-in-new-england-sunday-night/",
         topics.get(topics.lastKey()).get("url"));
 
-    topics = TopicReader.getTopics(Topics.get("backgroundlinking20"));
+    topics = TopicReader.load(Topics.get("backgroundlinking20"));
 
     assertEquals(50, topics.keySet().size());
     assertEquals(886, (int) topics.firstKey());
@@ -1769,7 +1831,7 @@ public class TopicReaderTest {
   @Test
   public void testEpidemicQATopics() throws IOException {
     SortedMap<Integer, Map<String, String>> consumerTopics;
-    consumerTopics = TopicReader.getTopics(Topics.get("epidemic-qa.consumer.prelim"));
+    consumerTopics = TopicReader.load(Topics.get("epidemic-qa.consumer.prelim"));
 
     // No consumer questions from CQ035 to CQ037
     assertEquals(42, consumerTopics.keySet().size());
@@ -1795,7 +1857,7 @@ public class TopicReaderTest {
                  consumerTopics.get(consumerTopics.lastKey()).get("background"));
 
     SortedMap<Integer, Map<String, String>> expertTopics;
-    expertTopics = TopicReader.getTopics(Topics.get("epidemic-qa.expert.prelim"));
+    expertTopics = TopicReader.load(Topics.get("epidemic-qa.expert.prelim"));
 
     assertEquals(45, expertTopics.keySet().size());
 
@@ -1821,197 +1883,197 @@ public class TopicReaderTest {
 
   @Test
   public void testMrTyDiTopics() throws IOException {
-    assertEquals(12377, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ar.train")).keySet().size());
-    assertEquals(3115, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ar.dev")).keySet().size());
-    assertEquals(1081, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ar.test")).keySet().size());
+    assertEquals(12377, TopicReader.load(Topics.get("mrtydi-v1.1-ar.train")).keySet().size());
+    assertEquals(3115, TopicReader.load(Topics.get("mrtydi-v1.1-ar.dev")).keySet().size());
+    assertEquals(1081, TopicReader.load(Topics.get("mrtydi-v1.1-ar.test")).keySet().size());
 
-    assertEquals(1713, TopicReader.getTopics(Topics.get("mrtydi-v1.1-bn.train")).keySet().size());
-    assertEquals(440, TopicReader.getTopics(Topics.get("mrtydi-v1.1-bn.dev")).keySet().size());
-    assertEquals(111, TopicReader.getTopics(Topics.get("mrtydi-v1.1-bn.test")).keySet().size());
+    assertEquals(1713, TopicReader.load(Topics.get("mrtydi-v1.1-bn.train")).keySet().size());
+    assertEquals(440, TopicReader.load(Topics.get("mrtydi-v1.1-bn.dev")).keySet().size());
+    assertEquals(111, TopicReader.load(Topics.get("mrtydi-v1.1-bn.test")).keySet().size());
 
-    assertEquals(3547, TopicReader.getTopics(Topics.get("mrtydi-v1.1-en.train")).keySet().size());
-    assertEquals(878, TopicReader.getTopics(Topics.get("mrtydi-v1.1-en.dev")).keySet().size());
-    assertEquals(744, TopicReader.getTopics(Topics.get("mrtydi-v1.1-en.test")).keySet().size());
+    assertEquals(3547, TopicReader.load(Topics.get("mrtydi-v1.1-en.train")).keySet().size());
+    assertEquals(878, TopicReader.load(Topics.get("mrtydi-v1.1-en.dev")).keySet().size());
+    assertEquals(744, TopicReader.load(Topics.get("mrtydi-v1.1-en.test")).keySet().size());
 
-    assertEquals(6561, TopicReader.getTopics(Topics.get("mrtydi-v1.1-fi.train")).keySet().size());
-    assertEquals(1738, TopicReader.getTopics(Topics.get("mrtydi-v1.1-fi.dev")).keySet().size());
-    assertEquals(1254, TopicReader.getTopics(Topics.get("mrtydi-v1.1-fi.test")).keySet().size());
+    assertEquals(6561, TopicReader.load(Topics.get("mrtydi-v1.1-fi.train")).keySet().size());
+    assertEquals(1738, TopicReader.load(Topics.get("mrtydi-v1.1-fi.dev")).keySet().size());
+    assertEquals(1254, TopicReader.load(Topics.get("mrtydi-v1.1-fi.test")).keySet().size());
 
-    assertEquals(4902, TopicReader.getTopics(Topics.get("mrtydi-v1.1-id.train")).keySet().size());
-    assertEquals(1224, TopicReader.getTopics(Topics.get("mrtydi-v1.1-id.dev")).keySet().size());
-    assertEquals(829, TopicReader.getTopics(Topics.get("mrtydi-v1.1-id.test")).keySet().size());
+    assertEquals(4902, TopicReader.load(Topics.get("mrtydi-v1.1-id.train")).keySet().size());
+    assertEquals(1224, TopicReader.load(Topics.get("mrtydi-v1.1-id.dev")).keySet().size());
+    assertEquals(829, TopicReader.load(Topics.get("mrtydi-v1.1-id.test")).keySet().size());
 
-    assertEquals(3697, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ja.train")).keySet().size());
-    assertEquals(928, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ja.dev")).keySet().size());
-    assertEquals(720, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ja.test")).keySet().size());
+    assertEquals(3697, TopicReader.load(Topics.get("mrtydi-v1.1-ja.train")).keySet().size());
+    assertEquals(928, TopicReader.load(Topics.get("mrtydi-v1.1-ja.dev")).keySet().size());
+    assertEquals(720, TopicReader.load(Topics.get("mrtydi-v1.1-ja.test")).keySet().size());
 
-    assertEquals(1295, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ko.train")).keySet().size());
-    assertEquals(303, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ko.dev")).keySet().size());
-    assertEquals(421, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ko.test")).keySet().size());
+    assertEquals(1295, TopicReader.load(Topics.get("mrtydi-v1.1-ko.train")).keySet().size());
+    assertEquals(303, TopicReader.load(Topics.get("mrtydi-v1.1-ko.dev")).keySet().size());
+    assertEquals(421, TopicReader.load(Topics.get("mrtydi-v1.1-ko.test")).keySet().size());
 
-    assertEquals(5366, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ru.train")).keySet().size());
-    assertEquals(1375, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ru.dev")).keySet().size());
-    assertEquals(995, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ru.test")).keySet().size());
+    assertEquals(5366, TopicReader.load(Topics.get("mrtydi-v1.1-ru.train")).keySet().size());
+    assertEquals(1375, TopicReader.load(Topics.get("mrtydi-v1.1-ru.dev")).keySet().size());
+    assertEquals(995, TopicReader.load(Topics.get("mrtydi-v1.1-ru.test")).keySet().size());
 
-    assertEquals(2072, TopicReader.getTopics(Topics.get("mrtydi-v1.1-sw.train")).keySet().size());
-    assertEquals(526, TopicReader.getTopics(Topics.get("mrtydi-v1.1-sw.dev")).keySet().size());
-    assertEquals(670, TopicReader.getTopics(Topics.get("mrtydi-v1.1-sw.test")).keySet().size());
+    assertEquals(2072, TopicReader.load(Topics.get("mrtydi-v1.1-sw.train")).keySet().size());
+    assertEquals(526, TopicReader.load(Topics.get("mrtydi-v1.1-sw.dev")).keySet().size());
+    assertEquals(670, TopicReader.load(Topics.get("mrtydi-v1.1-sw.test")).keySet().size());
 
-    assertEquals(3880, TopicReader.getTopics(Topics.get("mrtydi-v1.1-te.train")).keySet().size());
-    assertEquals(983, TopicReader.getTopics(Topics.get("mrtydi-v1.1-te.dev")).keySet().size());
-    assertEquals(646, TopicReader.getTopics(Topics.get("mrtydi-v1.1-te.test")).keySet().size());
+    assertEquals(3880, TopicReader.load(Topics.get("mrtydi-v1.1-te.train")).keySet().size());
+    assertEquals(983, TopicReader.load(Topics.get("mrtydi-v1.1-te.dev")).keySet().size());
+    assertEquals(646, TopicReader.load(Topics.get("mrtydi-v1.1-te.test")).keySet().size());
 
-    assertEquals(3319, TopicReader.getTopics(Topics.get("mrtydi-v1.1-th.train")).keySet().size());
-    assertEquals(807, TopicReader.getTopics(Topics.get("mrtydi-v1.1-th.dev")).keySet().size());
-    assertEquals(1190, TopicReader.getTopics(Topics.get("mrtydi-v1.1-th.test")).keySet().size());
+    assertEquals(3319, TopicReader.load(Topics.get("mrtydi-v1.1-th.train")).keySet().size());
+    assertEquals(807, TopicReader.load(Topics.get("mrtydi-v1.1-th.dev")).keySet().size());
+    assertEquals(1190, TopicReader.load(Topics.get("mrtydi-v1.1-th.test")).keySet().size());
   }
 
   @Test
   public void testBeirTopics() throws IOException {
-    assertEquals(50,    TopicReader.getTopics(Topics.get("beir-v1.0.0-trec-covid.test")).keySet().size());
-    assertEquals(500,   TopicReader.getTopics(Topics.get("beir-v1.0.0-bioasq.test")).keySet().size());
-    assertEquals(323,   TopicReader.getTopics(Topics.get("beir-v1.0.0-nfcorpus.test")).keySet().size());
-    assertEquals(3452,  TopicReader.getTopics(Topics.get("beir-v1.0.0-nq.test")).keySet().size());
-    assertEquals(7405,  TopicReader.getTopics(Topics.get("beir-v1.0.0-hotpotqa.test")).keySet().size());
-    assertEquals(648,   TopicReader.getTopics(Topics.get("beir-v1.0.0-fiqa.test")).keySet().size());
-    assertEquals(97,    TopicReader.getTopics(Topics.get("beir-v1.0.0-signal1m.test")).keySet().size());
-    assertEquals(57,    TopicReader.getTopics(Topics.get("beir-v1.0.0-trec-news.test")).keySet().size());
-    assertEquals(249,   TopicReader.getTopics(Topics.get("beir-v1.0.0-robust04.test")).keySet().size());
-    assertEquals(1406,  TopicReader.getTopics(Topics.get("beir-v1.0.0-arguana.test")).keySet().size());
-    assertEquals(49,    TopicReader.getTopics(Topics.get("beir-v1.0.0-webis-touche2020.test")).keySet().size());
-    assertEquals(699,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-android.test")).keySet().size());
-    assertEquals(1570,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-english.test")).keySet().size());
-    assertEquals(1595,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-gaming.test")).keySet().size());
-    assertEquals(885,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-gis.test")).keySet().size());
-    assertEquals(804,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-mathematica.test")).keySet().size());
-    assertEquals(1039,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-physics.test")).keySet().size());
-    assertEquals(876,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-programmers.test")).keySet().size());
-    assertEquals(652,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-stats.test")).keySet().size());
-    assertEquals(2906,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-tex.test")).keySet().size());
-    assertEquals(1072,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-unix.test")).keySet().size());
-    assertEquals(506,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-webmasters.test")).keySet().size());
-    assertEquals(541,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-wordpress.test")).keySet().size());
-    assertEquals(10000, TopicReader.getTopics(Topics.get("beir-v1.0.0-quora.test")).keySet().size());
-    assertEquals(400,   TopicReader.getTopics(Topics.get("beir-v1.0.0-dbpedia-entity.test")).keySet().size());
-    assertEquals(1000,  TopicReader.getTopics(Topics.get("beir-v1.0.0-scidocs.test")).keySet().size());
-    assertEquals(6666,  TopicReader.getTopics(Topics.get("beir-v1.0.0-fever.test")).keySet().size());
-    assertEquals(1535,  TopicReader.getTopics(Topics.get("beir-v1.0.0-climate-fever.test")).keySet().size());
-    assertEquals(300,   TopicReader.getTopics(Topics.get("beir-v1.0.0-scifact.test")).keySet().size());
+    assertEquals(50,    TopicReader.load(Topics.get("beir-v1.0.0-trec-covid.test")).keySet().size());
+    assertEquals(500,   TopicReader.load(Topics.get("beir-v1.0.0-bioasq.test")).keySet().size());
+    assertEquals(323,   TopicReader.load(Topics.get("beir-v1.0.0-nfcorpus.test")).keySet().size());
+    assertEquals(3452,  TopicReader.load(Topics.get("beir-v1.0.0-nq.test")).keySet().size());
+    assertEquals(7405,  TopicReader.load(Topics.get("beir-v1.0.0-hotpotqa.test")).keySet().size());
+    assertEquals(648,   TopicReader.load(Topics.get("beir-v1.0.0-fiqa.test")).keySet().size());
+    assertEquals(97,    TopicReader.load(Topics.get("beir-v1.0.0-signal1m.test")).keySet().size());
+    assertEquals(57,    TopicReader.load(Topics.get("beir-v1.0.0-trec-news.test")).keySet().size());
+    assertEquals(249,   TopicReader.load(Topics.get("beir-v1.0.0-robust04.test")).keySet().size());
+    assertEquals(1406,  TopicReader.load(Topics.get("beir-v1.0.0-arguana.test")).keySet().size());
+    assertEquals(49,    TopicReader.load(Topics.get("beir-v1.0.0-webis-touche2020.test")).keySet().size());
+    assertEquals(699,   TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-android.test")).keySet().size());
+    assertEquals(1570,  TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-english.test")).keySet().size());
+    assertEquals(1595,  TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-gaming.test")).keySet().size());
+    assertEquals(885,   TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-gis.test")).keySet().size());
+    assertEquals(804,   TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-mathematica.test")).keySet().size());
+    assertEquals(1039,  TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-physics.test")).keySet().size());
+    assertEquals(876,   TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-programmers.test")).keySet().size());
+    assertEquals(652,   TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-stats.test")).keySet().size());
+    assertEquals(2906,  TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-tex.test")).keySet().size());
+    assertEquals(1072,  TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-unix.test")).keySet().size());
+    assertEquals(506,   TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-webmasters.test")).keySet().size());
+    assertEquals(541,   TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-wordpress.test")).keySet().size());
+    assertEquals(10000, TopicReader.load(Topics.get("beir-v1.0.0-quora.test")).keySet().size());
+    assertEquals(400,   TopicReader.load(Topics.get("beir-v1.0.0-dbpedia-entity.test")).keySet().size());
+    assertEquals(1000,  TopicReader.load(Topics.get("beir-v1.0.0-scidocs.test")).keySet().size());
+    assertEquals(6666,  TopicReader.load(Topics.get("beir-v1.0.0-fever.test")).keySet().size());
+    assertEquals(1535,  TopicReader.load(Topics.get("beir-v1.0.0-climate-fever.test")).keySet().size());
+    assertEquals(300,   TopicReader.load(Topics.get("beir-v1.0.0-scifact.test")).keySet().size());
   }
 
   @Test
   public void testBeirWPTopics() throws IOException {
-    assertEquals(50,    TopicReader.getTopics(Topics.get("beir-v1.0.0-trec-covid.test.wp")).keySet().size());
-    assertEquals(500,   TopicReader.getTopics(Topics.get("beir-v1.0.0-bioasq.test.wp")).keySet().size());
-    assertEquals(323,   TopicReader.getTopics(Topics.get("beir-v1.0.0-nfcorpus.test.wp")).keySet().size());
-    assertEquals(3452,  TopicReader.getTopics(Topics.get("beir-v1.0.0-nq.test.wp")).keySet().size());
-    assertEquals(7405,  TopicReader.getTopics(Topics.get("beir-v1.0.0-hotpotqa.test.wp")).keySet().size());
-    assertEquals(648,   TopicReader.getTopics(Topics.get("beir-v1.0.0-fiqa.test.wp")).keySet().size());
-    assertEquals(97,    TopicReader.getTopics(Topics.get("beir-v1.0.0-signal1m.test.wp")).keySet().size());
-    assertEquals(57,    TopicReader.getTopics(Topics.get("beir-v1.0.0-trec-news.test.wp")).keySet().size());
-    assertEquals(249,   TopicReader.getTopics(Topics.get("beir-v1.0.0-robust04.test.wp")).keySet().size());
-    assertEquals(1406,  TopicReader.getTopics(Topics.get("beir-v1.0.0-arguana.test.wp")).keySet().size());
-    assertEquals(49,    TopicReader.getTopics(Topics.get("beir-v1.0.0-webis-touche2020.test.wp")).keySet().size());
-    assertEquals(699,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-android.test.wp")).keySet().size());
-    assertEquals(1570,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-english.test.wp")).keySet().size());
-    assertEquals(1595,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-gaming.test.wp")).keySet().size());
-    assertEquals(885,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-gis.test.wp")).keySet().size());
-    assertEquals(804,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-mathematica.test.wp")).keySet().size());
-    assertEquals(1039,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-physics.test.wp")).keySet().size());
-    assertEquals(876,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-programmers.test.wp")).keySet().size());
-    assertEquals(652,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-stats.test.wp")).keySet().size());
-    assertEquals(2906,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-tex.test.wp")).keySet().size());
-    assertEquals(1072,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-unix.test.wp")).keySet().size());
-    assertEquals(506,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-webmasters.test.wp")).keySet().size());
-    assertEquals(541,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-wordpress.test.wp")).keySet().size());
-    assertEquals(10000, TopicReader.getTopics(Topics.get("beir-v1.0.0-quora.test.wp")).keySet().size());
-    assertEquals(400,   TopicReader.getTopics(Topics.get("beir-v1.0.0-dbpedia-entity.test.wp")).keySet().size());
-    assertEquals(1000,  TopicReader.getTopics(Topics.get("beir-v1.0.0-scidocs.test.wp")).keySet().size());
-    assertEquals(6666,  TopicReader.getTopics(Topics.get("beir-v1.0.0-fever.test.wp")).keySet().size());
-    assertEquals(1535,  TopicReader.getTopics(Topics.get("beir-v1.0.0-climate-fever.test.wp")).keySet().size());
-    assertEquals(300,   TopicReader.getTopics(Topics.get("beir-v1.0.0-scifact.test.wp")).keySet().size());
+    assertEquals(50,    TopicReader.load(Topics.get("beir-v1.0.0-trec-covid.test.wp")).keySet().size());
+    assertEquals(500,   TopicReader.load(Topics.get("beir-v1.0.0-bioasq.test.wp")).keySet().size());
+    assertEquals(323,   TopicReader.load(Topics.get("beir-v1.0.0-nfcorpus.test.wp")).keySet().size());
+    assertEquals(3452,  TopicReader.load(Topics.get("beir-v1.0.0-nq.test.wp")).keySet().size());
+    assertEquals(7405,  TopicReader.load(Topics.get("beir-v1.0.0-hotpotqa.test.wp")).keySet().size());
+    assertEquals(648,   TopicReader.load(Topics.get("beir-v1.0.0-fiqa.test.wp")).keySet().size());
+    assertEquals(97,    TopicReader.load(Topics.get("beir-v1.0.0-signal1m.test.wp")).keySet().size());
+    assertEquals(57,    TopicReader.load(Topics.get("beir-v1.0.0-trec-news.test.wp")).keySet().size());
+    assertEquals(249,   TopicReader.load(Topics.get("beir-v1.0.0-robust04.test.wp")).keySet().size());
+    assertEquals(1406,  TopicReader.load(Topics.get("beir-v1.0.0-arguana.test.wp")).keySet().size());
+    assertEquals(49,    TopicReader.load(Topics.get("beir-v1.0.0-webis-touche2020.test.wp")).keySet().size());
+    assertEquals(699,   TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-android.test.wp")).keySet().size());
+    assertEquals(1570,  TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-english.test.wp")).keySet().size());
+    assertEquals(1595,  TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-gaming.test.wp")).keySet().size());
+    assertEquals(885,   TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-gis.test.wp")).keySet().size());
+    assertEquals(804,   TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-mathematica.test.wp")).keySet().size());
+    assertEquals(1039,  TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-physics.test.wp")).keySet().size());
+    assertEquals(876,   TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-programmers.test.wp")).keySet().size());
+    assertEquals(652,   TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-stats.test.wp")).keySet().size());
+    assertEquals(2906,  TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-tex.test.wp")).keySet().size());
+    assertEquals(1072,  TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-unix.test.wp")).keySet().size());
+    assertEquals(506,   TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-webmasters.test.wp")).keySet().size());
+    assertEquals(541,   TopicReader.load(Topics.get("beir-v1.0.0-cqadupstack-wordpress.test.wp")).keySet().size());
+    assertEquals(10000, TopicReader.load(Topics.get("beir-v1.0.0-quora.test.wp")).keySet().size());
+    assertEquals(400,   TopicReader.load(Topics.get("beir-v1.0.0-dbpedia-entity.test.wp")).keySet().size());
+    assertEquals(1000,  TopicReader.load(Topics.get("beir-v1.0.0-scidocs.test.wp")).keySet().size());
+    assertEquals(6666,  TopicReader.load(Topics.get("beir-v1.0.0-fever.test.wp")).keySet().size());
+    assertEquals(1535,  TopicReader.load(Topics.get("beir-v1.0.0-climate-fever.test.wp")).keySet().size());
+    assertEquals(300,   TopicReader.load(Topics.get("beir-v1.0.0-scifact.test.wp")).keySet().size());
   }
 
   @Test
   public void testBrightTopics() throws IOException {
-    assertEquals(103, TopicReader.getTopics(Topics.get("bright-biology")).keySet().size());
-    assertEquals(116, TopicReader.getTopics(Topics.get("bright-earth-science")).keySet().size());
-    assertEquals(103, TopicReader.getTopics(Topics.get("bright-economics")).keySet().size());
-    assertEquals(101, TopicReader.getTopics(Topics.get("bright-psychology")).keySet().size());
-    assertEquals(101, TopicReader.getTopics(Topics.get("bright-robotics")).keySet().size());
-    assertEquals(117, TopicReader.getTopics(Topics.get("bright-stackoverflow")).keySet().size());
-    assertEquals(108, TopicReader.getTopics(Topics.get("bright-sustainable-living")).keySet().size());
-    assertEquals(112, TopicReader.getTopics(Topics.get("bright-pony")).keySet().size());
-    assertEquals(142, TopicReader.getTopics(Topics.get("bright-leetcode")).keySet().size());
-    assertEquals(111, TopicReader.getTopics(Topics.get("bright-aops")).keySet().size());
-    assertEquals(76, TopicReader.getTopics(Topics.get("bright-theoremqa-theorems")).keySet().size());
-    assertEquals(194, TopicReader.getTopics(Topics.get("bright-theoremqa-questions")).keySet().size());
+    assertEquals(103, TopicReader.load(Topics.get("bright-biology")).keySet().size());
+    assertEquals(116, TopicReader.load(Topics.get("bright-earth-science")).keySet().size());
+    assertEquals(103, TopicReader.load(Topics.get("bright-economics")).keySet().size());
+    assertEquals(101, TopicReader.load(Topics.get("bright-psychology")).keySet().size());
+    assertEquals(101, TopicReader.load(Topics.get("bright-robotics")).keySet().size());
+    assertEquals(117, TopicReader.load(Topics.get("bright-stackoverflow")).keySet().size());
+    assertEquals(108, TopicReader.load(Topics.get("bright-sustainable-living")).keySet().size());
+    assertEquals(112, TopicReader.load(Topics.get("bright-pony")).keySet().size());
+    assertEquals(142, TopicReader.load(Topics.get("bright-leetcode")).keySet().size());
+    assertEquals(111, TopicReader.load(Topics.get("bright-aops")).keySet().size());
+    assertEquals(76, TopicReader.load(Topics.get("bright-theoremqa-theorems")).keySet().size());
+    assertEquals(194, TopicReader.load(Topics.get("bright-theoremqa-questions")).keySet().size());
   }
 
   @Test
   public void testBrightOriginalTopics() throws IOException {
-    assertEquals(103, TopicReader.getTopics(Topics.get("bright-biology-original")).keySet().size());
-    assertEquals(116, TopicReader.getTopics(Topics.get("bright-earth-science-original")).keySet().size());
-    assertEquals(103, TopicReader.getTopics(Topics.get("bright-economics-original")).keySet().size());
-    assertEquals(101, TopicReader.getTopics(Topics.get("bright-psychology-original")).keySet().size());
-    assertEquals(101, TopicReader.getTopics(Topics.get("bright-robotics-original")).keySet().size());
-    assertEquals(117, TopicReader.getTopics(Topics.get("bright-stackoverflow-original")).keySet().size());
-    assertEquals(108, TopicReader.getTopics(Topics.get("bright-sustainable-living-original")).keySet().size());
-    assertEquals(112, TopicReader.getTopics(Topics.get("bright-pony-original")).keySet().size());
-    assertEquals(142, TopicReader.getTopics(Topics.get("bright-leetcode-original")).keySet().size());
-    assertEquals(111, TopicReader.getTopics(Topics.get("bright-aops-original")).keySet().size());
-    assertEquals(76, TopicReader.getTopics(Topics.get("bright-theoremqa-theorems-original")).keySet().size());
-    assertEquals(194, TopicReader.getTopics(Topics.get("bright-theoremqa-questions-original")).keySet().size());
+    assertEquals(103, TopicReader.load(Topics.get("bright-biology-original")).keySet().size());
+    assertEquals(116, TopicReader.load(Topics.get("bright-earth-science-original")).keySet().size());
+    assertEquals(103, TopicReader.load(Topics.get("bright-economics-original")).keySet().size());
+    assertEquals(101, TopicReader.load(Topics.get("bright-psychology-original")).keySet().size());
+    assertEquals(101, TopicReader.load(Topics.get("bright-robotics-original")).keySet().size());
+    assertEquals(117, TopicReader.load(Topics.get("bright-stackoverflow-original")).keySet().size());
+    assertEquals(108, TopicReader.load(Topics.get("bright-sustainable-living-original")).keySet().size());
+    assertEquals(112, TopicReader.load(Topics.get("bright-pony-original")).keySet().size());
+    assertEquals(142, TopicReader.load(Topics.get("bright-leetcode-original")).keySet().size());
+    assertEquals(111, TopicReader.load(Topics.get("bright-aops-original")).keySet().size());
+    assertEquals(76, TopicReader.load(Topics.get("bright-theoremqa-theorems-original")).keySet().size());
+    assertEquals(194, TopicReader.load(Topics.get("bright-theoremqa-questions-original")).keySet().size());
   }
 
   @Test
   public void testMBEIRTopics() throws IOException {
-    assertEquals(4170, TopicReader.getTopics(Topics.get("mbeir-cirr_task7.test")).keySet().size());
-    assertEquals(3241, TopicReader.getTopics(Topics.get("mbeir-edis_task2.test")).keySet().size());
-    assertEquals(1719, TopicReader.getTopics(Topics.get("mbeir-fashion200k_task0.test")).keySet().size());
-    assertEquals(4889, TopicReader.getTopics(Topics.get("mbeir-fashion200k_task3.test")).keySet().size());
-    assertEquals(6003, TopicReader.getTopics(Topics.get("mbeir-fashioniq_task7.test")).keySet().size());
-    assertEquals(11323, TopicReader.getTopics(Topics.get("mbeir-infoseek_task6.test")).keySet().size());
-    assertEquals(17593, TopicReader.getTopics(Topics.get("mbeir-infoseek_task8.test")).keySet().size());
-    assertEquals(24809, TopicReader.getTopics(Topics.get("mbeir-mscoco_task0.test")).keySet().size());
-    assertEquals(5000, TopicReader.getTopics(Topics.get("mbeir-mscoco_task3.test")).keySet().size());
-    assertEquals(2120, TopicReader.getTopics(Topics.get("mbeir-nights_task4.test")).keySet().size());
-    assertEquals(50004, TopicReader.getTopics(Topics.get("mbeir-oven_task6.test")).keySet().size());
-    assertEquals(14741, TopicReader.getTopics(Topics.get("mbeir-oven_task8.test")).keySet().size());
-    assertEquals(19995, TopicReader.getTopics(Topics.get("mbeir-visualnews_task0.test")).keySet().size());
-    assertEquals(20000, TopicReader.getTopics(Topics.get("mbeir-visualnews_task3.test")).keySet().size());
-    assertEquals(2455, TopicReader.getTopics(Topics.get("mbeir-webqa_task1.test")).keySet().size());
-    assertEquals(2511, TopicReader.getTopics(Topics.get("mbeir-webqa_task2.test")).keySet().size());
+    assertEquals(4170, TopicReader.load(Topics.get("mbeir-cirr_task7.test")).keySet().size());
+    assertEquals(3241, TopicReader.load(Topics.get("mbeir-edis_task2.test")).keySet().size());
+    assertEquals(1719, TopicReader.load(Topics.get("mbeir-fashion200k_task0.test")).keySet().size());
+    assertEquals(4889, TopicReader.load(Topics.get("mbeir-fashion200k_task3.test")).keySet().size());
+    assertEquals(6003, TopicReader.load(Topics.get("mbeir-fashioniq_task7.test")).keySet().size());
+    assertEquals(11323, TopicReader.load(Topics.get("mbeir-infoseek_task6.test")).keySet().size());
+    assertEquals(17593, TopicReader.load(Topics.get("mbeir-infoseek_task8.test")).keySet().size());
+    assertEquals(24809, TopicReader.load(Topics.get("mbeir-mscoco_task0.test")).keySet().size());
+    assertEquals(5000, TopicReader.load(Topics.get("mbeir-mscoco_task3.test")).keySet().size());
+    assertEquals(2120, TopicReader.load(Topics.get("mbeir-nights_task4.test")).keySet().size());
+    assertEquals(50004, TopicReader.load(Topics.get("mbeir-oven_task6.test")).keySet().size());
+    assertEquals(14741, TopicReader.load(Topics.get("mbeir-oven_task8.test")).keySet().size());
+    assertEquals(19995, TopicReader.load(Topics.get("mbeir-visualnews_task0.test")).keySet().size());
+    assertEquals(20000, TopicReader.load(Topics.get("mbeir-visualnews_task3.test")).keySet().size());
+    assertEquals(2455, TopicReader.load(Topics.get("mbeir-webqa_task1.test")).keySet().size());
+    assertEquals(2511, TopicReader.load(Topics.get("mbeir-webqa_task2.test")).keySet().size());
   }
 
   @Test public void testMMEBVisDocTopics() throws IOException {
-    assertEquals(500, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_arxivqa.test")).keySet().size());
-    assertEquals(451, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_docvqa.test")).keySet().size());
-    assertEquals(494, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_infovqa.test")).keySet().size());
-    assertEquals(100, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_shiftproject.test")).keySet().size());
-    assertEquals(100, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_artificial_intelligence.test")).keySet().size());
-    assertEquals(100, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_energy.test")).keySet().size());
-    assertEquals(100, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_government_reports.test")).keySet().size());
-    assertEquals(100, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_healthcare_industry.test")).keySet().size());
-    assertEquals(280, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_tabfquad.test")).keySet().size());
-    assertEquals(1646, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_tatdqa.test")).keySet().size());
-    assertEquals(160, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_biomedical_lectures_v2.test")).keySet().size());
-    assertEquals(640, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_biomedical_lectures_v2_multilingual.test")).keySet().size());
-    assertEquals(58, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_economics_reports_v2.test")).keySet().size());
-    assertEquals(232, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_economics_reports_v2_multilingual.test")).keySet().size());
-    assertEquals(52, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_esg_reports_human_labeled_v2.test")).keySet().size());
-    assertEquals(57, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_esg_reports_v2.test")).keySet().size());
-    assertEquals(228, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_esg_reports_v2_multilingual.test")).keySet().size());
-    assertEquals(816, TopicReader.getTopics(Topics.get("mmeb-visdoc-VisRAG_ArxivQA.train")).keySet().size());
-    assertEquals(63, TopicReader.getTopics(Topics.get("mmeb-visdoc-VisRAG_ChartQA.train")).keySet().size());
-    assertEquals(718, TopicReader.getTopics(Topics.get("mmeb-visdoc-VisRAG_InfoVQA.train")).keySet().size());
-    assertEquals(591, TopicReader.getTopics(Topics.get("mmeb-visdoc-VisRAG_MP-DocVQA.train")).keySet().size());
-    assertEquals(863, TopicReader.getTopics(Topics.get("mmeb-visdoc-VisRAG_PlotQA.train")).keySet().size());
-    assertEquals(556, TopicReader.getTopics(Topics.get("mmeb-visdoc-VisRAG_SlideVQA.train")).keySet().size());
-    assertEquals(1142, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoSeek-doc.test")).keySet().size());
-    assertEquals(1142, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoSeek-page.test")).keySet().size());
-    assertEquals(838, TopicReader.getTopics(Topics.get("mmeb-visdoc-MMLongBench-doc.test")).keySet().size());
-    assertEquals(838, TopicReader.getTopics(Topics.get("mmeb-visdoc-MMLongBench-page.test")).keySet().size());
+    assertEquals(500, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_arxivqa.test")).keySet().size());
+    assertEquals(451, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_docvqa.test")).keySet().size());
+    assertEquals(494, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_infovqa.test")).keySet().size());
+    assertEquals(100, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_shiftproject.test")).keySet().size());
+    assertEquals(100, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_artificial_intelligence.test")).keySet().size());
+    assertEquals(100, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_energy.test")).keySet().size());
+    assertEquals(100, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_government_reports.test")).keySet().size());
+    assertEquals(100, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_healthcare_industry.test")).keySet().size());
+    assertEquals(280, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_tabfquad.test")).keySet().size());
+    assertEquals(1646, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_tatdqa.test")).keySet().size());
+    assertEquals(160, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_biomedical_lectures_v2.test")).keySet().size());
+    assertEquals(640, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_biomedical_lectures_v2_multilingual.test")).keySet().size());
+    assertEquals(58, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_economics_reports_v2.test")).keySet().size());
+    assertEquals(232, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_economics_reports_v2_multilingual.test")).keySet().size());
+    assertEquals(52, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_esg_reports_human_labeled_v2.test")).keySet().size());
+    assertEquals(57, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_esg_reports_v2.test")).keySet().size());
+    assertEquals(228, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_esg_reports_v2_multilingual.test")).keySet().size());
+    assertEquals(816, TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_ArxivQA.train")).keySet().size());
+    assertEquals(63, TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_ChartQA.train")).keySet().size());
+    assertEquals(718, TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_InfoVQA.train")).keySet().size());
+    assertEquals(591, TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_MP-DocVQA.train")).keySet().size());
+    assertEquals(863, TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_PlotQA.train")).keySet().size());
+    assertEquals(556, TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_SlideVQA.train")).keySet().size());
+    assertEquals(1142, TopicReader.load(Topics.get("mmeb-visdoc-ViDoSeek-doc.test")).keySet().size());
+    assertEquals(1142, TopicReader.load(Topics.get("mmeb-visdoc-ViDoSeek-page.test")).keySet().size());
+    assertEquals(838, TopicReader.load(Topics.get("mmeb-visdoc-MMLongBench-doc.test")).keySet().size());
+    assertEquals(838, TopicReader.load(Topics.get("mmeb-visdoc-MMLongBench-page.test")).keySet().size());
   }
 
   @Test
@@ -2036,50 +2098,50 @@ public class TopicReaderTest {
   
   @Test
   public void testHC4Topics() throws IOException {
-    assertEquals(10, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.dev.title")).keySet().size());
-    assertEquals(10, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.dev.desc")).keySet().size());
-    assertEquals(10, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.dev.desc.title")).keySet().size());
+    assertEquals(10, TopicReader.load(Topics.get("hc4-v1.0-fa.dev.title")).keySet().size());
+    assertEquals(10, TopicReader.load(Topics.get("hc4-v1.0-fa.dev.desc")).keySet().size());
+    assertEquals(10, TopicReader.load(Topics.get("hc4-v1.0-fa.dev.desc.title")).keySet().size());
 
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.test.title")).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.test.desc")).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.test.desc.title")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-fa.test.title")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-fa.test.desc")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-fa.test.desc.title")).keySet().size());
 
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.en.test.title")).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.en.test.desc")).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.en.test.desc.title")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-fa.en.test.title")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-fa.en.test.desc")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-fa.en.test.desc.title")).keySet().size());
 
-    assertEquals(4, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.dev.title")).keySet().size());
-    assertEquals(4, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.dev.desc")).keySet().size());
-    assertEquals(4, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.dev.desc.title")).keySet().size());
+    assertEquals(4, TopicReader.load(Topics.get("hc4-v1.0-ru.dev.title")).keySet().size());
+    assertEquals(4, TopicReader.load(Topics.get("hc4-v1.0-ru.dev.desc")).keySet().size());
+    assertEquals(4, TopicReader.load(Topics.get("hc4-v1.0-ru.dev.desc.title")).keySet().size());
 
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.test.title")).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.test.desc")).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.test.desc.title")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-ru.test.title")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-ru.test.desc")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-ru.test.desc.title")).keySet().size());
 
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.en.test.title")).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.en.test.desc")).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.en.test.desc.title")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-ru.en.test.title")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-ru.en.test.desc")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-ru.en.test.desc.title")).keySet().size());
 
-    assertEquals(10, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.dev.title")).keySet().size());
-    assertEquals(10, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.dev.desc")).keySet().size());
-    assertEquals(10, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.dev.desc.title")).keySet().size());
+    assertEquals(10, TopicReader.load(Topics.get("hc4-v1.0-zh.dev.title")).keySet().size());
+    assertEquals(10, TopicReader.load(Topics.get("hc4-v1.0-zh.dev.desc")).keySet().size());
+    assertEquals(10, TopicReader.load(Topics.get("hc4-v1.0-zh.dev.desc.title")).keySet().size());
 
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.test.title")).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.test.desc")).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.test.desc.title")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-zh.test.title")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-zh.test.desc")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-zh.test.desc.title")).keySet().size());
 
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.en.test.title")).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.en.test.desc")).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.en.test.desc.title")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-zh.en.test.title")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-zh.en.test.desc")).keySet().size());
+    assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-zh.en.test.desc.title")).keySet().size());
   }
 
   @Test
   public void testNeuCLIR22OriginalTopics() throws IOException {
     SortedMap<Integer, Map<String, String>> t, d, dt;
 
-    t = TopicReader.getTopics(Topics.get("neuclir22-en.original-title"));
-    d = TopicReader.getTopics(Topics.get("neuclir22-en.original-desc"));
-    dt = TopicReader.getTopics(Topics.get("neuclir22-en.original-desc_title"));
+    t = TopicReader.load(Topics.get("neuclir22-en.original-title"));
+    d = TopicReader.load(Topics.get("neuclir22-en.original-desc"));
+    dt = TopicReader.load(Topics.get("neuclir22-en.original-desc_title"));
 
     assertEquals(114, t.keySet().size());
     assertEquals(114, d.keySet().size());
@@ -2093,9 +2155,9 @@ public class TopicReaderTest {
     }
 
     // Persian
-    t = TopicReader.getTopics(Topics.get("neuclir22-fa.ht-title"));
-    d = TopicReader.getTopics(Topics.get("neuclir22-fa.ht-desc"));
-    dt = TopicReader.getTopics(Topics.get("neuclir22-fa.ht-desc_title"));
+    t = TopicReader.load(Topics.get("neuclir22-fa.ht-title"));
+    d = TopicReader.load(Topics.get("neuclir22-fa.ht-desc"));
+    dt = TopicReader.load(Topics.get("neuclir22-fa.ht-desc_title"));
 
     assertEquals(114, t.keySet().size());
     assertEquals(114, d.keySet().size());
@@ -2108,9 +2170,9 @@ public class TopicReaderTest {
       assertEquals(dt.get(k).get("title"), d.get(k).get("title") + " " + t.get(k).get("title"));
     }
 
-    t = TopicReader.getTopics(Topics.get("neuclir22-fa.mt-title"));
-    d = TopicReader.getTopics(Topics.get("neuclir22-fa.mt-desc"));
-    dt = TopicReader.getTopics(Topics.get("neuclir22-fa.mt-desc_title"));
+    t = TopicReader.load(Topics.get("neuclir22-fa.mt-title"));
+    d = TopicReader.load(Topics.get("neuclir22-fa.mt-desc"));
+    dt = TopicReader.load(Topics.get("neuclir22-fa.mt-desc_title"));
 
     assertEquals(114, t.keySet().size());
     assertEquals(114, d.keySet().size());
@@ -2124,9 +2186,9 @@ public class TopicReaderTest {
     }
 
     // Russian
-    t = TopicReader.getTopics(Topics.get("neuclir22-ru.ht-title"));
-    d = TopicReader.getTopics(Topics.get("neuclir22-ru.ht-desc"));
-    dt = TopicReader.getTopics(Topics.get("neuclir22-ru.ht-desc_title"));
+    t = TopicReader.load(Topics.get("neuclir22-ru.ht-title"));
+    d = TopicReader.load(Topics.get("neuclir22-ru.ht-desc"));
+    dt = TopicReader.load(Topics.get("neuclir22-ru.ht-desc_title"));
 
     assertEquals(114, t.keySet().size());
     assertEquals(114, d.keySet().size());
@@ -2139,9 +2201,9 @@ public class TopicReaderTest {
       assertEquals(dt.get(k).get("title"), d.get(k).get("title") + " " + t.get(k).get("title"));
     }
 
-    t = TopicReader.getTopics(Topics.get("neuclir22-ru.mt-title"));
-    d = TopicReader.getTopics(Topics.get("neuclir22-ru.mt-desc"));
-    dt = TopicReader.getTopics(Topics.get("neuclir22-ru.mt-desc_title"));
+    t = TopicReader.load(Topics.get("neuclir22-ru.mt-title"));
+    d = TopicReader.load(Topics.get("neuclir22-ru.mt-desc"));
+    dt = TopicReader.load(Topics.get("neuclir22-ru.mt-desc_title"));
 
     assertEquals(114, t.keySet().size());
     assertEquals(114, d.keySet().size());
@@ -2155,9 +2217,9 @@ public class TopicReaderTest {
     }
 
     // Chinese
-    t = TopicReader.getTopics(Topics.get("neuclir22-zh.ht-title"));
-    d = TopicReader.getTopics(Topics.get("neuclir22-zh.ht-desc"));
-    dt = TopicReader.getTopics(Topics.get("neuclir22-zh.ht-desc_title"));
+    t = TopicReader.load(Topics.get("neuclir22-zh.ht-title"));
+    d = TopicReader.load(Topics.get("neuclir22-zh.ht-desc"));
+    dt = TopicReader.load(Topics.get("neuclir22-zh.ht-desc_title"));
 
     assertEquals(114, t.keySet().size());
     assertEquals(114, d.keySet().size());
@@ -2170,9 +2232,9 @@ public class TopicReaderTest {
       assertEquals(dt.get(k).get("title"), d.get(k).get("title") + " " + t.get(k).get("title"));
     }
 
-    t = TopicReader.getTopics(Topics.get("neuclir22-zh.mt-title"));
-    d = TopicReader.getTopics(Topics.get("neuclir22-zh.mt-desc"));
-    dt = TopicReader.getTopics(Topics.get("neuclir22-zh.mt-desc_title"));
+    t = TopicReader.load(Topics.get("neuclir22-zh.mt-title"));
+    d = TopicReader.load(Topics.get("neuclir22-zh.mt-desc"));
+    dt = TopicReader.load(Topics.get("neuclir22-zh.mt-desc_title"));
 
     assertEquals(114, t.keySet().size());
     assertEquals(114, d.keySet().size());
@@ -2188,74 +2250,74 @@ public class TopicReaderTest {
 
   @Test
   public void testNeuCLIR22SpladeTopics() throws IOException {
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-fa.splade.ht-title")).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-fa.splade.ht-desc")).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-fa.splade.ht-desc_title")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-fa.splade.ht-title")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-fa.splade.ht-desc")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-fa.splade.ht-desc_title")).keySet().size());
 
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-fa.splade.mt-title")).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-fa.splade.mt-desc")).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-fa.splade.mt-desc_title")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-fa.splade.mt-title")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-fa.splade.mt-desc")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-fa.splade.mt-desc_title")).keySet().size());
 
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-ru.splade.ht-title")).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-ru.splade.ht-desc")).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-ru.splade.ht-desc_title")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-ru.splade.ht-title")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-ru.splade.ht-desc")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-ru.splade.ht-desc_title")).keySet().size());
 
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-ru.splade.mt-title")).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-ru.splade.mt-desc")).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-ru.splade.mt-desc_title")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-ru.splade.mt-title")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-ru.splade.mt-desc")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-ru.splade.mt-desc_title")).keySet().size());
 
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-zh.splade.ht-title")).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-zh.splade.ht-desc")).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-zh.splade.ht-desc_title")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-zh.splade.ht-title")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-zh.splade.ht-desc")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-zh.splade.ht-desc_title")).keySet().size());
 
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-zh.splade.mt-title")).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-zh.splade.mt-desc")).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-zh.splade.mt-desc_title")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-zh.splade.mt-title")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-zh.splade.mt-desc")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-zh.splade.mt-desc_title")).keySet().size());
   }
 
   @Test
   public void testMIRACLTopics() throws IOException {
-    assertEquals(2896, TopicReader.getTopics(Topics.get("miracl-v1.0-ar-dev")).keySet().size());
-    assertEquals(411, TopicReader.getTopics(Topics.get("miracl-v1.0-bn-dev")).keySet().size());
-    assertEquals(799, TopicReader.getTopics(Topics.get("miracl-v1.0-en-dev")).keySet().size());
-    assertEquals(648, TopicReader.getTopics(Topics.get("miracl-v1.0-es-dev")).keySet().size());
-    assertEquals(632, TopicReader.getTopics(Topics.get("miracl-v1.0-fa-dev")).keySet().size());
-    assertEquals(1271, TopicReader.getTopics(Topics.get("miracl-v1.0-fi-dev")).keySet().size());
-    assertEquals(343, TopicReader.getTopics(Topics.get("miracl-v1.0-fr-dev")).keySet().size());
-    assertEquals(350, TopicReader.getTopics(Topics.get("miracl-v1.0-hi-dev")).keySet().size());
-    assertEquals(960, TopicReader.getTopics(Topics.get("miracl-v1.0-id-dev")).keySet().size());
-    assertEquals(860, TopicReader.getTopics(Topics.get("miracl-v1.0-ja-dev")).keySet().size());
-    assertEquals(213, TopicReader.getTopics(Topics.get("miracl-v1.0-ko-dev")).keySet().size());
-    assertEquals(1252, TopicReader.getTopics(Topics.get("miracl-v1.0-ru-dev")).keySet().size());
-    assertEquals(482, TopicReader.getTopics(Topics.get("miracl-v1.0-sw-dev")).keySet().size());
-    assertEquals(828, TopicReader.getTopics(Topics.get("miracl-v1.0-te-dev")).keySet().size());
-    assertEquals(733, TopicReader.getTopics(Topics.get("miracl-v1.0-th-dev")).keySet().size());
-    assertEquals(393, TopicReader.getTopics(Topics.get("miracl-v1.0-zh-dev")).keySet().size());
-    assertEquals(305, TopicReader.getTopics(Topics.get("miracl-v1.0-de-dev")).keySet().size());
-    assertEquals(119, TopicReader.getTopics(Topics.get("miracl-v1.0-yo-dev")).keySet().size());
+    assertEquals(2896, TopicReader.load(Topics.get("miracl-v1.0-ar-dev")).keySet().size());
+    assertEquals(411, TopicReader.load(Topics.get("miracl-v1.0-bn-dev")).keySet().size());
+    assertEquals(799, TopicReader.load(Topics.get("miracl-v1.0-en-dev")).keySet().size());
+    assertEquals(648, TopicReader.load(Topics.get("miracl-v1.0-es-dev")).keySet().size());
+    assertEquals(632, TopicReader.load(Topics.get("miracl-v1.0-fa-dev")).keySet().size());
+    assertEquals(1271, TopicReader.load(Topics.get("miracl-v1.0-fi-dev")).keySet().size());
+    assertEquals(343, TopicReader.load(Topics.get("miracl-v1.0-fr-dev")).keySet().size());
+    assertEquals(350, TopicReader.load(Topics.get("miracl-v1.0-hi-dev")).keySet().size());
+    assertEquals(960, TopicReader.load(Topics.get("miracl-v1.0-id-dev")).keySet().size());
+    assertEquals(860, TopicReader.load(Topics.get("miracl-v1.0-ja-dev")).keySet().size());
+    assertEquals(213, TopicReader.load(Topics.get("miracl-v1.0-ko-dev")).keySet().size());
+    assertEquals(1252, TopicReader.load(Topics.get("miracl-v1.0-ru-dev")).keySet().size());
+    assertEquals(482, TopicReader.load(Topics.get("miracl-v1.0-sw-dev")).keySet().size());
+    assertEquals(828, TopicReader.load(Topics.get("miracl-v1.0-te-dev")).keySet().size());
+    assertEquals(733, TopicReader.load(Topics.get("miracl-v1.0-th-dev")).keySet().size());
+    assertEquals(393, TopicReader.load(Topics.get("miracl-v1.0-zh-dev")).keySet().size());
+    assertEquals(305, TopicReader.load(Topics.get("miracl-v1.0-de-dev")).keySet().size());
+    assertEquals(119, TopicReader.load(Topics.get("miracl-v1.0-yo-dev")).keySet().size());
   }
 
   @Test
   public void testCIRALTopics() throws IOException {
-    assertEquals(10, TopicReader.getTopics(Topics.get("ciral-v1.0-ha-dev-native")).keySet().size());
-    assertEquals(10, TopicReader.getTopics(Topics.get("ciral-v1.0-so-dev-native")).keySet().size());
-    assertEquals(10, TopicReader.getTopics(Topics.get("ciral-v1.0-sw-dev-native")).keySet().size());
-    assertEquals(10, TopicReader.getTopics(Topics.get("ciral-v1.0-yo-dev-native")).keySet().size());
-    assertEquals(80, TopicReader.getTopics(Topics.get("ciral-v1.0-ha-test-a")).keySet().size());
-    assertEquals(99, TopicReader.getTopics(Topics.get("ciral-v1.0-so-test-a")).keySet().size());
-    assertEquals(85, TopicReader.getTopics(Topics.get("ciral-v1.0-sw-test-a")).keySet().size());
-    assertEquals(100, TopicReader.getTopics(Topics.get("ciral-v1.0-yo-test-a")).keySet().size());
-    assertEquals(80, TopicReader.getTopics(Topics.get("ciral-v1.0-ha-test-a-native")).keySet().size());
-    assertEquals(99, TopicReader.getTopics(Topics.get("ciral-v1.0-so-test-a-native")).keySet().size());
-    assertEquals(85, TopicReader.getTopics(Topics.get("ciral-v1.0-sw-test-a-native")).keySet().size());
-    assertEquals(100, TopicReader.getTopics(Topics.get("ciral-v1.0-yo-test-a-native")).keySet().size());
-    assertEquals(312, TopicReader.getTopics(Topics.get("ciral-v1.0-ha-test-b")).keySet().size());
-    assertEquals(239, TopicReader.getTopics(Topics.get("ciral-v1.0-so-test-b")).keySet().size());
-    assertEquals(113, TopicReader.getTopics(Topics.get("ciral-v1.0-sw-test-b")).keySet().size());
-    assertEquals(554, TopicReader.getTopics(Topics.get("ciral-v1.0-yo-test-b")).keySet().size());
-    assertEquals(312, TopicReader.getTopics(Topics.get("ciral-v1.0-ha-test-b-native")).keySet().size());
-    assertEquals(239, TopicReader.getTopics(Topics.get("ciral-v1.0-so-test-b-native")).keySet().size());
-    assertEquals(112, TopicReader.getTopics(Topics.get("ciral-v1.0-sw-test-b-native")).keySet().size());
-    assertEquals(554, TopicReader.getTopics(Topics.get("ciral-v1.0-yo-test-b-native")).keySet().size());
+    assertEquals(10, TopicReader.load(Topics.get("ciral-v1.0-ha-dev-native")).keySet().size());
+    assertEquals(10, TopicReader.load(Topics.get("ciral-v1.0-so-dev-native")).keySet().size());
+    assertEquals(10, TopicReader.load(Topics.get("ciral-v1.0-sw-dev-native")).keySet().size());
+    assertEquals(10, TopicReader.load(Topics.get("ciral-v1.0-yo-dev-native")).keySet().size());
+    assertEquals(80, TopicReader.load(Topics.get("ciral-v1.0-ha-test-a")).keySet().size());
+    assertEquals(99, TopicReader.load(Topics.get("ciral-v1.0-so-test-a")).keySet().size());
+    assertEquals(85, TopicReader.load(Topics.get("ciral-v1.0-sw-test-a")).keySet().size());
+    assertEquals(100, TopicReader.load(Topics.get("ciral-v1.0-yo-test-a")).keySet().size());
+    assertEquals(80, TopicReader.load(Topics.get("ciral-v1.0-ha-test-a-native")).keySet().size());
+    assertEquals(99, TopicReader.load(Topics.get("ciral-v1.0-so-test-a-native")).keySet().size());
+    assertEquals(85, TopicReader.load(Topics.get("ciral-v1.0-sw-test-a-native")).keySet().size());
+    assertEquals(100, TopicReader.load(Topics.get("ciral-v1.0-yo-test-a-native")).keySet().size());
+    assertEquals(312, TopicReader.load(Topics.get("ciral-v1.0-ha-test-b")).keySet().size());
+    assertEquals(239, TopicReader.load(Topics.get("ciral-v1.0-so-test-b")).keySet().size());
+    assertEquals(113, TopicReader.load(Topics.get("ciral-v1.0-sw-test-b")).keySet().size());
+    assertEquals(554, TopicReader.load(Topics.get("ciral-v1.0-yo-test-b")).keySet().size());
+    assertEquals(312, TopicReader.load(Topics.get("ciral-v1.0-ha-test-b-native")).keySet().size());
+    assertEquals(239, TopicReader.load(Topics.get("ciral-v1.0-so-test-b-native")).keySet().size());
+    assertEquals(112, TopicReader.load(Topics.get("ciral-v1.0-sw-test-b-native")).keySet().size());
+    assertEquals(554, TopicReader.load(Topics.get("ciral-v1.0-yo-test-b-native")).keySet().size());
   }
 }

--- a/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
@@ -32,14 +32,14 @@ public class TopicReaderTest {
   @Test
   public void testIterateThroughAllEnums() {
     int cnt = 0;
-    for (Topics topic : Topics.values()) {
+    for (Topics topic : Topics.registry().values()) {
       cnt++; 
 
       // Verify that we can fetch the TopicReader class given the name of the topic file.
       String path = topic.path;
       assertEquals(topic.readerClass, TopicReader.getTopicReaderClassByFile(path));
     }
-    assertEquals(433, cnt);
+    assertEquals(460, cnt);
   }
 
   @Test
@@ -76,7 +76,7 @@ public class TopicReaderTest {
   public void testCacmTopics() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.CACM);
+    topics = TopicReader.getTopics(Topics.get("cacm"));
     assertNotNull(topics);
     assertEquals(64, topics.size());
     assertEquals(1, (int) topics.firstKey());
@@ -89,7 +89,7 @@ public class TopicReaderTest {
   public void testNewswireTopics() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.TREC1_ADHOC);
+    topics = TopicReader.getTopics(Topics.get("adhoc.51-100"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(51, (int) topics.firstKey());
@@ -97,7 +97,7 @@ public class TopicReaderTest {
     assertEquals(100, (int) topics.lastKey());
     assertEquals("Controlling the Transfer of High Technology", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2_ADHOC);
+    topics = TopicReader.getTopics(Topics.get("adhoc.101-150"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(101, (int) topics.firstKey());
@@ -105,7 +105,7 @@ public class TopicReaderTest {
     assertEquals(150, (int) topics.lastKey());
     assertEquals("U.S. Political Campaign Financing", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC3_ADHOC);
+    topics = TopicReader.getTopics(Topics.get("adhoc.151-200"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(151, (int) topics.firstKey());
@@ -113,7 +113,7 @@ public class TopicReaderTest {
     assertEquals(200, (int) topics.lastKey());
     assertEquals("Impact of foreign textile imports on U.S. textile industry", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.ROBUST04);
+    topics = TopicReader.getTopics(Topics.get("robust04"));
     assertNotNull(topics);
     assertEquals(250, topics.size());
     assertEquals(301, (int) topics.firstKey());
@@ -121,7 +121,7 @@ public class TopicReaderTest {
     assertEquals(700, (int) topics.lastKey());
     assertEquals("gasoline tax U.S.", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.ROBUST05);
+    topics = TopicReader.getTopics(Topics.get("robust05"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(303, (int) topics.firstKey());
@@ -129,7 +129,7 @@ public class TopicReaderTest {
     assertEquals(689, (int) topics.lastKey());
     assertEquals("family-planning aid", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.CORE17);
+    topics = TopicReader.getTopics(Topics.get("core17"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(307, (int) topics.firstKey());
@@ -137,7 +137,7 @@ public class TopicReaderTest {
     assertEquals(690, (int) topics.lastKey());
     assertEquals("college education advantage", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.CORE18);
+    topics = TopicReader.getTopics(Topics.get("core18"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(321, (int) topics.firstKey());
@@ -150,11 +150,11 @@ public class TopicReaderTest {
   public void testDseTopics() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.SLIDEVQA_TEST);
+    topics = TopicReader.getTopics(Topics.get("slidevqa.test"));
     assertNotNull(topics);
     assertEquals(2214, topics.size());
 
-    topics = TopicReader.getTopics(Topics.WIKI_SS_NQ_TEST);
+    topics = TopicReader.getTopics(Topics.get("wiki-ss-nq.test"));
     assertNotNull(topics);
     assertEquals(3610, topics.size());
   }
@@ -163,7 +163,7 @@ public class TopicReaderTest {
   public void testTrecTitleParsing() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.TREC1_ADHOC);
+    topics = TopicReader.getTopics(Topics.get("adhoc.51-100"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
 
@@ -176,7 +176,7 @@ public class TopicReaderTest {
     assertEquals("Criminal Actions Against Officers of Failed Financial Institutions", topics.get(87).get("title"));
     assertEquals("What Backing Does the National Rifle Association Have?", topics.get(93).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2_ADHOC);
+    topics = TopicReader.getTopics(Topics.get("adhoc.101-150"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
 
@@ -190,43 +190,43 @@ public class TopicReaderTest {
   public void testNewswireTopics_TopicIdsAsStrings() throws IOException {
     Map<String, Map<String, String>> topics;
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.TREC1_ADHOC);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("adhoc.51-100"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("Airbus Subsidies", topics.get("51").get("title"));
     assertEquals("Controlling the Transfer of High Technology", topics.get("100").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.TREC2_ADHOC);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("adhoc.101-150"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("Design of the \"Star Wars\" Anti-missile Defense System", topics.get("101").get("title"));
     assertEquals("U.S. Political Campaign Financing", topics.get("150").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.TREC3_ADHOC);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("adhoc.151-200"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("Coping with overcrowded prisons", topics.get("151").get("title"));
     assertEquals("Impact of foreign textile imports on U.S. textile industry", topics.get("200").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.ROBUST04);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("robust04"));
     assertNotNull(topics);
     assertEquals(250, topics.size());
     assertEquals("International Organized Crime", topics.get("301").get("title"));
     assertEquals("gasoline tax U.S.", topics.get("700").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.ROBUST05);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("robust05"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("Hubble Telescope Achievements", topics.get("303").get("title"));
     assertEquals("family-planning aid", topics.get("689").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.CORE17);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("core17"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("New Hydroelectric Projects", topics.get("307").get("title"));
     assertEquals("college education advantage", topics.get("690").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.CORE18);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("core18"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("Women in Parliaments", topics.get("321").get("title"));
@@ -237,7 +237,7 @@ public class TopicReaderTest {
   public void testWebTopics() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.WT10G);
+    topics = TopicReader.getTopics(Topics.get("adhoc.451-550"));
     assertNotNull(topics);
     assertEquals(100, topics.size());
     assertEquals(451, (int) topics.firstKey());
@@ -245,7 +245,7 @@ public class TopicReaderTest {
     assertEquals(550, (int) topics.lastKey());
     assertEquals("how are the volcanoes made?", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2004_TERABYTE);
+    topics = TopicReader.getTopics(Topics.get("terabyte04.701-750"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(701, (int) topics.firstKey());
@@ -253,7 +253,7 @@ public class TopicReaderTest {
     assertEquals(750, (int) topics.lastKey());
     assertEquals("John Edwards womens issues", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2005_TERABYTE);
+    topics = TopicReader.getTopics(Topics.get("terabyte05.751-800"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(751, (int) topics.firstKey());
@@ -261,7 +261,7 @@ public class TopicReaderTest {
     assertEquals(800, (int) topics.lastKey());
     assertEquals("Ovarian Cancer Treatment", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2006_TERABYTE);
+    topics = TopicReader.getTopics(Topics.get("terabyte06.801-850"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(801, (int) topics.firstKey());
@@ -269,7 +269,7 @@ public class TopicReaderTest {
     assertEquals(850, (int) topics.lastKey());
     assertEquals("Mississippi River flood", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2007_MILLION_QUERY);
+    topics = TopicReader.getTopics(Topics.get("mq.1-10000"));
     assertNotNull(topics);
     assertEquals(10000, topics.keySet().size());
     assertEquals(1, (int) topics.firstKey());
@@ -277,7 +277,7 @@ public class TopicReaderTest {
     assertEquals(10000, (int) topics.lastKey());
     assertEquals("californa mission", topics.get(topics.lastKey()).get("title").trim());
 
-    topics = TopicReader.getTopics(Topics.TREC2008_MILLION_QUERY);
+    topics = TopicReader.getTopics(Topics.get("mq.10001-20000"));
     assertNotNull(topics);
     assertEquals(10000, topics.keySet().size());
     assertEquals(10001, (int) topics.firstKey());
@@ -285,7 +285,7 @@ public class TopicReaderTest {
     assertEquals(20000, (int) topics.lastKey());
     assertEquals("manchester city hall", topics.get(topics.lastKey()).get("title").trim());
 
-    topics = TopicReader.getTopics(Topics.TREC2009_MILLION_QUERY);
+    topics = TopicReader.getTopics(Topics.get("mq.20001-60000"));
     assertNotNull(topics);
     assertEquals(40000, topics.keySet().size());
     assertEquals(20001, (int) topics.firstKey());
@@ -295,7 +295,7 @@ public class TopicReaderTest {
     assertEquals("bird shingles", topics.get(topics.lastKey()).get("title").trim());
     assertEquals("4", topics.get(topics.lastKey()).get("priority").trim());
 
-    topics = TopicReader.getTopics(Topics.TREC2010_WEB);
+    topics = TopicReader.getTopics(Topics.get("web.51-100"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(51, (int) topics.firstKey());
@@ -303,7 +303,7 @@ public class TopicReaderTest {
     assertEquals(100, (int) topics.lastKey());
     assertEquals("rincon puerto rico", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2011_WEB);
+    topics = TopicReader.getTopics(Topics.get("web.101-150"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(101, (int) topics.firstKey());
@@ -311,7 +311,7 @@ public class TopicReaderTest {
     assertEquals(150, (int) topics.lastKey());
     assertEquals("tn highway patrol", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2012_WEB);
+    topics = TopicReader.getTopics(Topics.get("web.151-200"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(151, (int) topics.firstKey());
@@ -319,7 +319,7 @@ public class TopicReaderTest {
     assertEquals(200, (int) topics.lastKey());
     assertEquals("ontario california airport", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2013_WEB);
+    topics = TopicReader.getTopics(Topics.get("web.201-250"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(201, (int) topics.firstKey());
@@ -327,7 +327,7 @@ public class TopicReaderTest {
     assertEquals(250, (int) topics.lastKey());
     assertEquals("ford edge problems", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2014_WEB);
+    topics = TopicReader.getTopics(Topics.get("web.251-300"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(251, (int) topics.firstKey());
@@ -340,43 +340,43 @@ public class TopicReaderTest {
   public void testWebTopics_TopicIdsAsStrings() throws IOException {
     Map<String, Map<String, String>> topics;
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.WT10G);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("adhoc.451-550"));
     assertNotNull(topics);
     assertEquals(100, topics.size());
     assertEquals("What is a Bengals cat?", topics.get("451").get("title"));
     assertEquals("how are the volcanoes made?", topics.get("550").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.TREC2004_TERABYTE);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("terabyte04.701-750"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("U.S. oil industry history", topics.get("701").get("title"));
     assertEquals("John Edwards womens issues", topics.get("750").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.TREC2005_TERABYTE);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("terabyte05.751-800"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("Scrabble Players", topics.get("751").get("title"));
     assertEquals("Ovarian Cancer Treatment", topics.get("800").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.TREC2006_TERABYTE);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("terabyte06.801-850"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("Kudzu Pueraria lobata", topics.get("801").get("title"));
     assertEquals("Mississippi River flood", topics.get("850").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.TREC2007_MILLION_QUERY);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("mq.1-10000"));
     assertNotNull(topics);
     assertEquals(10000, topics.keySet().size());
     assertEquals("after school program evaluation", topics.get("1").get("title").trim());
     assertEquals("californa mission", topics.get("10000").get("title").trim());
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.TREC2008_MILLION_QUERY);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("mq.10001-20000"));
     assertNotNull(topics);
     assertEquals(10000, topics.keySet().size());
     assertEquals("comparability of pay analyses", topics.get("10001").get("title").trim());
     assertEquals("manchester city hall", topics.get("20000").get("title").trim());
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.TREC2009_MILLION_QUERY);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("mq.20001-60000"));
     assertNotNull(topics);
     assertEquals(40000, topics.keySet().size());
     assertEquals("obama family tree", topics.get("20001").get("title").trim());
@@ -384,31 +384,31 @@ public class TopicReaderTest {
     assertEquals("bird shingles", topics.get("60000").get("title").trim());
     assertEquals("4", topics.get("60000").get("priority").trim());
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.TREC2010_WEB);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("web.51-100"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("horse hooves", topics.get("51").get("title"));
     assertEquals("rincon puerto rico", topics.get("100").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.TREC2011_WEB);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("web.101-150"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("ritz carlton lake las vegas", topics.get("101").get("title"));
     assertEquals("tn highway patrol", topics.get("150").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.TREC2012_WEB);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("web.151-200"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("403b", topics.get("151").get("title"));
     assertEquals("ontario california airport", topics.get("200").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.TREC2013_WEB);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("web.201-250"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("raspberry pi", topics.get("201").get("title"));
     assertEquals("ford edge problems", topics.get("250").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.TREC2014_WEB);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("web.251-300"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("identifying spider bites", topics.get("251").get("title"));
@@ -419,7 +419,7 @@ public class TopicReaderTest {
   public void testMicoblogTopics() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.MB11);
+    topics = TopicReader.getTopics(Topics.get("microblog2011"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(1, (int) topics.firstKey());
@@ -427,7 +427,7 @@ public class TopicReaderTest {
     assertEquals(50, (int) topics.lastKey());
     assertEquals("war prisoners, Hatch Act", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.MB12);
+    topics = TopicReader.getTopics(Topics.get("microblog2012"));
     assertNotNull(topics);
     assertEquals(60, topics.size());
     assertEquals(51, (int) topics.firstKey());
@@ -435,7 +435,7 @@ public class TopicReaderTest {
     assertEquals(110, (int) topics.lastKey());
     assertEquals("economic trade sanctions", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.MB13);
+    topics = TopicReader.getTopics(Topics.get("microblog2013"));
     assertNotNull(topics);
     assertEquals(60, topics.size());
     assertEquals(111, (int) topics.firstKey());
@@ -443,7 +443,7 @@ public class TopicReaderTest {
     assertEquals(170, (int) topics.lastKey());
     assertEquals("Tony Mendez", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.MB14);
+    topics = TopicReader.getTopics(Topics.get("microblog2014"));
     assertNotNull(topics);
     assertEquals(55, topics.size());
     assertEquals(171, (int) topics.firstKey());
@@ -456,25 +456,25 @@ public class TopicReaderTest {
   public void testMicoblogTopics_TopicIdsAsStrings() throws IOException {
     Map<String, Map<String, String>> topics;
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.MB11);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("microblog2011"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("BBC World Service staff cuts", topics.get("1").get("title"));
     assertEquals("war prisoners, Hatch Act", topics.get("50").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.MB12);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("microblog2012"));
     assertNotNull(topics);
     assertEquals(60, topics.size());
     assertEquals("British Government cuts", topics.get("51").get("title"));
     assertEquals("economic trade sanctions", topics.get("110").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.MB13);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("microblog2013"));
     assertNotNull(topics);
     assertEquals(60, topics.size());
     assertEquals("water shortages", topics.get("111").get("title"));
     assertEquals("Tony Mendez", topics.get("170").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.MB14);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("microblog2014"));
     assertNotNull(topics);
     assertEquals(55, topics.size());
     assertEquals("Ron Weasley birthday", topics.get("171").get("title"));
@@ -485,7 +485,7 @@ public class TopicReaderTest {
   public void testCAR() throws IOException {
     SortedMap<String, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.CAR17V15_BENCHMARK_Y1_TEST);
+    topics = TopicReader.getTopics(Topics.get("car17v1.5.benchmarkY1test"));
     assertNotNull(topics);
     assertEquals(2125, topics.size());
     assertEquals("Aftertaste/Aftertaste%20processing%20in%20the%20cerebral%20cortex", topics.firstKey());
@@ -493,7 +493,7 @@ public class TopicReaderTest {
     assertEquals("Yellowstone%20National%20Park/Recreation", topics.lastKey());
     assertEquals("Yellowstone National Park/Recreation", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.CAR17V20_BENCHMARK_Y1_TEST);
+    topics = TopicReader.getTopics(Topics.get("car17v2.0.benchmarkY1test"));
     assertNotNull(topics);
     assertEquals(2254, topics.size());
     assertEquals("enwiki:Aftertaste", topics.firstKey());
@@ -506,7 +506,7 @@ public class TopicReaderTest {
   public void testCAR_TopicIdsAsStrings() throws IOException {
     Map<String, Map<String, String>> topics;
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.CAR17V15_BENCHMARK_Y1_TEST);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("car17v1.5.benchmarkY1test"));
     assertNotNull(topics);
     assertEquals(2125, topics.size());
     assertEquals("Aftertaste/Aftertaste processing in the cerebral cortex",
@@ -514,7 +514,7 @@ public class TopicReaderTest {
     assertEquals("Yellowstone National Park/Recreation",
         topics.get("Yellowstone%20National%20Park/Recreation").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.CAR17V20_BENCHMARK_Y1_TEST);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("car17v2.0.benchmarkY1test"));
     assertNotNull(topics);
     assertEquals(2254, topics.size());
     assertEquals("Aftertaste",
@@ -526,7 +526,7 @@ public class TopicReaderTest {
   public void testDprNq() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.DPR_NQ_DEV);
+    topics = TopicReader.getTopics(Topics.get("dpr.nq.dev"));
     assertNotNull(topics);
     assertEquals(8757, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -537,7 +537,7 @@ public class TopicReaderTest {
     assertEquals("['2010']", topics.get(topics.lastKey()).get("answers"));
     assertEquals("who did the artwork for pink floyd 's wall", topics.get(1726).get("title"));
 
-    topics = TopicReader.getTopics(Topics.DPR_NQ_TEST);
+    topics = TopicReader.getTopics(Topics.get("dpr.nq.test"));
     assertNotNull(topics);
     assertEquals(3610, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -553,7 +553,7 @@ public class TopicReaderTest {
   public void testDprTrivia() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.DPR_TRIVIA_DEV);
+    topics = TopicReader.getTopics(Topics.get("dpr.trivia.dev"));
     assertNotNull(topics);
     assertEquals(8837, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -563,7 +563,7 @@ public class TopicReaderTest {
     assertEquals("Name the artist and the title of this 1978 classic that remains popular today: We were at the beach Everybody had matching towels Somebody went under a dock And there they saw a rock It wasnt a rock", topics.get(topics.lastKey()).get("title"));
     assertEquals("['Rock Lobster by the B-52s']", topics.get(topics.lastKey()).get("answers"));
 
-    topics = TopicReader.getTopics(Topics.DPR_TRIVIA_TEST);
+    topics = TopicReader.getTopics(Topics.get("dpr.trivia.test"));
     assertNotNull(topics);
     assertEquals(11313, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -578,7 +578,7 @@ public class TopicReaderTest {
   public void testDprWq() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.DPR_WQ_TEST);
+    topics = TopicReader.getTopics(Topics.get("dpr.wq.test"));
     assertNotNull(topics);
     assertEquals(2032, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -593,7 +593,7 @@ public class TopicReaderTest {
   public void testDprCurated() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.DPR_CURATED_TEST);
+    topics = TopicReader.getTopics(Topics.get("dpr.curated.test"));
     assertNotNull(topics);
     assertEquals(694, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -608,7 +608,7 @@ public class TopicReaderTest {
   public void testDprSquad() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.DPR_SQUAD_TEST);
+    topics = TopicReader.getTopics(Topics.get("dpr.squad.test"));
     assertNotNull(topics);
     assertEquals(10570, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -623,7 +623,7 @@ public class TopicReaderTest {
   public void testNq() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.NQ_DEV);
+    topics = TopicReader.getTopics(Topics.get("nq.dev"));
     assertNotNull(topics);
     assertEquals(8757, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -634,7 +634,7 @@ public class TopicReaderTest {
     assertEquals("['2010']", topics.get(topics.lastKey()).get("answers"));
     assertEquals("who did the artwork for pink floyd's wall", topics.get(1726).get("title"));
 
-    topics = TopicReader.getTopics(Topics.NQ_TEST);
+    topics = TopicReader.getTopics(Topics.get("nq.test"));
     assertNotNull(topics);
     assertEquals(3610, topics.size());
     assertEquals(0, (int) topics.firstKey());
@@ -648,25 +648,25 @@ public class TopicReaderTest {
 
   @Test
   public void testGarT5Nq() throws IOException {
-    assertEquals(3610, TopicReader.getTopics(Topics.NQ_TEST_GART5_ANSWERS).keySet().size());
-    assertEquals(3610, TopicReader.getTopics(Topics.NQ_TEST_GART5_TITLES).keySet().size());
-    assertEquals(3610, TopicReader.getTopics(Topics.NQ_TEST_GART5_SENTENCES).keySet().size());
-    assertEquals(3610, TopicReader.getTopics(Topics.NQ_TEST_GART5_ALL).keySet().size());
+    assertEquals(3610, TopicReader.getTopics(Topics.get("nq.test.gar-t5.answers")).keySet().size());
+    assertEquals(3610, TopicReader.getTopics(Topics.get("nq.test.gar-t5.titles")).keySet().size());
+    assertEquals(3610, TopicReader.getTopics(Topics.get("nq.test.gar-t5.sentences")).keySet().size());
+    assertEquals(3610, TopicReader.getTopics(Topics.get("nq.test.gar-t5.all")).keySet().size());
   }
 
   @Test
   public void testGarT5Trivia() throws IOException {
-    assertEquals(11313, TopicReader.getTopics(Topics.DPR_TRIVIA_TEST_GART5_ANSWERS).keySet().size());
-    assertEquals(11313, TopicReader.getTopics(Topics.DPR_TRIVIA_TEST_GART5_TITLES).keySet().size());
-    assertEquals(11313, TopicReader.getTopics(Topics.DPR_TRIVIA_TEST_GART5_SENTENCES).keySet().size());
-    assertEquals(11313, TopicReader.getTopics(Topics.DPR_TRIVIA_TEST_GART5_ALL).keySet().size());
+    assertEquals(11313, TopicReader.getTopics(Topics.get("dpr.trivia.test.gar-t5.answers")).keySet().size());
+    assertEquals(11313, TopicReader.getTopics(Topics.get("dpr.trivia.test.gar-t5.titles")).keySet().size());
+    assertEquals(11313, TopicReader.getTopics(Topics.get("dpr.trivia.test.gar-t5.sentences")).keySet().size());
+    assertEquals(11313, TopicReader.getTopics(Topics.get("dpr.trivia.test.gar-t5.all")).keySet().size());
   }
 
   @Test
   public void testTREC19DL() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_PASSAGE);
+    topics = TopicReader.getTopics(Topics.get("dl19-passage"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -675,7 +675,7 @@ public class TopicReaderTest {
     assertEquals("how is the weather in jamaica", topics.get(topics.lastKey()).get("title"));
     assertEquals("does legionella pneumophila cause pneumonia", topics.get(168216).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_PASSAGE_WP);
+    topics = TopicReader.getTopics(Topics.get("dl19-passage.wp"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -684,7 +684,7 @@ public class TopicReaderTest {
     assertEquals("how is the weather in jamaica", topics.get(topics.lastKey()).get("title"));
     assertEquals("does legion ##ella p ##ne ##um ##op ##hila cause pneumonia", topics.get(168216).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_PASSAGE_UNICOIL);
+    topics = TopicReader.getTopics(Topics.get("dl19-passage.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -692,7 +692,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(595, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_PASSAGE_UNICOIL_NOEXP);
+    topics = TopicReader.getTopics(Topics.get("dl19-passage.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -700,7 +700,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(586, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_PASSAGE_SPLADE_DISTILL_COCODENSER_MEDIUM);
+    topics = TopicReader.getTopics(Topics.get("dl19-passage.splade_distil_cocodenser_medium"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -708,7 +708,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(1382, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_PASSAGE_SPLADE_PP_ED);
+    topics = TopicReader.getTopics(Topics.get("dl19-passage.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -716,7 +716,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(18791, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_PASSAGE_SPLADE_PP_SD);
+    topics = TopicReader.getTopics(Topics.get("dl19-passage.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -724,7 +724,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(17675, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_DOC);
+    topics = TopicReader.getTopics(Topics.get("dl19-doc"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -733,7 +733,7 @@ public class TopicReaderTest {
     assertEquals("how is the weather in jamaica", topics.get(topics.lastKey()).get("title"));
     assertEquals("how long to hold bow in yoga", topics.get(1132213).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_DOC_WP);
+    topics = TopicReader.getTopics(Topics.get("dl19-doc.wp"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -742,7 +742,7 @@ public class TopicReaderTest {
     assertEquals("how is the weather in jamaica", topics.get(topics.lastKey()).get("title"));
     assertEquals("how long to hold bow in yoga", topics.get(1132213).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_DOC_UNICOIL);
+    topics = TopicReader.getTopics(Topics.get("dl19-doc.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -750,7 +750,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(595, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_DOC_UNICOIL_NOEXP);
+    topics = TopicReader.getTopics(Topics.get("dl19-doc.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -758,7 +758,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(586, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_PASSAGE_SPLADE_DISTILL_COCODENSER_MEDIUM);
+    topics = TopicReader.getTopics(Topics.get("dl19-passage.splade_distil_cocodenser_medium"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -766,7 +766,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(1382, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_PASSAGE_SPLADE_PP_ED);
+    topics = TopicReader.getTopics(Topics.get("dl19-passage.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -774,7 +774,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(18791, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_PASSAGE_SPLADE_PP_SD);
+    topics = TopicReader.getTopics(Topics.get("dl19-passage.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -782,7 +782,7 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals(17675, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2019_DL_PASSAGE_COHERE_EMBED_ENGLISH_30);
+    topics = TopicReader.getTopics(Topics.get("dl19-passage.cohere-embed-english-v3.0"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
     assertEquals(19335, (int) topics.firstKey());
@@ -795,7 +795,7 @@ public class TopicReaderTest {
   public void testTREC20DL() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.TREC2020_DL);
+    topics = TopicReader.getTopics(Topics.get("dl20"));
     assertNotNull(topics);
     assertEquals(200, topics.size());
     assertEquals(3505, (int) topics.firstKey());
@@ -804,7 +804,7 @@ public class TopicReaderTest {
     assertEquals("why did the ancient egyptians call their land kemet, or black land?", topics.get(topics.lastKey()).get("title"));
     assertEquals("who is aziz hashim", topics.get(1030303).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2020_DL_WP);
+    topics = TopicReader.getTopics(Topics.get("dl20.wp"));
     assertNotNull(topics);
     assertEquals(200, topics.size());
     assertEquals(3505, (int) topics.firstKey());
@@ -813,7 +813,7 @@ public class TopicReaderTest {
     assertEquals("why did the ancient egyptians call their land ke ##met , or black land ?", topics.get(topics.lastKey()).get("title"));
     assertEquals("who is aziz hash ##im", topics.get(1030303).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2020_DL_UNICOIL);
+    topics = TopicReader.getTopics(Topics.get("dl20.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(200, topics.size());
     assertEquals(3505, (int) topics.firstKey());
@@ -821,7 +821,7 @@ public class TopicReaderTest {
     assertEquals(1136962, (int) topics.lastKey());
     assertEquals(1169, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2020_DL_UNICOIL_NOEXP);
+    topics = TopicReader.getTopics(Topics.get("dl20.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(200, topics.size());
     assertEquals(3505, (int) topics.firstKey());
@@ -829,7 +829,7 @@ public class TopicReaderTest {
     assertEquals(1136962, (int) topics.lastKey());
     assertEquals(1164, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2020_DL_SPLADE_DISTILL_COCODENSER_MEDIUM);
+    topics = TopicReader.getTopics(Topics.get("dl20.splade_distil_cocodenser_medium"));
     assertNotNull(topics);
     assertEquals(54, topics.size());
     assertEquals(23849, (int) topics.firstKey());
@@ -837,7 +837,7 @@ public class TopicReaderTest {
     assertEquals(1136962, (int) topics.lastKey());
     assertEquals(2075, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2020_DL_SPLADE_PP_ED);
+    topics = TopicReader.getTopics(Topics.get("dl20.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(200, topics.size());
     assertEquals(3505, (int) topics.firstKey());
@@ -845,7 +845,7 @@ public class TopicReaderTest {
     assertEquals(1136962, (int) topics.lastKey());
     assertEquals(25909, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2020_DL_SPLADE_PP_SD);
+    topics = TopicReader.getTopics(Topics.get("dl20.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(200, topics.size());
     assertEquals(3505, (int) topics.firstKey());
@@ -853,7 +853,7 @@ public class TopicReaderTest {
     assertEquals(1136962, (int) topics.lastKey());
     assertEquals(30994, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2020_DL_COHERE_EMBED_ENGLISH_30);
+    topics = TopicReader.getTopics(Topics.get("dl20.cohere-embed-english-v3.0"));
     assertNotNull(topics);
     assertEquals(200, topics.size());
     assertEquals(3505, (int) topics.firstKey());
@@ -866,7 +866,7 @@ public class TopicReaderTest {
   public void testTREC21DL() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.TREC2021_DL);
+    topics = TopicReader.getTopics(Topics.get("dl21"));
     assertNotNull(topics);
     assertEquals(477, topics.size());
     assertEquals(2082, (int) topics.firstKey());
@@ -875,7 +875,7 @@ public class TopicReaderTest {
     assertEquals("why does lacquered brass tarnish", topics.get(topics.lastKey()).get("title"));
     assertEquals("who killed nicholas ii of russia", topics.get(1043135).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2021_DL_UNICOIL);
+    topics = TopicReader.getTopics(Topics.get("dl21.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(477, topics.size());
     assertEquals(2082, (int) topics.firstKey());
@@ -883,7 +883,7 @@ public class TopicReaderTest {
     assertEquals(1136769, (int) topics.lastKey());
     assertEquals(712, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2021_DL_UNICOIL_NOEXP);
+    topics = TopicReader.getTopics(Topics.get("dl21.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(477, topics.size());
     assertEquals(2082, (int) topics.firstKey());
@@ -891,7 +891,7 @@ public class TopicReaderTest {
     assertEquals(1136769, (int) topics.lastKey());
     assertEquals(633, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2021_DL_SPLADE_PP_ED);
+    topics = TopicReader.getTopics(Topics.get("dl21.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(477, topics.size());
     assertEquals(2082, (int) topics.firstKey());
@@ -899,7 +899,7 @@ public class TopicReaderTest {
     assertEquals(1136769, (int) topics.lastKey());
     assertEquals(25398, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2021_DL_SPLADE_PP_SD);
+    topics = TopicReader.getTopics(Topics.get("dl21.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(477, topics.size());
     assertEquals(2082, (int) topics.firstKey());
@@ -907,7 +907,7 @@ public class TopicReaderTest {
     assertEquals(1136769, (int) topics.lastKey());
     assertEquals(27149, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2021_DL_SNOWFLAKE_ARCTIC_EMBED_L);
+    topics = TopicReader.getTopics(Topics.get("dl21.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(477, topics.size());
     assertEquals(2082, (int) topics.firstKey());
@@ -920,7 +920,7 @@ public class TopicReaderTest {
   public void testTREC22DL() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.TREC2022_DL);
+    topics = TopicReader.getTopics(Topics.get("dl22"));
     assertNotNull(topics);
     assertEquals(500, topics.size());
     assertEquals(588, (int) topics.firstKey());
@@ -929,7 +929,7 @@ public class TopicReaderTest {
     assertEquals("is a dairy farm considered as an agriculture", topics.get(topics.lastKey()).get("title"));
     assertEquals("how does magic leap optics work", topics.get(2056323).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2022_DL_UNICOIL);
+    topics = TopicReader.getTopics(Topics.get("dl22.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(500, topics.size());
     assertEquals(588, (int) topics.firstKey());
@@ -937,7 +937,7 @@ public class TopicReaderTest {
     assertEquals(2056473, (int) topics.lastKey());
     assertEquals(720, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2022_DL_UNICOIL_NOEXP);
+    topics = TopicReader.getTopics(Topics.get("dl22.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(500, topics.size());
     assertEquals(588, (int) topics.firstKey());
@@ -945,7 +945,7 @@ public class TopicReaderTest {
     assertEquals(2056473, (int) topics.lastKey());
     assertEquals(726, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2022_DL_SPLADE_PP_ED);
+    topics = TopicReader.getTopics(Topics.get("dl22.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(500, topics.size());
     assertEquals(588, (int) topics.firstKey());
@@ -953,7 +953,7 @@ public class TopicReaderTest {
     assertEquals(2056473, (int) topics.lastKey());
     assertEquals(28012, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2022_DL_SPLADE_PP_SD);
+    topics = TopicReader.getTopics(Topics.get("dl22.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(500, topics.size());
     assertEquals(588, (int) topics.firstKey());
@@ -961,7 +961,7 @@ public class TopicReaderTest {
     assertEquals(2056473, (int) topics.lastKey());
     assertEquals(33891, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2022_DL_SNOWFLAKE_ARCTIC_EMBED_L);
+    topics = TopicReader.getTopics(Topics.get("dl22.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(500, topics.size());
     assertEquals(588, (int) topics.firstKey());
@@ -974,7 +974,7 @@ public class TopicReaderTest {
   public void testTREC23DL() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.TREC2023_DL);
+    topics = TopicReader.getTopics(Topics.get("dl23"));
     assertNotNull(topics);
     assertEquals(700, topics.size());
     assertEquals(2000138, (int) topics.firstKey());
@@ -983,7 +983,7 @@ public class TopicReaderTest {
     assertEquals("How do birth control and hormone levels affect menstrual cycle variations?", topics.get(topics.lastKey()).get("title"));
     assertEquals("How do birth control and hormone levels affect menstrual cycle variations?", topics.get(3100949).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2023_DL_UNICOIL);
+    topics = TopicReader.getTopics(Topics.get("dl23.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(700, topics.size());
     assertEquals(2000138, (int) topics.firstKey());
@@ -991,7 +991,7 @@ public class TopicReaderTest {
     assertEquals(3100949, (int) topics.lastKey());
     assertEquals(31334, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2023_DL_UNICOIL_NOEXP);
+    topics = TopicReader.getTopics(Topics.get("dl23.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(700, topics.size());
     assertEquals(2000138, (int) topics.firstKey());
@@ -999,7 +999,7 @@ public class TopicReaderTest {
     assertEquals(3100949, (int) topics.lastKey());
     assertEquals(31283, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2023_DL_SPLADE_PP_ED);
+    topics = TopicReader.getTopics(Topics.get("dl23.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(700, topics.size());
     assertEquals(2000138, (int) topics.firstKey());
@@ -1007,7 +1007,7 @@ public class TopicReaderTest {
     assertEquals(3100949, (int) topics.lastKey());
     assertEquals(139500, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2023_DL_SPLADE_PP_SD);
+    topics = TopicReader.getTopics(Topics.get("dl23.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(700, topics.size());
     assertEquals(2000138, (int) topics.firstKey());
@@ -1015,7 +1015,7 @@ public class TopicReaderTest {
     assertEquals(3100949, (int) topics.lastKey());
     assertEquals(181700, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.TREC2023_DL_SNOWFLAKE_ARCTIC_EMBED_L);
+    topics = TopicReader.getTopics(Topics.get("dl23.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(700, topics.size());
     assertEquals(2000138, (int) topics.firstKey());
@@ -1028,7 +1028,7 @@ public class TopicReaderTest {
   public void testTREC24_RAG_RAGGY_DEV() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.TREC2024_RAG_RAGGY_DEV);
+    topics = TopicReader.getTopics(Topics.get("rag24.raggy-dev"));
     assertNotNull(topics);
     assertEquals(120, topics.size());
     assertEquals(23287, (int) topics.firstKey());
@@ -1037,7 +1037,7 @@ public class TopicReaderTest {
     assertEquals("Can older adults gain strength by training once per week?", topics.get(topics.lastKey()).get("title"));
     assertEquals("Can older adults gain strength by training once per week?", topics.get(3100918).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2024_RAG_RAGGY_DEV_SNOWFLAKE_ARCTIC_EMBED_L);
+    topics = TopicReader.getTopics(Topics.get("rag24.raggy-dev.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(120, topics.size());
     assertEquals(23287, (int) topics.firstKey());
@@ -1050,7 +1050,7 @@ public class TopicReaderTest {
   public void testTREC24_RAG_RESEARCHY_DEV() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.TREC2024_RAG_RESEARCHY_DEV);
+    topics = TopicReader.getTopics(Topics.get("rag24.researchy-dev"));
     assertNotNull(topics);
     assertEquals(600, topics.size());
     assertEquals(429, (int) topics.firstKey());
@@ -1059,7 +1059,7 @@ public class TopicReaderTest {
     assertEquals("how do video games improve problem solving", topics.get(topics.lastKey()).get("title"));
     assertEquals("how do video games improve problem solving", topics.get(1009569).get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2024_RAG_RESEARCHY_DEV_SNOWFLAKE_ARCTIC_EMBED_L);
+    topics = TopicReader.getTopics(Topics.get("rag24.researchy-dev.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(600, topics.size());
     assertEquals(429, (int) topics.firstKey());
@@ -1072,7 +1072,7 @@ public class TopicReaderTest {
   public void testTREC24_RAG_TEST() throws IOException {
     SortedMap<String, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.TREC2024_RAG_TEST);
+    topics = TopicReader.getTopics(Topics.get("rag24.test"));
     assertNotNull(topics);
     assertEquals(301, topics.size());
     assertEquals("2024-105741", topics.firstKey());
@@ -1081,7 +1081,7 @@ public class TopicReaderTest {
     assertEquals("how would advance electronics course impact students", topics.get(topics.lastKey()).get("title"));
     assertEquals("how the solar eclipse can affect mental health", topics.get("2024-79154").get("title"));
 
-    topics = TopicReader.getTopics(Topics.TREC2024_RAG_TEST_SNOWFLAKE_ARCTIC_EMBED_L);
+    topics = TopicReader.getTopics(Topics.get("rag24.test.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(301, topics.size());
     assertEquals("2024-105741", topics.firstKey());
@@ -1094,7 +1094,7 @@ public class TopicReaderTest {
   public void testTREC25_RAG_TEST() throws IOException {
     SortedMap<String, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.TREC2025_RAG_TEST);
+    topics = TopicReader.getTopics(Topics.get("rag25.test"));
     assertNotNull(topics);
     assertEquals(105, topics.size());
     assertEquals("100", topics.firstKey());
@@ -1108,7 +1108,7 @@ public class TopicReaderTest {
   public void testMSMARCO_V1() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_DOC_DEV);
+    topics = TopicReader.getTopics(Topics.get("msmarco-doc.dev"));
     assertNotNull(topics);
     assertEquals(5193, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1116,7 +1116,7 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals("why do bears hibernate", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_DOC_DEV_WP);
+    topics = TopicReader.getTopics(Topics.get("msmarco-doc.dev.wp"));
     assertNotNull(topics);
     assertEquals(5193, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1124,7 +1124,7 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals("why do bears hi ##ber ##nate", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_DOC_DEV_UNICOIL);
+    topics = TopicReader.getTopics(Topics.get("msmarco-doc.dev.unicoil"));
     assertNotNull(topics);
     assertEquals(5193, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1132,7 +1132,7 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(682, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_DOC_DEV_UNICOIL_NOEXP);
+    topics = TopicReader.getTopics(Topics.get("msmarco-doc.dev.unicoil-noexp"));
     assertNotNull(topics);
     assertEquals(5193, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1140,7 +1140,7 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(577, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_DOC_TEST);
+    topics = TopicReader.getTopics(Topics.get("msmarco-doc.test"));
     assertNotNull(topics);
     assertEquals(5793, topics.size());
     assertEquals(57, (int) topics.firstKey());
@@ -1148,7 +1148,7 @@ public class TopicReaderTest {
     assertEquals(1136966, (int) topics.lastKey());
     assertEquals("#ffffff color code", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_PASSAGE_DEV_SUBSET);
+    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1156,7 +1156,7 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals("why do bears hibernate", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_PASSAGE_DEV_SUBSET_WP);
+    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.wp"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1164,7 +1164,7 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals("why do bears hi ##ber ##nate", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_PASSAGE_DEV_SUBSET_DEEPIMPACT);
+    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.deepimpact"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1172,56 +1172,56 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals("why hibernate bears", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_PASSAGE_DEV_SUBSET_UNICOIL);
+    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.unicoil"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(619, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(686, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_PASSAGE_DEV_SUBSET_UNICOIL_NOEXP);
+    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.unicoil-noexp"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(609, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(577, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_PASSAGE_DEV_SUBSET_UNICOIL_TILDE);
+    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.unicoil-tilde-expansion"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(584, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(610, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_PASSAGE_DEV_SUBSET_DISTILL_SPLADE_MAX);
+    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.distill-splade-max"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(1991, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(2409, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_DISTILL_COCODENSER_MEDIUM);
+    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.splade_distil_cocodenser_medium"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(1695, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(1682, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_ED);
+    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(21944, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(24271, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_PASSAGE_DEV_SUBSET_SPLADE_PP_SD);
+    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(25539, topics.get(topics.firstKey()).get("title").split(" ").length);
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals(30718, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_PASSAGE_DEV_SUBSET_COHERE_EMBED_ENGLISH_30);
+    topics = TopicReader.getTopics(Topics.get("msmarco-passage.dev-subset.cohere-embed-english-v3.0"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1229,7 +1229,7 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals("[0.0107421875", topics.get(topics.lastKey()).get("vector").split(",")[0]);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_PASSAGE_TEST_SUBSET);
+    topics = TopicReader.getTopics(Topics.get("msmarco-passage.test-subset"));
     assertNotNull(topics);
     assertEquals(6837, topics.size());
     assertEquals(57, (int) topics.firstKey());
@@ -1242,7 +1242,7 @@ public class TopicReaderTest {
   public void testMSMARCO_V2() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_DOC_DEV);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-doc.dev"));
     assertNotNull(topics);
     assertEquals(4552, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1250,7 +1250,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals("why do children get aggressive", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_DOC_DEV_UNICOIL);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-doc.dev.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(4552, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1258,7 +1258,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals(608, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_DOC_DEV_UNICOIL_NOEXP);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-doc.dev.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(4552, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1266,7 +1266,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals(533, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_DOC_DEV_SNOWFLAKE_ARCTIC_EMBED_L);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-doc.dev.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(4552, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1274,7 +1274,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals("[-0.04409797489643097", topics.get(topics.lastKey()).get("vector").split(",")[0]);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_DOC_DEV2);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-doc.dev2"));
     assertNotNull(topics);
     assertEquals(5000, topics.size());
     assertEquals(361, (int) topics.firstKey());
@@ -1282,7 +1282,7 @@ public class TopicReaderTest {
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals("why do a ferritin level", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_DOC_DEV2_UNICOIL);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-doc.dev2.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(5000, topics.size());
     assertEquals(361, (int) topics.firstKey());
@@ -1290,7 +1290,7 @@ public class TopicReaderTest {
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals(664, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_DOC_DEV2_UNICOIL_NOEXP);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-doc.dev2.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(5000, topics.size());
     assertEquals(361, (int) topics.firstKey());
@@ -1298,7 +1298,7 @@ public class TopicReaderTest {
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals(537, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_DOC_DEV2_SNOWFLAKE_ARCTIC_EMBED_L);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-doc.dev2.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(5000, topics.size());
     assertEquals(361, (int) topics.firstKey());
@@ -1306,7 +1306,7 @@ public class TopicReaderTest {
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals("[0.006848456338047981", topics.get(topics.lastKey()).get("vector").split(",")[0]);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_PASSAGE_DEV);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev"));
     assertNotNull(topics);
     assertEquals(3903, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1314,7 +1314,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals("why do children get aggressive", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_PASSAGE_DEV_UNICOIL);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(3903, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1322,7 +1322,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals(608, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_PASSAGE_DEV_UNICOIL_NOEXP);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(3903, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1330,7 +1330,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals(533, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_PASSAGE_DEV_SPLADE_PP_ED);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(3903, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1338,7 +1338,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals(30978, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_PASSAGE_DEV_SPLADE_PP_SD);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(3903, topics.size());
     assertEquals(2, (int) topics.firstKey());
@@ -1346,7 +1346,7 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals(35354, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_PASSAGE_DEV2);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev2"));
     assertNotNull(topics);
     assertEquals(4281, topics.size());
     assertEquals(1325, (int) topics.firstKey());
@@ -1354,7 +1354,7 @@ public class TopicReaderTest {
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals("why do a ferritin level", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_PASSAGE_DEV2_UNICOIL);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev2.unicoil.0shot"));
     assertNotNull(topics);
     assertEquals(4281, topics.size());
     assertEquals(1325, (int) topics.firstKey());
@@ -1362,7 +1362,7 @@ public class TopicReaderTest {
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals(664, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_PASSAGE_DEV2_UNICOIL_NOEXP);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev2.unicoil-noexp.0shot"));
     assertNotNull(topics);
     assertEquals(4281, topics.size());
     assertEquals(1325, (int) topics.firstKey());
@@ -1370,7 +1370,7 @@ public class TopicReaderTest {
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals(537, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_PASSAGE_DEV2_SPLADE_PP_ED);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev2.splade-pp-ed"));
     assertNotNull(topics);
     assertEquals(4281, topics.size());
     assertEquals(1325, (int) topics.firstKey());
@@ -1378,7 +1378,7 @@ public class TopicReaderTest {
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals(18984, topics.get(topics.lastKey()).get("title").split(" ").length);
 
-    topics = TopicReader.getTopics(Topics.MSMARCO_V2_PASSAGE_DEV2_SPLADE_PP_SD);
+    topics = TopicReader.getTopics(Topics.get("msmarco-v2-passage.dev2.splade-pp-sd"));
     assertNotNull(topics);
     assertEquals(4281, topics.size());
     assertEquals(1325, (int) topics.firstKey());
@@ -1391,49 +1391,49 @@ public class TopicReaderTest {
   public void testMSMARO_TopicIdsAsStrings() throws IOException {
     Map<String, Map<String, String>> topics;
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.MSMARCO_DOC_DEV);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("msmarco-doc.dev"));
     assertNotNull(topics);
     assertEquals(5193, topics.size());
     assertEquals("androgen receptor define", topics.get("2").get("title"));
     assertEquals("why do bears hibernate", topics.get("1102400").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.MSMARCO_DOC_TEST);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("msmarco-doc.test"));
     assertNotNull(topics);
     assertEquals(5793, topics.size());
     assertEquals("term service agreement definition", topics.get("57").get("title"));
     assertEquals("#ffffff color code", topics.get("1136966").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.MSMARCO_PASSAGE_DEV_SUBSET);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("msmarco-passage.dev-subset"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
     assertEquals("Androgen receptor define", topics.get("2").get("title"));
     assertEquals("why do bears hibernate", topics.get("1102400").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.MSMARCO_PASSAGE_TEST_SUBSET);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("msmarco-passage.test-subset"));
     assertNotNull(topics);
     assertEquals(6837, topics.size());
     assertEquals("term service agreement definition", topics.get("57").get("title"));
     assertEquals("#ffffff color code", topics.get("1136966").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.MSMARCO_V2_DOC_DEV);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("msmarco-v2-doc.dev"));
     assertNotNull(topics);
     assertEquals(4552, topics.size());
     assertEquals("Androgen receptor define", topics.get("2").get("title"));
     assertEquals("why do children get aggressive", topics.get("1102390").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.MSMARCO_V2_DOC_DEV2);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("msmarco-v2-doc.dev2"));
     assertNotNull(topics);
     assertEquals(5000, topics.size());
     assertEquals(". irritability medical definition", topics.get("361").get("title"));
     assertEquals("why do a ferritin level", topics.get("1102413").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.MSMARCO_V2_PASSAGE_DEV);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("msmarco-v2-passage.dev"));
     assertNotNull(topics);
     assertEquals(3903, topics.size());
     assertEquals("Androgen receptor define", topics.get("2").get("title"));
     assertEquals("why do children get aggressive", topics.get("1102390").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.MSMARCO_V2_PASSAGE_DEV2);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("msmarco-v2-passage.dev2"));
     assertNotNull(topics);
     assertEquals(4281, topics.size());
     assertEquals("323 area code zip code", topics.get("1325").get("title"));
@@ -1444,7 +1444,7 @@ public class TopicReaderTest {
   public void testNonEnglishTopics1() throws IOException {
     SortedMap<String, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.NTCIR8_ZH);
+    topics = TopicReader.getTopics(Topics.get("ntcir8zh.eval"));
     assertNotNull(topics);
     assertEquals(73, topics.size());
     assertEquals("ACLIA2-CS-0002", topics.firstKey());
@@ -1452,7 +1452,7 @@ public class TopicReaderTest {
     assertEquals("ACLIA2-CS-0100", topics.lastKey());
     assertEquals("为什么美军占领了巴格达？", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.CLEF2006_FR);
+    topics = TopicReader.getTopics(Topics.get("clef06fr.mono.fr"));
     assertNotNull(topics);
     assertEquals(49, topics.size());
     assertEquals("301-AH", topics.firstKey());
@@ -1465,7 +1465,7 @@ public class TopicReaderTest {
   public void testNonEnglishTopics2() throws IOException {
       SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.TREC2002_AR);
+    topics = TopicReader.getTopics(Topics.get("trec02ar-ar"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(26, (int) topics.firstKey());
@@ -1473,7 +1473,7 @@ public class TopicReaderTest {
     assertEquals(75, (int) topics.lastKey());
     assertEquals("فيروسات الكمبيوتر في الوطن العربي", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.FIRE2012_BN);
+    topics = TopicReader.getTopics(Topics.get("fire12bn.176-225"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(176, (int) topics.firstKey());
@@ -1481,7 +1481,7 @@ public class TopicReaderTest {
     assertEquals(225, (int) topics.lastKey());
     assertEquals("স্যাটানিক ভার্সেস বিতর্ক", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.FIRE2012_HI);
+    topics = TopicReader.getTopics(Topics.get("fire12hi.176-225"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(176, (int) topics.firstKey());
@@ -1489,7 +1489,7 @@ public class TopicReaderTest {
     assertEquals(225, (int) topics.lastKey());
     assertEquals("सेटेनिक वर्सेज विवाद", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.getTopics(Topics.FIRE2012_EN);
+    topics = TopicReader.getTopics(Topics.get("fire12en.176-225"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals(176, (int) topics.firstKey());
@@ -1502,43 +1502,43 @@ public class TopicReaderTest {
   public void testNonEnglishTopics_TopicIdsAsStrings() throws IOException {
     Map<String, Map<String, String>> topics;
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.TREC1_ADHOC);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("adhoc.51-100"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("Airbus Subsidies", topics.get("51").get("title"));
     assertEquals("Controlling the Transfer of High Technology", topics.get("100").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.NTCIR8_ZH);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("ntcir8zh.eval"));
     assertNotNull(topics);
     assertEquals(73, topics.size());
     assertEquals("《千里走单骑》和张艺谋是什么关系？", topics.get("ACLIA2-CS-0002").get("title"));
     assertEquals("为什么美军占领了巴格达？", topics.get("ACLIA2-CS-0100").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.CLEF2006_FR);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("clef06fr.mono.fr"));
     assertNotNull(topics);
     assertEquals(49, topics.size());
     assertEquals("Les Produits Nestlé", topics.get("301-AH").get("title"));
     assertEquals("Le Décès d'Ayrton Senna", topics.get("350-AH").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.TREC2002_AR);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("trec02ar-ar"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("مجلس المقاومة الوطني الكردستاني", topics.get("26").get("title"));
     assertEquals("فيروسات الكمبيوتر في الوطن العربي", topics.get("75").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.FIRE2012_BN);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("fire12bn.176-225"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("ওয়াই এস আর রেড্ডির মৃত্যু", topics.get("176").get("title"));
     assertEquals("স্যাটানিক ভার্সেস বিতর্ক", topics.get("225").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.FIRE2012_HI);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("fire12hi.176-225"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("वाई एस आर रेड्डी की मौत", topics.get("176").get("title"));
     assertEquals("सेटेनिक वर्सेज विवाद", topics.get("225").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIds(Topics.FIRE2012_EN);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("fire12en.176-225"));
     assertNotNull(topics);
     assertEquals(50, topics.size());
     assertEquals("YSR Reddy death", topics.get("176").get("title"));
@@ -1550,7 +1550,7 @@ public class TopicReaderTest {
     Map<Integer, Map<String, String>> topics;
 
     // Round 1
-    topics = TopicReader.getTopics(Topics.COVID_ROUND1);
+    topics = TopicReader.getTopics(Topics.get("covid-round1"));
     assertEquals(30, topics.keySet().size());
 
     assertEquals("coronavirus origin", topics.get(1).get("query"));
@@ -1566,25 +1566,25 @@ public class TopicReaderTest {
         topics.get(30).get("narrative"));
 
     // Round 2
-    topics = TopicReader.getTopics(Topics.COVID_ROUND2);
+    topics = TopicReader.getTopics(Topics.get("covid-round2"));
     assertEquals(35, topics.keySet().size());
 
     assertEquals("coronavirus public datasets", topics.get(35).get("query"));
 
     // Round 3
-    topics = TopicReader.getTopics(Topics.COVID_ROUND3);
+    topics = TopicReader.getTopics(Topics.get("covid-round3"));
     assertEquals(40, topics.keySet().size());
 
     assertEquals("coronavirus mutations", topics.get(40).get("query"));
 
     // Round 4
-    topics = TopicReader.getTopics(Topics.COVID_ROUND4);
+    topics = TopicReader.getTopics(Topics.get("covid-round4"));
     assertEquals(45, topics.keySet().size());
 
     assertEquals("coronavirus mental health impact", topics.get(45).get("query"));
 
     // Round 5
-    topics = TopicReader.getTopics(Topics.COVID_ROUND5);
+    topics = TopicReader.getTopics(Topics.get("covid-round5"));
     assertEquals(50, topics.keySet().size());
 
     assertEquals("mRNA vaccine coronavirus", topics.get(50).get("query"));
@@ -1595,35 +1595,35 @@ public class TopicReaderTest {
     Map<Integer, Map<String, String>> topics;
 
     // Round 1
-    topics = TopicReader.getTopics(Topics.COVID_ROUND1_UDEL);
+    topics = TopicReader.getTopics(Topics.get("covid-round1-udel"));
     assertEquals(30, topics.keySet().size());
 
     assertEquals("coronavirus remdesivir remdesivir effective treatment COVID-19",
         topics.get(30).get("query"));
 
     // Round 2
-    topics = TopicReader.getTopics(Topics.COVID_ROUND2_UDEL);
+    topics = TopicReader.getTopics(Topics.get("covid-round2-udel"));
     assertEquals(35, topics.keySet().size());
 
     assertEquals("coronavirus public datasets public datasets COVID-19",
         topics.get(35).get("query"));
 
     // Round 3
-    topics = TopicReader.getTopics(Topics.COVID_ROUND3_UDEL);
+    topics = TopicReader.getTopics(Topics.get("covid-round3-udel"));
     assertEquals(40, topics.keySet().size());
 
     assertEquals("coronavirus mutations observed mutations SARS-CoV-2 genome mutations",
         topics.get(40).get("query"));
 
     // Round 4
-    topics = TopicReader.getTopics(Topics.COVID_ROUND4_UDEL);
+    topics = TopicReader.getTopics(Topics.get("covid-round4-udel"));
     assertEquals(45, topics.keySet().size());
 
     assertEquals("coronavirus mental health impact COVID-19 pandemic impacted mental health",
         topics.get(45).get("query"));
 
     // Round 5
-    topics = TopicReader.getTopics(Topics.COVID_ROUND5_UDEL);
+    topics = TopicReader.getTopics(Topics.get("covid-round5-udel"));
     assertEquals(50, topics.keySet().size());
 
     assertEquals("mRNA vaccine coronavirus mRNA vaccine SARS-CoV-2 virus",
@@ -1635,7 +1635,7 @@ public class TopicReaderTest {
     Map<String, Map<String, String>> topics;
 
     // Round 1
-    topics = TopicReader.getTopicsWithStringIds(Topics.COVID_ROUND1);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round1"));
 
     assertEquals(30, topics.keySet().size());
 
@@ -1652,25 +1652,25 @@ public class TopicReaderTest {
         topics.get("30").get("narrative"));
 
     // Round 2
-    topics = TopicReader.getTopicsWithStringIds(Topics.COVID_ROUND2);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round2"));
     assertEquals(35, topics.keySet().size());
 
     assertEquals("coronavirus public datasets", topics.get("35").get("query"));
 
     // Round 3
-    topics = TopicReader.getTopicsWithStringIds(Topics.COVID_ROUND3);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round3"));
     assertEquals(40, topics.keySet().size());
 
     assertEquals("coronavirus mutations", topics.get("40").get("query"));
 
     // Round 4
-    topics = TopicReader.getTopicsWithStringIds(Topics.COVID_ROUND4);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round4"));
     assertEquals(45, topics.keySet().size());
 
     assertEquals("coronavirus mental health impact", topics.get("45").get("query"));
 
     // Round 5
-    topics = TopicReader.getTopicsWithStringIds(Topics.COVID_ROUND5);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round5"));
     assertEquals(50, topics.keySet().size());
 
     assertEquals("mRNA vaccine coronavirus", topics.get("50").get("query"));
@@ -1681,35 +1681,35 @@ public class TopicReaderTest {
     Map<String, Map<String, String>> topics;
 
     // Round 1
-    topics = TopicReader.getTopicsWithStringIds(Topics.COVID_ROUND1_UDEL);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round1-udel"));
     assertEquals(30, topics.keySet().size());
 
     assertEquals("coronavirus remdesivir remdesivir effective treatment COVID-19",
         topics.get("30").get("query"));
 
     // Round 2
-    topics = TopicReader.getTopicsWithStringIds(Topics.COVID_ROUND2_UDEL);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round2-udel"));
     assertEquals(35, topics.keySet().size());
 
     assertEquals("coronavirus public datasets public datasets COVID-19",
         topics.get("35").get("query"));
 
     // Round 3
-    topics = TopicReader.getTopicsWithStringIds(Topics.COVID_ROUND3_UDEL);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round3-udel"));
     assertEquals(40, topics.keySet().size());
 
     assertEquals("coronavirus mutations observed mutations SARS-CoV-2 genome mutations",
         topics.get("40").get("query"));
 
     // Round 4
-    topics = TopicReader.getTopicsWithStringIds(Topics.COVID_ROUND4_UDEL);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round4-udel"));
     assertEquals(45, topics.keySet().size());
 
     assertEquals("coronavirus mental health impact COVID-19 pandemic impacted mental health",
         topics.get("45").get("query"));
 
     // Round 5
-    topics = TopicReader.getTopicsWithStringIds(Topics.COVID_ROUND5_UDEL);
+    topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round5-udel"));
     assertEquals(50, topics.keySet().size());
 
     assertEquals("mRNA vaccine coronavirus mRNA vaccine SARS-CoV-2 virus",
@@ -1720,7 +1720,7 @@ public class TopicReaderTest {
   public void testBackgroundLinkingTopics() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
-    topics = TopicReader.getTopics(Topics.TREC2018_BL);
+    topics = TopicReader.getTopics(Topics.get("backgroundlinking18"));
 
     assertEquals(50, topics.keySet().size());
     assertEquals(321, (int) topics.firstKey());
@@ -1735,7 +1735,7 @@ public class TopicReaderTest {
         "cellulosic-ethanol-once-the-way-of-the-future-is-off-to-a-delayed-boisterous-start/" +
         "2013/11/08/a1c41a70-35c7-11e3-8a0e-4e2cf80831fc_story.html", topics.get(topics.lastKey()).get("url"));
 
-    topics = TopicReader.getTopics(Topics.TREC2019_BL);
+    topics = TopicReader.getTopics(Topics.get("backgroundlinking19"));
     
     assertEquals(60, topics.keySet().size());
     assertEquals(826, (int) topics.firstKey());
@@ -1750,7 +1750,7 @@ public class TopicReaderTest {
         "sun-erupts-to-mark-another-bastille-day-aurora-possible-in-new-england-sunday-night/",
         topics.get(topics.lastKey()).get("url"));
 
-    topics = TopicReader.getTopics(Topics.TREC2020_BL);
+    topics = TopicReader.getTopics(Topics.get("backgroundlinking20"));
 
     assertEquals(50, topics.keySet().size());
     assertEquals(886, (int) topics.firstKey());
@@ -1769,7 +1769,7 @@ public class TopicReaderTest {
   @Test
   public void testEpidemicQATopics() throws IOException {
     SortedMap<Integer, Map<String, String>> consumerTopics;
-    consumerTopics = TopicReader.getTopics(Topics.EPIDEMIC_QA_CONSUMER_PRELIM);
+    consumerTopics = TopicReader.getTopics(Topics.get("epidemic-qa.consumer.prelim"));
 
     // No consumer questions from CQ035 to CQ037
     assertEquals(42, consumerTopics.keySet().size());
@@ -1795,7 +1795,7 @@ public class TopicReaderTest {
                  consumerTopics.get(consumerTopics.lastKey()).get("background"));
 
     SortedMap<Integer, Map<String, String>> expertTopics;
-    expertTopics = TopicReader.getTopics(Topics.EPIDEMIC_QA_EXPERT_PRELIM);
+    expertTopics = TopicReader.getTopics(Topics.get("epidemic-qa.expert.prelim"));
 
     assertEquals(45, expertTopics.keySet().size());
 
@@ -1821,197 +1821,197 @@ public class TopicReaderTest {
 
   @Test
   public void testMrTyDiTopics() throws IOException {
-    assertEquals(12377, TopicReader.getTopics(Topics.MRTYDI_V11_AR_TRAIN).keySet().size());
-    assertEquals(3115, TopicReader.getTopics(Topics.MRTYDI_V11_AR_DEV).keySet().size());
-    assertEquals(1081, TopicReader.getTopics(Topics.MRTYDI_V11_AR_TEST).keySet().size());
+    assertEquals(12377, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ar.train")).keySet().size());
+    assertEquals(3115, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ar.dev")).keySet().size());
+    assertEquals(1081, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ar.test")).keySet().size());
 
-    assertEquals(1713, TopicReader.getTopics(Topics.MRTYDI_V11_BN_TRAIN).keySet().size());
-    assertEquals(440, TopicReader.getTopics(Topics.MRTYDI_V11_BN_DEV).keySet().size());
-    assertEquals(111, TopicReader.getTopics(Topics.MRTYDI_V11_BN_TEST).keySet().size());
+    assertEquals(1713, TopicReader.getTopics(Topics.get("mrtydi-v1.1-bn.train")).keySet().size());
+    assertEquals(440, TopicReader.getTopics(Topics.get("mrtydi-v1.1-bn.dev")).keySet().size());
+    assertEquals(111, TopicReader.getTopics(Topics.get("mrtydi-v1.1-bn.test")).keySet().size());
 
-    assertEquals(3547, TopicReader.getTopics(Topics.MRTYDI_V11_EN_TRAIN).keySet().size());
-    assertEquals(878, TopicReader.getTopics(Topics.MRTYDI_V11_EN_DEV).keySet().size());
-    assertEquals(744, TopicReader.getTopics(Topics.MRTYDI_V11_EN_TEST).keySet().size());
+    assertEquals(3547, TopicReader.getTopics(Topics.get("mrtydi-v1.1-en.train")).keySet().size());
+    assertEquals(878, TopicReader.getTopics(Topics.get("mrtydi-v1.1-en.dev")).keySet().size());
+    assertEquals(744, TopicReader.getTopics(Topics.get("mrtydi-v1.1-en.test")).keySet().size());
 
-    assertEquals(6561, TopicReader.getTopics(Topics.MRTYDI_V11_FI_TRAIN).keySet().size());
-    assertEquals(1738, TopicReader.getTopics(Topics.MRTYDI_V11_FI_DEV).keySet().size());
-    assertEquals(1254, TopicReader.getTopics(Topics.MRTYDI_V11_FI_TEST).keySet().size());
+    assertEquals(6561, TopicReader.getTopics(Topics.get("mrtydi-v1.1-fi.train")).keySet().size());
+    assertEquals(1738, TopicReader.getTopics(Topics.get("mrtydi-v1.1-fi.dev")).keySet().size());
+    assertEquals(1254, TopicReader.getTopics(Topics.get("mrtydi-v1.1-fi.test")).keySet().size());
 
-    assertEquals(4902, TopicReader.getTopics(Topics.MRTYDI_V11_ID_TRAIN).keySet().size());
-    assertEquals(1224, TopicReader.getTopics(Topics.MRTYDI_V11_ID_DEV).keySet().size());
-    assertEquals(829, TopicReader.getTopics(Topics.MRTYDI_V11_ID_TEST).keySet().size());
+    assertEquals(4902, TopicReader.getTopics(Topics.get("mrtydi-v1.1-id.train")).keySet().size());
+    assertEquals(1224, TopicReader.getTopics(Topics.get("mrtydi-v1.1-id.dev")).keySet().size());
+    assertEquals(829, TopicReader.getTopics(Topics.get("mrtydi-v1.1-id.test")).keySet().size());
 
-    assertEquals(3697, TopicReader.getTopics(Topics.MRTYDI_V11_JA_TRAIN).keySet().size());
-    assertEquals(928, TopicReader.getTopics(Topics.MRTYDI_V11_JA_DEV).keySet().size());
-    assertEquals(720, TopicReader.getTopics(Topics.MRTYDI_V11_JA_TEST).keySet().size());
+    assertEquals(3697, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ja.train")).keySet().size());
+    assertEquals(928, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ja.dev")).keySet().size());
+    assertEquals(720, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ja.test")).keySet().size());
 
-    assertEquals(1295, TopicReader.getTopics(Topics.MRTYDI_V11_KO_TRAIN).keySet().size());
-    assertEquals(303, TopicReader.getTopics(Topics.MRTYDI_V11_KO_DEV).keySet().size());
-    assertEquals(421, TopicReader.getTopics(Topics.MRTYDI_V11_KO_TEST).keySet().size());
+    assertEquals(1295, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ko.train")).keySet().size());
+    assertEquals(303, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ko.dev")).keySet().size());
+    assertEquals(421, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ko.test")).keySet().size());
 
-    assertEquals(5366, TopicReader.getTopics(Topics.MRTYDI_V11_RU_TRAIN).keySet().size());
-    assertEquals(1375, TopicReader.getTopics(Topics.MRTYDI_V11_RU_DEV).keySet().size());
-    assertEquals(995, TopicReader.getTopics(Topics.MRTYDI_V11_RU_TEST).keySet().size());
+    assertEquals(5366, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ru.train")).keySet().size());
+    assertEquals(1375, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ru.dev")).keySet().size());
+    assertEquals(995, TopicReader.getTopics(Topics.get("mrtydi-v1.1-ru.test")).keySet().size());
 
-    assertEquals(2072, TopicReader.getTopics(Topics.MRTYDI_V11_SW_TRAIN).keySet().size());
-    assertEquals(526, TopicReader.getTopics(Topics.MRTYDI_V11_SW_DEV).keySet().size());
-    assertEquals(670, TopicReader.getTopics(Topics.MRTYDI_V11_SW_TEST).keySet().size());
+    assertEquals(2072, TopicReader.getTopics(Topics.get("mrtydi-v1.1-sw.train")).keySet().size());
+    assertEquals(526, TopicReader.getTopics(Topics.get("mrtydi-v1.1-sw.dev")).keySet().size());
+    assertEquals(670, TopicReader.getTopics(Topics.get("mrtydi-v1.1-sw.test")).keySet().size());
 
-    assertEquals(3880, TopicReader.getTopics(Topics.MRTYDI_V11_TE_TRAIN).keySet().size());
-    assertEquals(983, TopicReader.getTopics(Topics.MRTYDI_V11_TE_DEV).keySet().size());
-    assertEquals(646, TopicReader.getTopics(Topics.MRTYDI_V11_TE_TEST).keySet().size());
+    assertEquals(3880, TopicReader.getTopics(Topics.get("mrtydi-v1.1-te.train")).keySet().size());
+    assertEquals(983, TopicReader.getTopics(Topics.get("mrtydi-v1.1-te.dev")).keySet().size());
+    assertEquals(646, TopicReader.getTopics(Topics.get("mrtydi-v1.1-te.test")).keySet().size());
 
-    assertEquals(3319, TopicReader.getTopics(Topics.MRTYDI_V11_TH_TRAIN).keySet().size());
-    assertEquals(807, TopicReader.getTopics(Topics.MRTYDI_V11_TH_DEV).keySet().size());
-    assertEquals(1190, TopicReader.getTopics(Topics.MRTYDI_V11_TH_TEST).keySet().size());
+    assertEquals(3319, TopicReader.getTopics(Topics.get("mrtydi-v1.1-th.train")).keySet().size());
+    assertEquals(807, TopicReader.getTopics(Topics.get("mrtydi-v1.1-th.dev")).keySet().size());
+    assertEquals(1190, TopicReader.getTopics(Topics.get("mrtydi-v1.1-th.test")).keySet().size());
   }
 
   @Test
   public void testBeirTopics() throws IOException {
-    assertEquals(50,    TopicReader.getTopics(Topics.BEIR_V1_0_0_TREC_COVID_TEST).keySet().size());
-    assertEquals(500,   TopicReader.getTopics(Topics.BEIR_V1_0_0_BIOASQ_TEST).keySet().size());
-    assertEquals(323,   TopicReader.getTopics(Topics.BEIR_V1_0_0_NFCORPUS_TEST).keySet().size());
-    assertEquals(3452,  TopicReader.getTopics(Topics.BEIR_V1_0_0_NQ_TEST).keySet().size());
-    assertEquals(7405,  TopicReader.getTopics(Topics.BEIR_V1_0_0_HOTPOTQA_TEST).keySet().size());
-    assertEquals(648,   TopicReader.getTopics(Topics.BEIR_V1_0_0_FIQA_TEST).keySet().size());
-    assertEquals(97,    TopicReader.getTopics(Topics.BEIR_V1_0_0_SIGNAL1M_TEST).keySet().size());
-    assertEquals(57,    TopicReader.getTopics(Topics.BEIR_V1_0_0_TREC_NEWS_TEST).keySet().size());
-    assertEquals(249,   TopicReader.getTopics(Topics.BEIR_V1_0_0_ROBUST04_TEST).keySet().size());
-    assertEquals(1406,  TopicReader.getTopics(Topics.BEIR_V1_0_0_ARGUANA_TEST).keySet().size());
-    assertEquals(49,    TopicReader.getTopics(Topics.BEIR_V1_0_0_WEBIS_TOUCHE2020_TEST).keySet().size());
-    assertEquals(699,   TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_ANDROID_TEST).keySet().size());
-    assertEquals(1570,  TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_ENGLISH_TEST).keySet().size());
-    assertEquals(1595,  TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_GAMING_TEST).keySet().size());
-    assertEquals(885,   TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_GIS_TEST).keySet().size());
-    assertEquals(804,   TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_MATHEMATICA_TEST).keySet().size());
-    assertEquals(1039,  TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_PHYSICS_TEST).keySet().size());
-    assertEquals(876,   TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_PROGRAMMERS_TEST).keySet().size());
-    assertEquals(652,   TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_STATS_TEST).keySet().size());
-    assertEquals(2906,  TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_TEX_TEST).keySet().size());
-    assertEquals(1072,  TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_UNIX_TEST).keySet().size());
-    assertEquals(506,   TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_WEBMASTERS_TEST).keySet().size());
-    assertEquals(541,   TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_WORDPRESS_TEST).keySet().size());
-    assertEquals(10000, TopicReader.getTopics(Topics.BEIR_V1_0_0_QUORA_TEST).keySet().size());
-    assertEquals(400,   TopicReader.getTopics(Topics.BEIR_V1_0_0_DBPEDIA_ENTITY_TEST).keySet().size());
-    assertEquals(1000,  TopicReader.getTopics(Topics.BEIR_V1_0_0_SCIDOCS_TEST).keySet().size());
-    assertEquals(6666,  TopicReader.getTopics(Topics.BEIR_V1_0_0_FEVER_TEST).keySet().size());
-    assertEquals(1535,  TopicReader.getTopics(Topics.BEIR_V1_0_0_CLIMATE_FEVER_TEST).keySet().size());
-    assertEquals(300,   TopicReader.getTopics(Topics.BEIR_V1_0_0_SCIFACT_TEST).keySet().size());
+    assertEquals(50,    TopicReader.getTopics(Topics.get("beir-v1.0.0-trec-covid.test")).keySet().size());
+    assertEquals(500,   TopicReader.getTopics(Topics.get("beir-v1.0.0-bioasq.test")).keySet().size());
+    assertEquals(323,   TopicReader.getTopics(Topics.get("beir-v1.0.0-nfcorpus.test")).keySet().size());
+    assertEquals(3452,  TopicReader.getTopics(Topics.get("beir-v1.0.0-nq.test")).keySet().size());
+    assertEquals(7405,  TopicReader.getTopics(Topics.get("beir-v1.0.0-hotpotqa.test")).keySet().size());
+    assertEquals(648,   TopicReader.getTopics(Topics.get("beir-v1.0.0-fiqa.test")).keySet().size());
+    assertEquals(97,    TopicReader.getTopics(Topics.get("beir-v1.0.0-signal1m.test")).keySet().size());
+    assertEquals(57,    TopicReader.getTopics(Topics.get("beir-v1.0.0-trec-news.test")).keySet().size());
+    assertEquals(249,   TopicReader.getTopics(Topics.get("beir-v1.0.0-robust04.test")).keySet().size());
+    assertEquals(1406,  TopicReader.getTopics(Topics.get("beir-v1.0.0-arguana.test")).keySet().size());
+    assertEquals(49,    TopicReader.getTopics(Topics.get("beir-v1.0.0-webis-touche2020.test")).keySet().size());
+    assertEquals(699,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-android.test")).keySet().size());
+    assertEquals(1570,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-english.test")).keySet().size());
+    assertEquals(1595,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-gaming.test")).keySet().size());
+    assertEquals(885,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-gis.test")).keySet().size());
+    assertEquals(804,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-mathematica.test")).keySet().size());
+    assertEquals(1039,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-physics.test")).keySet().size());
+    assertEquals(876,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-programmers.test")).keySet().size());
+    assertEquals(652,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-stats.test")).keySet().size());
+    assertEquals(2906,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-tex.test")).keySet().size());
+    assertEquals(1072,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-unix.test")).keySet().size());
+    assertEquals(506,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-webmasters.test")).keySet().size());
+    assertEquals(541,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-wordpress.test")).keySet().size());
+    assertEquals(10000, TopicReader.getTopics(Topics.get("beir-v1.0.0-quora.test")).keySet().size());
+    assertEquals(400,   TopicReader.getTopics(Topics.get("beir-v1.0.0-dbpedia-entity.test")).keySet().size());
+    assertEquals(1000,  TopicReader.getTopics(Topics.get("beir-v1.0.0-scidocs.test")).keySet().size());
+    assertEquals(6666,  TopicReader.getTopics(Topics.get("beir-v1.0.0-fever.test")).keySet().size());
+    assertEquals(1535,  TopicReader.getTopics(Topics.get("beir-v1.0.0-climate-fever.test")).keySet().size());
+    assertEquals(300,   TopicReader.getTopics(Topics.get("beir-v1.0.0-scifact.test")).keySet().size());
   }
 
   @Test
   public void testBeirWPTopics() throws IOException {
-    assertEquals(50,    TopicReader.getTopics(Topics.BEIR_V1_0_0_TREC_COVID_TEST_WP).keySet().size());
-    assertEquals(500,   TopicReader.getTopics(Topics.BEIR_V1_0_0_BIOASQ_TEST_WP).keySet().size());
-    assertEquals(323,   TopicReader.getTopics(Topics.BEIR_V1_0_0_NFCORPUS_TEST_WP).keySet().size());
-    assertEquals(3452,  TopicReader.getTopics(Topics.BEIR_V1_0_0_NQ_TEST_WP).keySet().size());
-    assertEquals(7405,  TopicReader.getTopics(Topics.BEIR_V1_0_0_HOTPOTQA_TEST_WP).keySet().size());
-    assertEquals(648,   TopicReader.getTopics(Topics.BEIR_V1_0_0_FIQA_TEST_WP).keySet().size());
-    assertEquals(97,    TopicReader.getTopics(Topics.BEIR_V1_0_0_SIGNAL1M_TEST_WP).keySet().size());
-    assertEquals(57,    TopicReader.getTopics(Topics.BEIR_V1_0_0_TREC_NEWS_TEST_WP).keySet().size());
-    assertEquals(249,   TopicReader.getTopics(Topics.BEIR_V1_0_0_ROBUST04_TEST_WP).keySet().size());
-    assertEquals(1406,  TopicReader.getTopics(Topics.BEIR_V1_0_0_ARGUANA_TEST_WP).keySet().size());
-    assertEquals(49,    TopicReader.getTopics(Topics.BEIR_V1_0_0_WEBIS_TOUCHE2020_TEST_WP).keySet().size());
-    assertEquals(699,   TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_ANDROID_TEST_WP).keySet().size());
-    assertEquals(1570,  TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_ENGLISH_TEST_WP).keySet().size());
-    assertEquals(1595,  TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_GAMING_TEST_WP).keySet().size());
-    assertEquals(885,   TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_GIS_TEST_WP).keySet().size());
-    assertEquals(804,   TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_MATHEMATICA_TEST_WP).keySet().size());
-    assertEquals(1039,  TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_PHYSICS_TEST_WP).keySet().size());
-    assertEquals(876,   TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_PROGRAMMERS_TEST_WP).keySet().size());
-    assertEquals(652,   TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_STATS_TEST_WP).keySet().size());
-    assertEquals(2906,  TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_TEX_TEST_WP).keySet().size());
-    assertEquals(1072,  TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_UNIX_TEST_WP).keySet().size());
-    assertEquals(506,   TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_WEBMASTERS_TEST_WP).keySet().size());
-    assertEquals(541,   TopicReader.getTopics(Topics.BEIR_V1_0_0_CQADUPSTACK_WORDPRESS_TEST_WP).keySet().size());
-    assertEquals(10000, TopicReader.getTopics(Topics.BEIR_V1_0_0_QUORA_TEST_WP).keySet().size());
-    assertEquals(400,   TopicReader.getTopics(Topics.BEIR_V1_0_0_DBPEDIA_ENTITY_TEST_WP).keySet().size());
-    assertEquals(1000,  TopicReader.getTopics(Topics.BEIR_V1_0_0_SCIDOCS_TEST_WP).keySet().size());
-    assertEquals(6666,  TopicReader.getTopics(Topics.BEIR_V1_0_0_FEVER_TEST_WP).keySet().size());
-    assertEquals(1535,  TopicReader.getTopics(Topics.BEIR_V1_0_0_CLIMATE_FEVER_TEST_WP).keySet().size());
-    assertEquals(300,   TopicReader.getTopics(Topics.BEIR_V1_0_0_SCIFACT_TEST_WP).keySet().size());
+    assertEquals(50,    TopicReader.getTopics(Topics.get("beir-v1.0.0-trec-covid.test.wp")).keySet().size());
+    assertEquals(500,   TopicReader.getTopics(Topics.get("beir-v1.0.0-bioasq.test.wp")).keySet().size());
+    assertEquals(323,   TopicReader.getTopics(Topics.get("beir-v1.0.0-nfcorpus.test.wp")).keySet().size());
+    assertEquals(3452,  TopicReader.getTopics(Topics.get("beir-v1.0.0-nq.test.wp")).keySet().size());
+    assertEquals(7405,  TopicReader.getTopics(Topics.get("beir-v1.0.0-hotpotqa.test.wp")).keySet().size());
+    assertEquals(648,   TopicReader.getTopics(Topics.get("beir-v1.0.0-fiqa.test.wp")).keySet().size());
+    assertEquals(97,    TopicReader.getTopics(Topics.get("beir-v1.0.0-signal1m.test.wp")).keySet().size());
+    assertEquals(57,    TopicReader.getTopics(Topics.get("beir-v1.0.0-trec-news.test.wp")).keySet().size());
+    assertEquals(249,   TopicReader.getTopics(Topics.get("beir-v1.0.0-robust04.test.wp")).keySet().size());
+    assertEquals(1406,  TopicReader.getTopics(Topics.get("beir-v1.0.0-arguana.test.wp")).keySet().size());
+    assertEquals(49,    TopicReader.getTopics(Topics.get("beir-v1.0.0-webis-touche2020.test.wp")).keySet().size());
+    assertEquals(699,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-android.test.wp")).keySet().size());
+    assertEquals(1570,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-english.test.wp")).keySet().size());
+    assertEquals(1595,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-gaming.test.wp")).keySet().size());
+    assertEquals(885,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-gis.test.wp")).keySet().size());
+    assertEquals(804,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-mathematica.test.wp")).keySet().size());
+    assertEquals(1039,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-physics.test.wp")).keySet().size());
+    assertEquals(876,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-programmers.test.wp")).keySet().size());
+    assertEquals(652,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-stats.test.wp")).keySet().size());
+    assertEquals(2906,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-tex.test.wp")).keySet().size());
+    assertEquals(1072,  TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-unix.test.wp")).keySet().size());
+    assertEquals(506,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-webmasters.test.wp")).keySet().size());
+    assertEquals(541,   TopicReader.getTopics(Topics.get("beir-v1.0.0-cqadupstack-wordpress.test.wp")).keySet().size());
+    assertEquals(10000, TopicReader.getTopics(Topics.get("beir-v1.0.0-quora.test.wp")).keySet().size());
+    assertEquals(400,   TopicReader.getTopics(Topics.get("beir-v1.0.0-dbpedia-entity.test.wp")).keySet().size());
+    assertEquals(1000,  TopicReader.getTopics(Topics.get("beir-v1.0.0-scidocs.test.wp")).keySet().size());
+    assertEquals(6666,  TopicReader.getTopics(Topics.get("beir-v1.0.0-fever.test.wp")).keySet().size());
+    assertEquals(1535,  TopicReader.getTopics(Topics.get("beir-v1.0.0-climate-fever.test.wp")).keySet().size());
+    assertEquals(300,   TopicReader.getTopics(Topics.get("beir-v1.0.0-scifact.test.wp")).keySet().size());
   }
 
   @Test
   public void testBrightTopics() throws IOException {
-    assertEquals(103, TopicReader.getTopics(Topics.BRIGHT_BIOLOGY).keySet().size());
-    assertEquals(116, TopicReader.getTopics(Topics.BRIGHT_EARTH_SCIENCE).keySet().size());
-    assertEquals(103, TopicReader.getTopics(Topics.BRIGHT_ECONOMICS).keySet().size());
-    assertEquals(101, TopicReader.getTopics(Topics.BRIGHT_PSYCHOLOGY).keySet().size());
-    assertEquals(101, TopicReader.getTopics(Topics.BRIGHT_ROBOTICS).keySet().size());
-    assertEquals(117, TopicReader.getTopics(Topics.BRIGHT_STACKOVERFLOW).keySet().size());
-    assertEquals(108, TopicReader.getTopics(Topics.BRIGHT_SUSTAINABLE_LIVING).keySet().size());
-    assertEquals(112, TopicReader.getTopics(Topics.BRIGHT_PONY).keySet().size());
-    assertEquals(142, TopicReader.getTopics(Topics.BRIGHT_LEETCODE).keySet().size());
-    assertEquals(111, TopicReader.getTopics(Topics.BRIGHT_AOPS).keySet().size());
-    assertEquals(76, TopicReader.getTopics(Topics.BRIGHT_THEOREMQA_THEOREMS).keySet().size());
-    assertEquals(194, TopicReader.getTopics(Topics.BRIGHT_THEOREMQA_QUESTIONS).keySet().size());
+    assertEquals(103, TopicReader.getTopics(Topics.get("bright-biology")).keySet().size());
+    assertEquals(116, TopicReader.getTopics(Topics.get("bright-earth-science")).keySet().size());
+    assertEquals(103, TopicReader.getTopics(Topics.get("bright-economics")).keySet().size());
+    assertEquals(101, TopicReader.getTopics(Topics.get("bright-psychology")).keySet().size());
+    assertEquals(101, TopicReader.getTopics(Topics.get("bright-robotics")).keySet().size());
+    assertEquals(117, TopicReader.getTopics(Topics.get("bright-stackoverflow")).keySet().size());
+    assertEquals(108, TopicReader.getTopics(Topics.get("bright-sustainable-living")).keySet().size());
+    assertEquals(112, TopicReader.getTopics(Topics.get("bright-pony")).keySet().size());
+    assertEquals(142, TopicReader.getTopics(Topics.get("bright-leetcode")).keySet().size());
+    assertEquals(111, TopicReader.getTopics(Topics.get("bright-aops")).keySet().size());
+    assertEquals(76, TopicReader.getTopics(Topics.get("bright-theoremqa-theorems")).keySet().size());
+    assertEquals(194, TopicReader.getTopics(Topics.get("bright-theoremqa-questions")).keySet().size());
   }
 
   @Test
   public void testBrightOriginalTopics() throws IOException {
-    assertEquals(103, TopicReader.getTopics(Topics.BRIGHT_BIOLOGY_ORIGINAL).keySet().size());
-    assertEquals(116, TopicReader.getTopics(Topics.BRIGHT_EARTH_SCIENCE_ORIGINAL).keySet().size());
-    assertEquals(103, TopicReader.getTopics(Topics.BRIGHT_ECONOMICS_ORIGINAL).keySet().size());
-    assertEquals(101, TopicReader.getTopics(Topics.BRIGHT_PSYCHOLOGY_ORIGINAL).keySet().size());
-    assertEquals(101, TopicReader.getTopics(Topics.BRIGHT_ROBOTICS_ORIGINAL).keySet().size());
-    assertEquals(117, TopicReader.getTopics(Topics.BRIGHT_STACKOVERFLOW_ORIGINAL).keySet().size());
-    assertEquals(108, TopicReader.getTopics(Topics.BRIGHT_SUSTAINABLE_LIVING_ORIGINAL).keySet().size());
-    assertEquals(112, TopicReader.getTopics(Topics.BRIGHT_PONY_ORIGINAL).keySet().size());
-    assertEquals(142, TopicReader.getTopics(Topics.BRIGHT_LEETCODE_ORIGINAL).keySet().size());
-    assertEquals(111, TopicReader.getTopics(Topics.BRIGHT_AOPS_ORIGINAL).keySet().size());
-    assertEquals(76, TopicReader.getTopics(Topics.BRIGHT_THEOREMQA_THEOREMS_ORIGINAL).keySet().size());
-    assertEquals(194, TopicReader.getTopics(Topics.BRIGHT_THEOREMQA_QUESTIONS_ORIGINAL).keySet().size());
+    assertEquals(103, TopicReader.getTopics(Topics.get("bright-biology-original")).keySet().size());
+    assertEquals(116, TopicReader.getTopics(Topics.get("bright-earth-science-original")).keySet().size());
+    assertEquals(103, TopicReader.getTopics(Topics.get("bright-economics-original")).keySet().size());
+    assertEquals(101, TopicReader.getTopics(Topics.get("bright-psychology-original")).keySet().size());
+    assertEquals(101, TopicReader.getTopics(Topics.get("bright-robotics-original")).keySet().size());
+    assertEquals(117, TopicReader.getTopics(Topics.get("bright-stackoverflow-original")).keySet().size());
+    assertEquals(108, TopicReader.getTopics(Topics.get("bright-sustainable-living-original")).keySet().size());
+    assertEquals(112, TopicReader.getTopics(Topics.get("bright-pony-original")).keySet().size());
+    assertEquals(142, TopicReader.getTopics(Topics.get("bright-leetcode-original")).keySet().size());
+    assertEquals(111, TopicReader.getTopics(Topics.get("bright-aops-original")).keySet().size());
+    assertEquals(76, TopicReader.getTopics(Topics.get("bright-theoremqa-theorems-original")).keySet().size());
+    assertEquals(194, TopicReader.getTopics(Topics.get("bright-theoremqa-questions-original")).keySet().size());
   }
 
   @Test
   public void testMBEIRTopics() throws IOException {
-    assertEquals(4170, TopicReader.getTopics(Topics.M_BEIR_CIRR_TASK7_TEST).keySet().size());
-    assertEquals(3241, TopicReader.getTopics(Topics.M_BEIR_EDIS_TASK2_TEST).keySet().size());
-    assertEquals(1719, TopicReader.getTopics(Topics.M_BEIR_FASHION200K_TASK0_TEST).keySet().size());
-    assertEquals(4889, TopicReader.getTopics(Topics.M_BEIR_FASHION200K_TASK3_TEST).keySet().size());
-    assertEquals(6003, TopicReader.getTopics(Topics.M_BEIR_FASHIONIQ_TASK7_TEST).keySet().size());
-    assertEquals(11323, TopicReader.getTopics(Topics.M_BEIR_INFOSEEK_TASK6_TEST).keySet().size());
-    assertEquals(17593, TopicReader.getTopics(Topics.M_BEIR_INFOSEEK_TASK8_TEST).keySet().size());
-    assertEquals(24809, TopicReader.getTopics(Topics.M_BEIR_MSCOCO_TASK0_TEST).keySet().size());
-    assertEquals(5000, TopicReader.getTopics(Topics.M_BEIR_MSCOCO_TASK3_TEST).keySet().size());
-    assertEquals(2120, TopicReader.getTopics(Topics.M_BEIR_NIGHTS_TASK4_TEST).keySet().size());
-    assertEquals(50004, TopicReader.getTopics(Topics.M_BEIR_OVEN_TASK6_TEST).keySet().size());
-    assertEquals(14741, TopicReader.getTopics(Topics.M_BEIR_OVEN_TASK8_TEST).keySet().size());
-    assertEquals(19995, TopicReader.getTopics(Topics.M_BEIR_VISUALNEWS_TASK0_TEST).keySet().size());
-    assertEquals(20000, TopicReader.getTopics(Topics.M_BEIR_VISUALNEWS_TASK3_TEST).keySet().size());
-    assertEquals(2455, TopicReader.getTopics(Topics.M_BEIR_WEBQA_TASK1_TEST).keySet().size());
-    assertEquals(2511, TopicReader.getTopics(Topics.M_BEIR_WEBQA_TASK2_TEST).keySet().size());
+    assertEquals(4170, TopicReader.getTopics(Topics.get("mbeir-cirr_task7.test")).keySet().size());
+    assertEquals(3241, TopicReader.getTopics(Topics.get("mbeir-edis_task2.test")).keySet().size());
+    assertEquals(1719, TopicReader.getTopics(Topics.get("mbeir-fashion200k_task0.test")).keySet().size());
+    assertEquals(4889, TopicReader.getTopics(Topics.get("mbeir-fashion200k_task3.test")).keySet().size());
+    assertEquals(6003, TopicReader.getTopics(Topics.get("mbeir-fashioniq_task7.test")).keySet().size());
+    assertEquals(11323, TopicReader.getTopics(Topics.get("mbeir-infoseek_task6.test")).keySet().size());
+    assertEquals(17593, TopicReader.getTopics(Topics.get("mbeir-infoseek_task8.test")).keySet().size());
+    assertEquals(24809, TopicReader.getTopics(Topics.get("mbeir-mscoco_task0.test")).keySet().size());
+    assertEquals(5000, TopicReader.getTopics(Topics.get("mbeir-mscoco_task3.test")).keySet().size());
+    assertEquals(2120, TopicReader.getTopics(Topics.get("mbeir-nights_task4.test")).keySet().size());
+    assertEquals(50004, TopicReader.getTopics(Topics.get("mbeir-oven_task6.test")).keySet().size());
+    assertEquals(14741, TopicReader.getTopics(Topics.get("mbeir-oven_task8.test")).keySet().size());
+    assertEquals(19995, TopicReader.getTopics(Topics.get("mbeir-visualnews_task0.test")).keySet().size());
+    assertEquals(20000, TopicReader.getTopics(Topics.get("mbeir-visualnews_task3.test")).keySet().size());
+    assertEquals(2455, TopicReader.getTopics(Topics.get("mbeir-webqa_task1.test")).keySet().size());
+    assertEquals(2511, TopicReader.getTopics(Topics.get("mbeir-webqa_task2.test")).keySet().size());
   }
 
   @Test public void testMMEBVisDocTopics() throws IOException {
-    assertEquals(500, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_ARXIVQA_TEST).keySet().size());
-    assertEquals(451, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_DOCVQA_TEST).keySet().size());
-    assertEquals(494, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_INFOVQA_TEST).keySet().size());
-    assertEquals(100, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_SHIFTPROJECT_TEST).keySet().size());
-    assertEquals(100, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_SYNTHETIC_DOCQA_ARTIFICIAL_INTELLIGENCE_TEST).keySet().size());
-    assertEquals(100, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_SYNTHETIC_DOCQA_ENERGY_TEST).keySet().size());
-    assertEquals(100, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_SYNTHETIC_DOCQA_GOVERNMENT_REPORTS_TEST).keySet().size());
-    assertEquals(100, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_SYNTHETIC_DOCQA_HEALTHCARE_INDUSTRY_TEST).keySet().size());
-    assertEquals(280, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_TABFQUAD_TEST).keySet().size());
-    assertEquals(1646, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_TATDQA_TEST).keySet().size());
-    assertEquals(160, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_BIOMEDICAL_LECTURES_V2_TEST).keySet().size());
-    assertEquals(640, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_BIOMEDICAL_LECTURES_V2_MULTILINGUAL_TEST).keySet().size());
-    assertEquals(58, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_ECONOMICS_REPORTS_V2_TEST).keySet().size());
-    assertEquals(232, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_ECONOMICS_REPORTS_V2_MULTILINGUAL_TEST).keySet().size());
-    assertEquals(52, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_ESG_REPORTS_HUMAN_LABELED_V2_TEST).keySet().size());
-    assertEquals(57, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_ESG_REPORTS_V2_TEST).keySet().size());
-    assertEquals(228, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDORE_ESG_REPORTS_V2_MULTILINGUAL_TEST).keySet().size());
-    assertEquals(816, TopicReader.getTopics(Topics.MMEB_VISDOC_VISRAG_ARXIVQA_TRAIN).keySet().size());
-    assertEquals(63, TopicReader.getTopics(Topics.MMEB_VISDOC_VISRAG_CHARTQA_TRAIN).keySet().size());
-    assertEquals(718, TopicReader.getTopics(Topics.MMEB_VISDOC_VISRAG_INFOVQA_TRAIN).keySet().size());
-    assertEquals(591, TopicReader.getTopics(Topics.MMEB_VISDOC_VISRAG_MP_DOCVQA_TRAIN).keySet().size());
-    assertEquals(863, TopicReader.getTopics(Topics.MMEB_VISDOC_VISRAG_PLOTQA_TRAIN).keySet().size());
-    assertEquals(556, TopicReader.getTopics(Topics.MMEB_VISDOC_VISRAG_SLIDEVQA_TRAIN).keySet().size());
-    assertEquals(1142, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDOSEEK_DOC_TEST).keySet().size());
-    assertEquals(1142, TopicReader.getTopics(Topics.MMEB_VISDOC_VIDOSEEK_PAGE_TEST).keySet().size());
-    assertEquals(838, TopicReader.getTopics(Topics.MMEB_VISDOC_MMLONGBENCH_DOC_TEST).keySet().size());
-    assertEquals(838, TopicReader.getTopics(Topics.MMEB_VISDOC_MMLONGBENCH_PAGE_TEST).keySet().size());
+    assertEquals(500, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_arxivqa.test")).keySet().size());
+    assertEquals(451, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_docvqa.test")).keySet().size());
+    assertEquals(494, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_infovqa.test")).keySet().size());
+    assertEquals(100, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_shiftproject.test")).keySet().size());
+    assertEquals(100, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_artificial_intelligence.test")).keySet().size());
+    assertEquals(100, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_energy.test")).keySet().size());
+    assertEquals(100, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_government_reports.test")).keySet().size());
+    assertEquals(100, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_healthcare_industry.test")).keySet().size());
+    assertEquals(280, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_tabfquad.test")).keySet().size());
+    assertEquals(1646, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_tatdqa.test")).keySet().size());
+    assertEquals(160, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_biomedical_lectures_v2.test")).keySet().size());
+    assertEquals(640, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_biomedical_lectures_v2_multilingual.test")).keySet().size());
+    assertEquals(58, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_economics_reports_v2.test")).keySet().size());
+    assertEquals(232, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_economics_reports_v2_multilingual.test")).keySet().size());
+    assertEquals(52, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_esg_reports_human_labeled_v2.test")).keySet().size());
+    assertEquals(57, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_esg_reports_v2.test")).keySet().size());
+    assertEquals(228, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoRe_esg_reports_v2_multilingual.test")).keySet().size());
+    assertEquals(816, TopicReader.getTopics(Topics.get("mmeb-visdoc-VisRAG_ArxivQA.train")).keySet().size());
+    assertEquals(63, TopicReader.getTopics(Topics.get("mmeb-visdoc-VisRAG_ChartQA.train")).keySet().size());
+    assertEquals(718, TopicReader.getTopics(Topics.get("mmeb-visdoc-VisRAG_InfoVQA.train")).keySet().size());
+    assertEquals(591, TopicReader.getTopics(Topics.get("mmeb-visdoc-VisRAG_MP-DocVQA.train")).keySet().size());
+    assertEquals(863, TopicReader.getTopics(Topics.get("mmeb-visdoc-VisRAG_PlotQA.train")).keySet().size());
+    assertEquals(556, TopicReader.getTopics(Topics.get("mmeb-visdoc-VisRAG_SlideVQA.train")).keySet().size());
+    assertEquals(1142, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoSeek-doc.test")).keySet().size());
+    assertEquals(1142, TopicReader.getTopics(Topics.get("mmeb-visdoc-ViDoSeek-page.test")).keySet().size());
+    assertEquals(838, TopicReader.getTopics(Topics.get("mmeb-visdoc-MMLongBench-doc.test")).keySet().size());
+    assertEquals(838, TopicReader.getTopics(Topics.get("mmeb-visdoc-MMLongBench-page.test")).keySet().size());
   }
 
   @Test
@@ -2036,50 +2036,50 @@ public class TopicReaderTest {
   
   @Test
   public void testHC4Topics() throws IOException {
-    assertEquals(10, TopicReader.getTopics(Topics.HC4_V1_0_FA_DEV_TITLE).keySet().size());
-    assertEquals(10, TopicReader.getTopics(Topics.HC4_V1_0_FA_DEV_DESC).keySet().size());
-    assertEquals(10, TopicReader.getTopics(Topics.HC4_V1_0_FA_DEV_DESC_TITLE).keySet().size());
+    assertEquals(10, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.dev.title")).keySet().size());
+    assertEquals(10, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.dev.desc")).keySet().size());
+    assertEquals(10, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.dev.desc.title")).keySet().size());
 
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_FA_TEST_TITLE).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_FA_TEST_DESC).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_FA_TEST_DESC_TITLE).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.test.title")).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.test.desc")).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.test.desc.title")).keySet().size());
 
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_FA_EN_TEST_TITLE).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_FA_EN_TEST_DESC).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_FA_EN_TEST_DESC_TITLE).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.en.test.title")).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.en.test.desc")).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-fa.en.test.desc.title")).keySet().size());
 
-    assertEquals(4, TopicReader.getTopics(Topics.HC4_V1_0_RU_DEV_TITLE).keySet().size());
-    assertEquals(4, TopicReader.getTopics(Topics.HC4_V1_0_RU_DEV_DESC).keySet().size());
-    assertEquals(4, TopicReader.getTopics(Topics.HC4_V1_0_RU_DEV_DESC_TITLE).keySet().size());
+    assertEquals(4, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.dev.title")).keySet().size());
+    assertEquals(4, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.dev.desc")).keySet().size());
+    assertEquals(4, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.dev.desc.title")).keySet().size());
 
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_RU_TEST_TITLE).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_RU_TEST_DESC).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_RU_TEST_DESC_TITLE).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.test.title")).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.test.desc")).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.test.desc.title")).keySet().size());
 
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_RU_EN_TEST_TITLE).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_RU_EN_TEST_DESC).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_RU_EN_TEST_DESC_TITLE).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.en.test.title")).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.en.test.desc")).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-ru.en.test.desc.title")).keySet().size());
 
-    assertEquals(10, TopicReader.getTopics(Topics.HC4_V1_0_ZH_DEV_TITLE).keySet().size());
-    assertEquals(10, TopicReader.getTopics(Topics.HC4_V1_0_ZH_DEV_DESC).keySet().size());
-    assertEquals(10, TopicReader.getTopics(Topics.HC4_V1_0_ZH_DEV_DESC_TITLE).keySet().size());
+    assertEquals(10, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.dev.title")).keySet().size());
+    assertEquals(10, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.dev.desc")).keySet().size());
+    assertEquals(10, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.dev.desc.title")).keySet().size());
 
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_ZH_TEST_TITLE).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_ZH_TEST_DESC).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_ZH_TEST_DESC_TITLE).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.test.title")).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.test.desc")).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.test.desc.title")).keySet().size());
 
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_ZH_EN_TEST_TITLE).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_ZH_EN_TEST_DESC).keySet().size());
-    assertEquals(50, TopicReader.getTopics(Topics.HC4_V1_0_ZH_EN_TEST_DESC_TITLE).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.en.test.title")).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.en.test.desc")).keySet().size());
+    assertEquals(50, TopicReader.getTopics(Topics.get("hc4-v1.0-zh.en.test.desc.title")).keySet().size());
   }
 
   @Test
   public void testNeuCLIR22OriginalTopics() throws IOException {
     SortedMap<Integer, Map<String, String>> t, d, dt;
 
-    t = TopicReader.getTopics(Topics.NEUCLIR22_EN_TITLE);
-    d = TopicReader.getTopics(Topics.NEUCLIR22_EN_DESC);
-    dt = TopicReader.getTopics(Topics.NEUCLIR22_EN_DESC_TITLE);
+    t = TopicReader.getTopics(Topics.get("neuclir22-en.original-title"));
+    d = TopicReader.getTopics(Topics.get("neuclir22-en.original-desc"));
+    dt = TopicReader.getTopics(Topics.get("neuclir22-en.original-desc_title"));
 
     assertEquals(114, t.keySet().size());
     assertEquals(114, d.keySet().size());
@@ -2093,9 +2093,9 @@ public class TopicReaderTest {
     }
 
     // Persian
-    t = TopicReader.getTopics(Topics.NEUCLIR22_FA_HT_TITLE);
-    d = TopicReader.getTopics(Topics.NEUCLIR22_FA_HT_DESC);
-    dt = TopicReader.getTopics(Topics.NEUCLIR22_FA_HT_DESC_TITLE);
+    t = TopicReader.getTopics(Topics.get("neuclir22-fa.ht-title"));
+    d = TopicReader.getTopics(Topics.get("neuclir22-fa.ht-desc"));
+    dt = TopicReader.getTopics(Topics.get("neuclir22-fa.ht-desc_title"));
 
     assertEquals(114, t.keySet().size());
     assertEquals(114, d.keySet().size());
@@ -2108,9 +2108,9 @@ public class TopicReaderTest {
       assertEquals(dt.get(k).get("title"), d.get(k).get("title") + " " + t.get(k).get("title"));
     }
 
-    t = TopicReader.getTopics(Topics.NEUCLIR22_FA_MT_TITLE);
-    d = TopicReader.getTopics(Topics.NEUCLIR22_FA_MT_DESC);
-    dt = TopicReader.getTopics(Topics.NEUCLIR22_FA_MT_DESC_TITLE);
+    t = TopicReader.getTopics(Topics.get("neuclir22-fa.mt-title"));
+    d = TopicReader.getTopics(Topics.get("neuclir22-fa.mt-desc"));
+    dt = TopicReader.getTopics(Topics.get("neuclir22-fa.mt-desc_title"));
 
     assertEquals(114, t.keySet().size());
     assertEquals(114, d.keySet().size());
@@ -2124,9 +2124,9 @@ public class TopicReaderTest {
     }
 
     // Russian
-    t = TopicReader.getTopics(Topics.NEUCLIR22_RU_HT_TITLE);
-    d = TopicReader.getTopics(Topics.NEUCLIR22_RU_HT_DESC);
-    dt = TopicReader.getTopics(Topics.NEUCLIR22_RU_HT_DESC_TITLE);
+    t = TopicReader.getTopics(Topics.get("neuclir22-ru.ht-title"));
+    d = TopicReader.getTopics(Topics.get("neuclir22-ru.ht-desc"));
+    dt = TopicReader.getTopics(Topics.get("neuclir22-ru.ht-desc_title"));
 
     assertEquals(114, t.keySet().size());
     assertEquals(114, d.keySet().size());
@@ -2139,9 +2139,9 @@ public class TopicReaderTest {
       assertEquals(dt.get(k).get("title"), d.get(k).get("title") + " " + t.get(k).get("title"));
     }
 
-    t = TopicReader.getTopics(Topics.NEUCLIR22_RU_MT_TITLE);
-    d = TopicReader.getTopics(Topics.NEUCLIR22_RU_MT_DESC);
-    dt = TopicReader.getTopics(Topics.NEUCLIR22_RU_MT_DESC_TITLE);
+    t = TopicReader.getTopics(Topics.get("neuclir22-ru.mt-title"));
+    d = TopicReader.getTopics(Topics.get("neuclir22-ru.mt-desc"));
+    dt = TopicReader.getTopics(Topics.get("neuclir22-ru.mt-desc_title"));
 
     assertEquals(114, t.keySet().size());
     assertEquals(114, d.keySet().size());
@@ -2155,9 +2155,9 @@ public class TopicReaderTest {
     }
 
     // Chinese
-    t = TopicReader.getTopics(Topics.NEUCLIR22_ZH_HT_TITLE);
-    d = TopicReader.getTopics(Topics.NEUCLIR22_ZH_HT_DESC);
-    dt = TopicReader.getTopics(Topics.NEUCLIR22_ZH_HT_DESC_TITLE);
+    t = TopicReader.getTopics(Topics.get("neuclir22-zh.ht-title"));
+    d = TopicReader.getTopics(Topics.get("neuclir22-zh.ht-desc"));
+    dt = TopicReader.getTopics(Topics.get("neuclir22-zh.ht-desc_title"));
 
     assertEquals(114, t.keySet().size());
     assertEquals(114, d.keySet().size());
@@ -2170,9 +2170,9 @@ public class TopicReaderTest {
       assertEquals(dt.get(k).get("title"), d.get(k).get("title") + " " + t.get(k).get("title"));
     }
 
-    t = TopicReader.getTopics(Topics.NEUCLIR22_ZH_MT_TITLE);
-    d = TopicReader.getTopics(Topics.NEUCLIR22_ZH_MT_DESC);
-    dt = TopicReader.getTopics(Topics.NEUCLIR22_ZH_MT_DESC_TITLE);
+    t = TopicReader.getTopics(Topics.get("neuclir22-zh.mt-title"));
+    d = TopicReader.getTopics(Topics.get("neuclir22-zh.mt-desc"));
+    dt = TopicReader.getTopics(Topics.get("neuclir22-zh.mt-desc_title"));
 
     assertEquals(114, t.keySet().size());
     assertEquals(114, d.keySet().size());
@@ -2188,74 +2188,74 @@ public class TopicReaderTest {
 
   @Test
   public void testNeuCLIR22SpladeTopics() throws IOException {
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_FA_SPLADE_HT_TITLE).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_FA_SPLADE_HT_DESC).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_FA_SPLADE_HT_DESC_TITLE).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-fa.splade.ht-title")).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-fa.splade.ht-desc")).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-fa.splade.ht-desc_title")).keySet().size());
 
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_FA_SPLADE_MT_TITLE).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_FA_SPLADE_MT_DESC).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_FA_SPLADE_MT_DESC_TITLE).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-fa.splade.mt-title")).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-fa.splade.mt-desc")).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-fa.splade.mt-desc_title")).keySet().size());
 
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_RU_SPLADE_HT_TITLE).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_RU_SPLADE_HT_DESC).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_RU_SPLADE_HT_DESC_TITLE).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-ru.splade.ht-title")).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-ru.splade.ht-desc")).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-ru.splade.ht-desc_title")).keySet().size());
 
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_RU_SPLADE_MT_TITLE).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_RU_SPLADE_MT_DESC).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_RU_SPLADE_MT_DESC_TITLE).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-ru.splade.mt-title")).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-ru.splade.mt-desc")).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-ru.splade.mt-desc_title")).keySet().size());
 
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_ZH_SPLADE_HT_TITLE).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_ZH_SPLADE_HT_DESC).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_ZH_SPLADE_HT_DESC_TITLE).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-zh.splade.ht-title")).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-zh.splade.ht-desc")).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-zh.splade.ht-desc_title")).keySet().size());
 
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_ZH_SPLADE_MT_TITLE).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_ZH_SPLADE_MT_DESC).keySet().size());
-    assertEquals(114, TopicReader.getTopics(Topics.NEUCLIR22_ZH_SPLADE_MT_DESC_TITLE).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-zh.splade.mt-title")).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-zh.splade.mt-desc")).keySet().size());
+    assertEquals(114, TopicReader.getTopics(Topics.get("neuclir22-zh.splade.mt-desc_title")).keySet().size());
   }
 
   @Test
   public void testMIRACLTopics() throws IOException {
-    assertEquals(2896, TopicReader.getTopics(Topics.MIRACL_V10_AR_DEV).keySet().size());
-    assertEquals(411, TopicReader.getTopics(Topics.MIRACL_V10_BN_DEV).keySet().size());
-    assertEquals(799, TopicReader.getTopics(Topics.MIRACL_V10_EN_DEV).keySet().size());
-    assertEquals(648, TopicReader.getTopics(Topics.MIRACL_V10_ES_DEV).keySet().size());
-    assertEquals(632, TopicReader.getTopics(Topics.MIRACL_V10_FA_DEV).keySet().size());
-    assertEquals(1271, TopicReader.getTopics(Topics.MIRACL_V10_FI_DEV).keySet().size());
-    assertEquals(343, TopicReader.getTopics(Topics.MIRACL_V10_FR_DEV).keySet().size());
-    assertEquals(350, TopicReader.getTopics(Topics.MIRACL_V10_HI_DEV).keySet().size());
-    assertEquals(960, TopicReader.getTopics(Topics.MIRACL_V10_ID_DEV).keySet().size());
-    assertEquals(860, TopicReader.getTopics(Topics.MIRACL_V10_JA_DEV).keySet().size());
-    assertEquals(213, TopicReader.getTopics(Topics.MIRACL_V10_KO_DEV).keySet().size());
-    assertEquals(1252, TopicReader.getTopics(Topics.MIRACL_V10_RU_DEV).keySet().size());
-    assertEquals(482, TopicReader.getTopics(Topics.MIRACL_V10_SW_DEV).keySet().size());
-    assertEquals(828, TopicReader.getTopics(Topics.MIRACL_V10_TE_DEV).keySet().size());
-    assertEquals(733, TopicReader.getTopics(Topics.MIRACL_V10_TH_DEV).keySet().size());
-    assertEquals(393, TopicReader.getTopics(Topics.MIRACL_V10_ZH_DEV).keySet().size());
-    assertEquals(305, TopicReader.getTopics(Topics.MIRACL_V10_DE_DEV).keySet().size());
-    assertEquals(119, TopicReader.getTopics(Topics.MIRACL_V10_YO_DEV).keySet().size());
+    assertEquals(2896, TopicReader.getTopics(Topics.get("miracl-v1.0-ar-dev")).keySet().size());
+    assertEquals(411, TopicReader.getTopics(Topics.get("miracl-v1.0-bn-dev")).keySet().size());
+    assertEquals(799, TopicReader.getTopics(Topics.get("miracl-v1.0-en-dev")).keySet().size());
+    assertEquals(648, TopicReader.getTopics(Topics.get("miracl-v1.0-es-dev")).keySet().size());
+    assertEquals(632, TopicReader.getTopics(Topics.get("miracl-v1.0-fa-dev")).keySet().size());
+    assertEquals(1271, TopicReader.getTopics(Topics.get("miracl-v1.0-fi-dev")).keySet().size());
+    assertEquals(343, TopicReader.getTopics(Topics.get("miracl-v1.0-fr-dev")).keySet().size());
+    assertEquals(350, TopicReader.getTopics(Topics.get("miracl-v1.0-hi-dev")).keySet().size());
+    assertEquals(960, TopicReader.getTopics(Topics.get("miracl-v1.0-id-dev")).keySet().size());
+    assertEquals(860, TopicReader.getTopics(Topics.get("miracl-v1.0-ja-dev")).keySet().size());
+    assertEquals(213, TopicReader.getTopics(Topics.get("miracl-v1.0-ko-dev")).keySet().size());
+    assertEquals(1252, TopicReader.getTopics(Topics.get("miracl-v1.0-ru-dev")).keySet().size());
+    assertEquals(482, TopicReader.getTopics(Topics.get("miracl-v1.0-sw-dev")).keySet().size());
+    assertEquals(828, TopicReader.getTopics(Topics.get("miracl-v1.0-te-dev")).keySet().size());
+    assertEquals(733, TopicReader.getTopics(Topics.get("miracl-v1.0-th-dev")).keySet().size());
+    assertEquals(393, TopicReader.getTopics(Topics.get("miracl-v1.0-zh-dev")).keySet().size());
+    assertEquals(305, TopicReader.getTopics(Topics.get("miracl-v1.0-de-dev")).keySet().size());
+    assertEquals(119, TopicReader.getTopics(Topics.get("miracl-v1.0-yo-dev")).keySet().size());
   }
 
   @Test
   public void testCIRALTopics() throws IOException {
-    assertEquals(10, TopicReader.getTopics(Topics.CIRAL_V10_HA_DEV_MONO).keySet().size());
-    assertEquals(10, TopicReader.getTopics(Topics.CIRAL_V10_SO_DEV_MONO).keySet().size());
-    assertEquals(10, TopicReader.getTopics(Topics.CIRAL_V10_SW_DEV_MONO).keySet().size());
-    assertEquals(10, TopicReader.getTopics(Topics.CIRAL_V10_YO_DEV_MONO).keySet().size());
-    assertEquals(80, TopicReader.getTopics(Topics.CIRAL_V10_HA_TEST_A).keySet().size());
-    assertEquals(99, TopicReader.getTopics(Topics.CIRAL_V10_SO_TEST_A).keySet().size());
-    assertEquals(85, TopicReader.getTopics(Topics.CIRAL_V10_SW_TEST_A).keySet().size());
-    assertEquals(100, TopicReader.getTopics(Topics.CIRAL_V10_YO_TEST_A).keySet().size());
-    assertEquals(80, TopicReader.getTopics(Topics.CIRAL_V10_HA_TEST_A_NATIVE).keySet().size());
-    assertEquals(99, TopicReader.getTopics(Topics.CIRAL_V10_SO_TEST_A_NATIVE).keySet().size());
-    assertEquals(85, TopicReader.getTopics(Topics.CIRAL_V10_SW_TEST_A_NATIVE).keySet().size());
-    assertEquals(100, TopicReader.getTopics(Topics.CIRAL_V10_YO_TEST_A_NATIVE).keySet().size());
-    assertEquals(312, TopicReader.getTopics(Topics.CIRAL_V10_HA_TEST_B).keySet().size());
-    assertEquals(239, TopicReader.getTopics(Topics.CIRAL_V10_SO_TEST_B).keySet().size());
-    assertEquals(113, TopicReader.getTopics(Topics.CIRAL_V10_SW_TEST_B).keySet().size());
-    assertEquals(554, TopicReader.getTopics(Topics.CIRAL_V10_YO_TEST_B).keySet().size());
-    assertEquals(312, TopicReader.getTopics(Topics.CIRAL_V10_HA_TEST_B_NATIVE).keySet().size());
-    assertEquals(239, TopicReader.getTopics(Topics.CIRAL_V10_SO_TEST_B_NATIVE).keySet().size());
-    assertEquals(112, TopicReader.getTopics(Topics.CIRAL_V10_SW_TEST_B_NATIVE).keySet().size());
-    assertEquals(554, TopicReader.getTopics(Topics.CIRAL_V10_YO_TEST_B_NATIVE).keySet().size());
+    assertEquals(10, TopicReader.getTopics(Topics.get("ciral-v1.0-ha-dev-native")).keySet().size());
+    assertEquals(10, TopicReader.getTopics(Topics.get("ciral-v1.0-so-dev-native")).keySet().size());
+    assertEquals(10, TopicReader.getTopics(Topics.get("ciral-v1.0-sw-dev-native")).keySet().size());
+    assertEquals(10, TopicReader.getTopics(Topics.get("ciral-v1.0-yo-dev-native")).keySet().size());
+    assertEquals(80, TopicReader.getTopics(Topics.get("ciral-v1.0-ha-test-a")).keySet().size());
+    assertEquals(99, TopicReader.getTopics(Topics.get("ciral-v1.0-so-test-a")).keySet().size());
+    assertEquals(85, TopicReader.getTopics(Topics.get("ciral-v1.0-sw-test-a")).keySet().size());
+    assertEquals(100, TopicReader.getTopics(Topics.get("ciral-v1.0-yo-test-a")).keySet().size());
+    assertEquals(80, TopicReader.getTopics(Topics.get("ciral-v1.0-ha-test-a-native")).keySet().size());
+    assertEquals(99, TopicReader.getTopics(Topics.get("ciral-v1.0-so-test-a-native")).keySet().size());
+    assertEquals(85, TopicReader.getTopics(Topics.get("ciral-v1.0-sw-test-a-native")).keySet().size());
+    assertEquals(100, TopicReader.getTopics(Topics.get("ciral-v1.0-yo-test-a-native")).keySet().size());
+    assertEquals(312, TopicReader.getTopics(Topics.get("ciral-v1.0-ha-test-b")).keySet().size());
+    assertEquals(239, TopicReader.getTopics(Topics.get("ciral-v1.0-so-test-b")).keySet().size());
+    assertEquals(113, TopicReader.getTopics(Topics.get("ciral-v1.0-sw-test-b")).keySet().size());
+    assertEquals(554, TopicReader.getTopics(Topics.get("ciral-v1.0-yo-test-b")).keySet().size());
+    assertEquals(312, TopicReader.getTopics(Topics.get("ciral-v1.0-ha-test-b-native")).keySet().size());
+    assertEquals(239, TopicReader.getTopics(Topics.get("ciral-v1.0-so-test-b-native")).keySet().size());
+    assertEquals(112, TopicReader.getTopics(Topics.get("ciral-v1.0-sw-test-b-native")).keySet().size());
+    assertEquals(554, TopicReader.getTopics(Topics.get("ciral-v1.0-yo-test-b-native")).keySet().size());
   }
 }

--- a/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
@@ -41,21 +41,21 @@ public class TopicReaderTest {
 
       // Verify that we can fetch the TopicReader class given the name of the topic file.
       String path = topic.path;
-      assertEquals(topic.readerClass, TopicReader.getTopicReaderClassByFile(path));
+      assertEquals(topic.readerClass, Topics.getTopicReaderClassForPath(path));
     }
-    assertEquals(460, cnt);
+    assertEquals(388, cnt);
   }
 
   @Test
   public void testTopicReaderClassLookup() {
-    assertEquals(TrecTopicReader.class, TopicReader.getTopicReaderClassByFile("tools/topics-and-qrels/topics.robust04.txt"));
-    assertEquals(TrecTopicReader.class, TopicReader.getTopicReaderClassByFile("topics.robust04.txt"));
+    assertEquals(TrecTopicReader.class, Topics.getTopicReaderClassForPath("tools/topics-and-qrels/topics.robust04.txt"));
+    assertEquals(TrecTopicReader.class, Topics.getTopicReaderClassForPath("topics.robust04.txt"));
 
-    assertEquals(CovidTopicReader.class, TopicReader.getTopicReaderClassByFile("tools/topics-and-qrels/topics.covid-round1.xml"));
-    assertEquals(CovidTopicReader.class, TopicReader.getTopicReaderClassByFile("topics.covid-round1.xml"));
+    assertEquals(CovidTopicReader.class, Topics.getTopicReaderClassForPath("tools/topics-and-qrels/topics.covid-round1.xml"));
+    assertEquals(CovidTopicReader.class, Topics.getTopicReaderClassForPath("topics.covid-round1.xml"));
 
     // Unknown TopicReader class.
-    assertNull(TopicReader.getTopicReaderClassByFile("topics.unknown.txt"));
+    assertNull(Topics.getTopicReaderClassForPath("topics.unknown.txt"));
   }
 
   @Test(expected = NullPointerException.class)
@@ -746,46 +746,6 @@ public class TopicReaderTest {
     assertEquals("how is the weather in jamaica", topics.get(topics.lastKey()).get("title"));
     assertEquals("does legion ##ella p ##ne ##um ##op ##hila cause pneumonia", topics.get(168216).get("title"));
 
-    topics = TopicReader.load(Topics.get("dl19-passage.unicoil.0shot"));
-    assertNotNull(topics);
-    assertEquals(43, topics.size());
-    assertEquals(19335, (int) topics.firstKey());
-    assertEquals(695, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1133167, (int) topics.lastKey());
-    assertEquals(595, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl19-passage.unicoil-noexp.0shot"));
-    assertNotNull(topics);
-    assertEquals(43, topics.size());
-    assertEquals(19335, (int) topics.firstKey());
-    assertEquals(668, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1133167, (int) topics.lastKey());
-    assertEquals(586, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl19-passage.splade_distil_cocodenser_medium"));
-    assertNotNull(topics);
-    assertEquals(43, topics.size());
-    assertEquals(19335, (int) topics.firstKey());
-    assertEquals(1890, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1133167, (int) topics.lastKey());
-    assertEquals(1382, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl19-passage.splade-pp-ed"));
-    assertNotNull(topics);
-    assertEquals(43, topics.size());
-    assertEquals(19335, (int) topics.firstKey());
-    assertEquals(28088, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1133167, (int) topics.lastKey());
-    assertEquals(18791, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl19-passage.splade-pp-sd"));
-    assertNotNull(topics);
-    assertEquals(43, topics.size());
-    assertEquals(19335, (int) topics.firstKey());
-    assertEquals(28936, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1133167, (int) topics.lastKey());
-    assertEquals(17675, topics.get(topics.lastKey()).get("title").split(" ").length);
-
     topics = TopicReader.load(Topics.get("dl19-doc"));
     assertNotNull(topics);
     assertEquals(43, topics.size());
@@ -803,46 +763,6 @@ public class TopicReaderTest {
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals("how is the weather in jamaica", topics.get(topics.lastKey()).get("title"));
     assertEquals("how long to hold bow in yoga", topics.get(1132213).get("title"));
-
-    topics = TopicReader.load(Topics.get("dl19-doc.unicoil.0shot"));
-    assertNotNull(topics);
-    assertEquals(43, topics.size());
-    assertEquals(19335, (int) topics.firstKey());
-    assertEquals(695, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1133167, (int) topics.lastKey());
-    assertEquals(595, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl19-doc.unicoil-noexp.0shot"));
-    assertNotNull(topics);
-    assertEquals(43, topics.size());
-    assertEquals(19335, (int) topics.firstKey());
-    assertEquals(668, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1133167, (int) topics.lastKey());
-    assertEquals(586, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl19-passage.splade_distil_cocodenser_medium"));
-    assertNotNull(topics);
-    assertEquals(43, topics.size());
-    assertEquals(19335, (int) topics.firstKey());
-    assertEquals(1890, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1133167, (int) topics.lastKey());
-    assertEquals(1382, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl19-passage.splade-pp-ed"));
-    assertNotNull(topics);
-    assertEquals(43, topics.size());
-    assertEquals(19335, (int) topics.firstKey());
-    assertEquals(28088, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1133167, (int) topics.lastKey());
-    assertEquals(18791, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl19-passage.splade-pp-sd"));
-    assertNotNull(topics);
-    assertEquals(43, topics.size());
-    assertEquals(19335, (int) topics.firstKey());
-    assertEquals(28936, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1133167, (int) topics.lastKey());
-    assertEquals(17675, topics.get(topics.lastKey()).get("title").split(" ").length);
 
     topics = TopicReader.load(Topics.get("dl19-passage.cohere-embed-english-v3.0"));
     assertNotNull(topics);
@@ -875,46 +795,6 @@ public class TopicReaderTest {
     assertEquals("why did the ancient egyptians call their land ke ##met , or black land ?", topics.get(topics.lastKey()).get("title"));
     assertEquals("who is aziz hash ##im", topics.get(1030303).get("title"));
 
-    topics = TopicReader.load(Topics.get("dl20.unicoil.0shot"));
-    assertNotNull(topics);
-    assertEquals(200, topics.size());
-    assertEquals(3505, (int) topics.firstKey());
-    assertEquals(706, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1136962, (int) topics.lastKey());
-    assertEquals(1169, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl20.unicoil-noexp.0shot"));
-    assertNotNull(topics);
-    assertEquals(200, topics.size());
-    assertEquals(3505, (int) topics.firstKey());
-    assertEquals(689, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1136962, (int) topics.lastKey());
-    assertEquals(1164, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl20.splade_distil_cocodenser_medium"));
-    assertNotNull(topics);
-    assertEquals(54, topics.size());
-    assertEquals(23849, (int) topics.firstKey());
-    assertEquals(2168, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1136962, (int) topics.lastKey());
-    assertEquals(2075, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl20.splade-pp-ed"));
-    assertNotNull(topics);
-    assertEquals(200, topics.size());
-    assertEquals(3505, (int) topics.firstKey());
-    assertEquals(30361, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1136962, (int) topics.lastKey());
-    assertEquals(25909, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl20.splade-pp-sd"));
-    assertNotNull(topics);
-    assertEquals(200, topics.size());
-    assertEquals(3505, (int) topics.firstKey());
-    assertEquals(35114, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1136962, (int) topics.lastKey());
-    assertEquals(30994, topics.get(topics.lastKey()).get("title").split(" ").length);
-
     topics = TopicReader.load(Topics.get("dl20.cohere-embed-english-v3.0"));
     assertNotNull(topics);
     assertEquals(200, topics.size());
@@ -936,38 +816,6 @@ public class TopicReaderTest {
     assertEquals(1136769, (int) topics.lastKey());
     assertEquals("why does lacquered brass tarnish", topics.get(topics.lastKey()).get("title"));
     assertEquals("who killed nicholas ii of russia", topics.get(1043135).get("title"));
-
-    topics = TopicReader.load(Topics.get("dl21.unicoil.0shot"));
-    assertNotNull(topics);
-    assertEquals(477, topics.size());
-    assertEquals(2082, (int) topics.firstKey());
-    assertEquals(693, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1136769, (int) topics.lastKey());
-    assertEquals(712, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl21.unicoil-noexp.0shot"));
-    assertNotNull(topics);
-    assertEquals(477, topics.size());
-    assertEquals(2082, (int) topics.firstKey());
-    assertEquals(624, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1136769, (int) topics.lastKey());
-    assertEquals(633, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl21.splade-pp-ed"));
-    assertNotNull(topics);
-    assertEquals(477, topics.size());
-    assertEquals(2082, (int) topics.firstKey());
-    assertEquals(23936, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1136769, (int) topics.lastKey());
-    assertEquals(25398, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl21.splade-pp-sd"));
-    assertNotNull(topics);
-    assertEquals(477, topics.size());
-    assertEquals(2082, (int) topics.firstKey());
-    assertEquals(26369, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1136769, (int) topics.lastKey());
-    assertEquals(27149, topics.get(topics.lastKey()).get("title").split(" ").length);
 
     topics = TopicReader.load(Topics.get("dl21.snowflake-arctic-embed-l"));
     assertNotNull(topics);
@@ -991,38 +839,6 @@ public class TopicReaderTest {
     assertEquals("is a dairy farm considered as an agriculture", topics.get(topics.lastKey()).get("title"));
     assertEquals("how does magic leap optics work", topics.get(2056323).get("title"));
 
-    topics = TopicReader.load(Topics.get("dl22.unicoil.0shot"));
-    assertNotNull(topics);
-    assertEquals(500, topics.size());
-    assertEquals(588, (int) topics.firstKey());
-    assertEquals(1016, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(2056473, (int) topics.lastKey());
-    assertEquals(720, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl22.unicoil-noexp.0shot"));
-    assertNotNull(topics);
-    assertEquals(500, topics.size());
-    assertEquals(588, (int) topics.firstKey());
-    assertEquals(900, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(2056473, (int) topics.lastKey());
-    assertEquals(726, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl22.splade-pp-ed"));
-    assertNotNull(topics);
-    assertEquals(500, topics.size());
-    assertEquals(588, (int) topics.firstKey());
-    assertEquals(25701, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(2056473, (int) topics.lastKey());
-    assertEquals(28012, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl22.splade-pp-sd"));
-    assertNotNull(topics);
-    assertEquals(500, topics.size());
-    assertEquals(588, (int) topics.firstKey());
-    assertEquals(31052, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(2056473, (int) topics.lastKey());
-    assertEquals(33891, topics.get(topics.lastKey()).get("title").split(" ").length);
-
     topics = TopicReader.load(Topics.get("dl22.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(500, topics.size());
@@ -1044,38 +860,6 @@ public class TopicReaderTest {
     assertEquals(3100949, (int) topics.lastKey());
     assertEquals("How do birth control and hormone levels affect menstrual cycle variations?", topics.get(topics.lastKey()).get("title"));
     assertEquals("How do birth control and hormone levels affect menstrual cycle variations?", topics.get(3100949).get("title"));
-
-    topics = TopicReader.load(Topics.get("dl23.unicoil.0shot"));
-    assertNotNull(topics);
-    assertEquals(700, topics.size());
-    assertEquals(2000138, (int) topics.firstKey());
-    assertEquals(34407, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(3100949, (int) topics.lastKey());
-    assertEquals(31334, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl23.unicoil-noexp.0shot"));
-    assertNotNull(topics);
-    assertEquals(700, topics.size());
-    assertEquals(2000138, (int) topics.firstKey());
-    assertEquals(37993, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(3100949, (int) topics.lastKey());
-    assertEquals(31283, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl23.splade-pp-ed"));
-    assertNotNull(topics);
-    assertEquals(700, topics.size());
-    assertEquals(2000138, (int) topics.firstKey());
-    assertEquals(138500, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(3100949, (int) topics.lastKey());
-    assertEquals(139500, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("dl23.splade-pp-sd"));
-    assertNotNull(topics);
-    assertEquals(700, topics.size());
-    assertEquals(2000138, (int) topics.firstKey());
-    assertEquals(163500, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(3100949, (int) topics.lastKey());
-    assertEquals(181700, topics.get(topics.lastKey()).get("title").split(" ").length);
 
     topics = TopicReader.load(Topics.get("dl23.snowflake-arctic-embed-l"));
     assertNotNull(topics);
@@ -1186,22 +970,6 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals("why do bears hi ##ber ##nate", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.load(Topics.get("msmarco-doc.dev.unicoil"));
-    assertNotNull(topics);
-    assertEquals(5193, topics.size());
-    assertEquals(2, (int) topics.firstKey());
-    assertEquals(617, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102400, (int) topics.lastKey());
-    assertEquals(682, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("msmarco-doc.dev.unicoil-noexp"));
-    assertNotNull(topics);
-    assertEquals(5193, topics.size());
-    assertEquals(2, (int) topics.firstKey());
-    assertEquals(609, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102400, (int) topics.lastKey());
-    assertEquals(577, topics.get(topics.lastKey()).get("title").split(" ").length);
-
     topics = TopicReader.load(Topics.get("msmarco-doc.test"));
     assertNotNull(topics);
     assertEquals(5793, topics.size());
@@ -1234,55 +1002,6 @@ public class TopicReaderTest {
     assertEquals(1102400, (int) topics.lastKey());
     assertEquals("why hibernate bears", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.unicoil"));
-    assertNotNull(topics);
-    assertEquals(6980, topics.size());
-    assertEquals(619, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102400, (int) topics.lastKey());
-    assertEquals(686, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.unicoil-noexp"));
-    assertNotNull(topics);
-    assertEquals(6980, topics.size());
-    assertEquals(609, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102400, (int) topics.lastKey());
-    assertEquals(577, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.unicoil-tilde-expansion"));
-    assertNotNull(topics);
-    assertEquals(6980, topics.size());
-    assertEquals(584, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102400, (int) topics.lastKey());
-    assertEquals(610, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.distill-splade-max"));
-    assertNotNull(topics);
-    assertEquals(6980, topics.size());
-    assertEquals(1991, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102400, (int) topics.lastKey());
-    assertEquals(2409, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.splade_distil_cocodenser_medium"));
-    assertNotNull(topics);
-    assertEquals(6980, topics.size());
-    assertEquals(1695, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102400, (int) topics.lastKey());
-    assertEquals(1682, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.splade-pp-ed"));
-    assertNotNull(topics);
-    assertEquals(6980, topics.size());
-    assertEquals(21944, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102400, (int) topics.lastKey());
-    assertEquals(24271, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.splade-pp-sd"));
-    assertNotNull(topics);
-    assertEquals(6980, topics.size());
-    assertEquals(25539, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102400, (int) topics.lastKey());
-    assertEquals(30718, topics.get(topics.lastKey()).get("title").split(" ").length);
-
     topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset.cohere-embed-english-v3.0"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
@@ -1312,22 +1031,6 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals("why do children get aggressive", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.load(Topics.get("msmarco-v2-doc.dev.unicoil.0shot"));
-    assertNotNull(topics);
-    assertEquals(4552, topics.size());
-    assertEquals(2, (int) topics.firstKey());
-    assertEquals(617, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102390, (int) topics.lastKey());
-    assertEquals(608, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("msmarco-v2-doc.dev.unicoil-noexp.0shot"));
-    assertNotNull(topics);
-    assertEquals(4552, topics.size());
-    assertEquals(2, (int) topics.firstKey());
-    assertEquals(609, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102390, (int) topics.lastKey());
-    assertEquals(533, topics.get(topics.lastKey()).get("title").split(" ").length);
-
     topics = TopicReader.load(Topics.get("msmarco-v2-doc.dev.snowflake-arctic-embed-l"));
     assertNotNull(topics);
     assertEquals(4552, topics.size());
@@ -1343,22 +1046,6 @@ public class TopicReaderTest {
     assertEquals(". irritability medical definition", topics.get(topics.firstKey()).get("title"));
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals("why do a ferritin level", topics.get(topics.lastKey()).get("title"));
-
-    topics = TopicReader.load(Topics.get("msmarco-v2-doc.dev2.unicoil.0shot"));
-    assertNotNull(topics);
-    assertEquals(5000, topics.size());
-    assertEquals(361, (int) topics.firstKey());
-    assertEquals(714, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102413, (int) topics.lastKey());
-    assertEquals(664, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("msmarco-v2-doc.dev2.unicoil-noexp.0shot"));
-    assertNotNull(topics);
-    assertEquals(5000, topics.size());
-    assertEquals(361, (int) topics.firstKey());
-    assertEquals(690, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102413, (int) topics.lastKey());
-    assertEquals(537, topics.get(topics.lastKey()).get("title").split(" ").length);
 
     topics = TopicReader.load(Topics.get("msmarco-v2-doc.dev2.snowflake-arctic-embed-l"));
     assertNotNull(topics);
@@ -1376,38 +1063,6 @@ public class TopicReaderTest {
     assertEquals(1102390, (int) topics.lastKey());
     assertEquals("why do children get aggressive", topics.get(topics.lastKey()).get("title"));
 
-    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev.unicoil.0shot"));
-    assertNotNull(topics);
-    assertEquals(3903, topics.size());
-    assertEquals(2, (int) topics.firstKey());
-    assertEquals(617, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102390, (int) topics.lastKey());
-    assertEquals(608, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev.unicoil-noexp.0shot"));
-    assertNotNull(topics);
-    assertEquals(3903, topics.size());
-    assertEquals(2, (int) topics.firstKey());
-    assertEquals(609, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102390, (int) topics.lastKey());
-    assertEquals(533, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev.splade-pp-ed"));
-    assertNotNull(topics);
-    assertEquals(3903, topics.size());
-    assertEquals(2, (int) topics.firstKey());
-    assertEquals(21944, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102390, (int) topics.lastKey());
-    assertEquals(30978, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev.splade-pp-sd"));
-    assertNotNull(topics);
-    assertEquals(3903, topics.size());
-    assertEquals(2, (int) topics.firstKey());
-    assertEquals(25539, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102390, (int) topics.lastKey());
-    assertEquals(35354, topics.get(topics.lastKey()).get("title").split(" ").length);
-
     topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev2"));
     assertNotNull(topics);
     assertEquals(4281, topics.size());
@@ -1415,38 +1070,6 @@ public class TopicReaderTest {
     assertEquals("323 area code zip code", topics.get(topics.firstKey()).get("title"));
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals("why do a ferritin level", topics.get(topics.lastKey()).get("title"));
-
-    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev2.unicoil.0shot"));
-    assertNotNull(topics);
-    assertEquals(4281, topics.size());
-    assertEquals(1325, (int) topics.firstKey());
-    assertEquals(671, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102413, (int) topics.lastKey());
-    assertEquals(664, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev2.unicoil-noexp.0shot"));
-    assertNotNull(topics);
-    assertEquals(4281, topics.size());
-    assertEquals(1325, (int) topics.firstKey());
-    assertEquals(649, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102413, (int) topics.lastKey());
-    assertEquals(537, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev2.splade-pp-ed"));
-    assertNotNull(topics);
-    assertEquals(4281, topics.size());
-    assertEquals(1325, (int) topics.firstKey());
-    assertEquals(14928, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102413, (int) topics.lastKey());
-    assertEquals(18984, topics.get(topics.lastKey()).get("title").split(" ").length);
-
-    topics = TopicReader.load(Topics.get("msmarco-v2-passage.dev2.splade-pp-sd"));
-    assertNotNull(topics);
-    assertEquals(4281, topics.size());
-    assertEquals(1325, (int) topics.firstKey());
-    assertEquals(15862, topics.get(topics.firstKey()).get("title").split(" ").length);
-    assertEquals(1102413, (int) topics.lastKey());
-    assertEquals(23387, topics.get(topics.lastKey()).get("title").split(" ").length);
   }
 
   @Test
@@ -1884,16 +1507,16 @@ public class TopicReaderTest {
   @Test
   public void testMrTyDiTopics() throws IOException {
     assertEquals(12377, TopicReader.load(Topics.get("mrtydi-v1.1-ar.train")).keySet().size());
-    assertEquals(3115, TopicReader.load(Topics.get("mrtydi-v1.1-ar.dev")).keySet().size());
-    assertEquals(1081, TopicReader.load(Topics.get("mrtydi-v1.1-ar.test")).keySet().size());
+    assertEquals(3115,  TopicReader.load(Topics.get("mrtydi-v1.1-ar.dev")).keySet().size());
+    assertEquals(1081,  TopicReader.load(Topics.get("mrtydi-v1.1-ar.test")).keySet().size());
 
     assertEquals(1713, TopicReader.load(Topics.get("mrtydi-v1.1-bn.train")).keySet().size());
-    assertEquals(440, TopicReader.load(Topics.get("mrtydi-v1.1-bn.dev")).keySet().size());
-    assertEquals(111, TopicReader.load(Topics.get("mrtydi-v1.1-bn.test")).keySet().size());
+    assertEquals(440,  TopicReader.load(Topics.get("mrtydi-v1.1-bn.dev")).keySet().size());
+    assertEquals(111,  TopicReader.load(Topics.get("mrtydi-v1.1-bn.test")).keySet().size());
 
     assertEquals(3547, TopicReader.load(Topics.get("mrtydi-v1.1-en.train")).keySet().size());
-    assertEquals(878, TopicReader.load(Topics.get("mrtydi-v1.1-en.dev")).keySet().size());
-    assertEquals(744, TopicReader.load(Topics.get("mrtydi-v1.1-en.test")).keySet().size());
+    assertEquals(878,  TopicReader.load(Topics.get("mrtydi-v1.1-en.dev")).keySet().size());
+    assertEquals(744,  TopicReader.load(Topics.get("mrtydi-v1.1-en.test")).keySet().size());
 
     assertEquals(6561, TopicReader.load(Topics.get("mrtydi-v1.1-fi.train")).keySet().size());
     assertEquals(1738, TopicReader.load(Topics.get("mrtydi-v1.1-fi.dev")).keySet().size());
@@ -1901,30 +1524,30 @@ public class TopicReaderTest {
 
     assertEquals(4902, TopicReader.load(Topics.get("mrtydi-v1.1-id.train")).keySet().size());
     assertEquals(1224, TopicReader.load(Topics.get("mrtydi-v1.1-id.dev")).keySet().size());
-    assertEquals(829, TopicReader.load(Topics.get("mrtydi-v1.1-id.test")).keySet().size());
+    assertEquals(829,  TopicReader.load(Topics.get("mrtydi-v1.1-id.test")).keySet().size());
 
     assertEquals(3697, TopicReader.load(Topics.get("mrtydi-v1.1-ja.train")).keySet().size());
-    assertEquals(928, TopicReader.load(Topics.get("mrtydi-v1.1-ja.dev")).keySet().size());
-    assertEquals(720, TopicReader.load(Topics.get("mrtydi-v1.1-ja.test")).keySet().size());
+    assertEquals(928,  TopicReader.load(Topics.get("mrtydi-v1.1-ja.dev")).keySet().size());
+    assertEquals(720,  TopicReader.load(Topics.get("mrtydi-v1.1-ja.test")).keySet().size());
 
     assertEquals(1295, TopicReader.load(Topics.get("mrtydi-v1.1-ko.train")).keySet().size());
-    assertEquals(303, TopicReader.load(Topics.get("mrtydi-v1.1-ko.dev")).keySet().size());
-    assertEquals(421, TopicReader.load(Topics.get("mrtydi-v1.1-ko.test")).keySet().size());
+    assertEquals(303,  TopicReader.load(Topics.get("mrtydi-v1.1-ko.dev")).keySet().size());
+    assertEquals(421,  TopicReader.load(Topics.get("mrtydi-v1.1-ko.test")).keySet().size());
 
     assertEquals(5366, TopicReader.load(Topics.get("mrtydi-v1.1-ru.train")).keySet().size());
     assertEquals(1375, TopicReader.load(Topics.get("mrtydi-v1.1-ru.dev")).keySet().size());
-    assertEquals(995, TopicReader.load(Topics.get("mrtydi-v1.1-ru.test")).keySet().size());
+    assertEquals(995,  TopicReader.load(Topics.get("mrtydi-v1.1-ru.test")).keySet().size());
 
     assertEquals(2072, TopicReader.load(Topics.get("mrtydi-v1.1-sw.train")).keySet().size());
-    assertEquals(526, TopicReader.load(Topics.get("mrtydi-v1.1-sw.dev")).keySet().size());
-    assertEquals(670, TopicReader.load(Topics.get("mrtydi-v1.1-sw.test")).keySet().size());
+    assertEquals(526,  TopicReader.load(Topics.get("mrtydi-v1.1-sw.dev")).keySet().size());
+    assertEquals(670,  TopicReader.load(Topics.get("mrtydi-v1.1-sw.test")).keySet().size());
 
     assertEquals(3880, TopicReader.load(Topics.get("mrtydi-v1.1-te.train")).keySet().size());
-    assertEquals(983, TopicReader.load(Topics.get("mrtydi-v1.1-te.dev")).keySet().size());
-    assertEquals(646, TopicReader.load(Topics.get("mrtydi-v1.1-te.test")).keySet().size());
+    assertEquals(983,  TopicReader.load(Topics.get("mrtydi-v1.1-te.dev")).keySet().size());
+    assertEquals(646,  TopicReader.load(Topics.get("mrtydi-v1.1-te.test")).keySet().size());
 
     assertEquals(3319, TopicReader.load(Topics.get("mrtydi-v1.1-th.train")).keySet().size());
-    assertEquals(807, TopicReader.load(Topics.get("mrtydi-v1.1-th.dev")).keySet().size());
+    assertEquals(807,  TopicReader.load(Topics.get("mrtydi-v1.1-th.dev")).keySet().size());
     assertEquals(1190, TopicReader.load(Topics.get("mrtydi-v1.1-th.test")).keySet().size());
   }
 
@@ -2006,7 +1629,7 @@ public class TopicReaderTest {
     assertEquals(112, TopicReader.load(Topics.get("bright-pony")).keySet().size());
     assertEquals(142, TopicReader.load(Topics.get("bright-leetcode")).keySet().size());
     assertEquals(111, TopicReader.load(Topics.get("bright-aops")).keySet().size());
-    assertEquals(76, TopicReader.load(Topics.get("bright-theoremqa-theorems")).keySet().size());
+    assertEquals(76,  TopicReader.load(Topics.get("bright-theoremqa-theorems")).keySet().size());
     assertEquals(194, TopicReader.load(Topics.get("bright-theoremqa-questions")).keySet().size());
   }
 
@@ -2022,58 +1645,58 @@ public class TopicReaderTest {
     assertEquals(112, TopicReader.load(Topics.get("bright-pony-original")).keySet().size());
     assertEquals(142, TopicReader.load(Topics.get("bright-leetcode-original")).keySet().size());
     assertEquals(111, TopicReader.load(Topics.get("bright-aops-original")).keySet().size());
-    assertEquals(76, TopicReader.load(Topics.get("bright-theoremqa-theorems-original")).keySet().size());
+    assertEquals(76,  TopicReader.load(Topics.get("bright-theoremqa-theorems-original")).keySet().size());
     assertEquals(194, TopicReader.load(Topics.get("bright-theoremqa-questions-original")).keySet().size());
   }
 
   @Test
   public void testMBEIRTopics() throws IOException {
-    assertEquals(4170, TopicReader.load(Topics.get("mbeir-cirr_task7.test")).keySet().size());
-    assertEquals(3241, TopicReader.load(Topics.get("mbeir-edis_task2.test")).keySet().size());
-    assertEquals(1719, TopicReader.load(Topics.get("mbeir-fashion200k_task0.test")).keySet().size());
-    assertEquals(4889, TopicReader.load(Topics.get("mbeir-fashion200k_task3.test")).keySet().size());
-    assertEquals(6003, TopicReader.load(Topics.get("mbeir-fashioniq_task7.test")).keySet().size());
+    assertEquals(4170,  TopicReader.load(Topics.get("mbeir-cirr_task7.test")).keySet().size());
+    assertEquals(3241,  TopicReader.load(Topics.get("mbeir-edis_task2.test")).keySet().size());
+    assertEquals(1719,  TopicReader.load(Topics.get("mbeir-fashion200k_task0.test")).keySet().size());
+    assertEquals(4889,  TopicReader.load(Topics.get("mbeir-fashion200k_task3.test")).keySet().size());
+    assertEquals(6003,  TopicReader.load(Topics.get("mbeir-fashioniq_task7.test")).keySet().size());
     assertEquals(11323, TopicReader.load(Topics.get("mbeir-infoseek_task6.test")).keySet().size());
     assertEquals(17593, TopicReader.load(Topics.get("mbeir-infoseek_task8.test")).keySet().size());
     assertEquals(24809, TopicReader.load(Topics.get("mbeir-mscoco_task0.test")).keySet().size());
-    assertEquals(5000, TopicReader.load(Topics.get("mbeir-mscoco_task3.test")).keySet().size());
-    assertEquals(2120, TopicReader.load(Topics.get("mbeir-nights_task4.test")).keySet().size());
+    assertEquals(5000,  TopicReader.load(Topics.get("mbeir-mscoco_task3.test")).keySet().size());
+    assertEquals(2120,  TopicReader.load(Topics.get("mbeir-nights_task4.test")).keySet().size());
     assertEquals(50004, TopicReader.load(Topics.get("mbeir-oven_task6.test")).keySet().size());
     assertEquals(14741, TopicReader.load(Topics.get("mbeir-oven_task8.test")).keySet().size());
     assertEquals(19995, TopicReader.load(Topics.get("mbeir-visualnews_task0.test")).keySet().size());
     assertEquals(20000, TopicReader.load(Topics.get("mbeir-visualnews_task3.test")).keySet().size());
-    assertEquals(2455, TopicReader.load(Topics.get("mbeir-webqa_task1.test")).keySet().size());
-    assertEquals(2511, TopicReader.load(Topics.get("mbeir-webqa_task2.test")).keySet().size());
+    assertEquals(2455,  TopicReader.load(Topics.get("mbeir-webqa_task1.test")).keySet().size());
+    assertEquals(2511,  TopicReader.load(Topics.get("mbeir-webqa_task2.test")).keySet().size());
   }
 
   @Test public void testMMEBVisDocTopics() throws IOException {
-    assertEquals(500, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_arxivqa.test")).keySet().size());
-    assertEquals(451, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_docvqa.test")).keySet().size());
-    assertEquals(494, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_infovqa.test")).keySet().size());
-    assertEquals(100, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_shiftproject.test")).keySet().size());
-    assertEquals(100, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_artificial_intelligence.test")).keySet().size());
-    assertEquals(100, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_energy.test")).keySet().size());
-    assertEquals(100, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_government_reports.test")).keySet().size());
-    assertEquals(100, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_healthcare_industry.test")).keySet().size());
-    assertEquals(280, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_tabfquad.test")).keySet().size());
+    assertEquals(500,  TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_arxivqa.test")).keySet().size());
+    assertEquals(451,  TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_docvqa.test")).keySet().size());
+    assertEquals(494,  TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_infovqa.test")).keySet().size());
+    assertEquals(100,  TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_shiftproject.test")).keySet().size());
+    assertEquals(100,  TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_artificial_intelligence.test")).keySet().size());
+    assertEquals(100,  TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_energy.test")).keySet().size());
+    assertEquals(100,  TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_government_reports.test")).keySet().size());
+    assertEquals(100,  TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_syntheticDocQA_healthcare_industry.test")).keySet().size());
+    assertEquals(280,  TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_tabfquad.test")).keySet().size());
     assertEquals(1646, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_tatdqa.test")).keySet().size());
-    assertEquals(160, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_biomedical_lectures_v2.test")).keySet().size());
-    assertEquals(640, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_biomedical_lectures_v2_multilingual.test")).keySet().size());
-    assertEquals(58, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_economics_reports_v2.test")).keySet().size());
-    assertEquals(232, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_economics_reports_v2_multilingual.test")).keySet().size());
-    assertEquals(52, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_esg_reports_human_labeled_v2.test")).keySet().size());
-    assertEquals(57, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_esg_reports_v2.test")).keySet().size());
-    assertEquals(228, TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_esg_reports_v2_multilingual.test")).keySet().size());
-    assertEquals(816, TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_ArxivQA.train")).keySet().size());
-    assertEquals(63, TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_ChartQA.train")).keySet().size());
-    assertEquals(718, TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_InfoVQA.train")).keySet().size());
-    assertEquals(591, TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_MP-DocVQA.train")).keySet().size());
-    assertEquals(863, TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_PlotQA.train")).keySet().size());
-    assertEquals(556, TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_SlideVQA.train")).keySet().size());
+    assertEquals(160,  TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_biomedical_lectures_v2.test")).keySet().size());
+    assertEquals(640,  TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_biomedical_lectures_v2_multilingual.test")).keySet().size());
+    assertEquals(58,   TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_economics_reports_v2.test")).keySet().size());
+    assertEquals(232,  TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_economics_reports_v2_multilingual.test")).keySet().size());
+    assertEquals(52,   TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_esg_reports_human_labeled_v2.test")).keySet().size());
+    assertEquals(57,   TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_esg_reports_v2.test")).keySet().size());
+    assertEquals(228,  TopicReader.load(Topics.get("mmeb-visdoc-ViDoRe_esg_reports_v2_multilingual.test")).keySet().size());
+    assertEquals(816,  TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_ArxivQA.train")).keySet().size());
+    assertEquals(63,   TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_ChartQA.train")).keySet().size());
+    assertEquals(718,  TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_InfoVQA.train")).keySet().size());
+    assertEquals(591,  TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_MP-DocVQA.train")).keySet().size());
+    assertEquals(863,  TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_PlotQA.train")).keySet().size());
+    assertEquals(556,  TopicReader.load(Topics.get("mmeb-visdoc-VisRAG_SlideVQA.train")).keySet().size());
     assertEquals(1142, TopicReader.load(Topics.get("mmeb-visdoc-ViDoSeek-doc.test")).keySet().size());
     assertEquals(1142, TopicReader.load(Topics.get("mmeb-visdoc-ViDoSeek-page.test")).keySet().size());
-    assertEquals(838, TopicReader.load(Topics.get("mmeb-visdoc-MMLongBench-doc.test")).keySet().size());
-    assertEquals(838, TopicReader.load(Topics.get("mmeb-visdoc-MMLongBench-page.test")).keySet().size());
+    assertEquals(838,  TopicReader.load(Topics.get("mmeb-visdoc-MMLongBench-doc.test")).keySet().size());
+    assertEquals(838,  TopicReader.load(Topics.get("mmeb-visdoc-MMLongBench-page.test")).keySet().size());
   }
 
   @Test
@@ -2110,9 +1733,9 @@ public class TopicReaderTest {
     assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-fa.en.test.desc")).keySet().size());
     assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-fa.en.test.desc.title")).keySet().size());
 
-    assertEquals(4, TopicReader.load(Topics.get("hc4-v1.0-ru.dev.title")).keySet().size());
-    assertEquals(4, TopicReader.load(Topics.get("hc4-v1.0-ru.dev.desc")).keySet().size());
-    assertEquals(4, TopicReader.load(Topics.get("hc4-v1.0-ru.dev.desc.title")).keySet().size());
+    assertEquals(4,  TopicReader.load(Topics.get("hc4-v1.0-ru.dev.title")).keySet().size());
+    assertEquals(4,  TopicReader.load(Topics.get("hc4-v1.0-ru.dev.desc")).keySet().size());
+    assertEquals(4,  TopicReader.load(Topics.get("hc4-v1.0-ru.dev.desc.title")).keySet().size());
 
     assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-ru.test.title")).keySet().size());
     assertEquals(50, TopicReader.load(Topics.get("hc4-v1.0-ru.test.desc")).keySet().size());
@@ -2278,38 +1901,38 @@ public class TopicReaderTest {
   @Test
   public void testMIRACLTopics() throws IOException {
     assertEquals(2896, TopicReader.load(Topics.get("miracl-v1.0-ar-dev")).keySet().size());
-    assertEquals(411, TopicReader.load(Topics.get("miracl-v1.0-bn-dev")).keySet().size());
-    assertEquals(799, TopicReader.load(Topics.get("miracl-v1.0-en-dev")).keySet().size());
-    assertEquals(648, TopicReader.load(Topics.get("miracl-v1.0-es-dev")).keySet().size());
-    assertEquals(632, TopicReader.load(Topics.get("miracl-v1.0-fa-dev")).keySet().size());
+    assertEquals(411,  TopicReader.load(Topics.get("miracl-v1.0-bn-dev")).keySet().size());
+    assertEquals(799,  TopicReader.load(Topics.get("miracl-v1.0-en-dev")).keySet().size());
+    assertEquals(648,  TopicReader.load(Topics.get("miracl-v1.0-es-dev")).keySet().size());
+    assertEquals(632,  TopicReader.load(Topics.get("miracl-v1.0-fa-dev")).keySet().size());
     assertEquals(1271, TopicReader.load(Topics.get("miracl-v1.0-fi-dev")).keySet().size());
-    assertEquals(343, TopicReader.load(Topics.get("miracl-v1.0-fr-dev")).keySet().size());
-    assertEquals(350, TopicReader.load(Topics.get("miracl-v1.0-hi-dev")).keySet().size());
-    assertEquals(960, TopicReader.load(Topics.get("miracl-v1.0-id-dev")).keySet().size());
-    assertEquals(860, TopicReader.load(Topics.get("miracl-v1.0-ja-dev")).keySet().size());
-    assertEquals(213, TopicReader.load(Topics.get("miracl-v1.0-ko-dev")).keySet().size());
+    assertEquals(343,  TopicReader.load(Topics.get("miracl-v1.0-fr-dev")).keySet().size());
+    assertEquals(350,  TopicReader.load(Topics.get("miracl-v1.0-hi-dev")).keySet().size());
+    assertEquals(960,  TopicReader.load(Topics.get("miracl-v1.0-id-dev")).keySet().size());
+    assertEquals(860,  TopicReader.load(Topics.get("miracl-v1.0-ja-dev")).keySet().size());
+    assertEquals(213,  TopicReader.load(Topics.get("miracl-v1.0-ko-dev")).keySet().size());
     assertEquals(1252, TopicReader.load(Topics.get("miracl-v1.0-ru-dev")).keySet().size());
-    assertEquals(482, TopicReader.load(Topics.get("miracl-v1.0-sw-dev")).keySet().size());
-    assertEquals(828, TopicReader.load(Topics.get("miracl-v1.0-te-dev")).keySet().size());
-    assertEquals(733, TopicReader.load(Topics.get("miracl-v1.0-th-dev")).keySet().size());
-    assertEquals(393, TopicReader.load(Topics.get("miracl-v1.0-zh-dev")).keySet().size());
-    assertEquals(305, TopicReader.load(Topics.get("miracl-v1.0-de-dev")).keySet().size());
-    assertEquals(119, TopicReader.load(Topics.get("miracl-v1.0-yo-dev")).keySet().size());
+    assertEquals(482,  TopicReader.load(Topics.get("miracl-v1.0-sw-dev")).keySet().size());
+    assertEquals(828,  TopicReader.load(Topics.get("miracl-v1.0-te-dev")).keySet().size());
+    assertEquals(733,  TopicReader.load(Topics.get("miracl-v1.0-th-dev")).keySet().size());
+    assertEquals(393,  TopicReader.load(Topics.get("miracl-v1.0-zh-dev")).keySet().size());
+    assertEquals(305,  TopicReader.load(Topics.get("miracl-v1.0-de-dev")).keySet().size());
+    assertEquals(119,  TopicReader.load(Topics.get("miracl-v1.0-yo-dev")).keySet().size());
   }
 
   @Test
   public void testCIRALTopics() throws IOException {
-    assertEquals(10, TopicReader.load(Topics.get("ciral-v1.0-ha-dev-native")).keySet().size());
-    assertEquals(10, TopicReader.load(Topics.get("ciral-v1.0-so-dev-native")).keySet().size());
-    assertEquals(10, TopicReader.load(Topics.get("ciral-v1.0-sw-dev-native")).keySet().size());
-    assertEquals(10, TopicReader.load(Topics.get("ciral-v1.0-yo-dev-native")).keySet().size());
-    assertEquals(80, TopicReader.load(Topics.get("ciral-v1.0-ha-test-a")).keySet().size());
-    assertEquals(99, TopicReader.load(Topics.get("ciral-v1.0-so-test-a")).keySet().size());
-    assertEquals(85, TopicReader.load(Topics.get("ciral-v1.0-sw-test-a")).keySet().size());
+    assertEquals(10,  TopicReader.load(Topics.get("ciral-v1.0-ha-dev-native")).keySet().size());
+    assertEquals(10,  TopicReader.load(Topics.get("ciral-v1.0-so-dev-native")).keySet().size());
+    assertEquals(10,  TopicReader.load(Topics.get("ciral-v1.0-sw-dev-native")).keySet().size());
+    assertEquals(10,  TopicReader.load(Topics.get("ciral-v1.0-yo-dev-native")).keySet().size());
+    assertEquals(80,  TopicReader.load(Topics.get("ciral-v1.0-ha-test-a")).keySet().size());
+    assertEquals(99,  TopicReader.load(Topics.get("ciral-v1.0-so-test-a")).keySet().size());
+    assertEquals(85,  TopicReader.load(Topics.get("ciral-v1.0-sw-test-a")).keySet().size());
     assertEquals(100, TopicReader.load(Topics.get("ciral-v1.0-yo-test-a")).keySet().size());
-    assertEquals(80, TopicReader.load(Topics.get("ciral-v1.0-ha-test-a-native")).keySet().size());
-    assertEquals(99, TopicReader.load(Topics.get("ciral-v1.0-so-test-a-native")).keySet().size());
-    assertEquals(85, TopicReader.load(Topics.get("ciral-v1.0-sw-test-a-native")).keySet().size());
+    assertEquals(80,  TopicReader.load(Topics.get("ciral-v1.0-ha-test-a-native")).keySet().size());
+    assertEquals(99,  TopicReader.load(Topics.get("ciral-v1.0-so-test-a-native")).keySet().size());
+    assertEquals(85,  TopicReader.load(Topics.get("ciral-v1.0-sw-test-a-native")).keySet().size());
     assertEquals(100, TopicReader.load(Topics.get("ciral-v1.0-yo-test-a-native")).keySet().size());
     assertEquals(312, TopicReader.load(Topics.get("ciral-v1.0-ha-test-b")).keySet().size());
     assertEquals(239, TopicReader.load(Topics.get("ciral-v1.0-so-test-b")).keySet().size());

--- a/src/test/java/io/anserini/search/topicreader/TopicsTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicsTest.java
@@ -19,9 +19,6 @@ package io.anserini.search.topicreader;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Map;
 import java.util.SortedMap;
 
@@ -55,19 +52,8 @@ public class TopicsTest {
   }
 
   @Test
-  public void testResolveMsMarcoV1Passage1() {
-    SortedMap<Integer, Map<String, String>> topics = Topics.resolve("msmarco-v1-passage.dev");
-
-    assertEquals(6980, topics.size());
-    assertEquals(Integer.valueOf(2), topics.firstKey());
-    assertEquals("Androgen receptor define", topics.get(topics.firstKey()).get("title"));
-    assertEquals(Integer.valueOf(1102400), topics.lastKey());
-    assertEquals("why do bears hibernate", topics.get(topics.lastKey()).get("title"));
-  }
-
-    @Test
-  public void testResolveMsMarcoV1Passage2() {
-    SortedMap<Integer, Map<String, String>> topics = Topics.resolve("msmarco-passage.dev-subset");
+  public void testLoadMsMarcoV1Passage1() {
+    SortedMap<Integer, Map<String, String>> topics = Topics.load("msmarco-v1-passage.dev");
 
     assertEquals(6980, topics.size());
     assertEquals(Integer.valueOf(2), topics.firstKey());
@@ -77,28 +63,36 @@ public class TopicsTest {
   }
 
   @Test
-  public void testResolveInvalidTopics() {
+  public void testLoadMsMarcoV1Passage2() {
+    SortedMap<Integer, Map<String, String>> topics = Topics.load("msmarco-passage.dev-subset");
+
+    assertEquals(6980, topics.size());
+    assertEquals(Integer.valueOf(2), topics.firstKey());
+    assertEquals("Androgen receptor define", topics.get(topics.firstKey()).get("title"));
+    assertEquals(Integer.valueOf(1102400), topics.lastKey());
+    assertEquals("why do bears hibernate", topics.get(topics.lastKey()).get("title"));
+  }
+
+  @Test
+  public void testLoadFromTopic() {
+    SortedMap<Integer, Map<String, String>> topics = Topics.load(Topics.get("msmarco-passage.dev-subset"));
+
+    assertEquals(6980, topics.size());
+    assertEquals(Integer.valueOf(2), topics.firstKey());
+    assertEquals("Androgen receptor define", topics.get(topics.firstKey()).get("title"));
+    assertEquals(Integer.valueOf(1102400), topics.lastKey());
+    assertEquals("why do bears hibernate", topics.get(topics.lastKey()).get("title"));
+  }
+
+  @Test
+  public void testLoadInvalidTopics() {
     String invalidTopics = "this-is-not-valid-topics";
 
     try {
-      Topics.resolve(invalidTopics);
+      Topics.load(invalidTopics);
       fail("Expected IllegalArgumentException to be thrown");
     } catch (IllegalArgumentException e) {
       assertEquals("\"" + invalidTopics + "\" does not refer to valid topics.", e.getMessage());
-    }
-  }
-
-  @Test
-  public void testResolveFileWithoutTopicReader() throws IOException {
-    Path topicsFile = Files.createTempFile("topics", ".txt");
-
-    try {
-      Topics.resolve(topicsFile.toString());
-      fail("Expected IllegalArgumentException to be thrown");
-    } catch (IllegalArgumentException e) {
-      assertEquals("Must specify the topic reader using -topicReader.", e.getMessage());
-    } finally {
-      Files.deleteIfExists(topicsFile);
     }
   }
 }

--- a/src/test/java/io/anserini/search/topicreader/TopicsTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicsTest.java
@@ -16,12 +16,6 @@
 
 package io.anserini.search.topicreader;
 
-import static io.anserini.search.topicreader.Topics.MSMARCO_PASSAGE_DEV_SUBSET;
-import static io.anserini.search.topicreader.Topics.TREC2019_DL_PASSAGE;
-import static io.anserini.search.topicreader.Topics.TREC2020_DL;
-import static io.anserini.search.topicreader.Topics.TREC2021_DL;
-import static io.anserini.search.topicreader.Topics.TREC2022_DL;
-import static io.anserini.search.topicreader.Topics.TREC2023_DL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -38,26 +32,26 @@ public class TopicsTest {
   @Test
   public void testBasic() {
     // Not intended to be exhaustive, just spot checks.
-    assertEquals(MSMARCO_PASSAGE_DEV_SUBSET, Topics.getByName("MSMARCO_PASSAGE_DEV_SUBSET"));
-    assertEquals(TREC2019_DL_PASSAGE, Topics.getByName("TREC2019_DL_PASSAGE"));
-    assertEquals(TREC2020_DL, Topics.getByName("TREC2020_DL"));
+    assertEquals("topics.msmarco-passage.dev-subset.txt", Topics.get("msmarco-passage.dev-subset").path);
+    assertEquals("topics.dl19-passage.txt", Topics.get("dl19-passage").path);
+    assertEquals("topics.dl20.txt", Topics.get("dl20").path);
   }
 
   @Test
   public void testSymbols() {
     // Not practical to exhaustively test all aliases, just spot checks.
-    assertEquals(MSMARCO_PASSAGE_DEV_SUBSET, Topics.getByName("msmarco-passage-dev"));
-    assertEquals(MSMARCO_PASSAGE_DEV_SUBSET, Topics.getByName("msmarco-v1-passage-dev"));
-    assertEquals(MSMARCO_PASSAGE_DEV_SUBSET, Topics.getByName("msmarco-v1-passage.dev"));
+    assertEquals(Topics.get("msmarco-passage.dev-subset"), Topics.get("msmarco-passage-dev"));
+    assertEquals(Topics.get("msmarco-passage.dev-subset"), Topics.get("msmarco-v1-passage-dev"));
+    assertEquals(Topics.get("msmarco-passage.dev-subset"), Topics.get("msmarco-v1-passage.dev"));
 
-    assertEquals(TREC2020_DL, Topics.getByName("dl20-passage"));
-    assertEquals(TREC2020_DL, Topics.getByName("dl20-doc"));
-    assertEquals(TREC2021_DL, Topics.getByName("dl21-passage"));
-    assertEquals(TREC2021_DL, Topics.getByName("dl21-doc"));
-    assertEquals(TREC2022_DL, Topics.getByName("dl22-passage"));
-    assertEquals(TREC2022_DL, Topics.getByName("dl22-doc"));
-    assertEquals(TREC2023_DL, Topics.getByName("dl23-passage"));
-    assertEquals(TREC2023_DL, Topics.getByName("dl23-doc"));
+    assertEquals(Topics.get("dl20"), Topics.get("dl20-passage"));
+    assertEquals(Topics.get("dl20"), Topics.get("dl20-doc"));
+    assertEquals(Topics.get("dl21"), Topics.get("dl21-passage"));
+    assertEquals(Topics.get("dl21"), Topics.get("dl21-doc"));
+    assertEquals(Topics.get("dl22"), Topics.get("dl22-passage"));
+    assertEquals(Topics.get("dl22"), Topics.get("dl22-doc"));
+    assertEquals(Topics.get("dl23"), Topics.get("dl23-passage"));
+    assertEquals(Topics.get("dl23"), Topics.get("dl23-doc"));
   }
 
   @Test
@@ -73,7 +67,7 @@ public class TopicsTest {
 
     @Test
   public void testResolveMsMarcoV1Passage2() {
-    SortedMap<Integer, Map<String, String>> topics = Topics.resolve("MSMARCO_PASSAGE_DEV_SUBSET");
+    SortedMap<Integer, Map<String, String>> topics = Topics.resolve("msmarco-passage.dev-subset");
 
     assertEquals(6980, topics.size());
     assertEquals(Integer.valueOf(2), topics.firstKey());


### PR DESCRIPTION
## Summary

- Add local topic metadata and aliases for registered topics.
- Refactor `Topics` into a metadata-backed registry loaded from JSON resources.
- Replace `Topics.resolve(...)` with explicit `Topics.load(...)` and `TopicReader.load(...)` entry points.
- Keep local-file topic loading explicit: local readable paths use `TopicReader.load(file, topicReader)`, while registry keys use `Topics.load(key)`.
- Update callers and tests to use canonical topic keys and remove legacy enum-style topic symbols and wrappers.
- Remove unused topic-loading helpers.

## Validation

- `mvn -Dtest=TopicsTest,TopicReaderTest,TopicsRegistryTest test`
- `mvn -Dtest=SearchCollectionTest test`
- `git diff --check`
