### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -698,3 +698,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@mihiit](https://github.com/mihiit) on 2026-07-21 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
 + Results reproduced by [@BakaryGibba](https://github.com/BakaryGibba) on 2026-07-26 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`02f25de`](https://github.com/castorini/anserini/commit/02f25dea042ee651085340d60ffbe9bc9820169b))
++ Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-02 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -245,3 +245,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@mihiit](https://github.com/mihiit) on 2026-07-23 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
 + Results reproduced by [@BakaryGibba](https://github.com/BakaryGibba) on 2026-07-27 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`02f25de`](https://github.com/castorini/anserini/commit/02f25dea042ee651085340d60ffbe9bc9820169b))
++ Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-02 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -605,3 +605,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@mihiit](https://github.com/mihiit) on 2026-07-21 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
 + Results reproduced by [@BakaryGibba](https://github.com/BakaryGibba) on 2026-07-26 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`02f25de`](https://github.com/castorini/anserini/commit/02f25dea042ee651085340d60ffbe9bc9820169b))
++ Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-02 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))


### PR DESCRIPTION
Worked through the first three lessons of the Anserini onboarding path and added
entries to the reproduction logs.

**Setup**
- macOS 15.6.1 (Apple Silicon)
- OpenJDK 21.0.12 (Homebrew)
- Maven 3.9.16
- Python 3

**Results**

`start-here.md` — downloaded and unpacked the MS MARCO passage collection,
converted to jsonl (9 files, 8,841,823 lines total), filtered queries to 6,980.
All counts matched the guide.

`experiments-msmarco-passage.md` — indexed 8,841,823 documents in 2:43 with 0
errors. BM25 retrieval run completed in 2:39. Got MRR@10 = 0.18741227770955546,
MAP = 0.1957, recall@1000 = 0.8573, all matching the guide exactly.

`experiments-msmarco-passage2.md` — prebuilt index run gave MRR@10 = 0.1875,
dense retrieval with BGE-base gave MRR@10 = 0.3521. Both matched.

**Notes**
- `brew install maven` pulled in OpenJDK 26 as a dependency and Maven picked
  that up by default. Had to set `JAVA_HOME` explicitly to point at
  openjdk@21 before building.
- `tools/scripts/msmarco/msmarco_passage_eval.py` line 26 emits a
  `SyntaxWarning: "\s" is an invalid escape sequence` on modern Python. Using a
  raw string for the regex would silence it.