### PR TITLE
[codex] Reorder TopicReader method arguments

### DIFF
--- a/src/main/java/io/anserini/encoder/EncodeQuery.java
+++ b/src/main/java/io/anserini/encoder/EncodeQuery.java
@@ -175,7 +175,7 @@ public class EncodeQuery {
     // Use the TopicReader infrastructure.
     String readerClass = TOPIC_READER_PACKAGE + args.topicReader + "TopicReader";
     Map<String, Map<String, String>> topics =
-        TopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass(readerClass, args.queriesPath);
+        TopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass(args.queriesPath, readerClass);
 
     if (topics == null || topics.isEmpty()) {
       System.err.println("No topics loaded. Check -queries path and -topicReader class.");

--- a/src/main/java/io/anserini/search/topicreader/TopicReader.java
+++ b/src/main/java/io/anserini/search/topicreader/TopicReader.java
@@ -201,11 +201,11 @@ public abstract class TopicReader<K> {
    * Returns a set of evaluation topics, reading from a file using a particular {@code TopicReader} class (as String).
    * This ridiculous method name is necessary for proper Python bindings via Pyjnius.
    *
-   * @param className {@code TopicReader} class
    * @param file topics file
+   * @param className {@code TopicReader} class
    * @return evaluation topics, with strings as topic ids
    */
-  public static Map<String, Map<String, String>> getTopicsWithStringIdsFromFileWithTopicReaderClass(String className, String file) {
+  public static Map<String, Map<String, String>> getTopicsWithStringIdsFromFileWithTopicReaderClass(String file, String className) {
     try {
       Class<?> clazz = Class.forName(className);
       Constructor<?>[] ctors = clazz.getDeclaredConstructors();

--- a/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
@@ -1703,16 +1703,13 @@ public class TopicReaderTest {
   public void testGetTopicsWithStringIdsFromFileWithTopicReader() {
     Map<String, Map<String, String>> topics;
 
-    topics = TopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass(TrecTopicReader.class.getName(),
-        "tools/topics-and-qrels/topics.robust04.txt");
-
+    topics = TopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass("tools/topics-and-qrels/topics.robust04.txt", TrecTopicReader.class.getName());
     assertNotNull(topics);
     assertEquals(250, topics.size());
     assertEquals("International Organized Crime", topics.get("301").get("title"));
     assertEquals("gasoline tax U.S.", topics.get("700").get("title"));
 
-    topics = TopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass(TsvIntTopicReader.class.getName(),
-        "tools/topics-and-qrels/topics.msmarco-doc.dev.txt");
+    topics = TopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass("tools/topics-and-qrels/topics.msmarco-doc.dev.txt", TsvIntTopicReader.class.getName());
     assertNotNull(topics);
     assertEquals(5193, topics.size());
     assertEquals("androgen receptor define", topics.get("2").get("title"));


### PR DESCRIPTION
## Summary

- Reorder `getTopicsWithStringIdsFromFileWithTopicReaderClass` parameters to place the topics file before the reader class.
- Align the method with the existing `load(file, topicReader)` argument convention.
- Update the `EncodeQuery` and test call sites accordingly.

## Validation

- `mvn clean -Dtest=TopicReaderTest#testGetTopicsWithStringIdsFromFileWithTopicReader test`
- `git diff --check`

The targeted test passed: 1 test, 0 failures, 0 errors. The full suite reached 1,047 tests with one unrelated error caused by a truncated cached MSMARCO V2 gzip file.
