### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -700,3 +700,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-07-28 (commit [`3a52e64`](https://github.com/castorini/anserini/commit/3a52e64fa331ade3de312b47b3674117aad399c4))
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`02f25de`](https://github.com/castorini/anserini/commit/02f25dea042ee651085340d60ffbe9bc9820169b))
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-02 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
++ Results reproduced by [@mahimairaja](https://github.com/mahimairaja) on 2026-08-04 (commit [`5b3e896`](https://github.com/castorini/anserini/commit/5b3e896e262caf07be1d3c6cb7768eafc839197b))

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -697,5 +697,6 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@carlosp2001](https://github.com/carlosp2001) on 2026-07-16 (commit [`bd93b89`](https://github.com/castorini/anserini/commit/7b2927358ac79c64a9b8ca9f94b898deed84e6ac))
 + Results reproduced by [@mihiit](https://github.com/mihiit) on 2026-07-21 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
 + Results reproduced by [@BakaryGibba](https://github.com/BakaryGibba) on 2026-07-26 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
++ Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-07-28 (commit [`3a52e64`](https://github.com/castorini/anserini/commit/3a52e64fa331ade3de312b47b3674117aad399c4))
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`02f25de`](https://github.com/castorini/anserini/commit/02f25dea042ee651085340d60ffbe9bc9820169b))
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-02 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -36,7 +36,12 @@ Instead of passing the path to an index in the `-index` parameter, we specify th
 Anserini downloads the index from a known location on UWaterloo servers, and stores a copy in `~/.cache/pyserini/indexes`.
 Go ahead and confirm it's there.
 
-The complete list of prebuilt indexes (and where to find them) is in the class [`IndexInfo`](https://github.com/castorini/anserini/blob/master/src/main/java/io/anserini/index/IndexInfo.java).
+The complete list of prebuilt indexes (and where to find them) is in the class [`PrebuiltIndex`](https://github.com/castorini/anserini/blob/master/src/main/java/io/anserini/index/prebuilt/PrebuiltIndex.java).
+You can also list them from the command line:
+
+```bash
+bin/run.sh io.anserini.cli.PrebuiltIndexRegistry --list --filter msmarco-v1-passage
+```
 
 We can then evaluate the run with the `trec_eval` tool.
 Let's compute the MRR@10 score, which is the official metric:
@@ -247,3 +252,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`02f25de`](https://github.com/castorini/anserini/commit/02f25dea042ee651085340d60ffbe9bc9820169b))
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-02 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
 + Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-08-03 (commit [`3a52e64`](https://github.com/castorini/anserini/commit/3a52e64fa331ade3de312b47b3674117aad399c4))
++ Results reproduced by [@mahimairaja](https://github.com/mahimairaja) on 2026-08-04 (commit [`5b3e896`](https://github.com/castorini/anserini/commit/5b3e896e262caf07be1d3c6cb7768eafc839197b))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -246,3 +246,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@BakaryGibba](https://github.com/BakaryGibba) on 2026-07-27 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`02f25de`](https://github.com/castorini/anserini/commit/02f25dea042ee651085340d60ffbe9bc9820169b))
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-02 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
++ Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-08-03 (commit [`3a52e64`](https://github.com/castorini/anserini/commit/3a52e64fa331ade3de312b47b3674117aad399c4))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -604,5 +604,6 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@carlosp2001](https://github.com/carlosp2001) on 2026-07-16 (commit [`bd93b89`](https://github.com/castorini/anserini/commit/7b2927358ac79c64a9b8ca9f94b898deed84e6ac))
 + Results reproduced by [@mihiit](https://github.com/mihiit) on 2026-07-21 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
 + Results reproduced by [@BakaryGibba](https://github.com/BakaryGibba) on 2026-07-26 (commit [`45118b9`](https://github.com/castorini/anserini/commit/45118b90c8bc90c31cddc2b206f8cd59f2d497d1))
++ Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-07-28 (commit [`3a52e64`](https://github.com/castorini/anserini/commit/3a52e64fa331ade3de312b47b3674117aad399c4))
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`02f25de`](https://github.com/castorini/anserini/commit/02f25dea042ee651085340d60ffbe9bc9820169b))
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-02 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -607,3 +607,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-07-28 (commit [`3a52e64`](https://github.com/castorini/anserini/commit/3a52e64fa331ade3de312b47b3674117aad399c4))
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`02f25de`](https://github.com/castorini/anserini/commit/02f25dea042ee651085340d60ffbe9bc9820169b))
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-02 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
++ Results reproduced by [@mahimairaja](https://github.com/mahimairaja) on 2026-08-04 (commit [`5b3e896`](https://github.com/castorini/anserini/commit/5b3e896e262caf07be1d3c6cb7768eafc839197b))


### PR DESCRIPTION
Add reproduction log entries for the Foundations of Retrieval onboarding path (lessons 1-3): `start-here.md`, BM25 baseline, and dense retrieval on MS MARCO passage ranking.

## Setup

Runs were performed in a Linux container rather than on a laptop. The BGE HNSW step needs roughly 55 GB peak disk (the 24 GB `.tar.gz` is gunzipped to a `.tar` alongside it, then untarred alongside that, before anything is deleted) and my machine had 22 GB free.

- OS: Ubuntu 22.04 (container), CPU only, 8 vCPU / 32 GB RAM
- Java: Eclipse Temurin JDK 21
- Maven: 3.9.x, built with `bin/qbuild.sh`
- Commit: `5b3e896`

## Results

All three lessons reproduced exactly against the documented values.

**start-here.md**

- `collection.tsv`: 8,841,823 lines
- `collection_jsonl`: 9 files totalling 8,841,823 lines (last file 841,823)
- `queries.dev.small.tsv`: 6,980 lines
- `qrels.dev.small.tsv`: 7,437 lines

**experiments-msmarco-passage.md** (BM25 baseline)

- MRR@10 = `0.18741227770955546` (official MS MARCO eval script) — exact match
- `map = 0.1957`, `recall_1000 = 0.8573` (trec_eval) — exact match
- trec_eval MRR@10 = `0.1874` — exact match

**experiments-msmarco-passage2.md** (dense retrieval)

- Prebuilt BM25 index: MRR@10 = `0.1875` — exact match
- BGE-base HNSW dense retrieval: MRR@10 = `0.3521` — exact match

No issues encountered with the documented steps.

## Additional edits

`experiments-msmarco-passage2.md` pointed readers to the `IndexInfo` class for the list of prebuilt indexes. That class was removed in 4fbd16ba ("Remove IndexInfo: move all prebuilt index metadata to PrebuiltIndex"), so the link currently returns a 404. Updated it to point at `PrebuiltIndex`, and added the `PrebuiltIndexRegistry` CLI invocation since that is how the list is enumerated at runtime.

Also restored the missing trailing newline on the three edited files, so that subsequent reproduction log entries show up as a clean one-line diff instead of modifying the previous contributor's line.
