### PR TITLE
Add anserini onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -708,3 +708,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@Evan-Lowry](https://github.com/Evan-Lowry) on 2026-08-13 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
 + Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-14 (commit [`1272378`](https://github.com/castorini/anserini/commit/127237835c675272668f0d65420602117fe50d09))
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`d02b3dd`](https://github.com/castorini/anserini/commit/d02b3dd3c85c81a675c4f5a7dc721ab249170817))
++ Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`efb96dd`](https://github.com/castorini/anserini/commit/efb96ddf50857058c68298efb4a5430d1af1f95e))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -263,3 +263,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Evan-Lowry](https://github.com/Evan-Lowry) on 2026-08-13 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
 + Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-15 (commit [`9bfc04b`](https://github.com/castorini/anserini/commit/9bfc04b2d5f22e3acf56edf43d06c1efa5fe2783))
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`d02b3dd`](https://github.com/castorini/anserini/commit/d02b3dd3c85c81a675c4f5a7dc721ab249170817))
++ Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`efb96dd`](https://github.com/castorini/anserini/commit/efb96ddf50857058c68298efb4a5430d1af1f95e))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -616,3 +616,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@mehra-es](https://github.com/mehra-es) on 2026-08-11 (commit [`4179733`](https://github.com/castorini/anserini/commit/4179733cc8aabefd22a7cb1f3e674cbc347a3953))
 + Results reproduced by [@Evan-Lowry](https://github.com/Evan-Lowry) on 2026-08-13 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`d02b3dd`](https://github.com/castorini/anserini/commit/d02b3dd3c85c81a675c4f5a7dc721ab249170817))
++ Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`efb96dd`](https://github.com/castorini/anserini/commit/efb96ddf50857058c68298efb4a5430d1af1f95e))


### PR DESCRIPTION
## Summary

Completed the Anserini onboarding reproduction exercises and added the
corresponding reproduction log entries.

Reproduced:
- Anserini MS MARCO Passage tour (start-here).
- MS MARCO Passage BM25 baseline.
- MS MARCO Passage dense retrieval with BGE.

## Setup

- Ubuntu on WSL2
- Java 21
- Anserini trunk commit: efb96dd

## Results

- MS MARCO Passage BM25 MRR@10: 0.18741 (matches the expected ~0.1874).
- Dense BGE retrieval MRR@10: 0.3521.
- All the results matched the guide.

The reproduction log entries were added to the corresponding documentation files.