### PR TITLE
[codex] Document prebuilt index metadata loading

### DIFF
--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -871,6 +871,9 @@ public class IndexReaderUtils {
   }
 
   public static Path getIndex(String index) throws IOException {
+    // Note that we always check for the ambiguous case below, so as a result we always read the prebuilt
+    // index metadata from GitHub. This means that this method will fail if there's an issue with GitHub.
+    // However, the prebuilt index metadata is cached in memory, per JVM, via the static holder singletons.
     PrebuiltIndexHandler handler = PrebuiltIndexHandler.get(index);
 
     // Check for the ambiguous case.

--- a/src/main/java/io/anserini/index/prebuilt/PrebuiltFlatIndex.java
+++ b/src/main/java/io/anserini/index/prebuilt/PrebuiltFlatIndex.java
@@ -28,7 +28,7 @@ public class PrebuiltFlatIndex extends PrebuiltIndex {
   }
 
   public static class Entry extends PrebuiltIndex.Entry {
-    // TODO (2026/01/30): currently, there are no special metadata that we track for flat indexes,
+    // TODO (2026/01/30): currently, there are no special metadata that we track for flat vector indexes,
     // but we should circle back and add some checks.
   }
 

--- a/src/main/java/io/anserini/index/prebuilt/PrebuiltHnswIndex.java
+++ b/src/main/java/io/anserini/index/prebuilt/PrebuiltHnswIndex.java
@@ -28,7 +28,7 @@ public class PrebuiltHnswIndex extends PrebuiltIndex {
   }
 
   public static class Entry extends PrebuiltIndex.Entry {
-    // TODO (2026/01/30): currently, there are no special metadata that we track for flat indexes,
+    // TODO (2026/01/30): currently, there are no special metadata that we track for HNSW indexes,
     // but we should circle back and add some checks.
   }
 

--- a/src/main/java/io/anserini/index/prebuilt/PrebuiltInvertedIndex.java
+++ b/src/main/java/io/anserini/index/prebuilt/PrebuiltInvertedIndex.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class PrebuiltInvertedIndex extends PrebuiltIndex {
   // This is the singleton instance of this class. Use the holder pattern to ensure thread safety.
   private static class Holder {


### PR DESCRIPTION
## Summary

- Document that IndexReaderUtils.getIndex checks prebuilt index metadata before local path fallback.
- Clarify that prebuilt index metadata is cached in memory per JVM through static holder singletons.
- Tighten TODO wording for flat vector and HNSW prebuilt index metadata.

## Validation

- git diff --check