### PR TITLE
Onboarding: reproduction log entries for start-here, BM25, and dense retrieval (Lessons 1-3)

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -694,4 +694,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@abubinfahd](https://github.com/abubinfahd) on 2026-07-13 (commit [`b98b8fb`](https://github.com/castorini/anserini/commit/b98b8fb7c874cfda814daddbaa429dc2b8d6f982))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`6f6b00d`](https://github.com/castorini/anserini/commit/6f6b00d0ecb160557514ed0e00f8767831d16f3a))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`c1fc59c`](https://github.com/castorini/anserini/commit/c1fc59ca973eb3dab0126cdb5d08fded64869431))
-+ Results reproduced by [@hannahnagpall05](https://github.com/hannahnagpall05) on 2026-07-21 (commit [`1d4f695`](https://github.com/castorini/anserini/commit/1d4f6953f30eeadc1f14dc8e9650d3a8b7c13a2d))
++ Results reproduced by [@hannahnagpall05](https://github.com/hannahnagpall05) on 2026-07-21 (commit [`cf102306`](https://github.com/castorini/anserini/commit/cf102306aae68c2e27a29516b6ee30f32e955dd1))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -694,3 +694,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@abubinfahd](https://github.com/abubinfahd) on 2026-07-13 (commit [`b98b8fb`](https://github.com/castorini/anserini/commit/b98b8fb7c874cfda814daddbaa429dc2b8d6f982))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`6f6b00d`](https://github.com/castorini/anserini/commit/6f6b00d0ecb160557514ed0e00f8767831d16f3a))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`c1fc59c`](https://github.com/castorini/anserini/commit/c1fc59ca973eb3dab0126cdb5d08fded64869431))
++ Results reproduced by [@hannahnagpall05](https://github.com/hannahnagpall05) on 2026-07-21 (commit [`1d4f695`](https://github.com/castorini/anserini/commit/1d4f6953f30eeadc1f14dc8e9650d3a8b7c13a2d))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -241,4 +241,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@abubinfahd](https://github.com/abubinfahd) on 2026-07-13 (commit [`b98b8fb`](https://github.com/castorini/anserini/commit/b98b8fb7c874cfda814daddbaa429dc2b8d6f982))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`6f6b00d`](https://github.com/castorini/anserini/commit/6f6b00d0ecb160557514ed0e00f8767831d16f3a))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`c1fc59c`](https://github.com/castorini/anserini/commit/c1fc59ca973eb3dab0126cdb5d08fded64869431))
-+ Results reproduced by [@hannahnagpall05](https://github.com/hannahnagpall05) on 2026-07-24 (commit ['f2e95ff](https://github.com/castorini/anserini/commit/f2e95ff6d8ea5f83fc4bf23a8dbce9b32dff869f))
++ Results reproduced by [@hannahnagpall05](https://github.com/hannahnagpall05) on 2026-07-24 (commit [`cf102306`](https://github.com/castorini/anserini/commit/cf102306aae68c2e27a29516b6ee30f32e955dd1))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -241,4 +241,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@abubinfahd](https://github.com/abubinfahd) on 2026-07-13 (commit [`b98b8fb`](https://github.com/castorini/anserini/commit/b98b8fb7c874cfda814daddbaa429dc2b8d6f982))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`6f6b00d`](https://github.com/castorini/anserini/commit/6f6b00d0ecb160557514ed0e00f8767831d16f3a))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`c1fc59c`](https://github.com/castorini/anserini/commit/c1fc59ca973eb3dab0126cdb5d08fded64869431))
-
++ Results reproduced by [@hannahnagpall05](https://github.com/hannahnagpall05) on 2026-07-24 (commit ['f2e95ff](https://github.com/castorini/anserini/commit/f2e95ff6d8ea5f83fc4bf23a8dbce9b32dff869f))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -601,4 +601,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@abubinfahd](https://github.com/abubinfahd) on 2026-07-13 (commit [`b98b8fb`](https://github.com/castorini/anserini/commit/b98b8fb7c874cfda814daddbaa429dc2b8d6f982))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`6f6b00d`](https://github.com/castorini/anserini/commit/6f6b00d0ecb160557514ed0e00f8767831d16f3a))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`c1fc59c`](https://github.com/castorini/anserini/commit/c1fc59ca973eb3dab0126cdb5d08fded64869431))
-+ Results reproduced by [@hannahnagpall05](https://github.com/hannahnagpall05) on 2026-07-21 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
++ Results reproduced by [@hannahnagpall05](https://github.com/hannahnagpall05) on 2026-07-21 (commit [`cf102306`](https://github.com/castorini/anserini/commit/cf102306aae68c2e27a29516b6ee30f32e955dd1))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -601,4 +601,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@abubinfahd](https://github.com/abubinfahd) on 2026-07-13 (commit [`b98b8fb`](https://github.com/castorini/anserini/commit/b98b8fb7c874cfda814daddbaa429dc2b8d6f982))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`6f6b00d`](https://github.com/castorini/anserini/commit/6f6b00d0ecb160557514ed0e00f8767831d16f3a))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`c1fc59c`](https://github.com/castorini/anserini/commit/c1fc59ca973eb3dab0126cdb5d08fded64869431))
-
++ Results reproduced by [@hannahnagpall05](https://github.com/hannahnagpall05) on 2026-07-21 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))


### PR DESCRIPTION
Onboarding: reproduction log entries for start-here, BM25, and dense retrieval (Lessons 1-3)

Completed Lessons 1-3 of the Anserini onboarding path (start-here.md,
experiments-msmarco-passage.md, experiments-msmarco-passage2.md).

Environment:
- Windows 11 + WSL2 (Ubuntu 26.04)
- JDK 21.0.11, Maven 3.9.12
- 16 GB RAM, 4 CPU threads allocated to WSL2

Results:
- Lesson 2 (BM25, self-built index): MRR@10 = 0.18741227770955546 ✓ (matches expected)
- Lesson 3 (BM25, prebuilt index): MRR@10 = 0.1875 ✓ (matches expected)
- Lesson 3 (dense retrieval, BGE-base HNSW): MRR@10 = 0.3521 ✓ (matches expected)

Issues encountered / notes:
- The default `-Xmx192G` heap size specified in `bin/run.sh` exceeded the available memory allocated to WSL2 and caused indexing failures. Reducing the heap allocation locally (e.g., `-Xmx6G`) allowed indexing to complete successfully. This was only a local configuration change and was not committed.
- Dense retrieval using the BGE-base HNSW model on a CPU-only WSL2 setup required substantially longer runtime (~33.5 hours) than the reference runtime reported in the documentation. Users running similar hardware configurations should expect significantly longer execution times.

All steps were completed successfully and the reported evaluation metrics matched the expected values.