### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -690,3 +690,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@sadia213](https://github.com/sadia213) on 2026-07-10 (commit [`b98b8fb7`](https://github.com/castorini/anserini/commit/b98b8fb7c874cfda814daddbaa429dc2b8d6f982))
 + Results reproduced by [@abubinfahd](https://github.com/abubinfahd) on 2026-07-13 (commit [`b98b8fb`](https://github.com/castorini/anserini/commit/b98b8fb7c874cfda814daddbaa429dc2b8d6f982))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`6f6b00d`](https://github.com/castorini/anserini/commit/6f6b00d0ecb160557514ed0e00f8767831d16f3a))
++ Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`c1fc59c`](https://github.com/castorini/anserini/commit/c1fc59ca973eb3dab0126cdb5d08fded64869431))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -237,3 +237,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@sadia213](https://github.com/sadia213) on 2026-07-12 (commit [`b98b8fb7`](https://github.com/castorini/anserini/commit/b98b8fb7c874cfda814daddbaa429dc2b8d6f982))
 + Results reproduced by [@abubinfahd](https://github.com/abubinfahd) on 2026-07-13 (commit [`b98b8fb`](https://github.com/castorini/anserini/commit/b98b8fb7c874cfda814daddbaa429dc2b8d6f982))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`6f6b00d`](https://github.com/castorini/anserini/commit/6f6b00d0ecb160557514ed0e00f8767831d16f3a))
++ Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`c1fc59c`](https://github.com/castorini/anserini/commit/c1fc59ca973eb3dab0126cdb5d08fded64869431))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -597,3 +597,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@sadia213](https://github.com/sadia213) on 2026-07-10 (commit [`b98b8fb7`](https://github.com/castorini/anserini/commit/b98b8fb7c874cfda814daddbaa429dc2b8d6f982))
 + Results reproduced by [@abubinfahd](https://github.com/abubinfahd) on 2026-07-13 (commit [`b98b8fb`](https://github.com/castorini/anserini/commit/b98b8fb7c874cfda814daddbaa429dc2b8d6f982))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`6f6b00d`](https://github.com/castorini/anserini/commit/6f6b00d0ecb160557514ed0e00f8767831d16f3a))
++ Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`c1fc59c`](https://github.com/castorini/anserini/commit/c1fc59ca973eb3dab0126cdb5d08fded64869431))


### PR DESCRIPTION
Adding my reproduction log entries for the onboarding exercises, covering the following guides:

+ Start Here (`docs/start-here.md`)
+ BM25 Baselines for MS MARCO Passage Ranking (`docs/experiments-msmarco-passage.md`)
+ Dense Retrieval for MS MARCO Passage Ranking (`docs/experiments-msmarco-passage2.md`)

**Setup:**
+ macOS 26.5 on Apple Silicon (arm64)
+ JDK 21 (Temurin 21.0.11), Maven 3.9.16
+ Built with `mvn clean package` as described in the guides

**Results:**
Everything worked as described. All retrieval runs completed successfully and the evaluation scores matched the expected values in the guides.

The entries reference commit [`c1fc59c`](https://github.com/castorini/anserini/commit/c1fc59ca973eb3dab0126cdb5d08fded64869431) on the main trunk, and I've confirmed they are chronologically sorted (dated 2026-07-16, after the most recent existing entries from 2026-07-15).
