### PR TITLE
Add Foundations of Retrieval reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -701,3 +701,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`02f25de`](https://github.com/castorini/anserini/commit/02f25dea042ee651085340d60ffbe9bc9820169b))
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-02 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
 + Results reproduced by [@mahimairaja](https://github.com/mahimairaja) on 2026-08-04 (commit [`5b3e896`](https://github.com/castorini/anserini/commit/5b3e896e262caf07be1d3c6cb7768eafc839197b))
++ Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`1272378`](https://github.com/castorini/anserini/commit/127237835c675272668f0d65420602117fe50d09))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -256,3 +256,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-02 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
 + Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-08-03 (commit [`3a52e64`](https://github.com/castorini/anserini/commit/3a52e64fa331ade3de312b47b3674117aad399c4))
 + Results reproduced by [@mahimairaja](https://github.com/mahimairaja) on 2026-08-04 (commit [`5b3e896`](https://github.com/castorini/anserini/commit/5b3e896e262caf07be1d3c6cb7768eafc839197b))
++ Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`1272378`](https://github.com/castorini/anserini/commit/127237835c675272668f0d65420602117fe50d09))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -608,3 +608,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`02f25de`](https://github.com/castorini/anserini/commit/02f25dea042ee651085340d60ffbe9bc9820169b))
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-02 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
 + Results reproduced by [@mahimairaja](https://github.com/mahimairaja) on 2026-08-04 (commit [`5b3e896`](https://github.com/castorini/anserini/commit/5b3e896e262caf07be1d3c6cb7768eafc839197b))
++ Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`1272378`](https://github.com/castorini/anserini/commit/127237835c675272668f0d65420602117fe50d09))


### PR DESCRIPTION
Reproduced the Anserini portion of the Foundations of Retrieval onboarding path (Lessons 1-3).

**Commit reproduced:** [`1272378`](https://github.com/castorini/anserini/commit/127237835c675272668f0d65420602117fe50d09)

**Environment:**
- macOS Tahoe 26.5, Apple M3, 16GB RAM
- Java 21 (OpenJDK 21.0.12), Maven 3.9.16

**Results:**
- `docs/start-here.md`: Successfully downloaded and converted the MS MARCO passage collection.
- `docs/experiments-msmarco-passage.md` (BM25 baseline): Indexed 8,841,823 docs. MRR@10 = 0.18741227770955546, MAP = 0.1957, Recall@1000 = 0.8573 (exact match).
- `docs/experiments-msmarco-passage2.md` (dense retrieval): BGE-base HNSW dense retrieval gave MRR@10 = 0.3521 (exact match).

**Notes / Issues encountered:**
- On Apple Silicon, the default indexing configuration exhausted available system resources.
- Reducing the indexing thread count to **4** allowed indexing to complete successfully while reproducing the expected retrieval results.
- This PR only updates the reproduction logs.