### PR TITLE
[codex] Update external topics and qrels metadata

### DIFF
--- a/src/main/java/io/anserini/eval/Qrels.java
+++ b/src/main/java/io/anserini/eval/Qrels.java
@@ -37,7 +37,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.anserini.util.CacheDirectoryResolver;
 
 public class Qrels {
-  private static final String COMMIT_ID = "1662f7ac99fe594b896b2562f06341b34daa50a0";
+  private static final String COMMIT_ID = "9b1c80887bbda7998021e78f3c36f1ee707fb0bb";
   public static final String URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/qrels/";
 
   private static final String QRELS_URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/qrels.json";

--- a/src/main/java/io/anserini/search/topicreader/Topics.java
+++ b/src/main/java/io/anserini/search/topicreader/Topics.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * A registry entry for a standard set of topics from various evaluations.
  */
 public final class Topics {
-  private static final String COMMIT_ID = "1662f7ac99fe594b896b2562f06341b34daa50a0";
+  private static final String COMMIT_ID = "9b1c80887bbda7998021e78f3c36f1ee707fb0bb";
   public static final String URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/topics/";
 
   private static final String TOPICS_URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/topics.json";

--- a/src/main/resources/qrels/local-qrels-aliases.json
+++ b/src/main/resources/qrels/local-qrels-aliases.json
@@ -5,11 +5,5 @@
   ],
   "msmarco-doc-dev": [
     "dummy.msmarco-doc-dev"
-  ],
-  "adhoc.351-400": [
-    "trec7-adhoc"
-  ],
-  "adhoc.401-450": [
-    "trec8-adhoc"
   ]
 }

--- a/src/main/resources/qrels/local-qrels.json
+++ b/src/main/resources/qrels/local-qrels.json
@@ -1,5 +1,3 @@
 {
-  "dummy": "qrels.dummy.txt",
-  "adhoc.351-400": "qrels.adhoc.351-400.txt",
-  "adhoc.401-450": "qrels.adhoc.401-450.txt"
+  "dummy": "qrels.dummy.txt"
 }

--- a/src/main/resources/topics/local-topics-aliases.json
+++ b/src/main/resources/topics/local-topics-aliases.json
@@ -5,11 +5,5 @@
   ],
   "msmarco-passage.dev-subset": [
     "dummy.msmarco-passage.dev-subset"
-  ],
-  "adhoc.351-400": [
-    "trec7-adhoc"
-  ],
-  "adhoc.401-450": [
-    "trec8-adhoc"
   ]
 }

--- a/src/main/resources/topics/local-topics.json
+++ b/src/main/resources/topics/local-topics.json
@@ -2,13 +2,5 @@
   "dummy": {
     "path": "topics.dummy.tsv",
     "reader_class": "io.anserini.search.topicreader.TsvStringTopicReader"
-  },
-  "adhoc.351-400": {
-    "path": "topics.adhoc.351-400.txt",
-    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
-  },
-  "adhoc.401-450": {
-    "path": "topics.adhoc.401-450.txt",
-    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
   }
 }


### PR DESCRIPTION
## Summary

- Update the external eval repository snapshot used for topics and qrels metadata.
- Remove redundant local TREC 7/8 bindings and aliases now supplied by the external registry.

## Validation

- `mvn -Dtest=QrelsTest,TopicsTest test` (93 tests passed)
- `git diff --check`
