### PR TITLE
Add Foundations of Retrieval reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -702,3 +702,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-02 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
 + Results reproduced by [@mahimairaja](https://github.com/mahimairaja) on 2026-08-04 (commit [`5b3e896`](https://github.com/castorini/anserini/commit/5b3e896e262caf07be1d3c6cb7768eafc839197b))
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`1272378`](https://github.com/castorini/anserini/commit/127237835c675272668f0d65420602117fe50d09))
++ Results reproduced by [@richardoo-707](https://github.com/richardoo-707) on 2026-08-09 (commit [`9387179`](https://github.com/castorini/anserini/commit/9387179b4650774209d6dd328b3733ff102c99fa))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -257,3 +257,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Hamza-Nadif](https://github.com/Hamza-Nadif) on 2026-08-03 (commit [`3a52e64`](https://github.com/castorini/anserini/commit/3a52e64fa331ade3de312b47b3674117aad399c4))
 + Results reproduced by [@mahimairaja](https://github.com/mahimairaja) on 2026-08-04 (commit [`5b3e896`](https://github.com/castorini/anserini/commit/5b3e896e262caf07be1d3c6cb7768eafc839197b))
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`1272378`](https://github.com/castorini/anserini/commit/127237835c675272668f0d65420602117fe50d09))
++ Results reproduced by [@richardoo-707](https://github.com/richardoo-707) on 2026-08-09 (commit [`9387179`](https://github.com/castorini/anserini/commit/9387179b4650774209d6dd328b3733ff102c99fa))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -609,3 +609,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-02 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
 + Results reproduced by [@mahimairaja](https://github.com/mahimairaja) on 2026-08-04 (commit [`5b3e896`](https://github.com/castorini/anserini/commit/5b3e896e262caf07be1d3c6cb7768eafc839197b))
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`1272378`](https://github.com/castorini/anserini/commit/127237835c675272668f0d65420602117fe50d09))
++ Results reproduced by [@richardoo-707](https://github.com/richardoo-707) on 2026-08-09 (commit [`9387179`](https://github.com/castorini/anserini/commit/9387179b4650774209d6dd328b3733ff102c99fa))


### PR DESCRIPTION
## Summary

Adds my reproduction-log entries for the Anserini portion of the Foundations of Retrieval onboarding path (lessons 1-3).

## Setup

- OS: Windows 11 x86_64
- CPU: AMD Ryzen 7 5800H; 15.9 GB RAM; CPU-only retrieval
- Storage: repositories, indexes, models, caches, and temporary files on a separate E: drive
- Java: Oracle JDK 21.0.12
- Maven: 3.9.16
- Reproduced commit: `9387179`

## Results

- `docs/start-here.md`: prepared 8,841,823 MS MARCO passages, 6,980 development queries, and 7,437 qrels; all documented counts matched.
- `docs/experiments-msmarco-passage.md`: indexed all 8,841,823 documents with 0 errors. BM25 produced MRR@10 `0.18741227770955546`, MAP@1000 `0.195686651429`, and Recall@1000 `0.857342406877`.
- `docs/experiments-msmarco-passage2.md`: the prebuilt BM25 run reproduced MRR@10 `0.187412`. The official BGE HNSW package was downloaded and its MD5 verified; a low-memory int8 search fallback over the official graph/vector data produced MRR@10 `0.351872640651` (documented target `0.3521`).

## Notes

The 26.21 GiB HNSW index was placed on a rotational E: drive. Full random-access retrieval through the documented launcher was impractically slow on this storage, so I used a local low-memory quantized search helper and report the small `0.00023` difference above rather than claiming an exact dense match.

`git diff --check` passes; this PR only updates the three reproduction logs.