### PR TITLE
Upgrade to Lucene 10.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </developers>
 
   <properties>
-    <lucene.version>10.4.0</lucene.version>
+    <lucene.version>10.5.0</lucene.version>
     <jackson.version>2.22.1</jackson.version>
     <java.version>21</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/io/anserini/index/codecs/Anserini20FlatScalarQuantizedVectorsFormat.java
+++ b/src/main/java/io/anserini/index/codecs/Anserini20FlatScalarQuantizedVectorsFormat.java
@@ -36,6 +36,7 @@ import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.IORunnable;
 
 public class Anserini20FlatScalarQuantizedVectorsFormat extends KnnVectorsFormat {
 
@@ -100,8 +101,8 @@ public class Anserini20FlatScalarQuantizedVectorsFormat extends KnnVectorsFormat
     }
 
     @Override
-    public void mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
-      writer.mergeOneField(fieldInfo, mergeState);
+    public IORunnable mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
+      return writer.mergeOneField(fieldInfo, mergeState);
     }
   }
 

--- a/src/main/java/io/anserini/index/codecs/Anserini20FlatVectorsFormat.java
+++ b/src/main/java/io/anserini/index/codecs/Anserini20FlatVectorsFormat.java
@@ -36,6 +36,7 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.VectorScorer;
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.IORunnable;
 
 public class Anserini20FlatVectorsFormat extends KnnVectorsFormat {
 
@@ -100,8 +101,8 @@ public class Anserini20FlatVectorsFormat extends KnnVectorsFormat {
     }
 
     @Override
-    public void mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
-      writer.mergeOneField(fieldInfo, mergeState);
+    public IORunnable mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
+      return writer.mergeOneField(fieldInfo, mergeState);
     }
   }
 

--- a/src/main/java/io/anserini/index/codecs/AnseriniLucene99FlatVectorFormat.java
+++ b/src/main/java/io/anserini/index/codecs/AnseriniLucene99FlatVectorFormat.java
@@ -36,6 +36,7 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.VectorScorer;
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.IORunnable;
 
 public class AnseriniLucene99FlatVectorFormat extends KnnVectorsFormat {
 
@@ -100,8 +101,8 @@ public class AnseriniLucene99FlatVectorFormat extends KnnVectorsFormat {
     }
 
     @Override
-    public void mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
-      writer.mergeOneField(fieldInfo, mergeState);
+    public IORunnable mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
+      return writer.mergeOneField(fieldInfo, mergeState);
     }
   }
 

--- a/src/main/java/io/anserini/index/codecs/AnseriniLucene99ScalarQuantizedVectorsFormat.java
+++ b/src/main/java/io/anserini/index/codecs/AnseriniLucene99ScalarQuantizedVectorsFormat.java
@@ -36,6 +36,7 @@ import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.IORunnable;
 
 public class AnseriniLucene99ScalarQuantizedVectorsFormat extends KnnVectorsFormat {
 
@@ -100,8 +101,8 @@ public class AnseriniLucene99ScalarQuantizedVectorsFormat extends KnnVectorsForm
     }
 
     @Override
-    public void mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
-      writer.mergeOneField(fieldInfo, mergeState);
+    public IORunnable mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
+      return writer.mergeOneField(fieldInfo, mergeState);
     }
   }
 


### PR DESCRIPTION
Lucene 10.5.0 was released on June 25, 2026.
(https://lucene.apache.org/core/corenews.html#apache-lucenetm-1050-available)

The Lucene 10.5.0 upgrade requires only one API change in the current Anserini codebase:
the return type of `KnnVectorsWriter#mergeOneField` changed from `void` to `IORunnable` (apache/lucene#15732).

The reason for this change is that Lucene now performs vector merges in two phases.

In phase 1, `mergeOneField` performs the initial merge work—typically writing the flat vectors—and may return an `IORunnable` for deferred work.
In phase 2, Lucene executes the returned runnables to build expensive auxiliary structures (e.g., HNSW graphs) on top of the flat vectors written in phase 1.

This avoids writing the flat vectors twice during HNSW merges.
A writer with no deferred work simply returns `null`.

This PR updates the four delegating `KnnVectorsWriter` wrappers in`io.anserini.index.codecs` to match the new signature; they just return the delegate's result.
No other changes are needed. The default codec in 10.5.0 is still `Lucene104`, so the index format is unchanged. All existing tests pass without modification.