### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -4,7 +4,7 @@ This page contains instructions for running BM25 baselines on the [MS MARCO *pas
 Note that there is a separate [MS MARCO *document* ranking task](experiments-msmarco-doc.md).
 This exercise will require a machine with at least 8 GB RAM and at least 15 GB free disk space.
 
-If you're a Waterloo student traversing the [onboarding path](https://github.com/lintool/guide/blob/master/ura.md), [start here](start-here.md).
+If you're a Waterloo student traversing the [onboarding path](https://github.com/castorini/onboarding/blob/master/ura.md), [start here](start-here.md).
 In general, don't try to rush through this guide by just blindly copying and pasting commands into a shell;
 that's what I call [cargo culting](https://en.wikipedia.org/wiki/Cargo_cult_programming).
 Instead, really try to understand what's going on.

--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -703,3 +703,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@mahimairaja](https://github.com/mahimairaja) on 2026-08-04 (commit [`5b3e896`](https://github.com/castorini/anserini/commit/5b3e896e262caf07be1d3c6cb7768eafc839197b))
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`1272378`](https://github.com/castorini/anserini/commit/127237835c675272668f0d65420602117fe50d09))
 + Results reproduced by [@Navid-Ebadi-2003](https://github.com/Navid-Ebadi-2003) on 2026-08-09 (commit [`b99e095`](https://github.com/castorini/anserini/commit/b99e09582d3c3880c87e43eb0e1040adb4cfa0ac))
++ Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-14 (commit [`1272378`](https://github.com/castorini/anserini/commit/127237835c675272668f0d65420602117fe50d09))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -258,3 +258,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@mahimairaja](https://github.com/mahimairaja) on 2026-08-04 (commit [`5b3e896`](https://github.com/castorini/anserini/commit/5b3e896e262caf07be1d3c6cb7768eafc839197b))
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`1272378`](https://github.com/castorini/anserini/commit/127237835c675272668f0d65420602117fe50d09))
 + Results reproduced by [@Navid-Ebadi-2003](https://github.com/Navid-Ebadi-2003) on 2026-08-09 (commit [`b99e095`](https://github.com/castorini/anserini/commit/b99e09582d3c3880c87e43eb0e1040adb4cfa0ac))
++ Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-15 (commit [`9bfc04b`](https://github.com/castorini/anserini/commit/9bfc04b2d5f22e3acf56edf43d06c1efa5fe2783))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -1,6 +1,6 @@
 # Anserini: Dense Retrieval for MS MARCO Passage Ranking
 
-If you're a Waterloo student traversing the [onboarding path](https://github.com/lintool/guide/blob/master/ura.md), [start here](start-here.md).
+If you're a Waterloo student traversing the [onboarding path](https://github.com/castorini/onboarding/blob/master/ura.md), [start here](start-here.md).
 In general, don't try to rush through this guide by just blindly copying and pasting commands into a shell;
 that's what I call [cargo culting](https://en.wikipedia.org/wiki/Cargo_cult_programming).
 Instead, really try to understand what's going on.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -608,5 +608,6 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@niloy-biswas](https://github.com/niloy-biswas) on 2026-07-30 (commit [`02f25de`](https://github.com/castorini/anserini/commit/02f25dea042ee651085340d60ffbe9bc9820169b))
 + Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-02 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
 + Results reproduced by [@mahimairaja](https://github.com/mahimairaja) on 2026-08-04 (commit [`5b3e896`](https://github.com/castorini/anserini/commit/5b3e896e262caf07be1d3c6cb7768eafc839197b))
++ Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-06 (commit [`1272378`](https://github.com/castorini/anserini/commit/127237835c675272668f0d65420602117fe50d09))
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`1272378`](https://github.com/castorini/anserini/commit/127237835c675272668f0d65420602117fe50d09))
 + Results reproduced by [@Navid-Ebadi-2003](https://github.com/Navid-Ebadi-2003) on 2026-08-09 (commit [`b99e095`](https://github.com/castorini/anserini/commit/b99e09582d3c3880c87e43eb0e1040adb4cfa0ac))


### PR DESCRIPTION
Worked through the first three lessons of the Foundations of Retrieval onboarding path
(Anserini portion) and added entries to the reproduction logs.

### Environment

| | |
|---|---|
| OS | Ubuntu, kernel 6.8.0-45-generic (x86_64) |
| CPU / RAM | 12 cores / 15 GB, no GPU |
| Java | OpenJDK 21.0.7 |
| Maven | 3.8.7 |
| Python | 3.12.3 (venv) |
| Commit | `9bfc04b` |

### Results

All values reproduced exactly as documented.

**start-here.md**: collection converted to 9 JSONL files, 8,841,823 documents,
0 unindexable / 0 empty / 0 skipped / 0 errors. Filtered query set: 6,980.

**experiments-msmarco-passage.md**

| Metric | Expected | Observed |
|---|---|---|
| MRR@10 | 0.18741227770955546 | 0.18741227770955546 |
| MAP | 0.1957 | 0.1957 |
| recall@1000 | 0.8573 | 0.8573 |

**experiments-msmarco-passage2.md**

| Metric | Expected | Observed |
|---|---|---|
| MRR@10, BM25 (prebuilt index) | 0.1875 | 0.1875 |
| MRR@10, BGE-base dense (HNSW) | 0.3521 | 0.3521 |

### Timings

The guides quote a circa-2022 M2 MacBook Air; these are from the machine above, for reference:

| Operation | Guide | This machine |
|---|---|---|
| Build inverted index (`-threads 9`) | ~3 min | 2:03 |
| BM25 retrieval (`-parallelism 4`) | ~2 min | 4:31 (~25.7 q/s) |

Indexing was faster, retrieval noticeably slower.

### Doc change included

`experiments-msmarco-passage.md` and `experiments-msmarco-passage2.md` linked the onboarding path
to `https://github.com/lintool/guide/blob/master/ura.md`, which is now a redirect stub. Updated
both to `https://github.com/castorini/onboarding/blob/master/ura.md`, matching what
`start-here.md` already uses.

### Notes

Hit the out-of-memory issue during indexing on a 15 GB machine. `bin/run.sh` passes `-Xmx192G`,
so the JVM was killed by the OOM killer. Resolved as the guide suggests in the Indexing section,
by running with a smaller heap (`-Xmx6G`); everything after that completed normally.