### PR TITLE
Reproduce MS MARCO BM25 and dense retrieval baselines

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -706,3 +706,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@Navid-Ebadi-2003](https://github.com/Navid-Ebadi-2003) on 2026-08-09 (commit [`b99e095`](https://github.com/castorini/anserini/commit/b99e09582d3c3880c87e43eb0e1040adb4cfa0ac))
 + Results reproduced by [@Evan-Lowry](https://github.com/Evan-Lowry) on 2026-08-13 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
 + Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-14 (commit [`1272378`](https://github.com/castorini/anserini/commit/127237835c675272668f0d65420602117fe50d09))
++ Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`d02b3dd`](https://github.com/castorini/anserini/commit/d02b3dd3c85c81a675c4f5a7dc721ab249170817))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -261,3 +261,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Navid-Ebadi-2003](https://github.com/Navid-Ebadi-2003) on 2026-08-09 (commit [`b99e095`](https://github.com/castorini/anserini/commit/b99e09582d3c3880c87e43eb0e1040adb4cfa0ac))
 + Results reproduced by [@Evan-Lowry](https://github.com/Evan-Lowry) on 2026-08-13 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
 + Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-15 (commit [`9bfc04b`](https://github.com/castorini/anserini/commit/9bfc04b2d5f22e3acf56edf43d06c1efa5fe2783))
++ Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`d02b3dd`](https://github.com/castorini/anserini/commit/d02b3dd3c85c81a675c4f5a7dc721ab249170817))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -614,3 +614,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@nomsou](https://github.com/nomsou) on 2026-08-07 (commit [`1272378`](https://github.com/castorini/anserini/commit/127237835c675272668f0d65420602117fe50d09))
 + Results reproduced by [@Navid-Ebadi-2003](https://github.com/Navid-Ebadi-2003) on 2026-08-09 (commit [`b99e095`](https://github.com/castorini/anserini/commit/b99e09582d3c3880c87e43eb0e1040adb4cfa0ac))
 + Results reproduced by [@Evan-Lowry](https://github.com/Evan-Lowry) on 2026-08-13 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
++ Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`d02b3dd`](https://github.com/castorini/anserini/commit/d02b3dd3c85c81a675c4f5a7dc721ab249170817))


### PR DESCRIPTION
This PR consolidates my Anserini onboarding reproduction-log updates for the MS MARCO passage lessons.

Environment and setup:
- Ubuntu 24.04 GitHub-hosted runners
- Java Temurin 21.0.12
- Anserini main-trunk commit: d02b3dd3c85c81a675c4f5a7dc721ab249170817
- MS MARCO passage dev set: 6,980 queries

Completed onboarding entries:
- Start Here / MS MARCO collection walkthrough reproduction log.
- BM25 baseline using the official prebuilt `msmarco-v1-passage` index with k1=0.82, b=0.68: MRR@10 = 0.1875, MAP = 0.1958, Recall@1000 = 0.8573.
- Dense retrieval using `msmarco-v1-passage.bge-base-en-v1.5.hnsw` with `BgeBaseEn15`: MRR@10 = 0.3521.

Notes:
- I initially attempted the fresh-indexing path from the BM25 lesson on a standard GitHub-hosted runner. Data preparation completed, but Lucene indexing exceeded the runner's available memory after roughly 2.93M passages, so I did not claim that fresh indexing completed successfully.
- I then reproduced the BM25 effectiveness results with Anserini's official prebuilt MS MARCO passage index.
- Because the dense HNSW index is large, I split the 6,980 queries into four independent shards, merged the resulting runs, and evaluated the complete merged run. All four shards and the final evaluation completed successfully.
- The missing `docs/start-here.md` reproduction-log entry has now been added.

The final repository diff contains only the three reproduction-log entries; temporary workflows used to collect results and resolve the upstream sync were removed before review.