### PR TITLE
Add reproduction log entries for Foundations of Retrieval lessons 1-3

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -697,3 +697,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@carlosp2001](https://github.com/carlosp2001) on 2026-07-16 (commit [`bd93b89`](https://github.com/castorini/anserini/commit/7b2927358ac79c64a9b8ca9f94b898deed84e6ac))
 + Results reproduced by [@mihiit](https://github.com/mihiit) on 2026-07-21 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
 + Results reproduced by [@BakaryGibba](https://github.com/BakaryGibba) on 2026-07-26 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
++ Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`02f25de`](https://github.com/castorini/anserini/commit/02f25dea042ee651085340d60ffbe9bc9820169b))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -244,3 +244,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@carlosp2001](https://github.com/carlosp2001) on 2026-07-18 (commit [`92f0bba`](https://github.com/castorini/anserini/commit/92f0bbac97ac1a658f9be2d02124a543c0b134e3))
 + Results reproduced by [@mihiit](https://github.com/mihiit) on 2026-07-23 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
 + Results reproduced by [@BakaryGibba](https://github.com/BakaryGibba) on 2026-07-27 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
++ Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`02f25de`](https://github.com/castorini/anserini/commit/02f25dea042ee651085340d60ffbe9bc9820169b))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -604,3 +604,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@carlosp2001](https://github.com/carlosp2001) on 2026-07-16 (commit [`bd93b89`](https://github.com/castorini/anserini/commit/7b2927358ac79c64a9b8ca9f94b898deed84e6ac))
 + Results reproduced by [@mihiit](https://github.com/mihiit) on 2026-07-21 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
 + Results reproduced by [@BakaryGibba](https://github.com/BakaryGibba) on 2026-07-26 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
++ Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`02f25de`](https://github.com/castorini/anserini/commit/02f25dea042ee651085340d60ffbe9bc9820169b))


### PR DESCRIPTION
Add reproduction log entries for the "Foundations of Retrieval" onboarding path (lessons 1-3): `start-here.md`, BM25 baseline, and dense retrieval (BGE) on MS MARCO passage ranking.

## Setup

- OS: macOS 26.5.2 (Darwin 25.5.0), Apple M4, 16 GB RAM
- Java: OpenJDK 21.0.12 (Homebrew)
- Maven: 3.9.16
- Build: `bin/qbuild.sh` (quick build, fatjar produced), verified against the CACM smoke test (`map 0.3123`, `P_30 0.1942` — matches expected)

## Results

All three lessons reproduced exactly against the documented expected values:

- **start-here.md**: downloaded/converted MS MARCO passage collection (checksum `31644046b18952c1386cd4564ba2ae69` verified), 9 JSONL files (8,841,823 docs total, last file 841,823 lines — matches), filtered dev queries to 6,980 lines, cross-referenced qrels/collection for a sample query — all as documented.
- **experiments-msmarco-passage.md** (BM25 baseline): indexed 8,841,823 docs (0 errors, ~3 min, 4.4G index). MRR@10 = `0.18741227770955546` (official MS MARCO eval script), `map = 0.1957`, `recall_1000 = 0.8573` (trec_eval) — exact match.
- **experiments-msmarco-passage2.md** (dense retrieval): prebuilt BM25 index run gave MRR@10 = `0.1875` (exact match). BGE-base HNSW dense retrieval (26 GB prebuilt index) gave MRR@10 = `0.3521` (exact match), confirming the expected improvement over BM25.

No issues encountered, aside from a transient GitHub API rate-limit (403) on the prebuilt-index metadata fetch, which resolved itself after the standard hourly reset.
