### PR TITLE
[codex] Fix document collection reproduction commands

### DIFF
--- a/docs/reproduce/from-document-collection/cw09b.md
+++ b/docs/reproduce/from-document-collection/cw09b.md
@@ -166,46 +166,46 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval` and `gdeval.pl`:
 
 ```bash
-tools/eval/gdeval.pl web.51-100 runs/run.lucene-inverted.cw09b.model-bm25.topics-web.51-100.txt
+bin/gdeval.pl web.51-100 runs/run.lucene-inverted.cw09b.model-bm25.topics-web.51-100.txt
 bin/trec_eval -m map -m P.30 web.51-100 runs/run.lucene-inverted.cw09b.model-bm25.topics-web.51-100.txt
-tools/eval/gdeval.pl web.101-150 runs/run.lucene-inverted.cw09b.model-bm25.topics-web.101-150.txt
+bin/gdeval.pl web.101-150 runs/run.lucene-inverted.cw09b.model-bm25.topics-web.101-150.txt
 bin/trec_eval -m map -m P.30 web.101-150 runs/run.lucene-inverted.cw09b.model-bm25.topics-web.101-150.txt
-tools/eval/gdeval.pl web.151-200 runs/run.lucene-inverted.cw09b.model-bm25.topics-web.151-200.txt
+bin/gdeval.pl web.151-200 runs/run.lucene-inverted.cw09b.model-bm25.topics-web.151-200.txt
 bin/trec_eval -m map -m P.30 web.151-200 runs/run.lucene-inverted.cw09b.model-bm25.topics-web.151-200.txt
 
-tools/eval/gdeval.pl web.51-100 runs/run.lucene-inverted.cw09b.model-bm25+rm3.topics-web.51-100.txt
+bin/gdeval.pl web.51-100 runs/run.lucene-inverted.cw09b.model-bm25+rm3.topics-web.51-100.txt
 bin/trec_eval -m map -m P.30 web.51-100 runs/run.lucene-inverted.cw09b.model-bm25+rm3.topics-web.51-100.txt
-tools/eval/gdeval.pl web.101-150 runs/run.lucene-inverted.cw09b.model-bm25+rm3.topics-web.101-150.txt
+bin/gdeval.pl web.101-150 runs/run.lucene-inverted.cw09b.model-bm25+rm3.topics-web.101-150.txt
 bin/trec_eval -m map -m P.30 web.101-150 runs/run.lucene-inverted.cw09b.model-bm25+rm3.topics-web.101-150.txt
-tools/eval/gdeval.pl web.151-200 runs/run.lucene-inverted.cw09b.model-bm25+rm3.topics-web.151-200.txt
+bin/gdeval.pl web.151-200 runs/run.lucene-inverted.cw09b.model-bm25+rm3.topics-web.151-200.txt
 bin/trec_eval -m map -m P.30 web.151-200 runs/run.lucene-inverted.cw09b.model-bm25+rm3.topics-web.151-200.txt
 
-tools/eval/gdeval.pl web.51-100 runs/run.lucene-inverted.cw09b.model-bm25+ax.topics-web.51-100.txt
+bin/gdeval.pl web.51-100 runs/run.lucene-inverted.cw09b.model-bm25+ax.topics-web.51-100.txt
 bin/trec_eval -m map -m P.30 web.51-100 runs/run.lucene-inverted.cw09b.model-bm25+ax.topics-web.51-100.txt
-tools/eval/gdeval.pl web.101-150 runs/run.lucene-inverted.cw09b.model-bm25+ax.topics-web.101-150.txt
+bin/gdeval.pl web.101-150 runs/run.lucene-inverted.cw09b.model-bm25+ax.topics-web.101-150.txt
 bin/trec_eval -m map -m P.30 web.101-150 runs/run.lucene-inverted.cw09b.model-bm25+ax.topics-web.101-150.txt
-tools/eval/gdeval.pl web.151-200 runs/run.lucene-inverted.cw09b.model-bm25+ax.topics-web.151-200.txt
+bin/gdeval.pl web.151-200 runs/run.lucene-inverted.cw09b.model-bm25+ax.topics-web.151-200.txt
 bin/trec_eval -m map -m P.30 web.151-200 runs/run.lucene-inverted.cw09b.model-bm25+ax.topics-web.151-200.txt
 
-tools/eval/gdeval.pl web.51-100 runs/run.lucene-inverted.cw09b.model-ql.topics-web.51-100.txt
+bin/gdeval.pl web.51-100 runs/run.lucene-inverted.cw09b.model-ql.topics-web.51-100.txt
 bin/trec_eval -m map -m P.30 web.51-100 runs/run.lucene-inverted.cw09b.model-ql.topics-web.51-100.txt
-tools/eval/gdeval.pl web.101-150 runs/run.lucene-inverted.cw09b.model-ql.topics-web.101-150.txt
+bin/gdeval.pl web.101-150 runs/run.lucene-inverted.cw09b.model-ql.topics-web.101-150.txt
 bin/trec_eval -m map -m P.30 web.101-150 runs/run.lucene-inverted.cw09b.model-ql.topics-web.101-150.txt
-tools/eval/gdeval.pl web.151-200 runs/run.lucene-inverted.cw09b.model-ql.topics-web.151-200.txt
+bin/gdeval.pl web.151-200 runs/run.lucene-inverted.cw09b.model-ql.topics-web.151-200.txt
 bin/trec_eval -m map -m P.30 web.151-200 runs/run.lucene-inverted.cw09b.model-ql.topics-web.151-200.txt
 
-tools/eval/gdeval.pl web.51-100 runs/run.lucene-inverted.cw09b.model-ql+rm3.topics-web.51-100.txt
+bin/gdeval.pl web.51-100 runs/run.lucene-inverted.cw09b.model-ql+rm3.topics-web.51-100.txt
 bin/trec_eval -m map -m P.30 web.51-100 runs/run.lucene-inverted.cw09b.model-ql+rm3.topics-web.51-100.txt
-tools/eval/gdeval.pl web.101-150 runs/run.lucene-inverted.cw09b.model-ql+rm3.topics-web.101-150.txt
+bin/gdeval.pl web.101-150 runs/run.lucene-inverted.cw09b.model-ql+rm3.topics-web.101-150.txt
 bin/trec_eval -m map -m P.30 web.101-150 runs/run.lucene-inverted.cw09b.model-ql+rm3.topics-web.101-150.txt
-tools/eval/gdeval.pl web.151-200 runs/run.lucene-inverted.cw09b.model-ql+rm3.topics-web.151-200.txt
+bin/gdeval.pl web.151-200 runs/run.lucene-inverted.cw09b.model-ql+rm3.topics-web.151-200.txt
 bin/trec_eval -m map -m P.30 web.151-200 runs/run.lucene-inverted.cw09b.model-ql+rm3.topics-web.151-200.txt
 
-tools/eval/gdeval.pl web.51-100 runs/run.lucene-inverted.cw09b.model-ql+ax.topics-web.51-100.txt
+bin/gdeval.pl web.51-100 runs/run.lucene-inverted.cw09b.model-ql+ax.topics-web.51-100.txt
 bin/trec_eval -m map -m P.30 web.51-100 runs/run.lucene-inverted.cw09b.model-ql+ax.topics-web.51-100.txt
-tools/eval/gdeval.pl web.101-150 runs/run.lucene-inverted.cw09b.model-ql+ax.topics-web.101-150.txt
+bin/gdeval.pl web.101-150 runs/run.lucene-inverted.cw09b.model-ql+ax.topics-web.101-150.txt
 bin/trec_eval -m map -m P.30 web.101-150 runs/run.lucene-inverted.cw09b.model-ql+ax.topics-web.101-150.txt
-tools/eval/gdeval.pl web.151-200 runs/run.lucene-inverted.cw09b.model-ql+ax.topics-web.151-200.txt
+bin/gdeval.pl web.151-200 runs/run.lucene-inverted.cw09b.model-ql+ax.topics-web.151-200.txt
 bin/trec_eval -m map -m P.30 web.151-200 runs/run.lucene-inverted.cw09b.model-ql+ax.topics-web.151-200.txt
 ```
 

--- a/docs/reproduce/from-document-collection/cw12.md
+++ b/docs/reproduce/from-document-collection/cw12.md
@@ -100,24 +100,24 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval` and `gdeval.pl`:
 
 ```bash
-tools/eval/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12.model-bm25.topics-web.201-250.txt
+bin/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12.model-bm25.topics-web.201-250.txt
 bin/trec_eval -m map -m P.30 web.201-250 runs/run.lucene-inverted.cw12.model-bm25.topics-web.201-250.txt
-tools/eval/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12.model-bm25.topics-web.251-300.txt
+bin/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12.model-bm25.topics-web.251-300.txt
 bin/trec_eval -m map -m P.30 web.251-300 runs/run.lucene-inverted.cw12.model-bm25.topics-web.251-300.txt
 
-tools/eval/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12.model-bm25+rm3.topics-web.201-250.txt
+bin/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12.model-bm25+rm3.topics-web.201-250.txt
 bin/trec_eval -m map -m P.30 web.201-250 runs/run.lucene-inverted.cw12.model-bm25+rm3.topics-web.201-250.txt
-tools/eval/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12.model-bm25+rm3.topics-web.251-300.txt
+bin/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12.model-bm25+rm3.topics-web.251-300.txt
 bin/trec_eval -m map -m P.30 web.251-300 runs/run.lucene-inverted.cw12.model-bm25+rm3.topics-web.251-300.txt
 
-tools/eval/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12.model-ql.topics-web.201-250.txt
+bin/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12.model-ql.topics-web.201-250.txt
 bin/trec_eval -m map -m P.30 web.201-250 runs/run.lucene-inverted.cw12.model-ql.topics-web.201-250.txt
-tools/eval/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12.model-ql.topics-web.251-300.txt
+bin/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12.model-ql.topics-web.251-300.txt
 bin/trec_eval -m map -m P.30 web.251-300 runs/run.lucene-inverted.cw12.model-ql.topics-web.251-300.txt
 
-tools/eval/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12.model-ql+rm3.topics-web.201-250.txt
+bin/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12.model-ql+rm3.topics-web.201-250.txt
 bin/trec_eval -m map -m P.30 web.201-250 runs/run.lucene-inverted.cw12.model-ql+rm3.topics-web.201-250.txt
-tools/eval/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12.model-ql+rm3.topics-web.251-300.txt
+bin/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12.model-ql+rm3.topics-web.251-300.txt
 bin/trec_eval -m map -m P.30 web.251-300 runs/run.lucene-inverted.cw12.model-ql+rm3.topics-web.251-300.txt
 ```
 

--- a/docs/reproduce/from-document-collection/cw12b13.md
+++ b/docs/reproduce/from-document-collection/cw12b13.md
@@ -126,34 +126,34 @@ bin/run.sh io.anserini.search.SearchCollection \
 Evaluation can be performed using `trec_eval` and `gdeval.pl`:
 
 ```bash
-tools/eval/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12b13.model-bm25.topics-web.201-250.txt
+bin/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12b13.model-bm25.topics-web.201-250.txt
 bin/trec_eval -m map -m P.30 web.201-250 runs/run.lucene-inverted.cw12b13.model-bm25.topics-web.201-250.txt
-tools/eval/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12b13.model-bm25.topics-web.251-300.txt
+bin/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12b13.model-bm25.topics-web.251-300.txt
 bin/trec_eval -m map -m P.30 web.251-300 runs/run.lucene-inverted.cw12b13.model-bm25.topics-web.251-300.txt
 
-tools/eval/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12b13.model-bm25+rm3.topics-web.201-250.txt
+bin/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12b13.model-bm25+rm3.topics-web.201-250.txt
 bin/trec_eval -m map -m P.30 web.201-250 runs/run.lucene-inverted.cw12b13.model-bm25+rm3.topics-web.201-250.txt
-tools/eval/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12b13.model-bm25+rm3.topics-web.251-300.txt
+bin/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12b13.model-bm25+rm3.topics-web.251-300.txt
 bin/trec_eval -m map -m P.30 web.251-300 runs/run.lucene-inverted.cw12b13.model-bm25+rm3.topics-web.251-300.txt
 
-tools/eval/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12b13.model-bm25+ax.topics-web.201-250.txt
+bin/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12b13.model-bm25+ax.topics-web.201-250.txt
 bin/trec_eval -m map -m P.30 web.201-250 runs/run.lucene-inverted.cw12b13.model-bm25+ax.topics-web.201-250.txt
-tools/eval/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12b13.model-bm25+ax.topics-web.251-300.txt
+bin/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12b13.model-bm25+ax.topics-web.251-300.txt
 bin/trec_eval -m map -m P.30 web.251-300 runs/run.lucene-inverted.cw12b13.model-bm25+ax.topics-web.251-300.txt
 
-tools/eval/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12b13.model-ql.topics-web.201-250.txt
+bin/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12b13.model-ql.topics-web.201-250.txt
 bin/trec_eval -m map -m P.30 web.201-250 runs/run.lucene-inverted.cw12b13.model-ql.topics-web.201-250.txt
-tools/eval/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12b13.model-ql.topics-web.251-300.txt
+bin/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12b13.model-ql.topics-web.251-300.txt
 bin/trec_eval -m map -m P.30 web.251-300 runs/run.lucene-inverted.cw12b13.model-ql.topics-web.251-300.txt
 
-tools/eval/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12b13.model-ql+rm3.topics-web.201-250.txt
+bin/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12b13.model-ql+rm3.topics-web.201-250.txt
 bin/trec_eval -m map -m P.30 web.201-250 runs/run.lucene-inverted.cw12b13.model-ql+rm3.topics-web.201-250.txt
-tools/eval/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12b13.model-ql+rm3.topics-web.251-300.txt
+bin/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12b13.model-ql+rm3.topics-web.251-300.txt
 bin/trec_eval -m map -m P.30 web.251-300 runs/run.lucene-inverted.cw12b13.model-ql+rm3.topics-web.251-300.txt
 
-tools/eval/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12b13.model-ql+ax.topics-web.201-250.txt
+bin/gdeval.pl web.201-250 runs/run.lucene-inverted.cw12b13.model-ql+ax.topics-web.201-250.txt
 bin/trec_eval -m map -m P.30 web.201-250 runs/run.lucene-inverted.cw12b13.model-ql+ax.topics-web.201-250.txt
-tools/eval/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12b13.model-ql+ax.topics-web.251-300.txt
+bin/gdeval.pl web.251-300 runs/run.lucene-inverted.cw12b13.model-ql+ax.topics-web.251-300.txt
 bin/trec_eval -m map -m P.30 web.251-300 runs/run.lucene-inverted.cw12b13.model-ql+ax.topics-web.251-300.txt
 ```
 

--- a/docs/reproduce/from-document-collection/nanoknow-v1.0-nq.md
+++ b/docs/reproduce/from-document-collection/nanoknow-v1.0-nq.md
@@ -52,16 +52,16 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/fineweb-edu-100b-official-index/ \
-  -topics nanoknow-v1.0-nq.supported.tsv \
+  -topics nanoknow-v1.0-nq.supported \
   -topicReader TsvInt \
-  -output runs/run.fineweb-edu-100b-official-index.model-bm25.topics-nanoknow-v1.0-nq.supported.tsv.txt \
+  -output runs/run.fineweb-edu-100b-official-index.model-bm25.topics-nanoknow-v1.0-nq.supported.txt \
   -bm25 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m recall.20 nanoknow-v1.0-nq.supported runs/run.fineweb-edu-100b-official-index.model-bm25.topics-nanoknow-v1.0-nq.supported.tsv.txt
+bin/trec_eval -c -m recall.20 nanoknow-v1.0-nq.supported runs/run.fineweb-edu-100b-official-index.model-bm25.topics-nanoknow-v1.0-nq.supported.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/nanoknow-v1.0-squad.md
+++ b/docs/reproduce/from-document-collection/nanoknow-v1.0-squad.md
@@ -52,16 +52,16 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/fineweb-edu-100b-official-index/ \
-  -topics nanoknow-v1.0-squad.supported.tsv \
+  -topics nanoknow-v1.0-squad.supported \
   -topicReader TsvInt \
-  -output runs/run.fineweb-edu-100b-official-index.model-bm25.topics-nanoknow-v1.0-squad.supported.tsv.txt \
+  -output runs/run.fineweb-edu-100b-official-index.model-bm25.topics-nanoknow-v1.0-squad.supported.txt \
   -bm25 &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m recall.20 nanoknow-v1.0-squad.supported runs/run.fineweb-edu-100b-official-index.model-bm25.topics-nanoknow-v1.0-squad.supported.tsv.txt
+bin/trec_eval -c -m recall.20 nanoknow-v1.0-squad.supported runs/run.fineweb-edu-100b-official-index.model-bm25.topics-nanoknow-v1.0-squad.supported.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/neuclir22-fa-dt-splade.md
+++ b/docs/reproduce/from-document-collection/neuclir22-fa-dt-splade.md
@@ -59,103 +59,103 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-fa-en-splade \
-  -topics neuclir22-en.splade.original-title.txt.gz \
+  -topics neuclir22-en.splade.original-title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-fa-en-splade \
-  -topics neuclir22-en.splade.original-desc.txt.gz \
+  -topics neuclir22-en.splade.original-desc \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-fa-en-splade \
-  -topics neuclir22-en.splade.original-desc_title.txt.gz \
+  -topics neuclir22-en.splade.original-desc_title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt \
   -impact -pretokenized &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-fa-en-splade \
-  -topics neuclir22-en.splade.original-title.txt.gz \
+  -topics neuclir22-en.splade.original-title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-fa-en-splade \
-  -topics neuclir22-en.splade.original-desc.txt.gz \
+  -topics neuclir22-en.splade.original-desc \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-fa-en-splade \
-  -topics neuclir22-en.splade.original-desc_title.txt.gz \
+  -topics neuclir22-en.splade.original-desc_title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-fa-en-splade \
-  -topics neuclir22-en.splade.original-title.txt.gz \
+  -topics neuclir22-en.splade.original-title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-fa-en-splade \
-  -topics neuclir22-en.splade.original-desc.txt.gz \
+  -topics neuclir22-en.splade.original-desc \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-fa-en-splade \
-  -topics neuclir22-en.splade.original-desc_title.txt.gz \
+  -topics neuclir22-en.splade.original-desc_title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt
 
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt
 
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m map neuclir22-fa runs/run.lucene-inverted.neuclir22-fa-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/neuclir22-ru-dt-splade.md
+++ b/docs/reproduce/from-document-collection/neuclir22-ru-dt-splade.md
@@ -59,103 +59,103 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-ru-en-splade \
-  -topics neuclir22-en.splade.original-title.txt.gz \
+  -topics neuclir22-en.splade.original-title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-ru-en-splade \
-  -topics neuclir22-en.splade.original-desc.txt.gz \
+  -topics neuclir22-en.splade.original-desc \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-ru-en-splade \
-  -topics neuclir22-en.splade.original-desc_title.txt.gz \
+  -topics neuclir22-en.splade.original-desc_title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt \
   -impact -pretokenized &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-ru-en-splade \
-  -topics neuclir22-en.splade.original-title.txt.gz \
+  -topics neuclir22-en.splade.original-title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-ru-en-splade \
-  -topics neuclir22-en.splade.original-desc.txt.gz \
+  -topics neuclir22-en.splade.original-desc \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-ru-en-splade \
-  -topics neuclir22-en.splade.original-desc_title.txt.gz \
+  -topics neuclir22-en.splade.original-desc_title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-ru-en-splade \
-  -topics neuclir22-en.splade.original-title.txt.gz \
+  -topics neuclir22-en.splade.original-title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-ru-en-splade \
-  -topics neuclir22-en.splade.original-desc.txt.gz \
+  -topics neuclir22-en.splade.original-desc \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-ru-en-splade \
-  -topics neuclir22-en.splade.original-desc_title.txt.gz \
+  -topics neuclir22-en.splade.original-desc_title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt
 
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt
 
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m map neuclir22-ru runs/run.lucene-inverted.neuclir22-ru-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt
 ```
 
 ## Effectiveness

--- a/docs/reproduce/from-document-collection/neuclir22-zh-dt-splade.md
+++ b/docs/reproduce/from-document-collection/neuclir22-zh-dt-splade.md
@@ -59,103 +59,103 @@ After indexing has completed, you should be able to perform retrieval as follows
 ```bash
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-zh-en-splade \
-  -topics neuclir22-en.splade.original-title.txt.gz \
+  -topics neuclir22-en.splade.original-title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-zh-en-splade \
-  -topics neuclir22-en.splade.original-desc.txt.gz \
+  -topics neuclir22-en.splade.original-desc \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt \
   -impact -pretokenized &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-zh-en-splade \
-  -topics neuclir22-en.splade.original-desc_title.txt.gz \
+  -topics neuclir22-en.splade.original-desc_title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt \
   -impact -pretokenized &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-zh-en-splade \
-  -topics neuclir22-en.splade.original-title.txt.gz \
+  -topics neuclir22-en.splade.original-title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-zh-en-splade \
-  -topics neuclir22-en.splade.original-desc.txt.gz \
+  -topics neuclir22-en.splade.original-desc \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-zh-en-splade \
-  -topics neuclir22-en.splade.original-desc_title.txt.gz \
+  -topics neuclir22-en.splade.original-desc_title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt \
   -impact -pretokenized -rm3 -collection JsonVectorCollection &
 
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-zh-en-splade \
-  -topics neuclir22-en.splade.original-title.txt.gz \
+  -topics neuclir22-en.splade.original-title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-zh-en-splade \
-  -topics neuclir22-en.splade.original-desc.txt.gz \
+  -topics neuclir22-en.splade.original-desc \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 bin/run.sh io.anserini.search.SearchCollection \
   -index indexes/lucene-inverted.neuclir22-zh-en-splade \
-  -topics neuclir22-en.splade.original-desc_title.txt.gz \
+  -topics neuclir22-en.splade.original-desc_title \
   -topicReader TsvInt \
-  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt \
+  -output runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt \
   -impact -pretokenized -rocchio -collection JsonVectorCollection &
 ```
 
 Evaluation can be performed using `trec_eval`:
 
 ```bash
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade.topics-neuclir22-en.splade.original-desc_title.txt
 
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rm3.topics-neuclir22-en.splade.original-desc_title.txt
 
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt.gz.txt
-bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
-bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt.gz.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-title.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc.txt
+bin/trec_eval -c -m ndcg_cut.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt
+python -m pyserini.eval.trec_eval -c -m judged.20 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m recall.1000 neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt
+bin/trec_eval -c -m map neuclir22-zh runs/run.lucene-inverted.neuclir22-zh-en-splade.model-splade+rocchio.topics-neuclir22-en.splade.original-desc_title.txt
 ```
 
 ## Effectiveness

--- a/src/main/java/io/anserini/eval/Qrels.java
+++ b/src/main/java/io/anserini/eval/Qrels.java
@@ -37,7 +37,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.anserini.util.CacheDirectoryResolver;
 
 public class Qrels {
-  private static final String COMMIT_ID = "9b1c80887bbda7998021e78f3c36f1ee707fb0bb";
+  private static final String COMMIT_ID = "895a3da315cfa2d038f96bf945a440b8eb78c748";
   public static final String URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/qrels/";
 
   private static final String QRELS_URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/qrels.json";

--- a/src/main/java/io/anserini/eval/Qrels.java
+++ b/src/main/java/io/anserini/eval/Qrels.java
@@ -37,7 +37,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.anserini.util.CacheDirectoryResolver;
 
 public class Qrels {
-  private static final String COMMIT_ID = "895a3da315cfa2d038f96bf945a440b8eb78c748";
+  private static final String COMMIT_ID = "5b819c1a45c8a0a3ec9426f476694f44a29dfaf3";
   public static final String URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/qrels/";
 
   private static final String QRELS_URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/qrels.json";

--- a/src/main/java/io/anserini/reproduce/ReproduceFromDocumentCollection.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromDocumentCollection.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -63,6 +64,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
+import io.anserini.eval.Qrels;
 import io.anserini.eval.TrecEval;
 import io.anserini.index.IndexCollection;
 import io.anserini.index.IndexFlatDenseVectors;
@@ -102,6 +104,8 @@ public class ReproduceFromDocumentCollection {
   private static final String SEARCH_FLAT_DENSE_COMMAND = "bin/run.sh io.anserini.search.SearchFlatDenseVectors";
   private static final String SEARCH_HNSW_DENSE_COMMAND = "bin/run.sh io.anserini.search.SearchHnswDenseVectors";
   private static final String SEARCH_INVERTED_DENSE_COMMAND = "bin/run.sh io.anserini.search.SearchInvertedDenseVectors";
+  private static final String GDEVAL_COMMAND = "bin/gdeval.pl";
+  private static final String GDEVAL_URL = "https://raw.githubusercontent.com/castorini/eval/d9a27f26089a6019cef1788bdc16f77d8ec0a474/eval/gdeval.pl";
 
   private static final Map<String, MainInvoker> MAIN_DISPATCH = Map.of(
       "io.anserini.index.IndexCollection", IndexCollection::main,
@@ -533,9 +537,6 @@ public class ReproduceFromDocumentCollection {
           int parseIndex = metric.get("parse_index").asInt();
           int precision = metric.get("metric_precision").asInt();
           String qrels = textOrNull(topic.get("qrels"));
-          if (qrels == null) {
-            qrels = textOrNull(topic.get("qrel"));
-          }
 
           String outputPath = constructRunfilePath(yaml, model, topic);
           JsonNode conversions = yaml.get("conversions");
@@ -547,13 +548,7 @@ public class ReproduceFromDocumentCollection {
             }
           }
 
-          StringBuilder evalCmd = new StringBuilder();
-          evalCmd.append(command);
-          if (params != null && !params.isBlank()) {
-            evalCmd.append(" ").append(params.trim());
-          }
-          evalCmd.append(" ").append(qrels);
-          evalCmd.append(" ").append(outputPath);
+          String evalCmd = constructEvaluationCommand(command, params, qrels, outputPath);
 
           if (args.dryRun) {
             LOG.info(evalCmd);
@@ -634,11 +629,28 @@ public class ReproduceFromDocumentCollection {
     }
   }
 
+  static String constructEvaluationCommand(String command, String params, String qrels, String outputPath) {
+    StringBuilder evalCmd = new StringBuilder(command);
+    if (params != null && !params.isBlank()) {
+      evalCmd.append(" ").append(params.trim());
+    }
+    if (qrels != null && !qrels.isBlank()) {
+      evalCmd.append(" ").append(qrels);
+    }
+    evalCmd.append(" ").append(outputPath);
+    return evalCmd.toString();
+  }
+
   private static String runCommandAndReturnOutput(String command) throws IOException, InterruptedException {
     if (command.contains("trec_eval") && !command.contains("pyserini")) {
       return runTrecEvalCommandAndReturnOutput(command);
     } else if (command.contains("io.anserini.index.IndexReaderUtils")) {
       return runIndexReaderUtilsCommandAndReturnOutput(command);
+    }
+
+    if (command.startsWith(GDEVAL_COMMAND + " ")) {
+      ensureGdevalAvailable(Paths.get(GDEVAL_COMMAND), URI.create(GDEVAL_URL));
+      command = resolveGdevalQrelsArgument(command);
     }
 
     ProcessBuilder pb = new ProcessBuilder("bash", "-lc", command);
@@ -653,6 +665,48 @@ public class ReproduceFromDocumentCollection {
       throw new RuntimeException("Command failed: " + command);
     }
     return buffer.toString(StandardCharsets.UTF_8);
+  }
+
+  static String resolveGdevalQrelsArgument(String command) throws IOException {
+    String[] args = command.trim().split("\\s+");
+    if (args.length < 3) {
+      throw new IllegalArgumentException("Invalid gdeval command: " + command);
+    }
+    args[args.length - 2] = Qrels.resolveQrelsPath(args[args.length - 2]).toString();
+    return String.join(" ", args);
+  }
+
+  static synchronized void ensureGdevalAvailable(Path destination, URI source) throws IOException {
+    if (Files.exists(destination)) {
+      return;
+    }
+
+    Files.createDirectories(destination.getParent());
+    Path temporary = Files.createTempFile(destination.getParent(), "gdeval-", ".tmp");
+    try {
+      LOG.info("Downloading {} to {}...", source, destination);
+      HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
+      HttpRequest request = HttpRequest.newBuilder(source).GET().build();
+      HttpResponse<Path> response;
+      try {
+        response = client.send(request, HttpResponse.BodyHandlers.ofFile(temporary));
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException("Interrupted while downloading " + source, e);
+      }
+
+      int status = response.statusCode();
+      if (status < 200 || status >= 300) {
+        throw new IOException("Failed to download " + source + " (HTTP " + status + ")");
+      }
+
+      Files.move(temporary, destination, StandardCopyOption.ATOMIC_MOVE);
+      if (!destination.toFile().setExecutable(true, false)) {
+        throw new IOException("Failed to make " + destination + " executable");
+      }
+    } finally {
+      Files.deleteIfExists(temporary);
+    }
   }
 
   private static String runIndexReaderUtilsCommandAndReturnOutput(String command) throws IOException {

--- a/src/main/java/io/anserini/search/topicreader/Topics.java
+++ b/src/main/java/io/anserini/search/topicreader/Topics.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * A registry entry for a standard set of topics from various evaluations.
  */
 public final class Topics {
-  private static final String COMMIT_ID = "5eeb3d60f50beb409abc1b564b39d627fab64f5f";
+  private static final String COMMIT_ID = "895a3da315cfa2d038f96bf945a440b8eb78c748";
   public static final String URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/topics/";
 
   private static final String TOPICS_URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/topics.json";

--- a/src/main/java/io/anserini/search/topicreader/Topics.java
+++ b/src/main/java/io/anserini/search/topicreader/Topics.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * A registry entry for a standard set of topics from various evaluations.
  */
 public final class Topics {
-  private static final String COMMIT_ID = "d9a27f26089a6019cef1788bdc16f77d8ec0a474";
+  private static final String COMMIT_ID = "5eeb3d60f50beb409abc1b564b39d627fab64f5f";
   public static final String URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/topics/";
 
   private static final String TOPICS_URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/topics.json";

--- a/src/main/java/io/anserini/search/topicreader/Topics.java
+++ b/src/main/java/io/anserini/search/topicreader/Topics.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * A registry entry for a standard set of topics from various evaluations.
  */
 public final class Topics {
-  private static final String COMMIT_ID = "895a3da315cfa2d038f96bf945a440b8eb78c748";
+  private static final String COMMIT_ID = "5b819c1a45c8a0a3ec9426f476694f44a29dfaf3";
   public static final String URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/topics/";
 
   private static final String TOPICS_URL = "https://raw.githubusercontent.com/castorini/eval/" + COMMIT_ID + "/topics.json";

--- a/src/main/resources/fine_tuning/collections.yaml
+++ b/src/main/resources/fine_tuning/collections.yaml
@@ -26,7 +26,7 @@ collections:
           metric: p20
           metric_precision: 4
           can_combine: true
-        - command: tools/eval/gdeval.pl
+        - command: bin/gdeval.pl
           params: ""
           separator: ","
           parse_index: -2
@@ -53,7 +53,7 @@ collections:
           metric: p20
           metric_precision: 4
           can_combine: true
-        - command: tools/eval/gdeval.pl
+        - command: bin/gdeval.pl
           params: ""
           separator: ","
           parse_index: -2

--- a/src/main/resources/reproduce/from-document-collection/configs/cw09b.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/cw09b.yaml
@@ -28,12 +28,12 @@ metrics:
     metric_precision: 4
     can_combine: true
   - metric: nDCG@20
-    command: tools/eval/gdeval.pl
+    command: bin/gdeval.pl
     separator: ","
     parse_index: 2
     metric_precision: 4
   - metric: ERR@20
-    command: tools/eval/gdeval.pl
+    command: bin/gdeval.pl
     separator: ","
     parse_index: 3
     metric_precision: 4

--- a/src/main/resources/reproduce/from-document-collection/configs/cw12.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/cw12.yaml
@@ -28,12 +28,12 @@ metrics:
     metric_precision: 4
     can_combine: true
   - metric: nDCG@20
-    command: tools/eval/gdeval.pl
+    command: bin/gdeval.pl
     separator: ","
     parse_index: 2
     metric_precision: 4
   - metric: ERR@20
-    command: tools/eval/gdeval.pl
+    command: bin/gdeval.pl
     separator: ","
     parse_index: 3
     metric_precision: 4

--- a/src/main/resources/reproduce/from-document-collection/configs/cw12b13.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/cw12b13.yaml
@@ -28,12 +28,12 @@ metrics:
     metric_precision: 4
     can_combine: true
   - metric: nDCG@20
-    command: tools/eval/gdeval.pl
+    command: bin/gdeval.pl
     separator: ","
     parse_index: 2
     metric_precision: 4
   - metric: ERR@20
-    command: tools/eval/gdeval.pl
+    command: bin/gdeval.pl
     separator: ","
     parse_index: 3
     metric_precision: 4

--- a/src/main/resources/reproduce/from-document-collection/configs/nanoknow-v1.0-nq.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/nanoknow-v1.0-nq.yaml
@@ -24,7 +24,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[NanoKnow v1.0: NQ-Open Validation](https://github.com/castorini/NanoKnow)"
-    id: nanoknow-v1.0-nq.supported.tsv
+    id: nanoknow-v1.0-nq.supported
     qrels: nanoknow-v1.0-nq.supported
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/nanoknow-v1.0-squad.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/nanoknow-v1.0-squad.yaml
@@ -24,7 +24,7 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[NanoKnow v1.0: SQuAD Validation](https://github.com/castorini/NanoKnow)"
-    id: nanoknow-v1.0-squad.supported.tsv
+    id: nanoknow-v1.0-squad.supported
     qrels: nanoknow-v1.0-squad.supported
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/neuclir22-fa-dt-splade.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/neuclir22-fa-dt-splade.yaml
@@ -44,13 +44,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[NeuCLIR 2022 (Persian): title (original English queries)](https://neuclir.github.io/)"
-    id: neuclir22-en.splade.original-title.txt.gz
+    id: neuclir22-en.splade.original-title
     qrels: neuclir22-fa
   - name: "[NeuCLIR 2022 (Persian): desc (original English queries)](https://neuclir.github.io/)"
-    id: neuclir22-en.splade.original-desc.txt.gz
+    id: neuclir22-en.splade.original-desc
     qrels: neuclir22-fa
   - name: "[NeuCLIR 2022 (Persian): desc+title (original English queries)](https://neuclir.github.io/)"
-    id: neuclir22-en.splade.original-desc_title.txt.gz
+    id: neuclir22-en.splade.original-desc_title
     qrels: neuclir22-fa
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/neuclir22-ru-dt-splade.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/neuclir22-ru-dt-splade.yaml
@@ -44,13 +44,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[NeuCLIR 2022 (Russian): title (original English queries)](https://neuclir.github.io/)"
-    id: neuclir22-en.splade.original-title.txt.gz
+    id: neuclir22-en.splade.original-title
     qrels: neuclir22-ru
   - name: "[NeuCLIR 2022 (Russian): desc (original English queries)](https://neuclir.github.io/)"
-    id: neuclir22-en.splade.original-desc.txt.gz
+    id: neuclir22-en.splade.original-desc
     qrels: neuclir22-ru
   - name: "[NeuCLIR 2022 (Russian): desc+title (original English queries)](https://neuclir.github.io/)"
-    id: neuclir22-en.splade.original-desc_title.txt.gz
+    id: neuclir22-en.splade.original-desc_title
     qrels: neuclir22-ru
 
 models:

--- a/src/main/resources/reproduce/from-document-collection/configs/neuclir22-zh-dt-splade.yaml
+++ b/src/main/resources/reproduce/from-document-collection/configs/neuclir22-zh-dt-splade.yaml
@@ -44,13 +44,13 @@ metrics:
 topic_reader: TsvInt
 topics:
   - name: "[NeuCLIR 2022 (Chinese): title (original English queries)](https://neuclir.github.io/)"
-    id: neuclir22-en.splade.original-title.txt.gz
+    id: neuclir22-en.splade.original-title
     qrels: neuclir22-zh
   - name: "[NeuCLIR 2022 (Chinese): desc (original English queries)](https://neuclir.github.io/)"
-    id: neuclir22-en.splade.original-desc.txt.gz
+    id: neuclir22-en.splade.original-desc
     qrels: neuclir22-zh
   - name: "[NeuCLIR 2022 (Chinese): desc+title (original English queries)](https://neuclir.github.io/)"
-    id: neuclir22-en.splade.original-desc_title.txt.gz
+    id: neuclir22-en.splade.original-desc_title
     qrels: neuclir22-zh
 
 models:

--- a/src/test/java/io/anserini/eval/QrelsTest.java
+++ b/src/test/java/io/anserini/eval/QrelsTest.java
@@ -41,7 +41,7 @@ public class QrelsTest{
 
   @Test
   public void testTotalCount() {
-    assertEquals(250, Qrels.names().size());
+    assertEquals(254, Qrels.names().size());
     assertFalse(Qrels.names().contains("this-qrels-name-does-not-exist"));
   }
 
@@ -174,6 +174,66 @@ public class QrelsTest{
     assertEquals(0, qrels.getRelevanceGrade("xxx", "CACM-1410"));  // non-existent topic
     assertTrue(qrels.isDocJudged("1", "CACM-1410"));
     assertNull(qrels.getDocMap("xxx"));
+  }
+
+  @Test
+  public void testFeverDev() throws IOException {
+    Qrels qrels = Qrels.get("fever.dev");
+    assertNotNull(qrels);
+    assertEquals(6666, qrels.getQids().size());
+    assertEquals(8079, getQrelsCount(qrels));
+    assertEquals(2, qrels.getRelevanceGrade("137334", "Soul_Food_-LRB-film-RRB-"));
+  }
+
+  @Test
+  public void testNanoKnowNqSupported() throws IOException {
+    Qrels qrels = Qrels.get("nanoknow-v1.0-nq.supported");
+    assertNotNull(qrels);
+    assertEquals(2389, qrels.getQids().size());
+    assertEquals(56958, getQrelsCount(qrels));
+    assertEquals(1, qrels.getRelevanceGrade("0", "shard_01177_50695"));
+  }
+
+  @Test
+  public void testNanoKnowSquadSupported() throws IOException {
+    Qrels qrels = Qrels.get("nanoknow-v1.0-squad.supported");
+    assertNotNull(qrels);
+    assertEquals(7490, qrels.getQids().size());
+    assertEquals(151675, getQrelsCount(qrels));
+    assertEquals(1, qrels.getRelevanceGrade("0", "shard_01394_6521"));
+  }
+
+  @Test
+  public void testWeb51To100() throws IOException {
+    assertWebQrels("web.51-100", 48, 25329, "51", "clueweb09-en0001-01-17957", 1);
+  }
+
+  @Test
+  public void testWeb101To150() throws IOException {
+    assertWebQrels("web.101-150", 50, 19381, "101", "clueweb09-en0076-79-19134", 2);
+  }
+
+  @Test
+  public void testWeb151To200() throws IOException {
+    assertWebQrels("web.151-200", 50, 16055, "151", "clueweb09-en0000-00-17600", 1);
+  }
+
+  @Test
+  public void testWeb201To250() throws IOException {
+    assertWebQrels("web.201-250", 50, 14474, "201", "clueweb12-0000tw-05-12114", 1);
+  }
+
+  @Test
+  public void testWeb251To300() throws IOException {
+    assertWebQrels("web.251-300", 50, 14432, "251", "clueweb12-0000tw-34-04382", 1);
+  }
+
+  private void assertWebQrels(String name, int qids, int judgments, String qid, String docid, int grade) throws IOException {
+    Qrels qrels = Qrels.get(name);
+    assertNotNull(qrels);
+    assertEquals(qids, qrels.getQids().size());
+    assertEquals(judgments, getQrelsCount(qrels));
+    assertEquals(grade, qrels.getRelevanceGrade(qid, docid));
   }
 
   @Test

--- a/src/test/java/io/anserini/reproduce/ReproduceFromDocumentCollectionTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromDocumentCollectionTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -136,8 +137,7 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
     ReproduceFromDocumentCollection.main(new String[] {"--list"});
 
     List<?> outputConfigs = new ObjectMapper().readValue(out.toString(), List.class);
-    List<String> expectedConfigs = ReproductionUtils.listYamlConfigs(
-        ReproduceFromDocumentCollection.class, "reproduce/from-document-collection/configs");
+    List<String> expectedConfigs = ReproductionUtils.listYamlConfigs(ReproduceFromDocumentCollection.class, "reproduce/from-document-collection/configs");
     assertEquals(expectedConfigs.size(), outputConfigs.size());
   }
 
@@ -155,8 +155,7 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
   public void testWorkflowStageRequired() throws Exception {
     ReproduceFromDocumentCollection.main(new String[] {"--config", "cacm", "--dry-run"});
 
-    assertTrue(err.toString().contains(
-        "Error: Select at least one workflow stage: --download, --index, --verify, --search."));
+    assertTrue(err.toString().contains("Error: Select at least one workflow stage: --download, --index, --verify, --search."));
     assertTrue(err.toString().contains("Options for ReproduceFromDocumentCollection:"));
   }
 
@@ -166,6 +165,38 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
     assertNotNull(topics);
 
     ReproduceFromDocumentCollection.main(new String[] {"--config", "cacm", "--index", "--search", "--dry-run"});
+  }
+
+  @Test
+  public void testEvaluationCommandWithoutQrels() {
+    String command = ReproduceFromDocumentCollection.constructEvaluationCommand(
+        "python -m pyserini.eval.evaluate_dpr_retrieval",
+        "--topk 20 --retrieval",
+        null,
+        "runs/run.lucene-inverted.wikipedia-dpr-100w.model-bm25.topics-dpr.nq.test.txt.json");
+
+    assertEquals("python -m pyserini.eval.evaluate_dpr_retrieval --topk 20 --retrieval runs/run.lucene-inverted.wikipedia-dpr-100w.model-bm25.topics-dpr.nq.test.txt.json", command);
+  }
+
+  @Test
+  public void testExistingGdevalIsNotDownloadedAgain() throws Exception {
+    Path gdeval = createTempDir("gdeval").resolve("bin/gdeval.pl");
+    Files.createDirectories(gdeval.getParent());
+    Files.writeString(gdeval, "existing");
+
+    ReproduceFromDocumentCollection.ensureGdevalAvailable(gdeval, URI.create("https://invalid.example/gdeval.pl"));
+
+    assertEquals("existing", Files.readString(gdeval));
+  }
+
+  @Test
+  public void testGdevalQrelsPathResolution() throws Exception {
+    Path qrels = createTempFile("qrels", ".txt");
+    String run = "runs/run.lucene-inverted.cw09b.model-bm25.topics-web.51-100.txt";
+
+    String command = ReproduceFromDocumentCollection.resolveGdevalQrelsArgument("bin/gdeval.pl " + qrels + " " + run);
+
+    assertEquals("bin/gdeval.pl " + qrels + " " + run, command);
   }
 
   @Test
@@ -213,8 +244,7 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
 
       ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
       ReproduceFromDocumentCollection.Args args = new ReproduceFromDocumentCollection.Args();
-      Method resolveCorpusPath = ReproduceFromDocumentCollection.class.getDeclaredMethod(
-          "resolveCorpusPath", com.fasterxml.jackson.databind.JsonNode.class, ReproduceFromDocumentCollection.Args.class);
+      Method resolveCorpusPath = ReproduceFromDocumentCollection.class.getDeclaredMethod("resolveCorpusPath", com.fasterxml.jackson.databind.JsonNode.class, ReproduceFromDocumentCollection.Args.class);
       resolveCorpusPath.setAccessible(true);
 
       String resolved = (String) resolveCorpusPath.invoke(null, mapper.readTree("""

--- a/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
@@ -43,7 +43,7 @@ public class TopicReaderTest {
       String path = topic.path;
       assertEquals(topic.readerClass, Topics.getTopicReaderClassForPath(path));
     }
-    assertEquals(472, cnt);
+    assertEquals(476, cnt);
   }
 
   @Test

--- a/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
@@ -125,6 +125,33 @@ public class TopicReaderTest {
   }
 
   @Test
+  public void testFeverDevTopics() throws IOException {
+    SortedMap<Integer, Map<String, String>> topics = TopicReader.load(Topics.get("fever.dev"));
+    assertNotNull(topics);
+    assertEquals(9999, topics.size());
+    assertEquals("Colin Kaepernick became a starting quarterback during the 49ers 63rd season in the National Football League.", topics.get(91198).get("title"));
+    assertEquals("Shinji Mikami reviewed Resident Evil.", topics.get(75591).get("title"));
+  }
+
+  @Test
+  public void testNanoKnowNqSupportedTopics() throws IOException {
+    SortedMap<Integer, Map<String, String>> topics = TopicReader.load(Topics.get("nanoknow-v1.0-nq.supported"));
+    assertNotNull(topics);
+    assertEquals(2389, topics.size());
+    assertEquals("when was the last time anyone was on the moon", topics.get(0).get("title"));
+    assertEquals("what is the meaning of the name comanche", topics.get(3609).get("title"));
+  }
+
+  @Test
+  public void testNanoKnowSquadSupportedTopics() throws IOException {
+    SortedMap<Integer, Map<String, String>> topics = TopicReader.load(Topics.get("nanoknow-v1.0-squad.supported"));
+    assertNotNull(topics);
+    assertEquals(7490, topics.size());
+    assertEquals("Which NFL team represented the AFC at Super Bowl 50?", topics.get(0).get("title"));
+    assertEquals("What seldom used term of a unit of force equal to 1000 pound s of force?", topics.get(10568).get("title"));
+  }
+
+  @Test
   public void testLoadTopicsByPath() throws IOException {
     SortedMap<Integer, Map<String, String>> topics;
 
@@ -568,18 +595,14 @@ public class TopicReaderTest {
     topics = TopicReader.getTopicsWithStringIds(Topics.get("car17v1.5.benchmarkY1test"));
     assertNotNull(topics);
     assertEquals(2125, topics.size());
-    assertEquals("Aftertaste/Aftertaste processing in the cerebral cortex",
-        topics.get("Aftertaste/Aftertaste%20processing%20in%20the%20cerebral%20cortex").get("title"));
-    assertEquals("Yellowstone National Park/Recreation",
-        topics.get("Yellowstone%20National%20Park/Recreation").get("title"));
+    assertEquals("Aftertaste/Aftertaste processing in the cerebral cortex", topics.get("Aftertaste/Aftertaste%20processing%20in%20the%20cerebral%20cortex").get("title"));
+    assertEquals("Yellowstone National Park/Recreation", topics.get("Yellowstone%20National%20Park/Recreation").get("title"));
 
     topics = TopicReader.getTopicsWithStringIds(Topics.get("car17v2.0.benchmarkY1test"));
     assertNotNull(topics);
     assertEquals(2254, topics.size());
-    assertEquals("Aftertaste",
-        topics.get("enwiki:Aftertaste").get("title"));
-    assertEquals("Yellowstone National Park/Recreation",
-        topics.get("enwiki:Yellowstone%20National%20Park/Recreation").get("title"));  }
+    assertEquals("Aftertaste", topics.get("enwiki:Aftertaste").get("title"));
+    assertEquals("Yellowstone National Park/Recreation", topics.get("enwiki:Yellowstone%20National%20Park/Recreation").get("title"));  }
 
   @Test
   public void testDprNq() throws IOException {
@@ -1279,37 +1302,27 @@ public class TopicReaderTest {
     // Round 1
     topics = TopicReader.load(Topics.get("covid-round1-udel"));
     assertEquals(30, topics.keySet().size());
-
-    assertEquals("coronavirus remdesivir remdesivir effective treatment COVID-19",
-        topics.get(30).get("query"));
+    assertEquals("coronavirus remdesivir remdesivir effective treatment COVID-19", topics.get(30).get("query"));
 
     // Round 2
     topics = TopicReader.load(Topics.get("covid-round2-udel"));
     assertEquals(35, topics.keySet().size());
-
-    assertEquals("coronavirus public datasets public datasets COVID-19",
-        topics.get(35).get("query"));
+    assertEquals("coronavirus public datasets public datasets COVID-19", topics.get(35).get("query"));
 
     // Round 3
     topics = TopicReader.load(Topics.get("covid-round3-udel"));
     assertEquals(40, topics.keySet().size());
-
-    assertEquals("coronavirus mutations observed mutations SARS-CoV-2 genome mutations",
-        topics.get(40).get("query"));
+    assertEquals("coronavirus mutations observed mutations SARS-CoV-2 genome mutations", topics.get(40).get("query"));
 
     // Round 4
     topics = TopicReader.load(Topics.get("covid-round4-udel"));
     assertEquals(45, topics.keySet().size());
-
-    assertEquals("coronavirus mental health impact COVID-19 pandemic impacted mental health",
-        topics.get(45).get("query"));
+    assertEquals("coronavirus mental health impact COVID-19 pandemic impacted mental health", topics.get(45).get("query"));
 
     // Round 5
     topics = TopicReader.load(Topics.get("covid-round5-udel"));
     assertEquals(50, topics.keySet().size());
-
-    assertEquals("mRNA vaccine coronavirus mRNA vaccine SARS-CoV-2 virus",
-            topics.get(50).get("query"));
+    assertEquals("mRNA vaccine coronavirus mRNA vaccine SARS-CoV-2 virus", topics.get(50).get("query"));
   }
 
   @Test
@@ -1318,43 +1331,34 @@ public class TopicReaderTest {
 
     // Round 1
     topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round1"));
-
     assertEquals(30, topics.keySet().size());
 
     assertEquals("coronavirus origin", topics.get("1").get("query"));
     assertEquals("what is the origin of COVID-19", topics.get("1").get("question"));
-    assertEquals("seeking range of information about the SARS-CoV-2 virus's origin, " +
-            "including its evolution, animal source, and first transmission into humans",
-        topics.get("1").get("narrative"));
+    assertEquals("seeking range of information about the SARS-CoV-2 virus's origin, including its evolution, animal source, and first transmission into humans", topics.get("1").get("narrative"));
 
     assertEquals("coronavirus remdesivir", topics.get("30").get("query"));
     assertEquals("is remdesivir an effective treatment for COVID-19", topics.get("30").get("question"));
-    assertEquals(
-        "seeking specific information on clinical outcomes in COVID-19 patients treated with remdesivir",
-        topics.get("30").get("narrative"));
+    assertEquals("seeking specific information on clinical outcomes in COVID-19 patients treated with remdesivir", topics.get("30").get("narrative"));
 
     // Round 2
     topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round2"));
     assertEquals(35, topics.keySet().size());
-
     assertEquals("coronavirus public datasets", topics.get("35").get("query"));
 
     // Round 3
     topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round3"));
     assertEquals(40, topics.keySet().size());
-
     assertEquals("coronavirus mutations", topics.get("40").get("query"));
 
     // Round 4
     topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round4"));
     assertEquals(45, topics.keySet().size());
-
     assertEquals("coronavirus mental health impact", topics.get("45").get("query"));
 
     // Round 5
     topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round5"));
     assertEquals(50, topics.keySet().size());
-
     assertEquals("mRNA vaccine coronavirus", topics.get("50").get("query"));
   }
 
@@ -1365,37 +1369,27 @@ public class TopicReaderTest {
     // Round 1
     topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round1-udel"));
     assertEquals(30, topics.keySet().size());
-
-    assertEquals("coronavirus remdesivir remdesivir effective treatment COVID-19",
-        topics.get("30").get("query"));
+    assertEquals("coronavirus remdesivir remdesivir effective treatment COVID-19", topics.get("30").get("query"));
 
     // Round 2
     topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round2-udel"));
     assertEquals(35, topics.keySet().size());
-
-    assertEquals("coronavirus public datasets public datasets COVID-19",
-        topics.get("35").get("query"));
+    assertEquals("coronavirus public datasets public datasets COVID-19", topics.get("35").get("query"));
 
     // Round 3
     topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round3-udel"));
     assertEquals(40, topics.keySet().size());
-
-    assertEquals("coronavirus mutations observed mutations SARS-CoV-2 genome mutations",
-        topics.get("40").get("query"));
+    assertEquals("coronavirus mutations observed mutations SARS-CoV-2 genome mutations", topics.get("40").get("query"));
 
     // Round 4
     topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round4-udel"));
     assertEquals(45, topics.keySet().size());
-
-    assertEquals("coronavirus mental health impact COVID-19 pandemic impacted mental health",
-        topics.get("45").get("query"));
+    assertEquals("coronavirus mental health impact COVID-19 pandemic impacted mental health", topics.get("45").get("query"));
 
     // Round 5
     topics = TopicReader.getTopicsWithStringIds(Topics.get("covid-round5-udel"));
     assertEquals(50, topics.keySet().size());
-
-    assertEquals("mRNA vaccine coronavirus mRNA vaccine SARS-CoV-2 virus",
-            topics.get("50").get("query"));
+    assertEquals("mRNA vaccine coronavirus mRNA vaccine SARS-CoV-2 virus", topics.get("50").get("query"));
   }
 
   @Test
@@ -1407,45 +1401,33 @@ public class TopicReaderTest {
     assertEquals(50, topics.keySet().size());
     assertEquals(321, (int) topics.firstKey());
     assertEquals("9171debc316e5e2782e0d2404ca7d09d", topics.get(topics.firstKey()).get("title"));
-    assertEquals("https://www.washingtonpost.com/news/worldviews/wp/2016/09/01/" +
-        "women-are-half-of-the-world-but-only-22-percent-of-its-parliaments/",
-        topics.get(topics.firstKey()).get("url"));
+    assertEquals("https://www.washingtonpost.com/news/worldviews/wp/2016/09/01/women-are-half-of-the-world-but-only-22-percent-of-its-parliaments/", topics.get(topics.firstKey()).get("url"));
 
     assertEquals(825, (int) topics.lastKey());
     assertEquals("a1c41a70-35c7-11e3-8a0e-4e2cf80831fc", topics.get(topics.lastKey()).get("title"));
-    assertEquals("https://www.washingtonpost.com/business/economy/" +
-        "cellulosic-ethanol-once-the-way-of-the-future-is-off-to-a-delayed-boisterous-start/" +
-        "2013/11/08/a1c41a70-35c7-11e3-8a0e-4e2cf80831fc_story.html", topics.get(topics.lastKey()).get("url"));
+    assertEquals("https://www.washingtonpost.com/business/economy/cellulosic-ethanol-once-the-way-of-the-future-is-off-to-a-delayed-boisterous-start/2013/11/08/a1c41a70-35c7-11e3-8a0e-4e2cf80831fc_story.html", topics.get(topics.lastKey()).get("url"));
 
     topics = TopicReader.load(Topics.get("backgroundlinking19"));
     
     assertEquals(60, topics.keySet().size());
     assertEquals(826, (int) topics.firstKey());
     assertEquals("96ab542e-6a07-11e6-ba32-5a4bf5aad4fa", topics.get(topics.firstKey()).get("title"));
-    assertEquals("https://www.washingtonpost.com/sports/nationals/" +
-        "the-minor-leagues-life-in-pro-baseballs-shadowy-corner/" +
-        "2016/08/26/96ab542e-6a07-11e6-ba32-5a4bf5aad4fa_story.html", topics.get(topics.firstKey()).get("url"));
+    assertEquals("https://www.washingtonpost.com/sports/nationals/the-minor-leagues-life-in-pro-baseballs-shadowy-corner/2016/08/26/96ab542e-6a07-11e6-ba32-5a4bf5aad4fa_story.html", topics.get(topics.firstKey()).get("url"));
 
     assertEquals(885, (int) topics.lastKey());
     assertEquals("5ae44bfd66a49bcad7b55b29b55d63b6", topics.get(topics.lastKey()).get("title"));
-    assertEquals("https://www.washingtonpost.com/news/capital-weather-gang/wp/2017/07/14/" +
-        "sun-erupts-to-mark-another-bastille-day-aurora-possible-in-new-england-sunday-night/",
-        topics.get(topics.lastKey()).get("url"));
+    assertEquals("https://www.washingtonpost.com/news/capital-weather-gang/wp/2017/07/14/sun-erupts-to-mark-another-bastille-day-aurora-possible-in-new-england-sunday-night/", topics.get(topics.lastKey()).get("url"));
 
     topics = TopicReader.load(Topics.get("backgroundlinking20"));
 
     assertEquals(50, topics.keySet().size());
     assertEquals(886, (int) topics.firstKey());
     assertEquals("AEQZNZSVT5BGPPUTTJO7SNMOLE", topics.get(topics.firstKey()).get("title"));
-    assertEquals("https://www.washingtonpost.com/politics/2019/06/05/" +
-        "trump-says-transgender-troops-cant-serve-because-troops-cant-take-any-drugs-hes-wrong-many-ways/",
-        topics.get(topics.firstKey()).get("url"));
+    assertEquals("https://www.washingtonpost.com/politics/2019/06/05/trump-says-transgender-troops-cant-serve-because-troops-cant-take-any-drugs-hes-wrong-many-ways/", topics.get(topics.firstKey()).get("url"));
 
     assertEquals(935, (int) topics.lastKey());
     assertEquals("CCUJNXOJNFEJFBL57GD27EHMWI", topics.get(topics.lastKey()).get("title"));
-    assertEquals("https://www.washingtonpost.com/news/to-your-health/wp/2018/05/30/" +
-        "this-mock-pandemic-killed-150-million-people-next-time-it-might-not-be-a-drill/",
-        topics.get(topics.lastKey()).get("url"));
+    assertEquals("https://www.washingtonpost.com/news/to-your-health/wp/2018/05/30/this-mock-pandemic-killed-150-million-people-next-time-it-might-not-be-a-drill/", topics.get(topics.lastKey()).get("url"));
   }
 
   @Test
@@ -1456,25 +1438,17 @@ public class TopicReaderTest {
     // No consumer questions from CQ035 to CQ037
     assertEquals(42, consumerTopics.keySet().size());
     assertEquals(1, (int) consumerTopics.firstKey());
-    assertEquals("what is the origin of COVID-19",
-                 consumerTopics.get(consumerTopics.firstKey()).get("question"));
+    assertEquals("what is the origin of COVID-19", consumerTopics.get(consumerTopics.firstKey()).get("question"));
     assertEquals("CQ001", consumerTopics.get(consumerTopics.firstKey()).get("question_id"));
     assertEquals("coronavirus origin", consumerTopics.get(consumerTopics.firstKey()).get("query"));
-    // There's a typo in this but the same typo is present in the topics 
-    // document.
-    assertEquals("seeking information about whether the virus was designed in a lab or occured "+
-                 "naturally in animals and how it got to humans",
-                 consumerTopics.get(consumerTopics.firstKey()).get("background"));
+    // There's a typo in this but the same typo is present in the topics document.
+    assertEquals("seeking information about whether the virus was designed in a lab or occured naturally in animals and how it got to humans", consumerTopics.get(consumerTopics.firstKey()).get("background"));
 
     assertEquals(45, (int) consumerTopics.lastKey());
-    assertEquals("how has the COVID-19 pandemic impacted mental health?",
-                 consumerTopics.get(consumerTopics.lastKey()).get("question"));
+    assertEquals("how has the COVID-19 pandemic impacted mental health?", consumerTopics.get(consumerTopics.lastKey()).get("question"));
     assertEquals("CQ045", consumerTopics.get(consumerTopics.lastKey()).get("question_id"));
-    assertEquals("coronavirus mental health impact",
-                 consumerTopics.get(consumerTopics.lastKey()).get("query"));
-    assertEquals("seeking information about psychological effects of COVID-19 and "+
-                 "COVID-19 effect on mental health and pre-existing conditions",
-                 consumerTopics.get(consumerTopics.lastKey()).get("background"));
+    assertEquals("coronavirus mental health impact", consumerTopics.get(consumerTopics.lastKey()).get("query"));
+    assertEquals("seeking information about psychological effects of COVID-19 and COVID-19 effect on mental health and pre-existing conditions", consumerTopics.get(consumerTopics.lastKey()).get("background"));
 
     SortedMap<Integer, Map<String, String>> expertTopics;
     expertTopics = TopicReader.load(Topics.get("epidemic-qa.expert.prelim"));
@@ -1482,23 +1456,16 @@ public class TopicReaderTest {
     assertEquals(45, expertTopics.keySet().size());
 
     assertEquals(1, (int) expertTopics.firstKey());
-    assertEquals("what is the origin of COVID-19",
-                 expertTopics.get(expertTopics.firstKey()).get("question"));
+    assertEquals("what is the origin of COVID-19", expertTopics.get(expertTopics.firstKey()).get("question"));
     assertEquals("EQ001", expertTopics.get(expertTopics.firstKey()).get("question_id"));
     assertEquals("coronavirus origin", expertTopics.get(expertTopics.firstKey()).get("query"));
-    assertEquals("seeking range of information about the SARS-CoV-2 virus's origin, " + 
-                 "including its evolution, animal source, and first transmission into humans",
-                 expertTopics.get(expertTopics.firstKey()).get("background"));
+    assertEquals("seeking range of information about the SARS-CoV-2 virus's origin, including its evolution, animal source, and first transmission into humans", expertTopics.get(expertTopics.firstKey()).get("background"));
 
     assertEquals(45, (int) expertTopics.lastKey());
-    assertEquals("How has the COVID-19 pandemic impacted mental health?",
-                 expertTopics.get(expertTopics.lastKey()).get("question"));
+    assertEquals("How has the COVID-19 pandemic impacted mental health?", expertTopics.get(expertTopics.lastKey()).get("question"));
     assertEquals("EQ045", expertTopics.get(expertTopics.lastKey()).get("question_id"));
-    assertEquals("coronavirus mental health impact",
-                 expertTopics.get(expertTopics.lastKey()).get("query"));
-    assertEquals("Includes increasing/decreasing rates of depression, anxiety, panic disorder, "+
-                 "and other psychiatric and mental health conditions.",
-                 expertTopics.get(expertTopics.lastKey()).get("background"));
+    assertEquals("coronavirus mental health impact", expertTopics.get(expertTopics.lastKey()).get("query"));
+    assertEquals("Includes increasing/decreasing rates of depression, anxiety, panic disorder, and other psychiatric and mental health conditions.", expertTopics.get(expertTopics.lastKey()).get("background"));
   }
 
   @Test

--- a/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
@@ -43,7 +43,7 @@ public class TopicReaderTest {
       String path = topic.path;
       assertEquals(topic.readerClass, Topics.getTopicReaderClassForPath(path));
     }
-    assertEquals(476, cnt);
+    assertEquals(478, cnt);
   }
 
   @Test

--- a/src/test/java/io/anserini/search/topicreader/TopicsTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicsTest.java
@@ -30,7 +30,7 @@ public class TopicsTest {
 
   @Test
   public void testTotalCount() {
-    assertEquals(476, Topics.names().size());
+    assertEquals(478, Topics.names().size());
   }
 
   @Test

--- a/src/test/java/io/anserini/search/topicreader/TopicsTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicsTest.java
@@ -30,7 +30,7 @@ public class TopicsTest {
 
   @Test
   public void testTotalCount() {
-    assertEquals(472, Topics.names().size());
+    assertEquals(476, Topics.names().size());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- omit qrels arguments for evaluators that do not require them
- resolve registered qrels to cached paths before running `gdeval.pl`
- download a commit-pinned `gdeval.pl` into `bin/` when missing
- update reproduction configurations and documentation to use `bin/gdeval.pl`
- normalize NanoKnow and NeuCLIR topic registry identifiers
- advance the pinned external topics and qrels metadata
- add explicit FEVER, NanoKnow, and Web Track registry tests

## Validation

- `mvn -Dtest=ReproduceFromDocumentCollectionTest#testGdevalQrelsPathResolution+testExistingGdevalIsNotDownloadedAgain+testEvaluationCommandWithoutQrels clean test`
- `mvn -Dtest=QrelsTest,TopicReaderTest,TopicsTest test`
- `mvn -Dtest=QrelsTest,TopicReaderTest clean test`
- `bin/qbuild.sh`
- `bin/run.sh io.anserini.reproduce.ReproduceFromDocumentCollection --search --config cw09b --dry-run`
- `git diff --check`