### PR TITLE
[codex] Use canonical topic IDs in reproduction configs

### DIFF
--- a/docs/reproduce/from-document-collection/ciral-v1.0-ha-en.md
+++ b/docs/reproduce/from-document-collection/ciral-v1.0-ha-en.md
@@ -57,12 +57,12 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-ha-test-a.tsv runs/run.ciral-hausa-english.bm25-default.topics.ciral-v1.0-ha-test-a.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-ha-test-a.tsv runs/run.ciral-hausa-english.bm25-default.topics.ciral-v1.0-ha-test-a.txt
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-ha-test-a-pools.tsv runs/run.ciral-hausa-english.bm25-default.topics.ciral-v1.0-ha-test-a.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-ha-test-a-pools.tsv runs/run.ciral-hausa-english.bm25-default.topics.ciral-v1.0-ha-test-a.txt
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-ha-test-b.tsv runs/run.ciral-hausa-english.bm25-default.topics.ciral-v1.0-ha-test-b.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-ha-test-b.tsv runs/run.ciral-hausa-english.bm25-default.topics.ciral-v1.0-ha-test-b.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-ha-test-a runs/run.ciral-hausa-english.bm25-default.topics.ciral-v1.0-ha-test-a.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-ha-test-a runs/run.ciral-hausa-english.bm25-default.topics.ciral-v1.0-ha-test-a.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-ha-test-a-pools runs/run.ciral-hausa-english.bm25-default.topics.ciral-v1.0-ha-test-a.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-ha-test-a-pools runs/run.ciral-hausa-english.bm25-default.topics.ciral-v1.0-ha-test-a.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-ha-test-b runs/run.ciral-hausa-english.bm25-default.topics.ciral-v1.0-ha-test-b.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-ha-test-b runs/run.ciral-hausa-english.bm25-default.topics.ciral-v1.0-ha-test-b.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/ciral-v1.0-ha-en.md
+++ b/docs/reproduce/from-document-collection/ciral-v1.0-ha-en.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-ha-en/ \
-  -topics ciral-v1.0-ha-test-a.tsv \
+  -topics ciral-v1.0-ha-test-a \
   -topicReader TsvInt \
   -output runs/run.ciral-hausa-english.bm25-default.topics.ciral-v1.0-ha-test-a.txt \
   -bm25 -hits 1000 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-ha-en/ \
-  -topics ciral-v1.0-ha-test-a.tsv \
+  -topics ciral-v1.0-ha-test-a \
   -topicReader TsvInt \
   -output runs/run.ciral-hausa-english.bm25-default.topics.ciral-v1.0-ha-test-a.txt \
   -bm25 -hits 1000 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-ha-en/ \
-  -topics ciral-v1.0-ha-test-b.tsv \
+  -topics ciral-v1.0-ha-test-b \
   -topicReader TsvInt \
   -output runs/run.ciral-hausa-english.bm25-default.topics.ciral-v1.0-ha-test-b.txt \
   -bm25 -hits 1000 &

--- a/docs/reproduce/from-document-collection/ciral-v1.0-ha.md
+++ b/docs/reproduce/from-document-collection/ciral-v1.0-ha.md
@@ -57,12 +57,12 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-ha-test-a.tsv runs/run.ciral-hausa.bm25-default.topics.ciral-v1.0-ha-test-a-native.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-ha-test-a.tsv runs/run.ciral-hausa.bm25-default.topics.ciral-v1.0-ha-test-a-native.txt
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-ha-test-a-pools.tsv runs/run.ciral-hausa.bm25-default.topics.ciral-v1.0-ha-test-a-native.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-ha-test-a-pools.tsv runs/run.ciral-hausa.bm25-default.topics.ciral-v1.0-ha-test-a-native.txt
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-ha-test-b.tsv runs/run.ciral-hausa.bm25-default.topics.ciral-v1.0-ha-test-b-native.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-ha-test-b.tsv runs/run.ciral-hausa.bm25-default.topics.ciral-v1.0-ha-test-b-native.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-ha-test-a runs/run.ciral-hausa.bm25-default.topics.ciral-v1.0-ha-test-a-native.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-ha-test-a runs/run.ciral-hausa.bm25-default.topics.ciral-v1.0-ha-test-a-native.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-ha-test-a-pools runs/run.ciral-hausa.bm25-default.topics.ciral-v1.0-ha-test-a-native.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-ha-test-a-pools runs/run.ciral-hausa.bm25-default.topics.ciral-v1.0-ha-test-a-native.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-ha-test-b runs/run.ciral-hausa.bm25-default.topics.ciral-v1.0-ha-test-b-native.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-ha-test-b runs/run.ciral-hausa.bm25-default.topics.ciral-v1.0-ha-test-b-native.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/ciral-v1.0-ha.md
+++ b/docs/reproduce/from-document-collection/ciral-v1.0-ha.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-ha/ \
-  -topics ciral-v1.0-ha-test-a-native.tsv \
+  -topics ciral-v1.0-ha-test-a-native \
   -topicReader TsvInt \
   -output runs/run.ciral-hausa.bm25-default.topics.ciral-v1.0-ha-test-a-native.txt \
   -bm25 -hits 1000 -language ha &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-ha/ \
-  -topics ciral-v1.0-ha-test-a-native.tsv \
+  -topics ciral-v1.0-ha-test-a-native \
   -topicReader TsvInt \
   -output runs/run.ciral-hausa.bm25-default.topics.ciral-v1.0-ha-test-a-native.txt \
   -bm25 -hits 1000 -language ha &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-ha/ \
-  -topics ciral-v1.0-ha-test-b-native.tsv \
+  -topics ciral-v1.0-ha-test-b-native \
   -topicReader TsvInt \
   -output runs/run.ciral-hausa.bm25-default.topics.ciral-v1.0-ha-test-b-native.txt \
   -bm25 -hits 1000 -language ha &

--- a/docs/reproduce/from-document-collection/ciral-v1.0-so-en.md
+++ b/docs/reproduce/from-document-collection/ciral-v1.0-so-en.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-so-en/ \
-  -topics ciral-v1.0-so-test-a.tsv \
+  -topics ciral-v1.0-so-test-a \
   -topicReader TsvInt \
   -output runs/run.ciral-somali-english.bm25-default.topics.ciral-v1.0-so-test-a.txt \
   -bm25 -hits 1000 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-so-en/ \
-  -topics ciral-v1.0-so-test-a.tsv \
+  -topics ciral-v1.0-so-test-a \
   -topicReader TsvInt \
   -output runs/run.ciral-somali-english.bm25-default.topics.ciral-v1.0-so-test-a.txt \
   -bm25 -hits 1000 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-so-en/ \
-  -topics ciral-v1.0-so-test-b.tsv \
+  -topics ciral-v1.0-so-test-b \
   -topicReader TsvInt \
   -output runs/run.ciral-somali-english.bm25-default.topics.ciral-v1.0-so-test-b.txt \
   -bm25 -hits 1000 &

--- a/docs/reproduce/from-document-collection/ciral-v1.0-so-en.md
+++ b/docs/reproduce/from-document-collection/ciral-v1.0-so-en.md
@@ -57,12 +57,12 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-so-test-a.tsv runs/run.ciral-somali-english.bm25-default.topics.ciral-v1.0-so-test-a.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-so-test-a.tsv runs/run.ciral-somali-english.bm25-default.topics.ciral-v1.0-so-test-a.txt
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-so-test-a-pools.tsv runs/run.ciral-somali-english.bm25-default.topics.ciral-v1.0-so-test-a.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-so-test-a-pools.tsv runs/run.ciral-somali-english.bm25-default.topics.ciral-v1.0-so-test-a.txt
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-so-test-b.tsv runs/run.ciral-somali-english.bm25-default.topics.ciral-v1.0-so-test-b.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-so-test-b.tsv runs/run.ciral-somali-english.bm25-default.topics.ciral-v1.0-so-test-b.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-so-test-a runs/run.ciral-somali-english.bm25-default.topics.ciral-v1.0-so-test-a.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-so-test-a runs/run.ciral-somali-english.bm25-default.topics.ciral-v1.0-so-test-a.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-so-test-a-pools runs/run.ciral-somali-english.bm25-default.topics.ciral-v1.0-so-test-a.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-so-test-a-pools runs/run.ciral-somali-english.bm25-default.topics.ciral-v1.0-so-test-a.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-so-test-b runs/run.ciral-somali-english.bm25-default.topics.ciral-v1.0-so-test-b.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-so-test-b runs/run.ciral-somali-english.bm25-default.topics.ciral-v1.0-so-test-b.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/ciral-v1.0-so.md
+++ b/docs/reproduce/from-document-collection/ciral-v1.0-so.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-so/ \
-  -topics ciral-v1.0-so-test-a-native.tsv \
+  -topics ciral-v1.0-so-test-a-native \
   -topicReader TsvInt \
   -output runs/run.ciral-somali.bm25-default.topics.ciral-v1.0-so-test-a-native.txt \
   -bm25 -hits 1000 -language so &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-so/ \
-  -topics ciral-v1.0-so-test-a-native.tsv \
+  -topics ciral-v1.0-so-test-a-native \
   -topicReader TsvInt \
   -output runs/run.ciral-somali.bm25-default.topics.ciral-v1.0-so-test-a-native.txt \
   -bm25 -hits 1000 -language so &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-so/ \
-  -topics ciral-v1.0-so-test-b-native.tsv \
+  -topics ciral-v1.0-so-test-b-native \
   -topicReader TsvInt \
   -output runs/run.ciral-somali.bm25-default.topics.ciral-v1.0-so-test-b-native.txt \
   -bm25 -hits 1000 -language so &

--- a/docs/reproduce/from-document-collection/ciral-v1.0-so.md
+++ b/docs/reproduce/from-document-collection/ciral-v1.0-so.md
@@ -57,12 +57,12 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-so-test-a.tsv runs/run.ciral-somali.bm25-default.topics.ciral-v1.0-so-test-a-native.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-so-test-a.tsv runs/run.ciral-somali.bm25-default.topics.ciral-v1.0-so-test-a-native.txt
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-so-test-a-pools.tsv runs/run.ciral-somali.bm25-default.topics.ciral-v1.0-so-test-a-native.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-so-test-a-pools.tsv runs/run.ciral-somali.bm25-default.topics.ciral-v1.0-so-test-a-native.txt
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-so-test-b.tsv runs/run.ciral-somali.bm25-default.topics.ciral-v1.0-so-test-b-native.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-so-test-b.tsv runs/run.ciral-somali.bm25-default.topics.ciral-v1.0-so-test-b-native.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-so-test-a runs/run.ciral-somali.bm25-default.topics.ciral-v1.0-so-test-a-native.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-so-test-a runs/run.ciral-somali.bm25-default.topics.ciral-v1.0-so-test-a-native.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-so-test-a-pools runs/run.ciral-somali.bm25-default.topics.ciral-v1.0-so-test-a-native.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-so-test-a-pools runs/run.ciral-somali.bm25-default.topics.ciral-v1.0-so-test-a-native.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-so-test-b runs/run.ciral-somali.bm25-default.topics.ciral-v1.0-so-test-b-native.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-so-test-b runs/run.ciral-somali.bm25-default.topics.ciral-v1.0-so-test-b-native.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/ciral-v1.0-sw-en.md
+++ b/docs/reproduce/from-document-collection/ciral-v1.0-sw-en.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-sw-en/ \
-  -topics ciral-v1.0-sw-test-a.tsv \
+  -topics ciral-v1.0-sw-test-a \
   -topicReader TsvInt \
   -output runs/run.ciral-swahili-english.bm25-default.topics.ciral-v1.0-sw-test-a.txt \
   -bm25 -hits 1000 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-sw-en/ \
-  -topics ciral-v1.0-sw-test-a.tsv \
+  -topics ciral-v1.0-sw-test-a \
   -topicReader TsvInt \
   -output runs/run.ciral-swahili-english.bm25-default.topics.ciral-v1.0-sw-test-a.txt \
   -bm25 -hits 1000 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-sw-en/ \
-  -topics ciral-v1.0-sw-test-b.tsv \
+  -topics ciral-v1.0-sw-test-b \
   -topicReader TsvInt \
   -output runs/run.ciral-swahili-english.bm25-default.topics.ciral-v1.0-sw-test-b.txt \
   -bm25 -hits 1000 &

--- a/docs/reproduce/from-document-collection/ciral-v1.0-sw-en.md
+++ b/docs/reproduce/from-document-collection/ciral-v1.0-sw-en.md
@@ -57,12 +57,12 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-sw-test-a.tsv runs/run.ciral-swahili-english.bm25-default.topics.ciral-v1.0-sw-test-a.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-sw-test-a.tsv runs/run.ciral-swahili-english.bm25-default.topics.ciral-v1.0-sw-test-a.txt
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-sw-test-a-pools.tsv runs/run.ciral-swahili-english.bm25-default.topics.ciral-v1.0-sw-test-a.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-sw-test-a-pools.tsv runs/run.ciral-swahili-english.bm25-default.topics.ciral-v1.0-sw-test-a.txt
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-sw-test-b.tsv runs/run.ciral-swahili-english.bm25-default.topics.ciral-v1.0-sw-test-b.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-sw-test-b.tsv runs/run.ciral-swahili-english.bm25-default.topics.ciral-v1.0-sw-test-b.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-sw-test-a runs/run.ciral-swahili-english.bm25-default.topics.ciral-v1.0-sw-test-a.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-sw-test-a runs/run.ciral-swahili-english.bm25-default.topics.ciral-v1.0-sw-test-a.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-sw-test-a-pools runs/run.ciral-swahili-english.bm25-default.topics.ciral-v1.0-sw-test-a.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-sw-test-a-pools runs/run.ciral-swahili-english.bm25-default.topics.ciral-v1.0-sw-test-a.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-sw-test-b runs/run.ciral-swahili-english.bm25-default.topics.ciral-v1.0-sw-test-b.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-sw-test-b runs/run.ciral-swahili-english.bm25-default.topics.ciral-v1.0-sw-test-b.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/ciral-v1.0-sw.md
+++ b/docs/reproduce/from-document-collection/ciral-v1.0-sw.md
@@ -57,12 +57,12 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-sw-test-a.tsv runs/run.ciral-swahili.bm25-default.topics.ciral-v1.0-sw-test-a-native.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-sw-test-a.tsv runs/run.ciral-swahili.bm25-default.topics.ciral-v1.0-sw-test-a-native.txt
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-sw-test-a-pools.tsv runs/run.ciral-swahili.bm25-default.topics.ciral-v1.0-sw-test-a-native.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-sw-test-a-pools.tsv runs/run.ciral-swahili.bm25-default.topics.ciral-v1.0-sw-test-a-native.txt
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-sw-test-b.tsv runs/run.ciral-swahili.bm25-default.topics.ciral-v1.0-sw-test-b-native.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-sw-test-b.tsv runs/run.ciral-swahili.bm25-default.topics.ciral-v1.0-sw-test-b-native.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-sw-test-a runs/run.ciral-swahili.bm25-default.topics.ciral-v1.0-sw-test-a-native.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-sw-test-a runs/run.ciral-swahili.bm25-default.topics.ciral-v1.0-sw-test-a-native.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-sw-test-a-pools runs/run.ciral-swahili.bm25-default.topics.ciral-v1.0-sw-test-a-native.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-sw-test-a-pools runs/run.ciral-swahili.bm25-default.topics.ciral-v1.0-sw-test-a-native.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-sw-test-b runs/run.ciral-swahili.bm25-default.topics.ciral-v1.0-sw-test-b-native.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-sw-test-b runs/run.ciral-swahili.bm25-default.topics.ciral-v1.0-sw-test-b-native.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/ciral-v1.0-sw.md
+++ b/docs/reproduce/from-document-collection/ciral-v1.0-sw.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-sw/ \
-  -topics ciral-v1.0-sw-test-a-native.tsv \
+  -topics ciral-v1.0-sw-test-a-native \
   -topicReader TsvInt \
   -output runs/run.ciral-swahili.bm25-default.topics.ciral-v1.0-sw-test-a-native.txt \
   -bm25 -hits 1000 -language sw &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-sw/ \
-  -topics ciral-v1.0-sw-test-a-native.tsv \
+  -topics ciral-v1.0-sw-test-a-native \
   -topicReader TsvInt \
   -output runs/run.ciral-swahili.bm25-default.topics.ciral-v1.0-sw-test-a-native.txt \
   -bm25 -hits 1000 -language sw &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-sw/ \
-  -topics ciral-v1.0-sw-test-b-native.tsv \
+  -topics ciral-v1.0-sw-test-b-native \
   -topicReader TsvInt \
   -output runs/run.ciral-swahili.bm25-default.topics.ciral-v1.0-sw-test-b-native.txt \
   -bm25 -hits 1000 -language sw &

--- a/docs/reproduce/from-document-collection/ciral-v1.0-yo-en.md
+++ b/docs/reproduce/from-document-collection/ciral-v1.0-yo-en.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-yo-en/ \
-  -topics ciral-v1.0-yo-test-a.tsv \
+  -topics ciral-v1.0-yo-test-a \
   -topicReader TsvInt \
   -output runs/run.ciral-yoruba-english.bm25-default.topics.ciral-v1.0-yo-test-a.txt \
   -bm25 -hits 1000 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-yo-en/ \
-  -topics ciral-v1.0-yo-test-a.tsv \
+  -topics ciral-v1.0-yo-test-a \
   -topicReader TsvInt \
   -output runs/run.ciral-yoruba-english.bm25-default.topics.ciral-v1.0-yo-test-a.txt \
   -bm25 -hits 1000 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-yo-en/ \
-  -topics ciral-v1.0-yo-test-b.tsv \
+  -topics ciral-v1.0-yo-test-b \
   -topicReader TsvInt \
   -output runs/run.ciral-yoruba-english.bm25-default.topics.ciral-v1.0-yo-test-b.txt \
   -bm25 -hits 1000 &

--- a/docs/reproduce/from-document-collection/ciral-v1.0-yo-en.md
+++ b/docs/reproduce/from-document-collection/ciral-v1.0-yo-en.md
@@ -57,12 +57,12 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-yo-test-a.tsv runs/run.ciral-yoruba-english.bm25-default.topics.ciral-v1.0-yo-test-a.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-yo-test-a.tsv runs/run.ciral-yoruba-english.bm25-default.topics.ciral-v1.0-yo-test-a.txt
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-yo-test-a-pools.tsv runs/run.ciral-yoruba-english.bm25-default.topics.ciral-v1.0-yo-test-a.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-yo-test-a-pools.tsv runs/run.ciral-yoruba-english.bm25-default.topics.ciral-v1.0-yo-test-a.txt
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-yo-test-b.tsv runs/run.ciral-yoruba-english.bm25-default.topics.ciral-v1.0-yo-test-b.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-yo-test-b.tsv runs/run.ciral-yoruba-english.bm25-default.topics.ciral-v1.0-yo-test-b.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-yo-test-a runs/run.ciral-yoruba-english.bm25-default.topics.ciral-v1.0-yo-test-a.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-yo-test-a runs/run.ciral-yoruba-english.bm25-default.topics.ciral-v1.0-yo-test-a.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-yo-test-a-pools runs/run.ciral-yoruba-english.bm25-default.topics.ciral-v1.0-yo-test-a.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-yo-test-a-pools runs/run.ciral-yoruba-english.bm25-default.topics.ciral-v1.0-yo-test-a.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-yo-test-b runs/run.ciral-yoruba-english.bm25-default.topics.ciral-v1.0-yo-test-b.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-yo-test-b runs/run.ciral-yoruba-english.bm25-default.topics.ciral-v1.0-yo-test-b.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/ciral-v1.0-yo.md
+++ b/docs/reproduce/from-document-collection/ciral-v1.0-yo.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-yo/ \
-  -topics ciral-v1.0-yo-test-a-native.tsv \
+  -topics ciral-v1.0-yo-test-a-native \
   -topicReader TsvInt \
   -output runs/run.ciral-yoruba.bm25-default.topics.ciral-v1.0-yo-test-a-native.txt \
   -bm25 -hits 1000 -language yo &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-yo/ \
-  -topics ciral-v1.0-yo-test-a-native.tsv \
+  -topics ciral-v1.0-yo-test-a-native \
   -topicReader TsvInt \
   -output runs/run.ciral-yoruba.bm25-default.topics.ciral-v1.0-yo-test-a-native.txt \
   -bm25 -hits 1000 -language yo &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.ciral-v1.0-yo/ \
-  -topics ciral-v1.0-yo-test-b-native.tsv \
+  -topics ciral-v1.0-yo-test-b-native \
   -topicReader TsvInt \
   -output runs/run.ciral-yoruba.bm25-default.topics.ciral-v1.0-yo-test-b-native.txt \
   -bm25 -hits 1000 -language yo &

--- a/docs/reproduce/from-document-collection/ciral-v1.0-yo.md
+++ b/docs/reproduce/from-document-collection/ciral-v1.0-yo.md
@@ -57,12 +57,12 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-yo-test-a.tsv runs/run.ciral-yoruba.bm25-default.topics.ciral-v1.0-yo-test-a-native.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-yo-test-a.tsv runs/run.ciral-yoruba.bm25-default.topics.ciral-v1.0-yo-test-a-native.txt
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-yo-test-a-pools.tsv runs/run.ciral-yoruba.bm25-default.topics.ciral-v1.0-yo-test-a-native.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-yo-test-a-pools.tsv runs/run.ciral-yoruba.bm25-default.topics.ciral-v1.0-yo-test-a-native.txt
-bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-yo-test-b.tsv runs/run.ciral-yoruba.bm25-default.topics.ciral-v1.0-yo-test-b-native.txt
-bin/trec_eval -c -m recall.100 ciral-v1.0-yo-test-b.tsv runs/run.ciral-yoruba.bm25-default.topics.ciral-v1.0-yo-test-b-native.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-yo-test-a runs/run.ciral-yoruba.bm25-default.topics.ciral-v1.0-yo-test-a-native.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-yo-test-a runs/run.ciral-yoruba.bm25-default.topics.ciral-v1.0-yo-test-a-native.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-yo-test-a-pools runs/run.ciral-yoruba.bm25-default.topics.ciral-v1.0-yo-test-a-native.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-yo-test-a-pools runs/run.ciral-yoruba.bm25-default.topics.ciral-v1.0-yo-test-a-native.txt
+bin/trec_eval -c -m ndcg_cut.20 ciral-v1.0-yo-test-b runs/run.ciral-yoruba.bm25-default.topics.ciral-v1.0-yo-test-b-native.txt
+bin/trec_eval -c -m recall.100 ciral-v1.0-yo-test-b runs/run.ciral-yoruba.bm25-default.topics.ciral-v1.0-yo-test-b-native.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/dl19-passage.cos-dpr-distil.parquet.fw.md
+++ b/docs/reproduce/from-document-collection/dl19-passage.cos-dpr-distil.parquet.fw.md
@@ -74,19 +74,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchInvertedDenseVectors \
   -index indexes/lucene-inverted.msmarco-v1-passage.cos-dpr-distil.fw-40/ \
-  -topics dl19-passage.cos-dpr-distil.jsonl.gz \
+  -topics dl19-passage.cos-dpr-distil \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl19-passage.cos-dpr-distil.txt \
   -topicField vector -threads 16 -encoding fw -fw.q 40 -hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -m map -c -l 2 dl19-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-bin/trec_eval -m ndcg_cut.10 -c dl19-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-bin/trec_eval -m recall.100 -c -l 2 dl19-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-bin/trec_eval -m recall.1000 -c -l 2 dl19-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+bin/trec_eval -m map -c -l 2 dl19-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl19-passage.cos-dpr-distil.txt
+bin/trec_eval -m ndcg_cut.10 -c dl19-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl19-passage.cos-dpr-distil.txt
+bin/trec_eval -m recall.100 -c -l 2 dl19-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl19-passage.cos-dpr-distil.txt
+bin/trec_eval -m recall.1000 -c -l 2 dl19-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl19-passage.cos-dpr-distil.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/dl19-passage.cos-dpr-distil.parquet.lexlsh.md
+++ b/docs/reproduce/from-document-collection/dl19-passage.cos-dpr-distil.parquet.lexlsh.md
@@ -74,19 +74,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchInvertedDenseVectors \
   -index indexes/lucene-inverted.msmarco-v1-passage.cos-dpr-distil.lexlsh-600/ \
-  -topics dl19-passage.cos-dpr-distil.jsonl.gz \
+  -topics dl19-passage.cos-dpr-distil \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl19-passage.cos-dpr-distil.txt \
   -topicField vector -threads 16 -encoding lexlsh -lexlsh.b 600 -hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -m map -c -l 2 dl19-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-bin/trec_eval -m ndcg_cut.10 -c dl19-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-bin/trec_eval -m recall.100 -c -l 2 dl19-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
-bin/trec_eval -m recall.1000 -c -l 2 dl19-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl19-passage.cos-dpr-distil.jsonl.txt
+bin/trec_eval -m map -c -l 2 dl19-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl19-passage.cos-dpr-distil.txt
+bin/trec_eval -m ndcg_cut.10 -c dl19-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl19-passage.cos-dpr-distil.txt
+bin/trec_eval -m recall.100 -c -l 2 dl19-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl19-passage.cos-dpr-distil.txt
+bin/trec_eval -m recall.1000 -c -l 2 dl19-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl19-passage.cos-dpr-distil.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/dl20-passage.cos-dpr-distil.parquet.fw.md
+++ b/docs/reproduce/from-document-collection/dl20-passage.cos-dpr-distil.parquet.fw.md
@@ -74,19 +74,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchInvertedDenseVectors \
   -index indexes/lucene-inverted.msmarco-v1-passage.cos-dpr-distil.fw-40/ \
-  -topics dl20.cos-dpr-distil.jsonl.gz \
+  -topics dl20.cos-dpr-distil \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl20.cos-dpr-distil.txt \
   -topicField vector -threads 16 -encoding fw -fw.q 40 -hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -m map -c -l 2 dl20-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
-bin/trec_eval -m ndcg_cut.10 -c dl20-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
-bin/trec_eval -m recall.100 -c -l 2 dl20-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
-bin/trec_eval -m recall.1000 -c -l 2 dl20-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
+bin/trec_eval -m map -c -l 2 dl20-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl20.cos-dpr-distil.txt
+bin/trec_eval -m ndcg_cut.10 -c dl20-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl20.cos-dpr-distil.txt
+bin/trec_eval -m recall.100 -c -l 2 dl20-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl20.cos-dpr-distil.txt
+bin/trec_eval -m recall.1000 -c -l 2 dl20-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.dl20.cos-dpr-distil.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/dl20-passage.cos-dpr-distil.parquet.lexlsh.md
+++ b/docs/reproduce/from-document-collection/dl20-passage.cos-dpr-distil.parquet.lexlsh.md
@@ -74,19 +74,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchInvertedDenseVectors \
   -index indexes/lucene-inverted.msmarco-v1-passage.cos-dpr-distil.lexlsh-600/ \
-  -topics dl20.cos-dpr-distil.jsonl.gz \
+  -topics dl20.cos-dpr-distil \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl20.cos-dpr-distil.txt \
   -topicField vector -threads 16 -encoding lexlsh -lexlsh.b 600 -hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -m map -c -l 2 dl20-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
-bin/trec_eval -m ndcg_cut.10 -c dl20-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
-bin/trec_eval -m recall.100 -c -l 2 dl20-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
-bin/trec_eval -m recall.1000 -c -l 2 dl20-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl20.cos-dpr-distil.jsonl.txt
+bin/trec_eval -m map -c -l 2 dl20-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl20.cos-dpr-distil.txt
+bin/trec_eval -m ndcg_cut.10 -c dl20-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl20.cos-dpr-distil.txt
+bin/trec_eval -m recall.100 -c -l 2 dl20-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl20.cos-dpr-distil.txt
+bin/trec_eval -m recall.1000 -c -l 2 dl20-passage runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.dl20.cos-dpr-distil.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/hc4-neuclir22-fa-en.md
+++ b/docs/reproduce/from-document-collection/hc4-neuclir22-fa-en.md
@@ -51,57 +51,57 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-en \
-  -topics hc4-v1.0-fa.en.test.title.tsv \
+  -topics hc4-v1.0-fa.en.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-en.bm25-default.topics.hc4-v1.0-fa.en.test.title.txt \
   -bm25 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-en \
-  -topics hc4-v1.0-fa.en.test.desc.tsv \
+  -topics hc4-v1.0-fa.en.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-en.bm25-default.topics.hc4-v1.0-fa.en.test.desc.txt \
   -bm25 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-en \
-  -topics hc4-v1.0-fa.en.test.desc.title.tsv \
+  -topics hc4-v1.0-fa.en.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-en.bm25-default.topics.hc4-v1.0-fa.en.test.desc.title.txt \
   -bm25 &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-en \
-  -topics hc4-v1.0-fa.en.test.title.tsv \
+  -topics hc4-v1.0-fa.en.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-en.bm25-default+rm3.topics.hc4-v1.0-fa.en.test.title.txt \
   -bm25 -rm3 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-en \
-  -topics hc4-v1.0-fa.en.test.desc.tsv \
+  -topics hc4-v1.0-fa.en.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-en.bm25-default+rm3.topics.hc4-v1.0-fa.en.test.desc.txt \
   -bm25 -rm3 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-en \
-  -topics hc4-v1.0-fa.en.test.desc.title.tsv \
+  -topics hc4-v1.0-fa.en.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-en.bm25-default+rm3.topics.hc4-v1.0-fa.en.test.desc.title.txt \
   -bm25 -rm3 &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-en \
-  -topics hc4-v1.0-fa.en.test.title.tsv \
+  -topics hc4-v1.0-fa.en.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-en.bm25-default+rocchio.topics.hc4-v1.0-fa.en.test.title.txt \
   -bm25 -rocchio &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-en \
-  -topics hc4-v1.0-fa.en.test.desc.tsv \
+  -topics hc4-v1.0-fa.en.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-en.bm25-default+rocchio.topics.hc4-v1.0-fa.en.test.desc.txt \
   -bm25 -rocchio &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-en \
-  -topics hc4-v1.0-fa.en.test.desc.title.tsv \
+  -topics hc4-v1.0-fa.en.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-en.bm25-default+rocchio.topics.hc4-v1.0-fa.en.test.desc.title.txt \
   -bm25 -rocchio &

--- a/docs/reproduce/from-document-collection/hc4-neuclir22-fa.md
+++ b/docs/reproduce/from-document-collection/hc4-neuclir22-fa.md
@@ -51,57 +51,57 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa \
-  -topics hc4-v1.0-fa.test.title.tsv \
+  -topics hc4-v1.0-fa.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa.bm25-default.topics.hc4-v1.0-fa.test.title.txt \
   -bm25 -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa \
-  -topics hc4-v1.0-fa.test.desc.tsv \
+  -topics hc4-v1.0-fa.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa.bm25-default.topics.hc4-v1.0-fa.test.desc.txt \
   -bm25 -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa \
-  -topics hc4-v1.0-fa.test.desc.title.tsv \
+  -topics hc4-v1.0-fa.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa.bm25-default.topics.hc4-v1.0-fa.test.desc.title.txt \
   -bm25 -language fa &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa \
-  -topics hc4-v1.0-fa.test.title.tsv \
+  -topics hc4-v1.0-fa.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa.bm25-default+rm3.topics.hc4-v1.0-fa.test.title.txt \
   -bm25 -rm3 -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa \
-  -topics hc4-v1.0-fa.test.desc.tsv \
+  -topics hc4-v1.0-fa.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa.bm25-default+rm3.topics.hc4-v1.0-fa.test.desc.txt \
   -bm25 -rm3 -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa \
-  -topics hc4-v1.0-fa.test.desc.title.tsv \
+  -topics hc4-v1.0-fa.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa.bm25-default+rm3.topics.hc4-v1.0-fa.test.desc.title.txt \
   -bm25 -rm3 -language fa &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa \
-  -topics hc4-v1.0-fa.test.title.tsv \
+  -topics hc4-v1.0-fa.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa.bm25-default+rocchio.topics.hc4-v1.0-fa.test.title.txt \
   -bm25 -rocchio -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa \
-  -topics hc4-v1.0-fa.test.desc.tsv \
+  -topics hc4-v1.0-fa.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa.bm25-default+rocchio.topics.hc4-v1.0-fa.test.desc.txt \
   -bm25 -rocchio -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa \
-  -topics hc4-v1.0-fa.test.desc.title.tsv \
+  -topics hc4-v1.0-fa.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa.bm25-default+rocchio.topics.hc4-v1.0-fa.test.desc.title.txt \
   -bm25 -rocchio -language fa &

--- a/docs/reproduce/from-document-collection/hc4-neuclir22-ru-en.md
+++ b/docs/reproduce/from-document-collection/hc4-neuclir22-ru-en.md
@@ -52,57 +52,57 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-en \
-  -topics hc4-v1.0-ru.en.test.title.tsv \
+  -topics hc4-v1.0-ru.en.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-en.bm25-default.topics.hc4-v1.0-ru.en.test.title.txt \
   -bm25 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-en \
-  -topics hc4-v1.0-ru.en.test.desc.tsv \
+  -topics hc4-v1.0-ru.en.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-en.bm25-default.topics.hc4-v1.0-ru.en.test.desc.txt \
   -bm25 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-en \
-  -topics hc4-v1.0-ru.en.test.desc.title.tsv \
+  -topics hc4-v1.0-ru.en.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-en.bm25-default.topics.hc4-v1.0-ru.en.test.desc.title.txt \
   -bm25 &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-en \
-  -topics hc4-v1.0-ru.en.test.title.tsv \
+  -topics hc4-v1.0-ru.en.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-en.bm25-default+rm3.topics.hc4-v1.0-ru.en.test.title.txt \
   -bm25 -rm3 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-en \
-  -topics hc4-v1.0-ru.en.test.desc.tsv \
+  -topics hc4-v1.0-ru.en.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-en.bm25-default+rm3.topics.hc4-v1.0-ru.en.test.desc.txt \
   -bm25 -rm3 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-en \
-  -topics hc4-v1.0-ru.en.test.desc.title.tsv \
+  -topics hc4-v1.0-ru.en.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-en.bm25-default+rm3.topics.hc4-v1.0-ru.en.test.desc.title.txt \
   -bm25 -rm3 &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-en \
-  -topics hc4-v1.0-ru.en.test.title.tsv \
+  -topics hc4-v1.0-ru.en.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-en.bm25-default+rocchio.topics.hc4-v1.0-ru.en.test.title.txt \
   -bm25 -rocchio &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-en \
-  -topics hc4-v1.0-ru.en.test.desc.tsv \
+  -topics hc4-v1.0-ru.en.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-en.bm25-default+rocchio.topics.hc4-v1.0-ru.en.test.desc.txt \
   -bm25 -rocchio &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-en \
-  -topics hc4-v1.0-ru.en.test.desc.title.tsv \
+  -topics hc4-v1.0-ru.en.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-en.bm25-default+rocchio.topics.hc4-v1.0-ru.en.test.desc.title.txt \
   -bm25 -rocchio &

--- a/docs/reproduce/from-document-collection/hc4-neuclir22-ru.md
+++ b/docs/reproduce/from-document-collection/hc4-neuclir22-ru.md
@@ -52,57 +52,57 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru \
-  -topics hc4-v1.0-ru.test.title.tsv \
+  -topics hc4-v1.0-ru.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru.bm25-default.topics.hc4-v1.0-ru.test.title.txt \
   -bm25 -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru \
-  -topics hc4-v1.0-ru.test.desc.tsv \
+  -topics hc4-v1.0-ru.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru.bm25-default.topics.hc4-v1.0-ru.test.desc.txt \
   -bm25 -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru \
-  -topics hc4-v1.0-ru.test.desc.title.tsv \
+  -topics hc4-v1.0-ru.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru.bm25-default.topics.hc4-v1.0-ru.test.desc.title.txt \
   -bm25 -language ru &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru \
-  -topics hc4-v1.0-ru.test.title.tsv \
+  -topics hc4-v1.0-ru.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru.bm25-default+rm3.topics.hc4-v1.0-ru.test.title.txt \
   -bm25 -rm3 -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru \
-  -topics hc4-v1.0-ru.test.desc.tsv \
+  -topics hc4-v1.0-ru.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru.bm25-default+rm3.topics.hc4-v1.0-ru.test.desc.txt \
   -bm25 -rm3 -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru \
-  -topics hc4-v1.0-ru.test.desc.title.tsv \
+  -topics hc4-v1.0-ru.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru.bm25-default+rm3.topics.hc4-v1.0-ru.test.desc.title.txt \
   -bm25 -rm3 -language ru &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru \
-  -topics hc4-v1.0-ru.test.title.tsv \
+  -topics hc4-v1.0-ru.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru.bm25-default+rocchio.topics.hc4-v1.0-ru.test.title.txt \
   -bm25 -rocchio -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru \
-  -topics hc4-v1.0-ru.test.desc.tsv \
+  -topics hc4-v1.0-ru.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru.bm25-default+rocchio.topics.hc4-v1.0-ru.test.desc.txt \
   -bm25 -rocchio -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru \
-  -topics hc4-v1.0-ru.test.desc.title.tsv \
+  -topics hc4-v1.0-ru.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru.bm25-default+rocchio.topics.hc4-v1.0-ru.test.desc.title.txt \
   -bm25 -rocchio -language ru &

--- a/docs/reproduce/from-document-collection/hc4-neuclir22-zh-en.md
+++ b/docs/reproduce/from-document-collection/hc4-neuclir22-zh-en.md
@@ -51,57 +51,57 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-en \
-  -topics hc4-v1.0-zh.en.test.title.tsv \
+  -topics hc4-v1.0-zh.en.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-en.bm25-default.topics.hc4-v1.0-zh.en.test.title.txt \
   -bm25 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-en \
-  -topics hc4-v1.0-zh.en.test.desc.tsv \
+  -topics hc4-v1.0-zh.en.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-en.bm25-default.topics.hc4-v1.0-zh.en.test.desc.txt \
   -bm25 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-en \
-  -topics hc4-v1.0-zh.en.test.desc.title.tsv \
+  -topics hc4-v1.0-zh.en.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-en.bm25-default.topics.hc4-v1.0-zh.en.test.desc.title.txt \
   -bm25 &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-en \
-  -topics hc4-v1.0-zh.en.test.title.tsv \
+  -topics hc4-v1.0-zh.en.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-en.bm25-default+rm3.topics.hc4-v1.0-zh.en.test.title.txt \
   -bm25 -rm3 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-en \
-  -topics hc4-v1.0-zh.en.test.desc.tsv \
+  -topics hc4-v1.0-zh.en.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-en.bm25-default+rm3.topics.hc4-v1.0-zh.en.test.desc.txt \
   -bm25 -rm3 &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-en \
-  -topics hc4-v1.0-zh.en.test.desc.title.tsv \
+  -topics hc4-v1.0-zh.en.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-en.bm25-default+rm3.topics.hc4-v1.0-zh.en.test.desc.title.txt \
   -bm25 -rm3 &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-en \
-  -topics hc4-v1.0-zh.en.test.title.tsv \
+  -topics hc4-v1.0-zh.en.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-en.bm25-default+rocchio.topics.hc4-v1.0-zh.en.test.title.txt \
   -bm25 -rocchio &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-en \
-  -topics hc4-v1.0-zh.en.test.desc.tsv \
+  -topics hc4-v1.0-zh.en.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-en.bm25-default+rocchio.topics.hc4-v1.0-zh.en.test.desc.txt \
   -bm25 -rocchio &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-en \
-  -topics hc4-v1.0-zh.en.test.desc.title.tsv \
+  -topics hc4-v1.0-zh.en.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-en.bm25-default+rocchio.topics.hc4-v1.0-zh.en.test.desc.title.txt \
   -bm25 -rocchio &

--- a/docs/reproduce/from-document-collection/hc4-neuclir22-zh.md
+++ b/docs/reproduce/from-document-collection/hc4-neuclir22-zh.md
@@ -51,57 +51,57 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh \
-  -topics hc4-v1.0-zh.test.title.tsv \
+  -topics hc4-v1.0-zh.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh.bm25-default.topics.hc4-v1.0-zh.test.title.txt \
   -bm25 -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh \
-  -topics hc4-v1.0-zh.test.desc.tsv \
+  -topics hc4-v1.0-zh.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh.bm25-default.topics.hc4-v1.0-zh.test.desc.txt \
   -bm25 -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh \
-  -topics hc4-v1.0-zh.test.desc.title.tsv \
+  -topics hc4-v1.0-zh.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh.bm25-default.topics.hc4-v1.0-zh.test.desc.title.txt \
   -bm25 -language zh &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh \
-  -topics hc4-v1.0-zh.test.title.tsv \
+  -topics hc4-v1.0-zh.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh.bm25-default+rm3.topics.hc4-v1.0-zh.test.title.txt \
   -bm25 -rm3 -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh \
-  -topics hc4-v1.0-zh.test.desc.tsv \
+  -topics hc4-v1.0-zh.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh.bm25-default+rm3.topics.hc4-v1.0-zh.test.desc.txt \
   -bm25 -rm3 -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh \
-  -topics hc4-v1.0-zh.test.desc.title.tsv \
+  -topics hc4-v1.0-zh.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh.bm25-default+rm3.topics.hc4-v1.0-zh.test.desc.title.txt \
   -bm25 -rm3 -language zh &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh \
-  -topics hc4-v1.0-zh.test.title.tsv \
+  -topics hc4-v1.0-zh.test.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh.bm25-default+rocchio.topics.hc4-v1.0-zh.test.title.txt \
   -bm25 -rocchio -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh \
-  -topics hc4-v1.0-zh.test.desc.tsv \
+  -topics hc4-v1.0-zh.test.desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh.bm25-default+rocchio.topics.hc4-v1.0-zh.test.desc.txt \
   -bm25 -rocchio -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh \
-  -topics hc4-v1.0-zh.test.desc.title.tsv \
+  -topics hc4-v1.0-zh.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh.bm25-default+rocchio.topics.hc4-v1.0-zh.test.desc.title.txt \
   -bm25 -rocchio -language zh &

--- a/docs/reproduce/from-document-collection/hc4-v1.0-fa.md
+++ b/docs/reproduce/from-document-collection/hc4-v1.0-fa.md
@@ -50,111 +50,111 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.dev.title.tsv \
+  -topics hc4-v1.0-fa.dev.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default.topics.hc4-v1.0-fa.dev.title.txt \
   -bm25 -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.dev.desc.tsv \
+  -topics hc4-v1.0-fa.dev.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default.topics.hc4-v1.0-fa.dev.desc.txt \
   -bm25 -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.dev.desc.title.tsv \
+  -topics hc4-v1.0-fa.dev.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default.topics.hc4-v1.0-fa.dev.desc.title.txt \
   -bm25 -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.test.title.tsv \
+  -topics hc4-v1.0-fa.test.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default.topics.hc4-v1.0-fa.test.title.txt \
   -bm25 -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.test.desc.tsv \
+  -topics hc4-v1.0-fa.test.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default.topics.hc4-v1.0-fa.test.desc.txt \
   -bm25 -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.test.desc.title.tsv \
+  -topics hc4-v1.0-fa.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default.topics.hc4-v1.0-fa.test.desc.title.txt \
   -bm25 -language fa &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.dev.title.tsv \
+  -topics hc4-v1.0-fa.dev.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default+rm3.topics.hc4-v1.0-fa.dev.title.txt \
   -bm25 -rm3 -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.dev.desc.tsv \
+  -topics hc4-v1.0-fa.dev.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default+rm3.topics.hc4-v1.0-fa.dev.desc.txt \
   -bm25 -rm3 -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.dev.desc.title.tsv \
+  -topics hc4-v1.0-fa.dev.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default+rm3.topics.hc4-v1.0-fa.dev.desc.title.txt \
   -bm25 -rm3 -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.test.title.tsv \
+  -topics hc4-v1.0-fa.test.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default+rm3.topics.hc4-v1.0-fa.test.title.txt \
   -bm25 -rm3 -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.test.desc.tsv \
+  -topics hc4-v1.0-fa.test.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default+rm3.topics.hc4-v1.0-fa.test.desc.txt \
   -bm25 -rm3 -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.test.desc.title.tsv \
+  -topics hc4-v1.0-fa.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default+rm3.topics.hc4-v1.0-fa.test.desc.title.txt \
   -bm25 -rm3 -language fa &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.dev.title.tsv \
+  -topics hc4-v1.0-fa.dev.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default+rocchio.topics.hc4-v1.0-fa.dev.title.txt \
   -bm25 -rocchio -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.dev.desc.tsv \
+  -topics hc4-v1.0-fa.dev.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default+rocchio.topics.hc4-v1.0-fa.dev.desc.txt \
   -bm25 -rocchio -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.dev.desc.title.tsv \
+  -topics hc4-v1.0-fa.dev.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default+rocchio.topics.hc4-v1.0-fa.dev.desc.title.txt \
   -bm25 -rocchio -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.test.title.tsv \
+  -topics hc4-v1.0-fa.test.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default+rocchio.topics.hc4-v1.0-fa.test.title.txt \
   -bm25 -rocchio -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.test.desc.tsv \
+  -topics hc4-v1.0-fa.test.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default+rocchio.topics.hc4-v1.0-fa.test.desc.txt \
   -bm25 -rocchio -language fa &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-fa \
-  -topics hc4-v1.0-fa.test.desc.title.tsv \
+  -topics hc4-v1.0-fa.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-fa.bm25-default+rocchio.topics.hc4-v1.0-fa.test.desc.title.txt \
   -bm25 -rocchio -language fa &

--- a/docs/reproduce/from-document-collection/hc4-v1.0-ru.md
+++ b/docs/reproduce/from-document-collection/hc4-v1.0-ru.md
@@ -51,111 +51,111 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.dev.title.tsv \
+  -topics hc4-v1.0-ru.dev.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default.topics.hc4-v1.0-ru.dev.title.txt \
   -bm25 -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.dev.desc.tsv \
+  -topics hc4-v1.0-ru.dev.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default.topics.hc4-v1.0-ru.dev.desc.txt \
   -bm25 -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.dev.desc.title.tsv \
+  -topics hc4-v1.0-ru.dev.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default.topics.hc4-v1.0-ru.dev.desc.title.txt \
   -bm25 -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.test.title.tsv \
+  -topics hc4-v1.0-ru.test.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default.topics.hc4-v1.0-ru.test.title.txt \
   -bm25 -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.test.desc.tsv \
+  -topics hc4-v1.0-ru.test.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default.topics.hc4-v1.0-ru.test.desc.txt \
   -bm25 -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.test.desc.title.tsv \
+  -topics hc4-v1.0-ru.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default.topics.hc4-v1.0-ru.test.desc.title.txt \
   -bm25 -language ru &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.dev.title.tsv \
+  -topics hc4-v1.0-ru.dev.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default+rm3.topics.hc4-v1.0-ru.dev.title.txt \
   -bm25 -rm3 -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.dev.desc.tsv \
+  -topics hc4-v1.0-ru.dev.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default+rm3.topics.hc4-v1.0-ru.dev.desc.txt \
   -bm25 -rm3 -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.dev.desc.title.tsv \
+  -topics hc4-v1.0-ru.dev.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default+rm3.topics.hc4-v1.0-ru.dev.desc.title.txt \
   -bm25 -rm3 -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.test.title.tsv \
+  -topics hc4-v1.0-ru.test.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default+rm3.topics.hc4-v1.0-ru.test.title.txt \
   -bm25 -rm3 -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.test.desc.tsv \
+  -topics hc4-v1.0-ru.test.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default+rm3.topics.hc4-v1.0-ru.test.desc.txt \
   -bm25 -rm3 -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.test.desc.title.tsv \
+  -topics hc4-v1.0-ru.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default+rm3.topics.hc4-v1.0-ru.test.desc.title.txt \
   -bm25 -rm3 -language ru &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.dev.title.tsv \
+  -topics hc4-v1.0-ru.dev.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default+rocchio.topics.hc4-v1.0-ru.dev.title.txt \
   -bm25 -rocchio -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.dev.desc.tsv \
+  -topics hc4-v1.0-ru.dev.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default+rocchio.topics.hc4-v1.0-ru.dev.desc.txt \
   -bm25 -rocchio -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.dev.desc.title.tsv \
+  -topics hc4-v1.0-ru.dev.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default+rocchio.topics.hc4-v1.0-ru.dev.desc.title.txt \
   -bm25 -rocchio -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.test.title.tsv \
+  -topics hc4-v1.0-ru.test.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default+rocchio.topics.hc4-v1.0-ru.test.title.txt \
   -bm25 -rocchio -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.test.desc.tsv \
+  -topics hc4-v1.0-ru.test.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default+rocchio.topics.hc4-v1.0-ru.test.desc.txt \
   -bm25 -rocchio -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-ru \
-  -topics hc4-v1.0-ru.test.desc.title.tsv \
+  -topics hc4-v1.0-ru.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-ru.bm25-default+rocchio.topics.hc4-v1.0-ru.test.desc.title.txt \
   -bm25 -rocchio -language ru &

--- a/docs/reproduce/from-document-collection/hc4-v1.0-zh.md
+++ b/docs/reproduce/from-document-collection/hc4-v1.0-zh.md
@@ -50,111 +50,111 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.dev.title.tsv \
+  -topics hc4-v1.0-zh.dev.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default.topics.hc4-v1.0-zh.dev.title.txt \
   -bm25 -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.dev.desc.tsv \
+  -topics hc4-v1.0-zh.dev.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default.topics.hc4-v1.0-zh.dev.desc.txt \
   -bm25 -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.dev.desc.title.tsv \
+  -topics hc4-v1.0-zh.dev.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default.topics.hc4-v1.0-zh.dev.desc.title.txt \
   -bm25 -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.test.title.tsv \
+  -topics hc4-v1.0-zh.test.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default.topics.hc4-v1.0-zh.test.title.txt \
   -bm25 -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.test.desc.tsv \
+  -topics hc4-v1.0-zh.test.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default.topics.hc4-v1.0-zh.test.desc.txt \
   -bm25 -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.test.desc.title.tsv \
+  -topics hc4-v1.0-zh.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default.topics.hc4-v1.0-zh.test.desc.title.txt \
   -bm25 -language zh &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.dev.title.tsv \
+  -topics hc4-v1.0-zh.dev.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default+rm3.topics.hc4-v1.0-zh.dev.title.txt \
   -bm25 -rm3 -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.dev.desc.tsv \
+  -topics hc4-v1.0-zh.dev.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default+rm3.topics.hc4-v1.0-zh.dev.desc.txt \
   -bm25 -rm3 -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.dev.desc.title.tsv \
+  -topics hc4-v1.0-zh.dev.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default+rm3.topics.hc4-v1.0-zh.dev.desc.title.txt \
   -bm25 -rm3 -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.test.title.tsv \
+  -topics hc4-v1.0-zh.test.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default+rm3.topics.hc4-v1.0-zh.test.title.txt \
   -bm25 -rm3 -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.test.desc.tsv \
+  -topics hc4-v1.0-zh.test.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default+rm3.topics.hc4-v1.0-zh.test.desc.txt \
   -bm25 -rm3 -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.test.desc.title.tsv \
+  -topics hc4-v1.0-zh.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default+rm3.topics.hc4-v1.0-zh.test.desc.title.txt \
   -bm25 -rm3 -language zh &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.dev.title.tsv \
+  -topics hc4-v1.0-zh.dev.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default+rocchio.topics.hc4-v1.0-zh.dev.title.txt \
   -bm25 -rocchio -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.dev.desc.tsv \
+  -topics hc4-v1.0-zh.dev.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default+rocchio.topics.hc4-v1.0-zh.dev.desc.txt \
   -bm25 -rocchio -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.dev.desc.title.tsv \
+  -topics hc4-v1.0-zh.dev.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default+rocchio.topics.hc4-v1.0-zh.dev.desc.title.txt \
   -bm25 -rocchio -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.test.title.tsv \
+  -topics hc4-v1.0-zh.test.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default+rocchio.topics.hc4-v1.0-zh.test.title.txt \
   -bm25 -rocchio -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.test.desc.tsv \
+  -topics hc4-v1.0-zh.test.desc \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default+rocchio.topics.hc4-v1.0-zh.test.desc.txt \
   -bm25 -rocchio -language zh &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.hc4-v1.0-zh \
-  -topics hc4-v1.0-zh.test.desc.title.tsv \
+  -topics hc4-v1.0-zh.test.desc.title \
   -topicReader TsvInt \
   -output runs/run.hc4-v1.0-zh.bm25-default+rocchio.topics.hc4-v1.0-zh.test.desc.title.txt \
   -bm25 -rocchio -language zh &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ar-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ar-aca.md
@@ -47,8 +47,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-ar-dev.tsv runs/run.miracl-v1.0-ar.bm25.topics.miracl-v1.0-ar-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-ar-dev.tsv runs/run.miracl-v1.0-ar.bm25.topics.miracl-v1.0-ar-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-ar-dev runs/run.miracl-v1.0-ar.bm25.topics.miracl-v1.0-ar-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-ar-dev runs/run.miracl-v1.0-ar.bm25.topics.miracl-v1.0-ar-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ar-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ar-aca.md
@@ -38,7 +38,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-ar-aca/ \
-  -topics miracl-v1.0-ar-dev.tsv \
+  -topics miracl-v1.0-ar-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-ar.bm25.topics.miracl-v1.0-ar-dev.txt \
   -bm25 -hits 100 -language ar -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ar.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ar.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-ar-dev.tsv runs/run.miracl-v1.0-ar.bm25.topics.miracl-v1.0-ar-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-ar-dev.tsv runs/run.miracl-v1.0-ar.bm25.topics.miracl-v1.0-ar-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-ar-dev runs/run.miracl-v1.0-ar.bm25.topics.miracl-v1.0-ar-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-ar-dev runs/run.miracl-v1.0-ar.bm25.topics.miracl-v1.0-ar-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ar.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ar.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-ar/ \
-  -topics miracl-v1.0-ar-dev.tsv \
+  -topics miracl-v1.0-ar-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-ar.bm25.topics.miracl-v1.0-ar-dev.txt \
   -bm25 -hits 100 -language ar &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-bn-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-bn-aca.md
@@ -47,8 +47,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-bn-dev.tsv runs/run.miracl-v1.0-bn.bm25.topics.miracl-v1.0-bn-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-bn-dev.tsv runs/run.miracl-v1.0-bn.bm25.topics.miracl-v1.0-bn-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-bn-dev runs/run.miracl-v1.0-bn.bm25.topics.miracl-v1.0-bn-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-bn-dev runs/run.miracl-v1.0-bn.bm25.topics.miracl-v1.0-bn-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-bn-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-bn-aca.md
@@ -38,7 +38,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-bn-aca/ \
-  -topics miracl-v1.0-bn-dev.tsv \
+  -topics miracl-v1.0-bn-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-bn.bm25.topics.miracl-v1.0-bn-dev.txt \
   -bm25 -hits 100 -language bn -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-bn.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-bn.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-bn/ \
-  -topics miracl-v1.0-bn-dev.tsv \
+  -topics miracl-v1.0-bn-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-bn.bm25.topics.miracl-v1.0-bn-dev.txt \
   -bm25 -hits 100 -language bn &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-bn.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-bn.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-bn-dev.tsv runs/run.miracl-v1.0-bn.bm25.topics.miracl-v1.0-bn-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-bn-dev.tsv runs/run.miracl-v1.0-bn.bm25.topics.miracl-v1.0-bn-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-bn-dev runs/run.miracl-v1.0-bn.bm25.topics.miracl-v1.0-bn-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-bn-dev runs/run.miracl-v1.0-bn.bm25.topics.miracl-v1.0-bn-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-en-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-en-aca.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-en-dev.tsv runs/run.miracl-v1.0-en.bm25.topics.miracl-v1.0-en-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-en-dev.tsv runs/run.miracl-v1.0-en.bm25.topics.miracl-v1.0-en-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-en-dev runs/run.miracl-v1.0-en.bm25.topics.miracl-v1.0-en-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-en-dev runs/run.miracl-v1.0-en.bm25.topics.miracl-v1.0-en-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-en-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-en-aca.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-en-aca/ \
-  -topics miracl-v1.0-en-dev.tsv \
+  -topics miracl-v1.0-en-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-en.bm25.topics.miracl-v1.0-en-dev.txt \
   -bm25 -hits 100 -language en -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-en.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-en.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-en-dev.tsv runs/run.miracl-v1.0-en.bm25.topics.miracl-v1.0-en-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-en-dev.tsv runs/run.miracl-v1.0-en.bm25.topics.miracl-v1.0-en-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-en-dev runs/run.miracl-v1.0-en.bm25.topics.miracl-v1.0-en-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-en-dev runs/run.miracl-v1.0-en.bm25.topics.miracl-v1.0-en-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-en.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-en.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-en/ \
-  -topics miracl-v1.0-en-dev.tsv \
+  -topics miracl-v1.0-en-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-en.bm25.topics.miracl-v1.0-en-dev.txt \
   -bm25 -hits 100 -language en &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-es-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-es-aca.md
@@ -47,8 +47,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-es-dev.tsv runs/run.miracl-v1.0-es.bm25.topics.miracl-v1.0-es-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-es-dev.tsv runs/run.miracl-v1.0-es.bm25.topics.miracl-v1.0-es-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-es-dev runs/run.miracl-v1.0-es.bm25.topics.miracl-v1.0-es-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-es-dev runs/run.miracl-v1.0-es.bm25.topics.miracl-v1.0-es-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-es-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-es-aca.md
@@ -38,7 +38,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-es-aca/ \
-  -topics miracl-v1.0-es-dev.tsv \
+  -topics miracl-v1.0-es-dev \
   -topicReader TsvString \
   -output runs/run.miracl-v1.0-es.bm25.topics.miracl-v1.0-es-dev.txt \
   -bm25 -hits 100 -language es -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-es.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-es.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-es/ \
-  -topics miracl-v1.0-es-dev.tsv \
+  -topics miracl-v1.0-es-dev \
   -topicReader TsvString \
   -output runs/run.miracl-v1.0-es.bm25.topics.miracl-v1.0-es-dev.txt \
   -bm25 -hits 100 -language es &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-es.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-es.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-es-dev.tsv runs/run.miracl-v1.0-es.bm25.topics.miracl-v1.0-es-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-es-dev.tsv runs/run.miracl-v1.0-es.bm25.topics.miracl-v1.0-es-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-es-dev runs/run.miracl-v1.0-es.bm25.topics.miracl-v1.0-es-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-es-dev runs/run.miracl-v1.0-es.bm25.topics.miracl-v1.0-es-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-fa-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-fa-aca.md
@@ -38,7 +38,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-fa-aca/ \
-  -topics miracl-v1.0-fa-dev.tsv \
+  -topics miracl-v1.0-fa-dev \
   -topicReader TsvString \
   -output runs/run.miracl-v1.0-fa.bm25.topics.miracl-v1.0-fa-dev.txt \
   -bm25 -hits 100 -language fa -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-fa-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-fa-aca.md
@@ -47,8 +47,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-fa-dev.tsv runs/run.miracl-v1.0-fa.bm25.topics.miracl-v1.0-fa-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-fa-dev.tsv runs/run.miracl-v1.0-fa.bm25.topics.miracl-v1.0-fa-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-fa-dev runs/run.miracl-v1.0-fa.bm25.topics.miracl-v1.0-fa-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-fa-dev runs/run.miracl-v1.0-fa.bm25.topics.miracl-v1.0-fa-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-fa.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-fa.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-fa/ \
-  -topics miracl-v1.0-fa-dev.tsv \
+  -topics miracl-v1.0-fa-dev \
   -topicReader TsvString \
   -output runs/run.miracl-v1.0-fa.bm25.topics.miracl-v1.0-fa-dev.txt \
   -bm25 -hits 100 -language fa &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-fa.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-fa.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-fa-dev.tsv runs/run.miracl-v1.0-fa.bm25.topics.miracl-v1.0-fa-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-fa-dev.tsv runs/run.miracl-v1.0-fa.bm25.topics.miracl-v1.0-fa-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-fa-dev runs/run.miracl-v1.0-fa.bm25.topics.miracl-v1.0-fa-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-fa-dev runs/run.miracl-v1.0-fa.bm25.topics.miracl-v1.0-fa-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-fi-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-fi-aca.md
@@ -38,7 +38,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-fi-aca/ \
-  -topics miracl-v1.0-fi-dev.tsv \
+  -topics miracl-v1.0-fi-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-fi.bm25.topics.miracl-v1.0-fi-dev.txt \
   -bm25 -hits 100 -language fi -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-fi-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-fi-aca.md
@@ -47,8 +47,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-fi-dev.tsv runs/run.miracl-v1.0-fi.bm25.topics.miracl-v1.0-fi-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-fi-dev.tsv runs/run.miracl-v1.0-fi.bm25.topics.miracl-v1.0-fi-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-fi-dev runs/run.miracl-v1.0-fi.bm25.topics.miracl-v1.0-fi-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-fi-dev runs/run.miracl-v1.0-fi.bm25.topics.miracl-v1.0-fi-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-fi.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-fi.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-fi-dev.tsv runs/run.miracl-v1.0-fi.bm25.topics.miracl-v1.0-fi-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-fi-dev.tsv runs/run.miracl-v1.0-fi.bm25.topics.miracl-v1.0-fi-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-fi-dev runs/run.miracl-v1.0-fi.bm25.topics.miracl-v1.0-fi-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-fi-dev runs/run.miracl-v1.0-fi.bm25.topics.miracl-v1.0-fi-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-fi.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-fi.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-fi/ \
-  -topics miracl-v1.0-fi-dev.tsv \
+  -topics miracl-v1.0-fi-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-fi.bm25.topics.miracl-v1.0-fi-dev.txt \
   -bm25 -hits 100 -language fi &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-fr-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-fr-aca.md
@@ -38,7 +38,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-fr-aca/ \
-  -topics miracl-v1.0-fr-dev.tsv \
+  -topics miracl-v1.0-fr-dev \
   -topicReader TsvString \
   -output runs/run.miracl-v1.0-fr.bm25.topics.miracl-v1.0-fr-dev.txt \
   -bm25 -hits 100 -language fr -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-fr-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-fr-aca.md
@@ -47,8 +47,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-fr-dev.tsv runs/run.miracl-v1.0-fr.bm25.topics.miracl-v1.0-fr-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-fr-dev.tsv runs/run.miracl-v1.0-fr.bm25.topics.miracl-v1.0-fr-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-fr-dev runs/run.miracl-v1.0-fr.bm25.topics.miracl-v1.0-fr-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-fr-dev runs/run.miracl-v1.0-fr.bm25.topics.miracl-v1.0-fr-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-fr.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-fr.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-fr/ \
-  -topics miracl-v1.0-fr-dev.tsv \
+  -topics miracl-v1.0-fr-dev \
   -topicReader TsvString \
   -output runs/run.miracl-v1.0-fr.bm25.topics.miracl-v1.0-fr-dev.txt \
   -bm25 -hits 100 -language fr &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-fr.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-fr.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-fr-dev.tsv runs/run.miracl-v1.0-fr.bm25.topics.miracl-v1.0-fr-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-fr-dev.tsv runs/run.miracl-v1.0-fr.bm25.topics.miracl-v1.0-fr-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-fr-dev runs/run.miracl-v1.0-fr.bm25.topics.miracl-v1.0-fr-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-fr-dev runs/run.miracl-v1.0-fr.bm25.topics.miracl-v1.0-fr-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-hi-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-hi-aca.md
@@ -47,8 +47,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-hi-dev.tsv runs/run.miracl-v1.0-hi.bm25.topics.miracl-v1.0-hi-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-hi-dev.tsv runs/run.miracl-v1.0-hi.bm25.topics.miracl-v1.0-hi-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-hi-dev runs/run.miracl-v1.0-hi.bm25.topics.miracl-v1.0-hi-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-hi-dev runs/run.miracl-v1.0-hi.bm25.topics.miracl-v1.0-hi-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-hi-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-hi-aca.md
@@ -38,7 +38,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-hi-aca/ \
-  -topics miracl-v1.0-hi-dev.tsv \
+  -topics miracl-v1.0-hi-dev \
   -topicReader TsvString \
   -output runs/run.miracl-v1.0-hi.bm25.topics.miracl-v1.0-hi-dev.txt \
   -bm25 -hits 100 -language hi -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-hi.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-hi.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-hi/ \
-  -topics miracl-v1.0-hi-dev.tsv \
+  -topics miracl-v1.0-hi-dev \
   -topicReader TsvString \
   -output runs/run.miracl-v1.0-hi.bm25.topics.miracl-v1.0-hi-dev.txt \
   -bm25 -hits 100 -language hi &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-hi.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-hi.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-hi-dev.tsv runs/run.miracl-v1.0-hi.bm25.topics.miracl-v1.0-hi-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-hi-dev.tsv runs/run.miracl-v1.0-hi.bm25.topics.miracl-v1.0-hi-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-hi-dev runs/run.miracl-v1.0-hi.bm25.topics.miracl-v1.0-hi-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-hi-dev runs/run.miracl-v1.0-hi.bm25.topics.miracl-v1.0-hi-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-id-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-id-aca.md
@@ -38,7 +38,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-id-aca/ \
-  -topics miracl-v1.0-id-dev.tsv \
+  -topics miracl-v1.0-id-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-id.bm25.topics.miracl-v1.0-id-dev.txt \
   -bm25 -hits 100 -language id -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-id-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-id-aca.md
@@ -47,8 +47,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-id-dev.tsv runs/run.miracl-v1.0-id.bm25.topics.miracl-v1.0-id-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-id-dev.tsv runs/run.miracl-v1.0-id.bm25.topics.miracl-v1.0-id-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-id-dev runs/run.miracl-v1.0-id.bm25.topics.miracl-v1.0-id-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-id-dev runs/run.miracl-v1.0-id.bm25.topics.miracl-v1.0-id-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-id.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-id.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-id-dev.tsv runs/run.miracl-v1.0-id.bm25.topics.miracl-v1.0-id-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-id-dev.tsv runs/run.miracl-v1.0-id.bm25.topics.miracl-v1.0-id-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-id-dev runs/run.miracl-v1.0-id.bm25.topics.miracl-v1.0-id-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-id-dev runs/run.miracl-v1.0-id.bm25.topics.miracl-v1.0-id-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-id.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-id.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-id/ \
-  -topics miracl-v1.0-id-dev.tsv \
+  -topics miracl-v1.0-id-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-id.bm25.topics.miracl-v1.0-id-dev.txt \
   -bm25 -hits 100 -language id &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ja-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ja-aca.md
@@ -38,7 +38,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-ja-aca/ \
-  -topics miracl-v1.0-ja-dev.tsv \
+  -topics miracl-v1.0-ja-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-ja.bm25.topics.miracl-v1.0-ja-dev.txt \
   -bm25 -hits 100 -language ja -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ja-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ja-aca.md
@@ -47,8 +47,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-ja-dev.tsv runs/run.miracl-v1.0-ja.bm25.topics.miracl-v1.0-ja-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-ja-dev.tsv runs/run.miracl-v1.0-ja.bm25.topics.miracl-v1.0-ja-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-ja-dev runs/run.miracl-v1.0-ja.bm25.topics.miracl-v1.0-ja-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-ja-dev runs/run.miracl-v1.0-ja.bm25.topics.miracl-v1.0-ja-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ja.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ja.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-ja/ \
-  -topics miracl-v1.0-ja-dev.tsv \
+  -topics miracl-v1.0-ja-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-ja.bm25.topics.miracl-v1.0-ja-dev.txt \
   -bm25 -hits 100 -language ja &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ja.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ja.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-ja-dev.tsv runs/run.miracl-v1.0-ja.bm25.topics.miracl-v1.0-ja-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-ja-dev.tsv runs/run.miracl-v1.0-ja.bm25.topics.miracl-v1.0-ja-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-ja-dev runs/run.miracl-v1.0-ja.bm25.topics.miracl-v1.0-ja-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-ja-dev runs/run.miracl-v1.0-ja.bm25.topics.miracl-v1.0-ja-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ko-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ko-aca.md
@@ -47,8 +47,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-ko-dev.tsv runs/run.miracl-v1.0-ko.bm25.topics.miracl-v1.0-ko-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-ko-dev.tsv runs/run.miracl-v1.0-ko.bm25.topics.miracl-v1.0-ko-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-ko-dev runs/run.miracl-v1.0-ko.bm25.topics.miracl-v1.0-ko-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-ko-dev runs/run.miracl-v1.0-ko.bm25.topics.miracl-v1.0-ko-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ko-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ko-aca.md
@@ -38,7 +38,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-ko-aca/ \
-  -topics miracl-v1.0-ko-dev.tsv \
+  -topics miracl-v1.0-ko-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-ko.bm25.topics.miracl-v1.0-ko-dev.txt \
   -bm25 -hits 100 -language ko -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ko.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ko.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-ko/ \
-  -topics miracl-v1.0-ko-dev.tsv \
+  -topics miracl-v1.0-ko-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-ko.bm25.topics.miracl-v1.0-ko-dev.txt \
   -bm25 -hits 100 -language ko &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ko.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ko.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-ko-dev.tsv runs/run.miracl-v1.0-ko.bm25.topics.miracl-v1.0-ko-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-ko-dev.tsv runs/run.miracl-v1.0-ko.bm25.topics.miracl-v1.0-ko-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-ko-dev runs/run.miracl-v1.0-ko.bm25.topics.miracl-v1.0-ko-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-ko-dev runs/run.miracl-v1.0-ko.bm25.topics.miracl-v1.0-ko-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ru-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ru-aca.md
@@ -47,8 +47,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-ru-dev.tsv runs/run.miracl-v1.0-ru.bm25.topics.miracl-v1.0-ru-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-ru-dev.tsv runs/run.miracl-v1.0-ru.bm25.topics.miracl-v1.0-ru-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-ru-dev runs/run.miracl-v1.0-ru.bm25.topics.miracl-v1.0-ru-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-ru-dev runs/run.miracl-v1.0-ru.bm25.topics.miracl-v1.0-ru-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ru-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ru-aca.md
@@ -38,7 +38,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-ru-aca/ \
-  -topics miracl-v1.0-ru-dev.tsv \
+  -topics miracl-v1.0-ru-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-ru.bm25.topics.miracl-v1.0-ru-dev.txt \
   -bm25 -hits 100 -language ru -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ru.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ru.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-ru/ \
-  -topics miracl-v1.0-ru-dev.tsv \
+  -topics miracl-v1.0-ru-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-ru.bm25.topics.miracl-v1.0-ru-dev.txt \
   -bm25 -hits 100 -language ru &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-ru.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-ru.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-ru-dev.tsv runs/run.miracl-v1.0-ru.bm25.topics.miracl-v1.0-ru-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-ru-dev.tsv runs/run.miracl-v1.0-ru.bm25.topics.miracl-v1.0-ru-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-ru-dev runs/run.miracl-v1.0-ru.bm25.topics.miracl-v1.0-ru-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-ru-dev runs/run.miracl-v1.0-ru.bm25.topics.miracl-v1.0-ru-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-sw-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-sw-aca.md
@@ -38,7 +38,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-sw-aca/ \
-  -topics miracl-v1.0-sw-dev.tsv \
+  -topics miracl-v1.0-sw-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-sw.bm25.topics.miracl-v1.0-sw-dev.txt \
   -bm25 -hits 100 -language sw -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-sw-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-sw-aca.md
@@ -47,8 +47,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-sw-dev.tsv runs/run.miracl-v1.0-sw.bm25.topics.miracl-v1.0-sw-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-sw-dev.tsv runs/run.miracl-v1.0-sw.bm25.topics.miracl-v1.0-sw-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-sw-dev runs/run.miracl-v1.0-sw.bm25.topics.miracl-v1.0-sw-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-sw-dev runs/run.miracl-v1.0-sw.bm25.topics.miracl-v1.0-sw-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-sw.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-sw.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-sw/ \
-  -topics miracl-v1.0-sw-dev.tsv \
+  -topics miracl-v1.0-sw-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-sw.bm25.topics.miracl-v1.0-sw-dev.txt \
   -bm25 -hits 100 -language sw &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-sw.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-sw.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-sw-dev.tsv runs/run.miracl-v1.0-sw.bm25.topics.miracl-v1.0-sw-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-sw-dev.tsv runs/run.miracl-v1.0-sw.bm25.topics.miracl-v1.0-sw-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-sw-dev runs/run.miracl-v1.0-sw.bm25.topics.miracl-v1.0-sw-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-sw-dev runs/run.miracl-v1.0-sw.bm25.topics.miracl-v1.0-sw-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-te-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-te-aca.md
@@ -47,8 +47,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-te-dev.tsv runs/run.miracl-v1.0-te.bm25.topics.miracl-v1.0-te-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-te-dev.tsv runs/run.miracl-v1.0-te.bm25.topics.miracl-v1.0-te-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-te-dev runs/run.miracl-v1.0-te.bm25.topics.miracl-v1.0-te-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-te-dev runs/run.miracl-v1.0-te.bm25.topics.miracl-v1.0-te-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-te-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-te-aca.md
@@ -38,7 +38,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-te-aca/ \
-  -topics miracl-v1.0-te-dev.tsv \
+  -topics miracl-v1.0-te-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-te.bm25.topics.miracl-v1.0-te-dev.txt \
   -bm25 -hits 100 -language te -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-te.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-te.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-te-dev.tsv runs/run.miracl-v1.0-te.bm25.topics.miracl-v1.0-te-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-te-dev.tsv runs/run.miracl-v1.0-te.bm25.topics.miracl-v1.0-te-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-te-dev runs/run.miracl-v1.0-te.bm25.topics.miracl-v1.0-te-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-te-dev runs/run.miracl-v1.0-te.bm25.topics.miracl-v1.0-te-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-te.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-te.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-te/ \
-  -topics miracl-v1.0-te-dev.tsv \
+  -topics miracl-v1.0-te-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-te.bm25.topics.miracl-v1.0-te-dev.txt \
   -bm25 -hits 100 -language te &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-th-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-th-aca.md
@@ -47,8 +47,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-th-dev.tsv runs/run.miracl-v1.0-th.bm25.topics.miracl-v1.0-th-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-th-dev.tsv runs/run.miracl-v1.0-th.bm25.topics.miracl-v1.0-th-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-th-dev runs/run.miracl-v1.0-th.bm25.topics.miracl-v1.0-th-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-th-dev runs/run.miracl-v1.0-th.bm25.topics.miracl-v1.0-th-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-th-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-th-aca.md
@@ -38,7 +38,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-th-aca/ \
-  -topics miracl-v1.0-th-dev.tsv \
+  -topics miracl-v1.0-th-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-th.bm25.topics.miracl-v1.0-th-dev.txt \
   -bm25 -hits 100 -language th -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-th.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-th.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-th-dev.tsv runs/run.miracl-v1.0-th.bm25.topics.miracl-v1.0-th-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-th-dev.tsv runs/run.miracl-v1.0-th.bm25.topics.miracl-v1.0-th-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-th-dev runs/run.miracl-v1.0-th.bm25.topics.miracl-v1.0-th-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-th-dev runs/run.miracl-v1.0-th.bm25.topics.miracl-v1.0-th-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-th.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-th.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-th/ \
-  -topics miracl-v1.0-th-dev.tsv \
+  -topics miracl-v1.0-th-dev \
   -topicReader TsvInt \
   -output runs/run.miracl-v1.0-th.bm25.topics.miracl-v1.0-th-dev.txt \
   -bm25 -hits 100 -language th &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-zh-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-zh-aca.md
@@ -38,7 +38,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-zh-aca/ \
-  -topics miracl-v1.0-zh-dev.tsv \
+  -topics miracl-v1.0-zh-dev \
   -topicReader TsvString \
   -output runs/run.miracl-v1.0-zh.bm25.topics.miracl-v1.0-zh-dev.txt \
   -bm25 -hits 100 -language zh -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-zh-aca.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-zh-aca.md
@@ -47,8 +47,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-zh-dev.tsv runs/run.miracl-v1.0-zh.bm25.topics.miracl-v1.0-zh-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-zh-dev.tsv runs/run.miracl-v1.0-zh.bm25.topics.miracl-v1.0-zh-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-zh-dev runs/run.miracl-v1.0-zh.bm25.topics.miracl-v1.0-zh-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-zh-dev runs/run.miracl-v1.0-zh.bm25.topics.miracl-v1.0-zh-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/miracl-v1.0-zh.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-zh.md
@@ -36,7 +36,7 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.miracl-v1.0-zh/ \
-  -topics miracl-v1.0-zh-dev.tsv \
+  -topics miracl-v1.0-zh-dev \
   -topicReader TsvString \
   -output runs/run.miracl-v1.0-zh.bm25.topics.miracl-v1.0-zh-dev.txt \
   -bm25 -hits 100 -language zh &

--- a/docs/reproduce/from-document-collection/miracl-v1.0-zh.md
+++ b/docs/reproduce/from-document-collection/miracl-v1.0-zh.md
@@ -45,8 +45,8 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-zh-dev.tsv runs/run.miracl-v1.0-zh.bm25.topics.miracl-v1.0-zh-dev.txt
-bin/trec_eval -c -m recall.100 miracl-v1.0-zh-dev.tsv runs/run.miracl-v1.0-zh.bm25.topics.miracl-v1.0-zh-dev.txt
+bin/trec_eval -c -m ndcg_cut.10 miracl-v1.0-zh-dev runs/run.miracl-v1.0-zh.bm25.topics.miracl-v1.0-zh-dev.txt
+bin/trec_eval -c -m recall.100 miracl-v1.0-zh-dev runs/run.miracl-v1.0-zh.bm25.topics.miracl-v1.0-zh-dev.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-ar-aca.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-ar-aca.md
@@ -38,19 +38,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-arabic-aca/ \
-  -topics mrtydi-v1.1-ar.train.txt.gz \
+  -topics mrtydi-v1.1-ar.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ar.bm25.topics.mrtydi-v1.1-ar.train.txt \
   -bm25 -hits 100 -language ar -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-arabic-aca/ \
-  -topics mrtydi-v1.1-ar.dev.txt.gz \
+  -topics mrtydi-v1.1-ar.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ar.bm25.topics.mrtydi-v1.1-ar.dev.txt \
   -bm25 -hits 100 -language ar -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-arabic-aca/ \
-  -topics mrtydi-v1.1-ar.test.txt.gz \
+  -topics mrtydi-v1.1-ar.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ar.bm25.topics.mrtydi-v1.1-ar.test.txt \
   -bm25 -hits 100 -language ar -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-ar.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-ar.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-arabic/ \
-  -topics mrtydi-v1.1-ar.train.txt.gz \
+  -topics mrtydi-v1.1-ar.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ar.bm25.topics.mrtydi-v1.1-ar.train.txt \
   -bm25 -hits 100 -language ar &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-arabic/ \
-  -topics mrtydi-v1.1-ar.dev.txt.gz \
+  -topics mrtydi-v1.1-ar.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ar.bm25.topics.mrtydi-v1.1-ar.dev.txt \
   -bm25 -hits 100 -language ar &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-arabic/ \
-  -topics mrtydi-v1.1-ar.test.txt.gz \
+  -topics mrtydi-v1.1-ar.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ar.bm25.topics.mrtydi-v1.1-ar.test.txt \
   -bm25 -hits 100 -language ar &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-bn-aca.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-bn-aca.md
@@ -38,19 +38,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-bengali-aca/ \
-  -topics mrtydi-v1.1-bn.train.txt.gz \
+  -topics mrtydi-v1.1-bn.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-bn.bm25.topics.mrtydi-v1.1-bn.train.txt \
   -bm25 -hits 100 -language bn -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-bengali-aca/ \
-  -topics mrtydi-v1.1-bn.dev.txt.gz \
+  -topics mrtydi-v1.1-bn.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-bn.bm25.topics.mrtydi-v1.1-bn.dev.txt \
   -bm25 -hits 100 -language bn -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-bengali-aca/ \
-  -topics mrtydi-v1.1-bn.test.txt.gz \
+  -topics mrtydi-v1.1-bn.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-bn.bm25.topics.mrtydi-v1.1-bn.test.txt \
   -bm25 -hits 100 -language bn -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-bn.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-bn.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-bengali/ \
-  -topics mrtydi-v1.1-bn.train.txt.gz \
+  -topics mrtydi-v1.1-bn.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-bn.bm25.topics.mrtydi-v1.1-bn.train.txt \
   -bm25 -hits 100 -language bn &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-bengali/ \
-  -topics mrtydi-v1.1-bn.dev.txt.gz \
+  -topics mrtydi-v1.1-bn.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-bn.bm25.topics.mrtydi-v1.1-bn.dev.txt \
   -bm25 -hits 100 -language bn &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-bengali/ \
-  -topics mrtydi-v1.1-bn.test.txt.gz \
+  -topics mrtydi-v1.1-bn.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-bn.bm25.topics.mrtydi-v1.1-bn.test.txt \
   -bm25 -hits 100 -language bn &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-en-aca.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-en-aca.md
@@ -38,19 +38,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-english-aca/ \
-  -topics mrtydi-v1.1-en.train.txt.gz \
+  -topics mrtydi-v1.1-en.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-en.bm25.topics.mrtydi-v1.1-en.train.txt \
   -bm25 -hits 100 -language en -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-english-aca/ \
-  -topics mrtydi-v1.1-en.dev.txt.gz \
+  -topics mrtydi-v1.1-en.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-en.bm25.topics.mrtydi-v1.1-en.dev.txt \
   -bm25 -hits 100 -language en -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-english-aca/ \
-  -topics mrtydi-v1.1-en.test.txt.gz \
+  -topics mrtydi-v1.1-en.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-en.bm25.topics.mrtydi-v1.1-en.test.txt \
   -bm25 -hits 100 -language en -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-en.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-en.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-english/ \
-  -topics mrtydi-v1.1-en.train.txt.gz \
+  -topics mrtydi-v1.1-en.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-en.bm25.topics.mrtydi-v1.1-en.train.txt \
   -bm25 -hits 100 -language en &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-english/ \
-  -topics mrtydi-v1.1-en.dev.txt.gz \
+  -topics mrtydi-v1.1-en.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-en.bm25.topics.mrtydi-v1.1-en.dev.txt \
   -bm25 -hits 100 -language en &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-english/ \
-  -topics mrtydi-v1.1-en.test.txt.gz \
+  -topics mrtydi-v1.1-en.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-en.bm25.topics.mrtydi-v1.1-en.test.txt \
   -bm25 -hits 100 -language en &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-fi-aca.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-fi-aca.md
@@ -38,19 +38,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-finnish-aca/ \
-  -topics mrtydi-v1.1-fi.train.txt.gz \
+  -topics mrtydi-v1.1-fi.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-fi.bm25.topics.mrtydi-v1.1-fi.train.txt \
   -bm25 -hits 100 -language fi -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-finnish-aca/ \
-  -topics mrtydi-v1.1-fi.dev.txt.gz \
+  -topics mrtydi-v1.1-fi.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-fi.bm25.topics.mrtydi-v1.1-fi.dev.txt \
   -bm25 -hits 100 -language fi -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-finnish-aca/ \
-  -topics mrtydi-v1.1-fi.test.txt.gz \
+  -topics mrtydi-v1.1-fi.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-fi.bm25.topics.mrtydi-v1.1-fi.test.txt \
   -bm25 -hits 100 -language fi -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-fi.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-fi.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-finnish/ \
-  -topics mrtydi-v1.1-fi.train.txt.gz \
+  -topics mrtydi-v1.1-fi.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-fi.bm25.topics.mrtydi-v1.1-fi.train.txt \
   -bm25 -hits 100 -language fi &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-finnish/ \
-  -topics mrtydi-v1.1-fi.dev.txt.gz \
+  -topics mrtydi-v1.1-fi.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-fi.bm25.topics.mrtydi-v1.1-fi.dev.txt \
   -bm25 -hits 100 -language fi &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-finnish/ \
-  -topics mrtydi-v1.1-fi.test.txt.gz \
+  -topics mrtydi-v1.1-fi.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-fi.bm25.topics.mrtydi-v1.1-fi.test.txt \
   -bm25 -hits 100 -language fi &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-id-aca.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-id-aca.md
@@ -38,19 +38,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-indonesian-aca/ \
-  -topics mrtydi-v1.1-id.train.txt.gz \
+  -topics mrtydi-v1.1-id.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-id.bm25.topics.mrtydi-v1.1-id.train.txt \
   -bm25 -hits 100 -language id -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-indonesian-aca/ \
-  -topics mrtydi-v1.1-id.dev.txt.gz \
+  -topics mrtydi-v1.1-id.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-id.bm25.topics.mrtydi-v1.1-id.dev.txt \
   -bm25 -hits 100 -language id -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-indonesian-aca/ \
-  -topics mrtydi-v1.1-id.test.txt.gz \
+  -topics mrtydi-v1.1-id.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-id.bm25.topics.mrtydi-v1.1-id.test.txt \
   -bm25 -hits 100 -language id -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-id.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-id.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-indonesian/ \
-  -topics mrtydi-v1.1-id.train.txt.gz \
+  -topics mrtydi-v1.1-id.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-id.bm25.topics.mrtydi-v1.1-id.train.txt \
   -bm25 -hits 100 -language id &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-indonesian/ \
-  -topics mrtydi-v1.1-id.dev.txt.gz \
+  -topics mrtydi-v1.1-id.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-id.bm25.topics.mrtydi-v1.1-id.dev.txt \
   -bm25 -hits 100 -language id &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-indonesian/ \
-  -topics mrtydi-v1.1-id.test.txt.gz \
+  -topics mrtydi-v1.1-id.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-id.bm25.topics.mrtydi-v1.1-id.test.txt \
   -bm25 -hits 100 -language id &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-ja-aca.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-ja-aca.md
@@ -38,19 +38,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-japanese-aca/ \
-  -topics mrtydi-v1.1-ja.train.txt.gz \
+  -topics mrtydi-v1.1-ja.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ja.bm25.topics.mrtydi-v1.1-ja.train.txt \
   -bm25 -hits 100 -language ja -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-japanese-aca/ \
-  -topics mrtydi-v1.1-ja.dev.txt.gz \
+  -topics mrtydi-v1.1-ja.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ja.bm25.topics.mrtydi-v1.1-ja.dev.txt \
   -bm25 -hits 100 -language ja -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-japanese-aca/ \
-  -topics mrtydi-v1.1-ja.test.txt.gz \
+  -topics mrtydi-v1.1-ja.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ja.bm25.topics.mrtydi-v1.1-ja.test.txt \
   -bm25 -hits 100 -language ja -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-ja.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-ja.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-japanese/ \
-  -topics mrtydi-v1.1-ja.train.txt.gz \
+  -topics mrtydi-v1.1-ja.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ja.bm25.topics.mrtydi-v1.1-ja.train.txt \
   -bm25 -hits 100 -language ja &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-japanese/ \
-  -topics mrtydi-v1.1-ja.dev.txt.gz \
+  -topics mrtydi-v1.1-ja.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ja.bm25.topics.mrtydi-v1.1-ja.dev.txt \
   -bm25 -hits 100 -language ja &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-japanese/ \
-  -topics mrtydi-v1.1-ja.test.txt.gz \
+  -topics mrtydi-v1.1-ja.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ja.bm25.topics.mrtydi-v1.1-ja.test.txt \
   -bm25 -hits 100 -language ja &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-ko-aca.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-ko-aca.md
@@ -38,19 +38,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-korean-aca/ \
-  -topics mrtydi-v1.1-ko.train.txt.gz \
+  -topics mrtydi-v1.1-ko.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ko.bm25.topics.mrtydi-v1.1-ko.train.txt \
   -bm25 -hits 100 -language ko -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-korean-aca/ \
-  -topics mrtydi-v1.1-ko.dev.txt.gz \
+  -topics mrtydi-v1.1-ko.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ko.bm25.topics.mrtydi-v1.1-ko.dev.txt \
   -bm25 -hits 100 -language ko -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-korean-aca/ \
-  -topics mrtydi-v1.1-ko.test.txt.gz \
+  -topics mrtydi-v1.1-ko.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ko.bm25.topics.mrtydi-v1.1-ko.test.txt \
   -bm25 -hits 100 -language ko -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-ko.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-ko.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-korean/ \
-  -topics mrtydi-v1.1-ko.train.txt.gz \
+  -topics mrtydi-v1.1-ko.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ko.bm25.topics.mrtydi-v1.1-ko.train.txt \
   -bm25 -hits 100 -language ko &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-korean/ \
-  -topics mrtydi-v1.1-ko.dev.txt.gz \
+  -topics mrtydi-v1.1-ko.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ko.bm25.topics.mrtydi-v1.1-ko.dev.txt \
   -bm25 -hits 100 -language ko &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-korean/ \
-  -topics mrtydi-v1.1-ko.test.txt.gz \
+  -topics mrtydi-v1.1-ko.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ko.bm25.topics.mrtydi-v1.1-ko.test.txt \
   -bm25 -hits 100 -language ko &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-ru-aca.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-ru-aca.md
@@ -38,19 +38,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-russian-aca/ \
-  -topics mrtydi-v1.1-ru.train.txt.gz \
+  -topics mrtydi-v1.1-ru.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ru.bm25.topics.mrtydi-v1.1-ru.train.txt \
   -bm25 -hits 100 -language ru -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-russian-aca/ \
-  -topics mrtydi-v1.1-ru.dev.txt.gz \
+  -topics mrtydi-v1.1-ru.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ru.bm25.topics.mrtydi-v1.1-ru.dev.txt \
   -bm25 -hits 100 -language ru -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-russian-aca/ \
-  -topics mrtydi-v1.1-ru.test.txt.gz \
+  -topics mrtydi-v1.1-ru.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ru.bm25.topics.mrtydi-v1.1-ru.test.txt \
   -bm25 -hits 100 -language ru -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-ru.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-ru.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-russian/ \
-  -topics mrtydi-v1.1-ru.train.txt.gz \
+  -topics mrtydi-v1.1-ru.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ru.bm25.topics.mrtydi-v1.1-ru.train.txt \
   -bm25 -hits 100 -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-russian/ \
-  -topics mrtydi-v1.1-ru.dev.txt.gz \
+  -topics mrtydi-v1.1-ru.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ru.bm25.topics.mrtydi-v1.1-ru.dev.txt \
   -bm25 -hits 100 -language ru &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-russian/ \
-  -topics mrtydi-v1.1-ru.test.txt.gz \
+  -topics mrtydi-v1.1-ru.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-ru.bm25.topics.mrtydi-v1.1-ru.test.txt \
   -bm25 -hits 100 -language ru &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-sw-aca.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-sw-aca.md
@@ -38,19 +38,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-swahili-aca/ \
-  -topics mrtydi-v1.1-sw.train.txt.gz \
+  -topics mrtydi-v1.1-sw.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-sw.bm25.topics.mrtydi-v1.1-sw.train.txt \
   -bm25 -hits 100 -language sw -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-swahili-aca/ \
-  -topics mrtydi-v1.1-sw.dev.txt.gz \
+  -topics mrtydi-v1.1-sw.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-sw.bm25.topics.mrtydi-v1.1-sw.dev.txt \
   -bm25 -hits 100 -language sw -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-swahili-aca/ \
-  -topics mrtydi-v1.1-sw.test.txt.gz \
+  -topics mrtydi-v1.1-sw.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-sw.bm25.topics.mrtydi-v1.1-sw.test.txt \
   -bm25 -hits 100 -language sw -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-sw.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-sw.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-swahili/ \
-  -topics mrtydi-v1.1-sw.train.txt.gz \
+  -topics mrtydi-v1.1-sw.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-sw.bm25.topics.mrtydi-v1.1-sw.train.txt \
   -bm25 -hits 100 -language sw &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-swahili/ \
-  -topics mrtydi-v1.1-sw.dev.txt.gz \
+  -topics mrtydi-v1.1-sw.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-sw.bm25.topics.mrtydi-v1.1-sw.dev.txt \
   -bm25 -hits 100 -language sw &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-swahili/ \
-  -topics mrtydi-v1.1-sw.test.txt.gz \
+  -topics mrtydi-v1.1-sw.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-sw.bm25.topics.mrtydi-v1.1-sw.test.txt \
   -bm25 -hits 100 -language sw &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-te-aca.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-te-aca.md
@@ -38,19 +38,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-telugu-aca/ \
-  -topics mrtydi-v1.1-te.train.txt.gz \
+  -topics mrtydi-v1.1-te.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-te.bm25.topics.mrtydi-v1.1-te.train.txt \
   -bm25 -hits 100 -language te -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-telugu-aca/ \
-  -topics mrtydi-v1.1-te.dev.txt.gz \
+  -topics mrtydi-v1.1-te.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-te.bm25.topics.mrtydi-v1.1-te.dev.txt \
   -bm25 -hits 100 -language te -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-telugu-aca/ \
-  -topics mrtydi-v1.1-te.test.txt.gz \
+  -topics mrtydi-v1.1-te.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-te.bm25.topics.mrtydi-v1.1-te.test.txt \
   -bm25 -hits 100 -language te -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-te.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-te.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-telugu/ \
-  -topics mrtydi-v1.1-te.train.txt.gz \
+  -topics mrtydi-v1.1-te.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-te.bm25.topics.mrtydi-v1.1-te.train.txt \
   -bm25 -hits 100 -language te &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-telugu/ \
-  -topics mrtydi-v1.1-te.dev.txt.gz \
+  -topics mrtydi-v1.1-te.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-te.bm25.topics.mrtydi-v1.1-te.dev.txt \
   -bm25 -hits 100 -language te &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-telugu/ \
-  -topics mrtydi-v1.1-te.test.txt.gz \
+  -topics mrtydi-v1.1-te.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-te.bm25.topics.mrtydi-v1.1-te.test.txt \
   -bm25 -hits 100 -language te &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-th-aca.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-th-aca.md
@@ -38,19 +38,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-thai-aca/ \
-  -topics mrtydi-v1.1-th.train.txt.gz \
+  -topics mrtydi-v1.1-th.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-th.bm25.topics.mrtydi-v1.1-th.train.txt \
   -bm25 -hits 100 -language th -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-thai-aca/ \
-  -topics mrtydi-v1.1-th.dev.txt.gz \
+  -topics mrtydi-v1.1-th.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-th.bm25.topics.mrtydi-v1.1-th.dev.txt \
   -bm25 -hits 100 -language th -useAutoCompositeAnalyzer &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-thai-aca/ \
-  -topics mrtydi-v1.1-th.test.txt.gz \
+  -topics mrtydi-v1.1-th.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-th.bm25.topics.mrtydi-v1.1-th.test.txt \
   -bm25 -hits 100 -language th -useAutoCompositeAnalyzer &

--- a/docs/reproduce/from-document-collection/mrtydi-v1.1-th.md
+++ b/docs/reproduce/from-document-collection/mrtydi-v1.1-th.md
@@ -36,19 +36,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-thai/ \
-  -topics mrtydi-v1.1-th.train.txt.gz \
+  -topics mrtydi-v1.1-th.train \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-th.bm25.topics.mrtydi-v1.1-th.train.txt \
   -bm25 -hits 100 -language th &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-thai/ \
-  -topics mrtydi-v1.1-th.dev.txt.gz \
+  -topics mrtydi-v1.1-th.dev \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-th.bm25.topics.mrtydi-v1.1-th.dev.txt \
   -bm25 -hits 100 -language th &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.mrtydi-v1.1-thai/ \
-  -topics mrtydi-v1.1-th.test.txt.gz \
+  -topics mrtydi-v1.1-th.test \
   -topicReader TsvInt \
   -output runs/run.mrtydi-v1.1-th.bm25.topics.mrtydi-v1.1-th.test.txt \
   -bm25 -hits 100 -language th &

--- a/docs/reproduce/from-document-collection/msmarco-v1-passage.cos-dpr-distil.parquet.fw.md
+++ b/docs/reproduce/from-document-collection/msmarco-v1-passage.cos-dpr-distil.parquet.fw.md
@@ -70,19 +70,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchInvertedDenseVectors \
   -index indexes/lucene-inverted.msmarco-v1-passage.cos-dpr-distil.fw-40/ \
-  -topics msmarco-passage.dev-subset.cos-dpr-distil.jsonl.gz \
+  -topics msmarco-passage.dev-subset.cos-dpr-distil \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.txt \
   -topicField vector -threads 16 -encoding fw -fw.q 40 -hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m map msmarco-passage.dev-subset runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-bin/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-bin/trec_eval -c -m recall.100 msmarco-passage.dev-subset runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-bin/trec_eval -c -m recall.1000 msmarco-passage.dev-subset runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+bin/trec_eval -c -m map msmarco-passage.dev-subset runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.txt
+bin/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.txt
+bin/trec_eval -c -m recall.100 msmarco-passage.dev-subset runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.txt
+bin/trec_eval -c -m recall.1000 msmarco-passage.dev-subset runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-fw-40-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/msmarco-v1-passage.cos-dpr-distil.parquet.lexlsh.md
+++ b/docs/reproduce/from-document-collection/msmarco-v1-passage.cos-dpr-distil.parquet.lexlsh.md
@@ -70,19 +70,19 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchInvertedDenseVectors \
   -index indexes/lucene-inverted.msmarco-v1-passage.cos-dpr-distil.lexlsh-600/ \
-  -topics msmarco-passage.dev-subset.cos-dpr-distil.jsonl.gz \
+  -topics msmarco-passage.dev-subset.cos-dpr-distil \
   -topicReader JsonIntVector \
-  -output runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt \
+  -output runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.txt \
   -topicField vector -threads 16 -encoding lexlsh -lexlsh.b 600 -hits 1000 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m map msmarco-passage.dev-subset runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-bin/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-bin/trec_eval -c -m recall.100 msmarco-passage.dev-subset runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
-bin/trec_eval -c -m recall.1000 msmarco-passage.dev-subset runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.jsonl.txt
+bin/trec_eval -c -m map msmarco-passage.dev-subset runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.txt
+bin/trec_eval -c -M 10 -m recip_rank msmarco-passage.dev-subset runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.txt
+bin/trec_eval -c -m recall.100 msmarco-passage.dev-subset runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.txt
+bin/trec_eval -c -m recall.1000 msmarco-passage.dev-subset runs/run.msmarco-passage-cos-dpr-distil.parquet.cos-dpr-distil-lexlsh-600-cached_q.topics.msmarco-passage.dev-subset.cos-dpr-distil.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/neuclir22-fa-qt-splade.md
+++ b/docs/reproduce/from-document-collection/neuclir22-fa-qt-splade.md
@@ -59,111 +59,111 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.ht-title.txt.gz \
+  -topics neuclir22-fa.splade.ht-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade.topics.neuclir22-fa.splade.ht-title.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.ht-desc.txt.gz \
+  -topics neuclir22-fa.splade.ht-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade.topics.neuclir22-fa.splade.ht-desc.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.ht-desc_title.txt.gz \
+  -topics neuclir22-fa.splade.ht-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade.topics.neuclir22-fa.splade.ht-desc_title.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.mt-title.txt.gz \
+  -topics neuclir22-fa.splade.mt-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade.topics.neuclir22-fa.splade.mt-title.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.mt-desc.txt.gz \
+  -topics neuclir22-fa.splade.mt-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade.topics.neuclir22-fa.splade.mt-desc.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.mt-desc_title.txt.gz \
+  -topics neuclir22-fa.splade.mt-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade.topics.neuclir22-fa.splade.mt-desc_title.txt \
   -impact -pretokenized &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.ht-title.txt.gz \
+  -topics neuclir22-fa.splade.ht-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade+rm3.topics.neuclir22-fa.splade.ht-title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.ht-desc.txt.gz \
+  -topics neuclir22-fa.splade.ht-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade+rm3.topics.neuclir22-fa.splade.ht-desc.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.ht-desc_title.txt.gz \
+  -topics neuclir22-fa.splade.ht-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade+rm3.topics.neuclir22-fa.splade.ht-desc_title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.mt-title.txt.gz \
+  -topics neuclir22-fa.splade.mt-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade+rm3.topics.neuclir22-fa.splade.mt-title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.mt-desc.txt.gz \
+  -topics neuclir22-fa.splade.mt-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade+rm3.topics.neuclir22-fa.splade.mt-desc.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.mt-desc_title.txt.gz \
+  -topics neuclir22-fa.splade.mt-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade+rm3.topics.neuclir22-fa.splade.mt-desc_title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.ht-title.txt.gz \
+  -topics neuclir22-fa.splade.ht-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade+rocchio.topics.neuclir22-fa.splade.ht-title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.ht-desc.txt.gz \
+  -topics neuclir22-fa.splade.ht-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade+rocchio.topics.neuclir22-fa.splade.ht-desc.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.ht-desc_title.txt.gz \
+  -topics neuclir22-fa.splade.ht-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade+rocchio.topics.neuclir22-fa.splade.ht-desc_title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.mt-title.txt.gz \
+  -topics neuclir22-fa.splade.mt-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade+rocchio.topics.neuclir22-fa.splade.mt-title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.mt-desc.txt.gz \
+  -topics neuclir22-fa.splade.mt-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade+rocchio.topics.neuclir22-fa.splade.mt-desc.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-fa-splade \
-  -topics neuclir22-fa.splade.mt-desc_title.txt.gz \
+  -topics neuclir22-fa.splade.mt-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-fa-splade.splade+rocchio.topics.neuclir22-fa.splade.mt-desc_title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &

--- a/docs/reproduce/from-document-collection/neuclir22-ru-qt-splade.md
+++ b/docs/reproduce/from-document-collection/neuclir22-ru-qt-splade.md
@@ -59,111 +59,111 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.ht-title.txt.gz \
+  -topics neuclir22-ru.splade.ht-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade.topics.neuclir22-ru.splade.ht-title.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.ht-desc.txt.gz \
+  -topics neuclir22-ru.splade.ht-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade.topics.neuclir22-ru.splade.ht-desc.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.ht-desc_title.txt.gz \
+  -topics neuclir22-ru.splade.ht-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade.topics.neuclir22-ru.splade.ht-desc_title.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.mt-title.txt.gz \
+  -topics neuclir22-ru.splade.mt-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade.topics.neuclir22-ru.splade.mt-title.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.mt-desc.txt.gz \
+  -topics neuclir22-ru.splade.mt-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade.topics.neuclir22-ru.splade.mt-desc.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.mt-desc_title.txt.gz \
+  -topics neuclir22-ru.splade.mt-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade.topics.neuclir22-ru.splade.mt-desc_title.txt \
   -impact -pretokenized &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.ht-title.txt.gz \
+  -topics neuclir22-ru.splade.ht-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade+rm3.topics.neuclir22-ru.splade.ht-title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.ht-desc.txt.gz \
+  -topics neuclir22-ru.splade.ht-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade+rm3.topics.neuclir22-ru.splade.ht-desc.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.ht-desc_title.txt.gz \
+  -topics neuclir22-ru.splade.ht-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade+rm3.topics.neuclir22-ru.splade.ht-desc_title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.mt-title.txt.gz \
+  -topics neuclir22-ru.splade.mt-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade+rm3.topics.neuclir22-ru.splade.mt-title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.mt-desc.txt.gz \
+  -topics neuclir22-ru.splade.mt-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade+rm3.topics.neuclir22-ru.splade.mt-desc.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.mt-desc_title.txt.gz \
+  -topics neuclir22-ru.splade.mt-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade+rm3.topics.neuclir22-ru.splade.mt-desc_title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.ht-title.txt.gz \
+  -topics neuclir22-ru.splade.ht-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade+rocchio.topics.neuclir22-ru.splade.ht-title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.ht-desc.txt.gz \
+  -topics neuclir22-ru.splade.ht-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade+rocchio.topics.neuclir22-ru.splade.ht-desc.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.ht-desc_title.txt.gz \
+  -topics neuclir22-ru.splade.ht-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade+rocchio.topics.neuclir22-ru.splade.ht-desc_title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.mt-title.txt.gz \
+  -topics neuclir22-ru.splade.mt-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade+rocchio.topics.neuclir22-ru.splade.mt-title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.mt-desc.txt.gz \
+  -topics neuclir22-ru.splade.mt-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade+rocchio.topics.neuclir22-ru.splade.mt-desc.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-ru-splade \
-  -topics neuclir22-ru.splade.mt-desc_title.txt.gz \
+  -topics neuclir22-ru.splade.mt-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-ru-splade.splade+rocchio.topics.neuclir22-ru.splade.mt-desc_title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &

--- a/docs/reproduce/from-document-collection/neuclir22-zh-qt-splade.md
+++ b/docs/reproduce/from-document-collection/neuclir22-zh-qt-splade.md
@@ -59,111 +59,111 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.ht-title.txt.gz \
+  -topics neuclir22-zh.splade.ht-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade.topics.neuclir22-zh.splade.ht-title.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.ht-desc.txt.gz \
+  -topics neuclir22-zh.splade.ht-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade.topics.neuclir22-zh.splade.ht-desc.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.ht-desc_title.txt.gz \
+  -topics neuclir22-zh.splade.ht-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade.topics.neuclir22-zh.splade.ht-desc_title.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.mt-title.txt.gz \
+  -topics neuclir22-zh.splade.mt-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade.topics.neuclir22-zh.splade.mt-title.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.mt-desc.txt.gz \
+  -topics neuclir22-zh.splade.mt-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade.topics.neuclir22-zh.splade.mt-desc.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.mt-desc_title.txt.gz \
+  -topics neuclir22-zh.splade.mt-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade.topics.neuclir22-zh.splade.mt-desc_title.txt \
   -impact -pretokenized &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.ht-title.txt.gz \
+  -topics neuclir22-zh.splade.ht-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade+rm3.topics.neuclir22-zh.splade.ht-title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.ht-desc.txt.gz \
+  -topics neuclir22-zh.splade.ht-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade+rm3.topics.neuclir22-zh.splade.ht-desc.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.ht-desc_title.txt.gz \
+  -topics neuclir22-zh.splade.ht-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade+rm3.topics.neuclir22-zh.splade.ht-desc_title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.mt-title.txt.gz \
+  -topics neuclir22-zh.splade.mt-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade+rm3.topics.neuclir22-zh.splade.mt-title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.mt-desc.txt.gz \
+  -topics neuclir22-zh.splade.mt-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade+rm3.topics.neuclir22-zh.splade.mt-desc.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.mt-desc_title.txt.gz \
+  -topics neuclir22-zh.splade.mt-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade+rm3.topics.neuclir22-zh.splade.mt-desc_title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.ht-title.txt.gz \
+  -topics neuclir22-zh.splade.ht-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade+rocchio.topics.neuclir22-zh.splade.ht-title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.ht-desc.txt.gz \
+  -topics neuclir22-zh.splade.ht-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade+rocchio.topics.neuclir22-zh.splade.ht-desc.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.ht-desc_title.txt.gz \
+  -topics neuclir22-zh.splade.ht-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade+rocchio.topics.neuclir22-zh.splade.ht-desc_title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.mt-title.txt.gz \
+  -topics neuclir22-zh.splade.mt-title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade+rocchio.topics.neuclir22-zh.splade.mt-title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.mt-desc.txt.gz \
+  -topics neuclir22-zh.splade.mt-desc \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade+rocchio.topics.neuclir22-zh.splade.mt-desc.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-index.neuclir22-zh-splade \
-  -topics neuclir22-zh.splade.mt-desc_title.txt.gz \
+  -topics neuclir22-zh.splade.mt-desc_title \
   -topicReader TsvInt \
   -output runs/run.neuclir22-zh-splade.splade+rocchio.topics.neuclir22-zh.splade.mt-desc_title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard00.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard00.flat.onnx.md
@@ -58,18 +58,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard01.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard01.flat.onnx.md
@@ -58,18 +58,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard02.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard02.flat.onnx.md
@@ -58,18 +58,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard03.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard03.flat.onnx.md
@@ -58,18 +58,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard04.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard04.flat.onnx.md
@@ -58,18 +58,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard05.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard05.flat.onnx.md
@@ -58,18 +58,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard06.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard06.flat.onnx.md
@@ -58,18 +58,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard07.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard07.flat.onnx.md
@@ -58,18 +58,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard08.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard08.flat.onnx.md
@@ -58,18 +58,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard09.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard09.flat.onnx.md
@@ -58,18 +58,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.md
@@ -52,40 +52,40 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented/ \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented.bm25-default.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented.bm25-default.topics.rag25.test.txt \
   -bm25 &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented/ \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented.bm25-default+rm3.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented.bm25-default+rm3.topics.rag25.test.txt \
   -bm25 -rm3 -collection MsMarcoV2DocCollection &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented/ \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented.bm25-default+rocchio.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented.bm25-default+rocchio.topics.rag25.test.txt \
   -bm25 -rocchio -collection MsMarcoV2DocCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default.topics.rag25.test.txt
 
-bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default+rm3.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default+rm3.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default+rm3.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default+rm3.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default+rm3.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default+rm3.topics.rag25.test.txt
 
-bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default+rocchio.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default+rocchio.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default+rocchio.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default+rocchio.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default+rocchio.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented.bm25-default+rocchio.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.splade-v3.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-nist.splade-v3.onnx.md
@@ -83,18 +83,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented.splade-v3/ \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.txt \
   -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard00.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard00.flat.onnx.md
@@ -57,18 +57,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard00.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard01.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard01.flat.onnx.md
@@ -57,18 +57,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard01.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard02.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard02.flat.onnx.md
@@ -57,18 +57,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard02.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard03.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard03.flat.onnx.md
@@ -57,18 +57,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard03.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard04.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard04.flat.onnx.md
@@ -57,18 +57,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard04.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard05.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard05.flat.onnx.md
@@ -57,18 +57,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard05.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard06.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard06.flat.onnx.md
@@ -57,18 +57,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard06.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard07.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard07.flat.onnx.md
@@ -57,18 +57,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard07.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard08.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard08.flat.onnx.md
@@ -57,18 +57,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard08.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard09.flat.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard09.flat.onnx.md
@@ -57,18 +57,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchFlatDenseVectors \
   -index indexes/lucene-flat.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt \
   -topics rag25.test -topicReader JsonString -topicField title -encoder ArcticEmbedLEncoder &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-shard09.arctic-embed-l.arctic-embed-l-flat-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.md
@@ -52,40 +52,40 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented/ \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented.bm25-default.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented.bm25-default.topics.rag25.test.txt \
   -bm25 &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented/ \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented.bm25-default+rm3.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented.bm25-default+rm3.topics.rag25.test.txt \
   -bm25 -rm3 -collection MsMarcoV2DocCollection &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented/ \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented.bm25-default+rocchio.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented.bm25-default+rocchio.topics.rag25.test.txt \
   -bm25 -rocchio -collection MsMarcoV2DocCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default.topics.rag25.test.txt
 
-bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default+rm3.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default+rm3.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default+rm3.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default+rm3.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default+rm3.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default+rm3.topics.rag25.test.txt
 
-bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default+rocchio.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default+rocchio.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default+rocchio.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default+rocchio.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default+rocchio.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented.bm25-default+rocchio.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.splade-v3.onnx.md
+++ b/docs/reproduce/from-document-collection/rag25-doc-segmented-test-umbrela2.splade-v3.onnx.md
@@ -83,18 +83,18 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.msmarco-v2.1-doc-segmented.splade-v3/ \
-  -topics rag25.test.jsonl \
+  -topics rag25.test \
   -topicReader JsonString \
-  -output runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.jsonl.txt \
+  -output runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.txt \
   -impact -pretokenized -removeQuery -hits 1000 -encoder SpladeV3 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.jsonl.txt
-bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.jsonl.txt
+bin/trec_eval -c -m ndcg_cut.30 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m ndcg_cut.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.txt
+bin/trec_eval -c -m recall.100 rag25.test-umbrela2 runs/run.msmarco-v2.1-doc-segmented-splade-v3.splade-v3-onnx.topics.rag25.test.txt
 ```
 
 ## Effectiveness

--- a/src/main/java/io/anserini/search/SearchInvertedDenseVectors.java
+++ b/src/main/java/io/anserini/search/SearchInvertedDenseVectors.java
@@ -18,15 +18,11 @@ package io.anserini.search;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
-import java.util.TreeMap;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/io/anserini/search/SearchInvertedDenseVectors.java
+++ b/src/main/java/io/anserini/search/SearchInvertedDenseVectors.java
@@ -88,23 +88,7 @@ public final class SearchInvertedDenseVectors<K extends Comparable<K>> implement
 
     // We might not be able to successfully read topics for a variety of reasons. Gather all possible
     // exceptions together as an unchecked exception to make initialization and error reporting clearer.
-    SortedMap<K, Map<String, String>> topics = new TreeMap<>();
-    for (String topicsFile : args.topics) {
-      Path topicsFilePath = Paths.get(topicsFile);
-      if (!Files.exists(topicsFilePath) || !Files.isRegularFile(topicsFilePath) || !Files.isReadable(topicsFilePath)) {
-        throw new IllegalArgumentException(String.format("\"%s\" does not appear to be a valid topics file.", topicsFilePath));
-      }
-      try {
-        @SuppressWarnings("unchecked")
-        TopicReader<K> tr = (TopicReader<K>) Class
-            .forName(String.format("io.anserini.search.topicreader.%sTopicReader", args.topicReader))
-            .getConstructor(Path.class).newInstance(topicsFilePath);
-
-        topics.putAll(tr.read());
-      } catch (Exception e) {
-        throw new IllegalArgumentException(String.format("Unable to load topic reader \"%s\".", args.topicReader));
-      }
-    }
+    SortedMap<K, Map<String, String>> topics = TopicReader.load(args.topics, args.topicReader);
 
     // Now iterate through all the topics to pick out the right field with proper exception handling.
     try {

--- a/src/main/java/io/anserini/search/topicreader/Topics.java
+++ b/src/main/java/io/anserini/search/topicreader/Topics.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * A registry entry for a standard set of topics from various evaluations.
  */
 public final class Topics {
-  private static final String COMMIT_ID = "c1b4a7c56b98bbd8ab2986cb2f806e3ad2021f03";
+  private static final String COMMIT_ID = "d9a27f26089a6019cef1788bdc16f77d8ec0a474";
   public static final String URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/topics/";
 
   private static final String TOPICS_URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/topics.json";

--- a/src/main/java/io/anserini/search/topicreader/Topics.java
+++ b/src/main/java/io/anserini/search/topicreader/Topics.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * A registry entry for a standard set of topics from various evaluations.
  */
 public final class Topics {
-  private static final String COMMIT_ID = "9b1c80887bbda7998021e78f3c36f1ee707fb0bb";
+  private static final String COMMIT_ID = "c1b4a7c56b98bbd8ab2986cb2f806e3ad2021f03";
   public static final String URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/topics/";
 
   private static final String TOPICS_URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/topics.json";

--- a/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-ha-en.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-ha-en.yaml
@@ -32,13 +32,13 @@ topic_reader: TsvInt
 topics:
   - name: "[CIRAL Hausa: Test Set A (Shallow Judgements)](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-ha-test-a
-    qrels: ciral-v1.0-ha-test-a.tsv
+    qrels: ciral-v1.0-ha-test-a
   - name: "[CIRAL Hausa: Test Set A (Pools)](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-ha-test-a
-    qrels: ciral-v1.0-ha-test-a-pools.tsv
+    qrels: ciral-v1.0-ha-test-a-pools
   - name: "[CIRAL Hausa: Test Set B](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-ha-test-b
-    qrels: ciral-v1.0-ha-test-b.tsv
+    qrels: ciral-v1.0-ha-test-b
 
 models:
   - name: bm25-default

--- a/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-ha-en.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-ha-en.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[CIRAL Hausa: Test Set A (Shallow Judgements)](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-ha-test-a.tsv
+    id: ciral-v1.0-ha-test-a
     qrels: ciral-v1.0-ha-test-a.tsv
   - name: "[CIRAL Hausa: Test Set A (Pools)](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-ha-test-a.tsv
+    id: ciral-v1.0-ha-test-a
     qrels: ciral-v1.0-ha-test-a-pools.tsv
   - name: "[CIRAL Hausa: Test Set B](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-ha-test-b.tsv
+    id: ciral-v1.0-ha-test-b
     qrels: ciral-v1.0-ha-test-b.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-ha.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-ha.yaml
@@ -32,13 +32,13 @@ topic_reader: TsvInt
 topics:
   - name: "[CIRAL Hausa: Test Set A (Shallow Judgements)](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-ha-test-a-native
-    qrels: ciral-v1.0-ha-test-a.tsv
+    qrels: ciral-v1.0-ha-test-a
   - name: "[CIRAL Hausa: Test Set A (Pools)](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-ha-test-a-native
-    qrels: ciral-v1.0-ha-test-a-pools.tsv
+    qrels: ciral-v1.0-ha-test-a-pools
   - name: "[CIRAL Hausa: Test Set B](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-ha-test-b-native
-    qrels: ciral-v1.0-ha-test-b.tsv
+    qrels: ciral-v1.0-ha-test-b
 
 models:
   - name: bm25-default

--- a/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-ha.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-ha.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[CIRAL Hausa: Test Set A (Shallow Judgements)](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-ha-test-a-native.tsv
+    id: ciral-v1.0-ha-test-a-native
     qrels: ciral-v1.0-ha-test-a.tsv
   - name: "[CIRAL Hausa: Test Set A (Pools)](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-ha-test-a-native.tsv
+    id: ciral-v1.0-ha-test-a-native
     qrels: ciral-v1.0-ha-test-a-pools.tsv
   - name: "[CIRAL Hausa: Test Set B](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-ha-test-b-native.tsv
+    id: ciral-v1.0-ha-test-b-native
     qrels: ciral-v1.0-ha-test-b.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-so-en.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-so-en.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[CIRAL Somali: Test Set A (Shallow Judgements)](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-so-test-a.tsv
+    id: ciral-v1.0-so-test-a
     qrels: ciral-v1.0-so-test-a.tsv
   - name: "[CIRAL Somali: Test Set A (Pools)](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-so-test-a.tsv
+    id: ciral-v1.0-so-test-a
     qrels: ciral-v1.0-so-test-a-pools.tsv
   - name: "[CIRAL Somali: Test Set B](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-so-test-b.tsv
+    id: ciral-v1.0-so-test-b
     qrels: ciral-v1.0-so-test-b.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-so-en.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-so-en.yaml
@@ -32,13 +32,13 @@ topic_reader: TsvInt
 topics:
   - name: "[CIRAL Somali: Test Set A (Shallow Judgements)](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-so-test-a
-    qrels: ciral-v1.0-so-test-a.tsv
+    qrels: ciral-v1.0-so-test-a
   - name: "[CIRAL Somali: Test Set A (Pools)](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-so-test-a
-    qrels: ciral-v1.0-so-test-a-pools.tsv
+    qrels: ciral-v1.0-so-test-a-pools
   - name: "[CIRAL Somali: Test Set B](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-so-test-b
-    qrels: ciral-v1.0-so-test-b.tsv
+    qrels: ciral-v1.0-so-test-b
 
 models:
   - name: bm25-default

--- a/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-so.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-so.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[CIRAL Somali: Test Set A (Shallow Judgements)](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-so-test-a-native.tsv
+    id: ciral-v1.0-so-test-a-native
     qrels: ciral-v1.0-so-test-a.tsv
   - name: "[CIRAL Somali: Test Set A (Pools)](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-so-test-a-native.tsv
+    id: ciral-v1.0-so-test-a-native
     qrels: ciral-v1.0-so-test-a-pools.tsv
   - name: "[CIRAL Somali: Test Set B](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-so-test-b-native.tsv
+    id: ciral-v1.0-so-test-b-native
     qrels: ciral-v1.0-so-test-b.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-so.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-so.yaml
@@ -32,13 +32,13 @@ topic_reader: TsvInt
 topics:
   - name: "[CIRAL Somali: Test Set A (Shallow Judgements)](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-so-test-a-native
-    qrels: ciral-v1.0-so-test-a.tsv
+    qrels: ciral-v1.0-so-test-a
   - name: "[CIRAL Somali: Test Set A (Pools)](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-so-test-a-native
-    qrels: ciral-v1.0-so-test-a-pools.tsv
+    qrels: ciral-v1.0-so-test-a-pools
   - name: "[CIRAL Somali: Test Set B](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-so-test-b-native
-    qrels: ciral-v1.0-so-test-b.tsv
+    qrels: ciral-v1.0-so-test-b
 
 models:
   - name: bm25-default

--- a/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-sw-en.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-sw-en.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[CIRAL Swahili: Test Set A (Shallow Judgements)](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-sw-test-a.tsv
+    id: ciral-v1.0-sw-test-a
     qrels: ciral-v1.0-sw-test-a.tsv
   - name: "[CIRAL Swahili: Test Set A (Pools)](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-sw-test-a.tsv
+    id: ciral-v1.0-sw-test-a
     qrels: ciral-v1.0-sw-test-a-pools.tsv
   - name: "[CIRAL Swahili: Test Set B](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-sw-test-b.tsv
+    id: ciral-v1.0-sw-test-b
     qrels: ciral-v1.0-sw-test-b.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-sw-en.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-sw-en.yaml
@@ -32,13 +32,13 @@ topic_reader: TsvInt
 topics:
   - name: "[CIRAL Swahili: Test Set A (Shallow Judgements)](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-sw-test-a
-    qrels: ciral-v1.0-sw-test-a.tsv
+    qrels: ciral-v1.0-sw-test-a
   - name: "[CIRAL Swahili: Test Set A (Pools)](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-sw-test-a
-    qrels: ciral-v1.0-sw-test-a-pools.tsv
+    qrels: ciral-v1.0-sw-test-a-pools
   - name: "[CIRAL Swahili: Test Set B](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-sw-test-b
-    qrels: ciral-v1.0-sw-test-b.tsv
+    qrels: ciral-v1.0-sw-test-b
 
 models:
   - name: bm25-default

--- a/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-sw.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-sw.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[CIRAL Swahili: Test Set A (Shallow Judgements)](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-sw-test-a-native.tsv
+    id: ciral-v1.0-sw-test-a-native
     qrels: ciral-v1.0-sw-test-a.tsv
   - name: "[CIRAL Swahili: Test Set A (Pools)](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-sw-test-a-native.tsv
+    id: ciral-v1.0-sw-test-a-native
     qrels: ciral-v1.0-sw-test-a-pools.tsv
   - name: "[CIRAL Swahili: Test Set B](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-sw-test-b-native.tsv
+    id: ciral-v1.0-sw-test-b-native
     qrels: ciral-v1.0-sw-test-b.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-sw.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-sw.yaml
@@ -32,13 +32,13 @@ topic_reader: TsvInt
 topics:
   - name: "[CIRAL Swahili: Test Set A (Shallow Judgements)](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-sw-test-a-native
-    qrels: ciral-v1.0-sw-test-a.tsv
+    qrels: ciral-v1.0-sw-test-a
   - name: "[CIRAL Swahili: Test Set A (Pools)](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-sw-test-a-native
-    qrels: ciral-v1.0-sw-test-a-pools.tsv
+    qrels: ciral-v1.0-sw-test-a-pools
   - name: "[CIRAL Swahili: Test Set B](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-sw-test-b-native
-    qrels: ciral-v1.0-sw-test-b.tsv
+    qrels: ciral-v1.0-sw-test-b
 
 models:
   - name: bm25-default

--- a/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-yo-en.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-yo-en.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[CIRAL Yoruba: Test Set A (Shallow Judgements)](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-yo-test-a.tsv
+    id: ciral-v1.0-yo-test-a
     qrels: ciral-v1.0-yo-test-a.tsv
   - name: "[CIRAL Yoruba: Test Set A (Pools)](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-yo-test-a.tsv
+    id: ciral-v1.0-yo-test-a
     qrels: ciral-v1.0-yo-test-a-pools.tsv
   - name: "[CIRAL Yoruba: Test Set B](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-yo-test-b.tsv
+    id: ciral-v1.0-yo-test-b
     qrels: ciral-v1.0-yo-test-b.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-yo-en.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-yo-en.yaml
@@ -32,13 +32,13 @@ topic_reader: TsvInt
 topics:
   - name: "[CIRAL Yoruba: Test Set A (Shallow Judgements)](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-yo-test-a
-    qrels: ciral-v1.0-yo-test-a.tsv
+    qrels: ciral-v1.0-yo-test-a
   - name: "[CIRAL Yoruba: Test Set A (Pools)](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-yo-test-a
-    qrels: ciral-v1.0-yo-test-a-pools.tsv
+    qrels: ciral-v1.0-yo-test-a-pools
   - name: "[CIRAL Yoruba: Test Set B](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-yo-test-b
-    qrels: ciral-v1.0-yo-test-b.tsv
+    qrels: ciral-v1.0-yo-test-b
 
 models:
   - name: bm25-default

--- a/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-yo.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-yo.yaml
@@ -32,13 +32,13 @@ topic_reader: TsvInt
 topics:
   - name: "[CIRAL Yoruba: Test Set A (Shallow Judgements)](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-yo-test-a-native
-    qrels: ciral-v1.0-yo-test-a.tsv
+    qrels: ciral-v1.0-yo-test-a
   - name: "[CIRAL Yoruba: Test Set A (Pools)](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-yo-test-a-native
-    qrels: ciral-v1.0-yo-test-a-pools.tsv
+    qrels: ciral-v1.0-yo-test-a-pools
   - name: "[CIRAL Yoruba: Test Set B](https://huggingface.co/datasets/CIRAL/ciral)"
     id: ciral-v1.0-yo-test-b-native
-    qrels: ciral-v1.0-yo-test-b.tsv
+    qrels: ciral-v1.0-yo-test-b
 
 models:
   - name: bm25-default

--- a/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-yo.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/ciral-v1.0-yo.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[CIRAL Yoruba: Test Set A (Shallow Judgements)](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-yo-test-a-native.tsv
+    id: ciral-v1.0-yo-test-a-native
     qrels: ciral-v1.0-yo-test-a.tsv
   - name: "[CIRAL Yoruba: Test Set A (Pools)](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-yo-test-a-native.tsv
+    id: ciral-v1.0-yo-test-a-native
     qrels: ciral-v1.0-yo-test-a-pools.tsv
   - name: "[CIRAL Yoruba: Test Set B](https://huggingface.co/datasets/CIRAL/ciral)"
-    id: ciral-v1.0-yo-test-b-native.tsv
+    id: ciral-v1.0-yo-test-b-native
     qrels: ciral-v1.0-yo-test-b.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/dl19-passage.cos-dpr-distil.parquet.fw.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/dl19-passage.cos-dpr-distil.parquet.fw.yaml
@@ -49,7 +49,7 @@ metrics:
 topic_reader: JsonIntVector
 topics:
   - name: "[DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)"
-    id: dl19-passage.cos-dpr-distil.jsonl.gz
+    id: dl19-passage.cos-dpr-distil
     qrels: dl19-passage
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/dl19-passage.cos-dpr-distil.parquet.lexlsh.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/dl19-passage.cos-dpr-distil.parquet.lexlsh.yaml
@@ -49,7 +49,7 @@ metrics:
 topic_reader: JsonIntVector
 topics:
   - name: "[DL19 (Passage)](https://trec.nist.gov/data/deep2020.html)"
-    id: dl19-passage.cos-dpr-distil.jsonl.gz
+    id: dl19-passage.cos-dpr-distil
     qrels: dl19-passage
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/dl20-passage.cos-dpr-distil.parquet.fw.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/dl20-passage.cos-dpr-distil.parquet.fw.yaml
@@ -49,7 +49,7 @@ metrics:
 topic_reader: JsonIntVector
 topics:
   - name: "[DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)"
-    id: dl20.cos-dpr-distil.jsonl.gz
+    id: dl20.cos-dpr-distil
     qrels: dl20-passage
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/dl20-passage.cos-dpr-distil.parquet.lexlsh.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/dl20-passage.cos-dpr-distil.parquet.lexlsh.yaml
@@ -49,7 +49,7 @@ metrics:
 topic_reader: JsonIntVector
 topics:
   - name: "[DL20 (Passage)](https://trec.nist.gov/data/deep2020.html)"
-    id: dl20.cos-dpr-distil.jsonl.gz
+    id: dl20.cos-dpr-distil
     qrels: dl20-passage
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/hc4-neuclir22-fa-en.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/hc4-neuclir22-fa-en.yaml
@@ -44,13 +44,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[HC4 (Persian): test-topic title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-fa.en.test.title.tsv
+    id: hc4-v1.0-fa.en.test.title
     qrels: hc4-neuclir22-fa.test
   - name: "[HC4 (Persian): test-topic description](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-fa.en.test.desc.tsv
+    id: hc4-v1.0-fa.en.test.desc
     qrels: hc4-neuclir22-fa.test
   - name: "[HC4 (Persian): test-topic description+title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-fa.en.test.desc.title.tsv
+    id: hc4-v1.0-fa.en.test.desc.title
     qrels: hc4-neuclir22-fa.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/hc4-neuclir22-fa.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/hc4-neuclir22-fa.yaml
@@ -44,13 +44,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[HC4 (Persian): test-topic title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-fa.test.title.tsv
+    id: hc4-v1.0-fa.test.title
     qrels: hc4-neuclir22-fa.test
   - name: "[HC4 (Persian): test-topic description](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-fa.test.desc.tsv
+    id: hc4-v1.0-fa.test.desc
     qrels: hc4-neuclir22-fa.test
   - name: "[HC4 (Persian): test-topic description+title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-fa.test.desc.title.tsv
+    id: hc4-v1.0-fa.test.desc.title
     qrels: hc4-neuclir22-fa.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/hc4-neuclir22-ru-en.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/hc4-neuclir22-ru-en.yaml
@@ -44,13 +44,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[HC4 (Russian): test-topic title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-ru.en.test.title.tsv
+    id: hc4-v1.0-ru.en.test.title
     qrels: hc4-neuclir22-ru.test
   - name: "[HC4 (Russian): test-topic description](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-ru.en.test.desc.tsv
+    id: hc4-v1.0-ru.en.test.desc
     qrels: hc4-neuclir22-ru.test
   - name: "[HC4 (Russian): test-topic description+title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-ru.en.test.desc.title.tsv
+    id: hc4-v1.0-ru.en.test.desc.title
     qrels: hc4-neuclir22-ru.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/hc4-neuclir22-ru.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/hc4-neuclir22-ru.yaml
@@ -44,13 +44,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[HC4 (Russian): test-topic title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-ru.test.title.tsv
+    id: hc4-v1.0-ru.test.title
     qrels: hc4-neuclir22-ru.test
   - name: "[HC4 (Russian): test-topic description](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-ru.test.desc.tsv
+    id: hc4-v1.0-ru.test.desc
     qrels: hc4-neuclir22-ru.test
   - name: "[HC4 (Russian): test-topic description+title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-ru.test.desc.title.tsv
+    id: hc4-v1.0-ru.test.desc.title
     qrels: hc4-neuclir22-ru.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/hc4-neuclir22-zh-en.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/hc4-neuclir22-zh-en.yaml
@@ -44,13 +44,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[HC4 (Chinese): test-topic title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-zh.en.test.title.tsv
+    id: hc4-v1.0-zh.en.test.title
     qrels: hc4-neuclir22-zh.test
   - name: "[HC4 (Chinese): test-topic description](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-zh.en.test.desc.tsv
+    id: hc4-v1.0-zh.en.test.desc
     qrels: hc4-neuclir22-zh.test
   - name: "[HC4 (Chinese): test-topic description+title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-zh.en.test.desc.title.tsv
+    id: hc4-v1.0-zh.en.test.desc.title
     qrels: hc4-neuclir22-zh.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/hc4-neuclir22-zh.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/hc4-neuclir22-zh.yaml
@@ -44,13 +44,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[HC4 (Chinese): test-topic title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-zh.test.title.tsv
+    id: hc4-v1.0-zh.test.title
     qrels: hc4-neuclir22-zh.test
   - name: "[HC4 (Chinese): test-topic description](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-zh.test.desc.tsv
+    id: hc4-v1.0-zh.test.desc
     qrels: hc4-neuclir22-zh.test
   - name: "[HC4 (Chinese): test-topic description+title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-zh.test.desc.title.tsv
+    id: hc4-v1.0-zh.test.desc.title
     qrels: hc4-neuclir22-zh.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/hc4-v1.0-fa.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/hc4-v1.0-fa.yaml
@@ -44,22 +44,22 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[HC4 (Persian): dev-topic title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-fa.dev.title.tsv
+    id: hc4-v1.0-fa.dev.title
     qrels: hc4-v1.0-fa.dev
   - name: "[HC4 (Persian): dev-topic description](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-fa.dev.desc.tsv
+    id: hc4-v1.0-fa.dev.desc
     qrels: hc4-v1.0-fa.dev
   - name: "[HC4 (Persian): dev-topic description+title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-fa.dev.desc.title.tsv
+    id: hc4-v1.0-fa.dev.desc.title
     qrels: hc4-v1.0-fa.dev
   - name: "[HC4 (Persian): test-topic title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-fa.test.title.tsv
+    id: hc4-v1.0-fa.test.title
     qrels: hc4-v1.0-fa.test
   - name: "[HC4 (Persian): test-topic description](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-fa.test.desc.tsv
+    id: hc4-v1.0-fa.test.desc
     qrels: hc4-v1.0-fa.test
   - name: "[HC4 (Persian): test-topic description+title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-fa.test.desc.title.tsv
+    id: hc4-v1.0-fa.test.desc.title
     qrels: hc4-v1.0-fa.test
 
 

--- a/src/main/resources/reproduce/from-document-collection/configs/hc4-v1.0-ru.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/hc4-v1.0-ru.yaml
@@ -44,22 +44,22 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[HC4 (Russian): dev-topic title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-ru.dev.title.tsv
+    id: hc4-v1.0-ru.dev.title
     qrels: hc4-v1.0-ru.dev
   - name: "[HC4 (Russian): dev-topic description](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-ru.dev.desc.tsv
+    id: hc4-v1.0-ru.dev.desc
     qrels: hc4-v1.0-ru.dev
   - name: "[HC4 (Russian): dev-topic description+title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-ru.dev.desc.title.tsv
+    id: hc4-v1.0-ru.dev.desc.title
     qrels: hc4-v1.0-ru.dev
   - name: "[HC4 (Russian): test-topic title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-ru.test.title.tsv
+    id: hc4-v1.0-ru.test.title
     qrels: hc4-v1.0-ru.test
   - name: "[HC4 (Russian): test-topic description](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-ru.test.desc.tsv
+    id: hc4-v1.0-ru.test.desc
     qrels: hc4-v1.0-ru.test
   - name: "[HC4 (Russian): test-topic description+title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-ru.test.desc.title.tsv
+    id: hc4-v1.0-ru.test.desc.title
     qrels: hc4-v1.0-ru.test
 
 
@@ -160,4 +160,3 @@ models:
         - 0.7728
         - 0.7680
         - 0.8271
-

--- a/src/main/resources/reproduce/from-document-collection/configs/hc4-v1.0-zh.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/hc4-v1.0-zh.yaml
@@ -44,22 +44,22 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[HC4 (Chinese): dev-topic title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-zh.dev.title.tsv
+    id: hc4-v1.0-zh.dev.title
     qrels: hc4-v1.0-zh.dev
   - name: "[HC4 (Chinese): dev-topic description](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-zh.dev.desc.tsv
+    id: hc4-v1.0-zh.dev.desc
     qrels: hc4-v1.0-zh.dev
   - name: "[HC4 (Chinese): dev-topic description+title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-zh.dev.desc.title.tsv
+    id: hc4-v1.0-zh.dev.desc.title
     qrels: hc4-v1.0-zh.dev
   - name: "[HC4 (Chinese): test-topic title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-zh.test.title.tsv
+    id: hc4-v1.0-zh.test.title
     qrels: hc4-v1.0-zh.test
   - name: "[HC4 (Chinese): test-topic description](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-zh.test.desc.tsv
+    id: hc4-v1.0-zh.test.desc
     qrels: hc4-v1.0-zh.test
   - name: "[HC4 (Chinese): test-topic description+title](https://github.com/hltcoe/HC4)"
-    id: hc4-v1.0-zh.test.desc.title.tsv
+    id: hc4-v1.0-zh.test.desc.title
     qrels: hc4-v1.0-zh.test
 
 

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ar-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ar-aca.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Arabic): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-ar-dev
-    qrels: miracl-v1.0-ar-dev.tsv
+    qrels: miracl-v1.0-ar-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ar-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ar-aca.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Arabic): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-ar-dev.tsv
+    id: miracl-v1.0-ar-dev
     qrels: miracl-v1.0-ar-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ar.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ar.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Arabic): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-ar-dev
-    qrels: miracl-v1.0-ar-dev.tsv
+    qrels: miracl-v1.0-ar-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ar.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ar.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Arabic): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-ar-dev.tsv
+    id: miracl-v1.0-ar-dev
     qrels: miracl-v1.0-ar-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-bn-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-bn-aca.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Bengali): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-bn-dev
-    qrels: miracl-v1.0-bn-dev.tsv
+    qrels: miracl-v1.0-bn-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-bn-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-bn-aca.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Bengali): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-bn-dev.tsv
+    id: miracl-v1.0-bn-dev
     qrels: miracl-v1.0-bn-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-bn.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-bn.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Bengali): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-bn-dev
-    qrels: miracl-v1.0-bn-dev.tsv
+    qrels: miracl-v1.0-bn-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-bn.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-bn.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Bengali): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-bn-dev.tsv
+    id: miracl-v1.0-bn-dev
     qrels: miracl-v1.0-bn-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-en-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-en-aca.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (English): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-en-dev
-    qrels: miracl-v1.0-en-dev.tsv
+    qrels: miracl-v1.0-en-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-en-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-en-aca.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (English): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-en-dev.tsv
+    id: miracl-v1.0-en-dev
     qrels: miracl-v1.0-en-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-en.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-en.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (English): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-en-dev
-    qrels: miracl-v1.0-en-dev.tsv
+    qrels: miracl-v1.0-en-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-en.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-en.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (English): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-en-dev.tsv
+    id: miracl-v1.0-en-dev
     qrels: miracl-v1.0-en-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-es-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-es-aca.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvString
 topics:
   - name: "[MIRACL (Spanish): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-es-dev
-    qrels: miracl-v1.0-es-dev.tsv
+    qrels: miracl-v1.0-es-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-es-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-es-aca.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvString
 topics:
   - name: "[MIRACL (Spanish): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-es-dev.tsv
+    id: miracl-v1.0-es-dev
     qrels: miracl-v1.0-es-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-es.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-es.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvString
 topics:
   - name: "[MIRACL (Spanish): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-es-dev
-    qrels: miracl-v1.0-es-dev.tsv
+    qrels: miracl-v1.0-es-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-es.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-es.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvString
 topics:
   - name: "[MIRACL (Spanish): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-es-dev.tsv
+    id: miracl-v1.0-es-dev
     qrels: miracl-v1.0-es-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fa-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fa-aca.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvString
 topics:
   - name: "[MIRACL (Persian): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-fa-dev.tsv
+    id: miracl-v1.0-fa-dev
     qrels: miracl-v1.0-fa-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fa-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fa-aca.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvString
 topics:
   - name: "[MIRACL (Persian): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-fa-dev
-    qrels: miracl-v1.0-fa-dev.tsv
+    qrels: miracl-v1.0-fa-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fa.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fa.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvString
 topics:
   - name: "[MIRACL (Persian): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-fa-dev.tsv
+    id: miracl-v1.0-fa-dev
     qrels: miracl-v1.0-fa-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fa.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fa.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvString
 topics:
   - name: "[MIRACL (Persian): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-fa-dev
-    qrels: miracl-v1.0-fa-dev.tsv
+    qrels: miracl-v1.0-fa-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fi-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fi-aca.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Finnish): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-fi-dev
-    qrels: miracl-v1.0-fi-dev.tsv
+    qrels: miracl-v1.0-fi-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fi-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fi-aca.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Finnish): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-fi-dev.tsv
+    id: miracl-v1.0-fi-dev
     qrels: miracl-v1.0-fi-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fi.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fi.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Finnish): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-fi-dev
-    qrels: miracl-v1.0-fi-dev.tsv
+    qrels: miracl-v1.0-fi-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fi.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fi.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Finnish): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-fi-dev.tsv
+    id: miracl-v1.0-fi-dev
     qrels: miracl-v1.0-fi-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fr-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fr-aca.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvString
 topics:
   - name: "[MIRACL (French): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-fr-dev
-    qrels: miracl-v1.0-fr-dev.tsv
+    qrels: miracl-v1.0-fr-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fr-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fr-aca.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvString
 topics:
   - name: "[MIRACL (French): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-fr-dev.tsv
+    id: miracl-v1.0-fr-dev
     qrels: miracl-v1.0-fr-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fr.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fr.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvString
 topics:
   - name: "[MIRACL (French): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-fr-dev
-    qrels: miracl-v1.0-fr-dev.tsv
+    qrels: miracl-v1.0-fr-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fr.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-fr.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvString
 topics:
   - name: "[MIRACL (French): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-fr-dev.tsv
+    id: miracl-v1.0-fr-dev
     qrels: miracl-v1.0-fr-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-hi-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-hi-aca.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvString
 topics:
   - name: "[MIRACL (Hindi): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-hi-dev
-    qrels: miracl-v1.0-hi-dev.tsv
+    qrels: miracl-v1.0-hi-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-hi-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-hi-aca.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvString
 topics:
   - name: "[MIRACL (Hindi): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-hi-dev.tsv
+    id: miracl-v1.0-hi-dev
     qrels: miracl-v1.0-hi-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-hi.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-hi.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvString
 topics:
   - name: "[MIRACL (Hindi): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-hi-dev
-    qrels: miracl-v1.0-hi-dev.tsv
+    qrels: miracl-v1.0-hi-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-hi.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-hi.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvString
 topics:
   - name: "[MIRACL (Hindi): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-hi-dev.tsv
+    id: miracl-v1.0-hi-dev
     qrels: miracl-v1.0-hi-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-id-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-id-aca.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Indonesian): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-id-dev.tsv
+    id: miracl-v1.0-id-dev
     qrels: miracl-v1.0-id-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-id-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-id-aca.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Indonesian): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-id-dev
-    qrels: miracl-v1.0-id-dev.tsv
+    qrels: miracl-v1.0-id-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-id.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-id.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Indonesian): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-id-dev.tsv
+    id: miracl-v1.0-id-dev
     qrels: miracl-v1.0-id-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-id.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-id.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Indonesian): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-id-dev
-    qrels: miracl-v1.0-id-dev.tsv
+    qrels: miracl-v1.0-id-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ja-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ja-aca.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Japanese): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-ja-dev
-    qrels: miracl-v1.0-ja-dev.tsv
+    qrels: miracl-v1.0-ja-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ja-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ja-aca.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Japanese): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-ja-dev.tsv
+    id: miracl-v1.0-ja-dev
     qrels: miracl-v1.0-ja-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ja.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ja.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Japanese): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-ja-dev
-    qrels: miracl-v1.0-ja-dev.tsv
+    qrels: miracl-v1.0-ja-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ja.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ja.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Japanese): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-ja-dev.tsv
+    id: miracl-v1.0-ja-dev
     qrels: miracl-v1.0-ja-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ko-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ko-aca.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Korean): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-ko-dev.tsv
+    id: miracl-v1.0-ko-dev
     qrels: miracl-v1.0-ko-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ko-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ko-aca.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Korean): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-ko-dev
-    qrels: miracl-v1.0-ko-dev.tsv
+    qrels: miracl-v1.0-ko-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ko.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ko.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Korean): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-ko-dev.tsv
+    id: miracl-v1.0-ko-dev
     qrels: miracl-v1.0-ko-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ko.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ko.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Korean): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-ko-dev
-    qrels: miracl-v1.0-ko-dev.tsv
+    qrels: miracl-v1.0-ko-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ru-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ru-aca.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Russian): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-ru-dev.tsv
+    id: miracl-v1.0-ru-dev
     qrels: miracl-v1.0-ru-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ru-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ru-aca.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Russian): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-ru-dev
-    qrels: miracl-v1.0-ru-dev.tsv
+    qrels: miracl-v1.0-ru-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ru.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ru.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Russian): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-ru-dev.tsv
+    id: miracl-v1.0-ru-dev
     qrels: miracl-v1.0-ru-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ru.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-ru.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Russian): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-ru-dev
-    qrels: miracl-v1.0-ru-dev.tsv
+    qrels: miracl-v1.0-ru-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-sw-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-sw-aca.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Swahili): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-sw-dev
-    qrels: miracl-v1.0-sw-dev.tsv
+    qrels: miracl-v1.0-sw-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-sw-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-sw-aca.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Swahili): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-sw-dev.tsv
+    id: miracl-v1.0-sw-dev
     qrels: miracl-v1.0-sw-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-sw.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-sw.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Swahili): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-sw-dev
-    qrels: miracl-v1.0-sw-dev.tsv
+    qrels: miracl-v1.0-sw-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-sw.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-sw.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Swahili): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-sw-dev.tsv
+    id: miracl-v1.0-sw-dev
     qrels: miracl-v1.0-sw-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-te-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-te-aca.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Telugu): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-te-dev
-    qrels: miracl-v1.0-te-dev.tsv
+    qrels: miracl-v1.0-te-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-te-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-te-aca.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Telugu): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-te-dev.tsv
+    id: miracl-v1.0-te-dev
     qrels: miracl-v1.0-te-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-te.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-te.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Telugu): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-te-dev
-    qrels: miracl-v1.0-te-dev.tsv
+    qrels: miracl-v1.0-te-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-te.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-te.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Telugu): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-te-dev.tsv
+    id: miracl-v1.0-te-dev
     qrels: miracl-v1.0-te-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-th-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-th-aca.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Thai): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-th-dev.tsv
+    id: miracl-v1.0-th-dev
     qrels: miracl-v1.0-th-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-th-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-th-aca.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Thai): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-th-dev
-    qrels: miracl-v1.0-th-dev.tsv
+    qrels: miracl-v1.0-th-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-th.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-th.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Thai): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-th-dev.tsv
+    id: miracl-v1.0-th-dev
     qrels: miracl-v1.0-th-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-th.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-th.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvInt
 topics:
   - name: "[MIRACL (Thai): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-th-dev
-    qrels: miracl-v1.0-th-dev.tsv
+    qrels: miracl-v1.0-th-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-zh-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-zh-aca.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvString
 topics:
   - name: "[MIRACL (Chinese): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-zh-dev
-    qrels: miracl-v1.0-zh-dev.tsv
+    qrels: miracl-v1.0-zh-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-zh-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-zh-aca.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvString
 topics:
   - name: "[MIRACL (Chinese): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-zh-dev.tsv
+    id: miracl-v1.0-zh-dev
     qrels: miracl-v1.0-zh-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-zh.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-zh.yaml
@@ -32,7 +32,7 @@ topic_reader: TsvString
 topics:
   - name: "[MIRACL (Chinese): dev](https://github.com/project-miracl/miracl)"
     id: miracl-v1.0-zh-dev
-    qrels: miracl-v1.0-zh-dev.tsv
+    qrels: miracl-v1.0-zh-dev
 
 models:
   - name: bm25

--- a/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-zh.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/miracl-v1.0-zh.yaml
@@ -31,7 +31,7 @@ metrics:
 topic_reader: TsvString
 topics:
   - name: "[MIRACL (Chinese): dev](https://github.com/project-miracl/miracl)"
-    id: miracl-v1.0-zh-dev.tsv
+    id: miracl-v1.0-zh-dev
     qrels: miracl-v1.0-zh-dev.tsv
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ar-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ar-aca.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Arabic): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ar.train.txt.gz
+    id: mrtydi-v1.1-ar.train
     qrels: mrtydi-v1.1-ar.train
   - name: "[Mr. TyDi (Arabic): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ar.dev.txt.gz
+    id: mrtydi-v1.1-ar.dev
     qrels: mrtydi-v1.1-ar.dev
   - name: "[Mr. TyDi (Arabic): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ar.test.txt.gz
+    id: mrtydi-v1.1-ar.test
     qrels: mrtydi-v1.1-ar.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ar.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ar.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Arabic): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ar.train.txt.gz
+    id: mrtydi-v1.1-ar.train
     qrels: mrtydi-v1.1-ar.train
   - name: "[Mr. TyDi (Arabic): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ar.dev.txt.gz
+    id: mrtydi-v1.1-ar.dev
     qrels: mrtydi-v1.1-ar.dev
   - name: "[Mr. TyDi (Arabic): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ar.test.txt.gz
+    id: mrtydi-v1.1-ar.test
     qrels: mrtydi-v1.1-ar.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-bn-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-bn-aca.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Bengali): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-bn.train.txt.gz
+    id: mrtydi-v1.1-bn.train
     qrels: mrtydi-v1.1-bn.train
   - name: "[Mr. TyDi (Bengali): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-bn.dev.txt.gz
+    id: mrtydi-v1.1-bn.dev
     qrels: mrtydi-v1.1-bn.dev
   - name: "[Mr. TyDi (Bengali): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-bn.test.txt.gz
+    id: mrtydi-v1.1-bn.test
     qrels: mrtydi-v1.1-bn.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-bn.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-bn.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Bengali): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-bn.train.txt.gz
+    id: mrtydi-v1.1-bn.train
     qrels: mrtydi-v1.1-bn.train
   - name: "[Mr. TyDi (Bengali): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-bn.dev.txt.gz
+    id: mrtydi-v1.1-bn.dev
     qrels: mrtydi-v1.1-bn.dev
   - name: "[Mr. TyDi (Bengali): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-bn.test.txt.gz
+    id: mrtydi-v1.1-bn.test
     qrels: mrtydi-v1.1-bn.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-en-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-en-aca.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (English): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-en.train.txt.gz
+    id: mrtydi-v1.1-en.train
     qrels: mrtydi-v1.1-en.train
   - name: "[Mr. TyDi (English): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-en.dev.txt.gz
+    id: mrtydi-v1.1-en.dev
     qrels: mrtydi-v1.1-en.dev
   - name: "[Mr. TyDi (English): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-en.test.txt.gz
+    id: mrtydi-v1.1-en.test
     qrels: mrtydi-v1.1-en.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-en.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-en.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (English): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-en.train.txt.gz
+    id: mrtydi-v1.1-en.train
     qrels: mrtydi-v1.1-en.train
   - name: "[Mr. TyDi (English): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-en.dev.txt.gz
+    id: mrtydi-v1.1-en.dev
     qrels: mrtydi-v1.1-en.dev
   - name: "[Mr. TyDi (English): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-en.test.txt.gz
+    id: mrtydi-v1.1-en.test
     qrels: mrtydi-v1.1-en.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-fi-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-fi-aca.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Finnish): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-fi.train.txt.gz
+    id: mrtydi-v1.1-fi.train
     qrels: mrtydi-v1.1-fi.train
   - name: "[Mr. TyDi (Finnish): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-fi.dev.txt.gz
+    id: mrtydi-v1.1-fi.dev
     qrels: mrtydi-v1.1-fi.dev
   - name: "[Mr. TyDi (Finnish): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-fi.test.txt.gz
+    id: mrtydi-v1.1-fi.test
     qrels: mrtydi-v1.1-fi.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-fi.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-fi.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Finnish): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-fi.train.txt.gz
+    id: mrtydi-v1.1-fi.train
     qrels: mrtydi-v1.1-fi.train
   - name: "[Mr. TyDi (Finnish): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-fi.dev.txt.gz
+    id: mrtydi-v1.1-fi.dev
     qrels: mrtydi-v1.1-fi.dev
   - name: "[Mr. TyDi (Finnish): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-fi.test.txt.gz
+    id: mrtydi-v1.1-fi.test
     qrels: mrtydi-v1.1-fi.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-id-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-id-aca.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Indonesian): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-id.train.txt.gz
+    id: mrtydi-v1.1-id.train
     qrels: mrtydi-v1.1-id.train
   - name: "[Mr. TyDi (Indonesian): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-id.dev.txt.gz
+    id: mrtydi-v1.1-id.dev
     qrels: mrtydi-v1.1-id.dev
   - name: "[Mr. TyDi (Indonesian): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-id.test.txt.gz
+    id: mrtydi-v1.1-id.test
     qrels: mrtydi-v1.1-id.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-id.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-id.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Indonesian): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-id.train.txt.gz
+    id: mrtydi-v1.1-id.train
     qrels: mrtydi-v1.1-id.train
   - name: "[Mr. TyDi (Indonesian): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-id.dev.txt.gz
+    id: mrtydi-v1.1-id.dev
     qrels: mrtydi-v1.1-id.dev
   - name: "[Mr. TyDi (Indonesian): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-id.test.txt.gz
+    id: mrtydi-v1.1-id.test
     qrels: mrtydi-v1.1-id.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ja-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ja-aca.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Japanese): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ja.train.txt.gz
+    id: mrtydi-v1.1-ja.train
     qrels: mrtydi-v1.1-ja.train
   - name: "[Mr. TyDi (Japanese): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ja.dev.txt.gz
+    id: mrtydi-v1.1-ja.dev
     qrels: mrtydi-v1.1-ja.dev
   - name: "[Mr. TyDi (Japanese): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ja.test.txt.gz
+    id: mrtydi-v1.1-ja.test
     qrels: mrtydi-v1.1-ja.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ja.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ja.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Japanese): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ja.train.txt.gz
+    id: mrtydi-v1.1-ja.train
     qrels: mrtydi-v1.1-ja.train
   - name: "[Mr. TyDi (Japanese): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ja.dev.txt.gz
+    id: mrtydi-v1.1-ja.dev
     qrels: mrtydi-v1.1-ja.dev
   - name: "[Mr. TyDi (Japanese): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ja.test.txt.gz
+    id: mrtydi-v1.1-ja.test
     qrels: mrtydi-v1.1-ja.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ko-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ko-aca.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Korean): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ko.train.txt.gz
+    id: mrtydi-v1.1-ko.train
     qrels: mrtydi-v1.1-ko.train
   - name: "[Mr. TyDi (Korean): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ko.dev.txt.gz
+    id: mrtydi-v1.1-ko.dev
     qrels: mrtydi-v1.1-ko.dev
   - name: "[Mr. TyDi (Korean): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ko.test.txt.gz
+    id: mrtydi-v1.1-ko.test
     qrels: mrtydi-v1.1-ko.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ko.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ko.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Korean): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ko.train.txt.gz
+    id: mrtydi-v1.1-ko.train
     qrels: mrtydi-v1.1-ko.train
   - name: "[Mr. TyDi (Korean): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ko.dev.txt.gz
+    id: mrtydi-v1.1-ko.dev
     qrels: mrtydi-v1.1-ko.dev
   - name: "[Mr. TyDi (Korean): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ko.test.txt.gz
+    id: mrtydi-v1.1-ko.test
     qrels: mrtydi-v1.1-ko.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ru-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ru-aca.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Russian): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ru.train.txt.gz
+    id: mrtydi-v1.1-ru.train
     qrels: mrtydi-v1.1-ru.train
   - name: "[Mr. TyDi (Russian): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ru.dev.txt.gz
+    id: mrtydi-v1.1-ru.dev
     qrels: mrtydi-v1.1-ru.dev
   - name: "[Mr. TyDi (Russian): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ru.test.txt.gz
+    id: mrtydi-v1.1-ru.test
     qrels: mrtydi-v1.1-ru.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ru.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-ru.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Russian): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ru.train.txt.gz
+    id: mrtydi-v1.1-ru.train
     qrels: mrtydi-v1.1-ru.train
   - name: "[Mr. TyDi (Russian): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ru.dev.txt.gz
+    id: mrtydi-v1.1-ru.dev
     qrels: mrtydi-v1.1-ru.dev
   - name: "[Mr. TyDi (Russian): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-ru.test.txt.gz
+    id: mrtydi-v1.1-ru.test
     qrels: mrtydi-v1.1-ru.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-sw-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-sw-aca.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Swahili): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-sw.train.txt.gz
+    id: mrtydi-v1.1-sw.train
     qrels: mrtydi-v1.1-sw.train
   - name: "[Mr. TyDi (Swahili): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-sw.dev.txt.gz
+    id: mrtydi-v1.1-sw.dev
     qrels: mrtydi-v1.1-sw.dev
   - name: "[Mr. TyDi (Swahili): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-sw.test.txt.gz
+    id: mrtydi-v1.1-sw.test
     qrels: mrtydi-v1.1-sw.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-sw.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-sw.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Swahili): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-sw.train.txt.gz
+    id: mrtydi-v1.1-sw.train
     qrels: mrtydi-v1.1-sw.train
   - name: "[Mr. TyDi (Swahili): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-sw.dev.txt.gz
+    id: mrtydi-v1.1-sw.dev
     qrels: mrtydi-v1.1-sw.dev
   - name: "[Mr. TyDi (Swahili): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-sw.test.txt.gz
+    id: mrtydi-v1.1-sw.test
     qrels: mrtydi-v1.1-sw.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-te-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-te-aca.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Telugu): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-te.train.txt.gz
+    id: mrtydi-v1.1-te.train
     qrels: mrtydi-v1.1-te.train
   - name: "[Mr. TyDi (Telugu): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-te.dev.txt.gz
+    id: mrtydi-v1.1-te.dev
     qrels: mrtydi-v1.1-te.dev
   - name: "[Mr. TyDi (Telugu): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-te.test.txt.gz
+    id: mrtydi-v1.1-te.test
     qrels: mrtydi-v1.1-te.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-te.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-te.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Telugu): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-te.train.txt.gz
+    id: mrtydi-v1.1-te.train
     qrels: mrtydi-v1.1-te.train
   - name: "[Mr. TyDi (Telugu): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-te.dev.txt.gz
+    id: mrtydi-v1.1-te.dev
     qrels: mrtydi-v1.1-te.dev
   - name: "[Mr. TyDi (Telugu): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-te.test.txt.gz
+    id: mrtydi-v1.1-te.test
     qrels: mrtydi-v1.1-te.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-th-aca.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-th-aca.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Thai): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-th.train.txt.gz
+    id: mrtydi-v1.1-th.train
     qrels: mrtydi-v1.1-th.train
   - name: "[Mr. TyDi (Thai): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-th.dev.txt.gz
+    id: mrtydi-v1.1-th.dev
     qrels: mrtydi-v1.1-th.dev
   - name: "[Mr. TyDi (Thai): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-th.test.txt.gz
+    id: mrtydi-v1.1-th.test
     qrels: mrtydi-v1.1-th.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-th.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/mrtydi-v1.1-th.yaml
@@ -31,13 +31,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[Mr. TyDi (Thai): train](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-th.train.txt.gz
+    id: mrtydi-v1.1-th.train
     qrels: mrtydi-v1.1-th.train
   - name: "[Mr. TyDi (Thai): dev](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-th.dev.txt.gz
+    id: mrtydi-v1.1-th.dev
     qrels: mrtydi-v1.1-th.dev
   - name: "[Mr. TyDi (Thai): test](https://github.com/castorini/mr.tydi)"
-    id: mrtydi-v1.1-th.test.txt.gz
+    id: mrtydi-v1.1-th.test
     qrels: mrtydi-v1.1-th.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/msmarco-v1-passage.cos-dpr-distil.parquet.fw.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/msmarco-v1-passage.cos-dpr-distil.parquet.fw.yaml
@@ -49,7 +49,7 @@ metrics:
 topic_reader: JsonIntVector
 topics:
   - name: "[MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)"
-    id: msmarco-passage.dev-subset.cos-dpr-distil.jsonl.gz
+    id: msmarco-passage.dev-subset.cos-dpr-distil
     qrels: msmarco-passage.dev-subset
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/msmarco-v1-passage.cos-dpr-distil.parquet.lexlsh.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/msmarco-v1-passage.cos-dpr-distil.parquet.lexlsh.yaml
@@ -49,7 +49,7 @@ metrics:
 topic_reader: JsonIntVector
 topics:
   - name: "[MS MARCO Passage: Dev](https://github.com/microsoft/MSMARCO-Passage-Ranking)"
-    id: msmarco-passage.dev-subset.cos-dpr-distil.jsonl.gz
+    id: msmarco-passage.dev-subset.cos-dpr-distil
     qrels: msmarco-passage.dev-subset
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/neuclir22-fa-qt-splade.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/neuclir22-fa-qt-splade.yaml
@@ -44,22 +44,22 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[NeuCLIR 2022 (Persian): title (human-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-fa.splade.ht-title.txt.gz
+    id: neuclir22-fa.splade.ht-title
     qrels: neuclir22-fa
   - name: "[NeuCLIR 2022 (Persian): desc (human-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-fa.splade.ht-desc.txt.gz
+    id: neuclir22-fa.splade.ht-desc
     qrels: neuclir22-fa
   - name: "[NeuCLIR 2022 (Persian): desc+title (human-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-fa.splade.ht-desc_title.txt.gz
+    id: neuclir22-fa.splade.ht-desc_title
     qrels: neuclir22-fa
   - name: "[NeuCLIR 2022 (Persian): title (machine-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-fa.splade.mt-title.txt.gz
+    id: neuclir22-fa.splade.mt-title
     qrels: neuclir22-fa
   - name: "[NeuCLIR 2022 (Persian): desc (machine-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-fa.splade.mt-desc.txt.gz
+    id: neuclir22-fa.splade.mt-desc
     qrels: neuclir22-fa
   - name: "[NeuCLIR 2022 (Persian): desc+title (machine-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-fa.splade.mt-desc_title.txt.gz
+    id: neuclir22-fa.splade.mt-desc_title
     qrels: neuclir22-fa
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/neuclir22-ru-qt-splade.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/neuclir22-ru-qt-splade.yaml
@@ -44,22 +44,22 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[NeuCLIR 2022 (Russian): title (human-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-ru.splade.ht-title.txt.gz
+    id: neuclir22-ru.splade.ht-title
     qrels: neuclir22-ru
   - name: "[NeuCLIR 2022 (Russian): desc (human-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-ru.splade.ht-desc.txt.gz
+    id: neuclir22-ru.splade.ht-desc
     qrels: neuclir22-ru
   - name: "[NeuCLIR 2022 (Russian): desc+title (human-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-ru.splade.ht-desc_title.txt.gz
+    id: neuclir22-ru.splade.ht-desc_title
     qrels: neuclir22-ru
   - name: "[NeuCLIR 2022 (Russian): title (machine-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-ru.splade.mt-title.txt.gz
+    id: neuclir22-ru.splade.mt-title
     qrels: neuclir22-ru
   - name: "[NeuCLIR 2022 (Russian): desc (machine-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-ru.splade.mt-desc.txt.gz
+    id: neuclir22-ru.splade.mt-desc
     qrels: neuclir22-ru
   - name: "[NeuCLIR 2022 (Russian): desc+title (machine-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-ru.splade.mt-desc_title.txt.gz
+    id: neuclir22-ru.splade.mt-desc_title
     qrels: neuclir22-ru
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/neuclir22-zh-qt-splade.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/neuclir22-zh-qt-splade.yaml
@@ -44,22 +44,22 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[NeuCLIR 2022 (Chinese): title (human-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-zh.splade.ht-title.txt.gz
+    id: neuclir22-zh.splade.ht-title
     qrels: neuclir22-zh
   - name: "[NeuCLIR 2022 (Chinese): desc (human-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-zh.splade.ht-desc.txt.gz
+    id: neuclir22-zh.splade.ht-desc
     qrels: neuclir22-zh
   - name: "[NeuCLIR 2022 (Chinese): desc+title (human-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-zh.splade.ht-desc_title.txt.gz
+    id: neuclir22-zh.splade.ht-desc_title
     qrels: neuclir22-zh
   - name: "[NeuCLIR 2022 (Chinese): title (machine-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-zh.splade.mt-title.txt.gz
+    id: neuclir22-zh.splade.mt-title
     qrels: neuclir22-zh
   - name: "[NeuCLIR 2022 (Chinese): desc (machine-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-zh.splade.mt-desc.txt.gz
+    id: neuclir22-zh.splade.mt-desc
     qrels: neuclir22-zh
   - name: "[NeuCLIR 2022 (Chinese): desc+title (machine-translated queries)](https://neuclir.github.io/)"
-    id: neuclir22-zh.splade.mt-desc_title.txt.gz
+    id: neuclir22-zh.splade.mt-desc_title
     qrels: neuclir22-zh
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard00.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard00.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard01.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard01.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard02.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard02.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard03.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard03.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard04.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard04.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard05.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard05.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard06.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard06.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard07.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard07.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard08.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard08.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard09.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.arctic-embed-l.parquet.shard09.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.splade-v3.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.splade-v3.onnx.yaml
@@ -42,7 +42,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-nist.yaml
@@ -38,7 +38,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard00.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard00.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test-umbrela2
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard01.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard01.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test-umbrela2
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard02.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard02.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test-umbrela2
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard03.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard03.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test-umbrela2
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard04.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard04.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test-umbrela2
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard05.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard05.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test-umbrela2
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard06.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard06.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test-umbrela2
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard07.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard07.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test-umbrela2
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard08.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard08.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test-umbrela2
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard09.flat.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.arctic-embed-l.parquet.shard09.flat.onnx.yaml
@@ -35,7 +35,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test-umbrela2
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.splade-v3.onnx.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.splade-v3.onnx.yaml
@@ -42,7 +42,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test-umbrela2
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/rag25-doc-segmented-test-umbrela2.yaml
@@ -38,7 +38,7 @@ metrics:
 topic_reader: JsonString
 topics:
   - name: "RAG 25: Test queries"
-    id: rag25.test.jsonl
+    id: rag25.test
     qrels: rag25.test-umbrela2
 
 models:

--- a/src/test/java/io/anserini/search/SearchInvertedDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchInvertedDenseVectorsTest.java
@@ -144,7 +144,7 @@ public class SearchInvertedDenseVectorsTest extends StdOutStdErrRedirectableLuce
     SearchInvertedDenseVectors.main(searchArgs);
 
     assertTrue("Error output should contain the expected error message",
-        err.toString().contains("Error: \"fake/topics/here\" does not appear to be a valid topics file."));
+        err.toString().contains("Error: \"fake/topics/here\" does not refer to valid topics."));
   }
 
   @Test
@@ -172,7 +172,7 @@ public class SearchInvertedDenseVectorsTest extends StdOutStdErrRedirectableLuce
     SearchInvertedDenseVectors.main(searchArgs);
 
     assertTrue("Error output should contain the expected error message",
-        err.toString().contains("Error: Unable to load topic reader \"FakeJsonIntVector\"."));
+        err.toString().contains("Error: Unable to load topic reader \"FakeJsonIntVector\""));
   }
 
   @Test

--- a/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
@@ -43,7 +43,7 @@ public class TopicReaderTest {
       String path = topic.path;
       assertEquals(topic.readerClass, Topics.getTopicReaderClassForPath(path));
     }
-    assertEquals(469, cnt);
+    assertEquals(472, cnt);
   }
 
   @Test

--- a/src/test/java/io/anserini/search/topicreader/TopicsTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicsTest.java
@@ -30,7 +30,7 @@ public class TopicsTest {
 
   @Test
   public void testTotalCount() {
-    assertEquals(469, Topics.names().size());
+    assertEquals(472, Topics.names().size());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- replace filename-style topic IDs with canonical Topics registry keys in document-collection reproduction configs
- regenerate the corresponding reproduction documentation
- preserve canonical `.wp` IDs and leave unresolved IDs unchanged

## Validation

- `mvn -Dtest=ReproduceFromDocumentCollectionTest test`
- `git diff --check`
- Parsed all 625 reproduction YAML configs and verified all 200 changed IDs against the pinned registry