### PR TITLE
docs: add reproduction log entries for Foundations of Retrieval onboarding (Lessons 1-3)

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -694,3 +694,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@abubinfahd](https://github.com/abubinfahd) on 2026-07-13 (commit [`b98b8fb`](https://github.com/castorini/anserini/commit/b98b8fb7c874cfda814daddbaa429dc2b8d6f982))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`6f6b00d`](https://github.com/castorini/anserini/commit/6f6b00d0ecb160557514ed0e00f8767831d16f3a))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`c1fc59c`](https://github.com/castorini/anserini/commit/c1fc59ca973eb3dab0126cdb5d08fded64869431))
++ Results reproduced by [@carlosp2001](https://github.com/carlosp2001) on 2026-07-16 (commit [`bd93b89`](https://github.com/castorini/anserini/commit/7b2927358ac79c64a9b8ca9f94b898deed84e6ac))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -241,4 +241,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@abubinfahd](https://github.com/abubinfahd) on 2026-07-13 (commit [`b98b8fb`](https://github.com/castorini/anserini/commit/b98b8fb7c874cfda814daddbaa429dc2b8d6f982))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`6f6b00d`](https://github.com/castorini/anserini/commit/6f6b00d0ecb160557514ed0e00f8767831d16f3a))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`c1fc59c`](https://github.com/castorini/anserini/commit/c1fc59ca973eb3dab0126cdb5d08fded64869431))
-
++ Results reproduced by [@carlosp2001](https://github.com/carlosp2001) on 2026-07-18 (commit [`92f0bba`](https://github.com/castorini/anserini/commit/92f0bbac97ac1a658f9be2d02124a543c0b134e3))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -601,4 +601,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@abubinfahd](https://github.com/abubinfahd) on 2026-07-13 (commit [`b98b8fb`](https://github.com/castorini/anserini/commit/b98b8fb7c874cfda814daddbaa429dc2b8d6f982))
 + Results reproduced by [@mfrashidi](https://github.com/mfrashidi) on 2026-07-15 (commit [`6f6b00d`](https://github.com/castorini/anserini/commit/6f6b00d0ecb160557514ed0e00f8767831d16f3a))
 + Results reproduced by [@Leonoaix](https://github.com/Leonoaix) on 2026-07-16 (commit [`c1fc59c`](https://github.com/castorini/anserini/commit/c1fc59ca973eb3dab0126cdb5d08fded64869431))
-
++ Results reproduced by [@carlosp2001](https://github.com/carlosp2001) on 2026-07-16 (commit [`bd93b89`](https://github.com/castorini/anserini/commit/7b2927358ac79c64a9b8ca9f94b898deed84e6ac))


### PR DESCRIPTION
## Summary

Reproduction of the Foundations of Retrieval onboarding path (Lessons 1-3) in Anserini:
- `start-here.md`
- `experiments-msmarco-passage.md`
- `experiments-msmarco-passage2.md`

## Setup

- OS: macOS Darwin 25.5.0 (Apple Silicon)
- Java: OpenJDK 25.0.2
- Repo: local fork (`anserini_fork`)

## Results

**Lesson 2 — BM25 baseline (MS MARCO passage, built index)**
- MRR@10 = 0.1874

**Lesson 3 — Prebuilt indexes + dense retrieval (BGE-base HNSW)**
- BM25 (prebuilt index): MRR@10 = 0.1875
- Dense retrieval (BGE-base, HNSW): MRR@10 ≈ 0.3521

## Issues encountered

- Reduced JVM heap allocation from the suggested `-Xmx192G` to `-Xmx8G` due to local memory constraints when building the index in Lesson 2. No other issues — all steps completed successfully on this setup.

## Checklist

- [x] Reproduction Log entry added, chronologically sorted
- [x] Rebased on latest `upstream/master` to resolve conflicts from concurrent PRs
- [x] All 3 lessons completed as a single consolidated PR (no separate PRs per exercise)