### PR TITLE
[codex] Add missing topic and qrels test coverage

### DIFF
--- a/src/test/java/io/anserini/eval/QrelsTest.java
+++ b/src/test/java/io/anserini/eval/QrelsTest.java
@@ -1575,6 +1575,91 @@ public class QrelsTest{
   }
 
   @Test
+  public void testAdhocQrels() throws IOException {
+    assertQrels("adhoc.51-100", 50, 89179);
+    assertQrels("adhoc.101-150", 50, 62620);
+    assertQrels("adhoc.151-200", 50, 97319);
+    assertQrels("adhoc.451-550", 100, 140470);
+  }
+
+  @Test
+  public void testAtomicValidationQrels() throws IOException {
+    assertQrels("atomic.validation.i2t", 16131, 17801);
+    assertQrels("atomic.validation.t2i", 17173, 17801);
+  }
+
+  @Test
+  public void testFireQrels() throws IOException {
+    assertQrels("fire12bn.176-225", 50, 44823);
+    assertQrels("fire12en.176-225", 50, 36499);
+    assertQrels("fire12hi.176-225", 50, 39827);
+  }
+
+  @Test
+  public void testMBeirQrels() throws IOException {
+    assertQrels("m-beir-cirr-task7", 4170, 4216);
+    assertQrels("m-beir-edis-task2", 3241, 8341);
+    assertQrels("m-beir-fashion200k-task0", 1719, 4847);
+    assertQrels("m-beir-fashion200k-task3", 4889, 4889);
+    assertQrels("m-beir-fashioniq-task7", 6003, 6014);
+    assertQrels("m-beir-infoseek-task6", 11323, 73869);
+    assertQrels("m-beir-infoseek-task8", 17593, 131376);
+    assertQrels("m-beir-mscoco-task0", 24809, 24989);
+    assertQrels("m-beir-mscoco-task3", 5000, 24989);
+    assertQrels("m-beir-nights-task4", 2120, 2120);
+    assertQrels("m-beir-oven-task6", 50004, 492654);
+    assertQrels("m-beir-oven-task8", 14741, 261258);
+    assertQrels("m-beir-visualnews-task0", 19995, 20000);
+    assertQrels("m-beir-visualnews-task3", 20000, 20000);
+    assertQrels("m-beir-webqa-task1", 2455, 5002);
+    assertQrels("m-beir-webqa-task2", 2511, 3627);
+  }
+
+  @Test
+  public void testMicroblogQrels() throws IOException {
+    assertQrels("microblog2011", 49, 60129);
+    assertQrels("microblog2012", 59, 73073);
+    assertQrels("microblog2013", 60, 71279);
+    assertQrels("microblog2014", 55, 57985);
+  }
+
+  @Test
+  public void testAdditionalMiraclQrels() throws IOException {
+    assertQrels("miracl-v1.0-ar-train", 3495, 25382);
+    assertQrels("miracl-v1.0-bn-train", 1631, 16754);
+    assertQrels("miracl-v1.0-de-dev", 305, 3144);
+    assertQrels("miracl-v1.0-en-train", 2863, 29416);
+    assertQrels("miracl-v1.0-es-train", 2162, 21531);
+    assertQrels("miracl-v1.0-fa-train", 2107, 21844);
+    assertQrels("miracl-v1.0-fi-train", 2897, 20350);
+    assertQrels("miracl-v1.0-fr-train", 1143, 11426);
+    assertQrels("miracl-v1.0-hi-train", 1169, 11668);
+    assertQrels("miracl-v1.0-id-train", 4071, 41358);
+    assertQrels("miracl-v1.0-ja-train", 3477, 34387);
+    assertQrels("miracl-v1.0-ko-train", 868, 12767);
+    assertQrels("miracl-v1.0-ru-train", 4683, 33921);
+    assertQrels("miracl-v1.0-sw-train", 1901, 9359);
+    assertQrels("miracl-v1.0-te-train", 3452, 18608);
+    assertQrels("miracl-v1.0-th-train", 2972, 21293);
+    assertQrels("miracl-v1.0-yo-dev", 119, 1188);
+    assertQrels("miracl-v1.0-zh-train", 1312, 13113);
+  }
+
+  @Test
+  public void testTerabyteQrels() throws IOException {
+    assertQrels("terabyte04.701-750", 49, 58077);
+    assertQrels("terabyte05.751-800", 50, 45291);
+    assertQrels("terabyte06.801-850", 50, 31984);
+  }
+
+  private void assertQrels(String name, int qids, int judgments) throws IOException {
+    Qrels qrels = Qrels.get(name);
+    assertNotNull(qrels);
+    assertEquals(qids, qrels.getQids().size());
+    assertEquals(judgments, getQrelsCount(qrels));
+  }
+
+  @Test
   public void testPathResolution() throws IOException {
     Path expected;
     Path produced;

--- a/src/test/java/io/anserini/eval/QrelsTest.java
+++ b/src/test/java/io/anserini/eval/QrelsTest.java
@@ -81,10 +81,8 @@ public class QrelsTest{
   }
 
   private void assertDummyQrels(String name) throws IOException {
-    Qrels qrels = Qrels.get(name);
+    Qrels qrels = assertQrels(name, 2, 4);
     assertEquals(name, qrels.name());
-    assertEquals(2, qrels.getQids().size());
-    assertEquals(4, getQrelsCount(qrels));
     assertTrue(qrels.isDocJudged("1", "DOC1"));
     assertTrue(qrels.isDocJudged("1", "DOC2"));
     assertEquals(1, qrels.getRelevanceGrade("1", "DOC1"));
@@ -155,20 +153,17 @@ public class QrelsTest{
 
   @Test
   public void testName() throws IOException {
-    Qrels qrels = Qrels.get("cacm");
+    Qrels qrels = assertQrels("cacm", 52, 796);
     assertEquals("cacm", qrels.name());
 
-    qrels = Qrels.get("beir-v1.0.0-arguana-test");
+    qrels = assertQrels("beir-v1.0.0-arguana-test", 1406, 1406);
     assertEquals("beir-v1.0.0-arguana-test", qrels.name());
   }
 
   @Test
   public void testCacm() throws IOException {
-    Qrels qrels = Qrels.get("cacm");
-    assertNotNull(qrels);
+    Qrels qrels = assertQrels("cacm", 52, 796);
     assertEquals("cacm", qrels.name());
-    assertEquals(52, qrels.getQids().size());
-    assertEquals(796, getQrelsCount(qrels));
     assertEquals(1, qrels.getRelevanceGrade("1", "CACM-1410"));
     assertEquals(0, qrels.getRelevanceGrade("1", "CACM-1410x")); // non-existent docid
     assertEquals(0, qrels.getRelevanceGrade("xxx", "CACM-1410"));  // non-existent topic
@@ -178,70 +173,55 @@ public class QrelsTest{
 
   @Test
   public void testFeverDev() throws IOException {
-    Qrels qrels = Qrels.get("fever.dev");
-    assertNotNull(qrels);
-    assertEquals(6666, qrels.getQids().size());
-    assertEquals(8079, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("fever.dev", 6666, 8079);
     assertEquals(2, qrels.getRelevanceGrade("137334", "Soul_Food_-LRB-film-RRB-"));
   }
 
   @Test
   public void testNanoKnowNqSupported() throws IOException {
-    Qrels qrels = Qrels.get("nanoknow-v1.0-nq.supported");
-    assertNotNull(qrels);
-    assertEquals(2389, qrels.getQids().size());
-    assertEquals(56958, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("nanoknow-v1.0-nq.supported", 2389, 56958);
     assertEquals(1, qrels.getRelevanceGrade("0", "shard_01177_50695"));
   }
 
   @Test
   public void testNanoKnowSquadSupported() throws IOException {
-    Qrels qrels = Qrels.get("nanoknow-v1.0-squad.supported");
-    assertNotNull(qrels);
-    assertEquals(7490, qrels.getQids().size());
-    assertEquals(151675, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("nanoknow-v1.0-squad.supported", 7490, 151675);
     assertEquals(1, qrels.getRelevanceGrade("0", "shard_01394_6521"));
   }
 
   @Test
   public void testWeb51To100() throws IOException {
-    assertWebQrels("web.51-100", 48, 25329, "51", "clueweb09-en0001-01-17957", 1);
+    Qrels qrels = assertQrels("web.51-100", 48, 25329);
+    assertEquals(1, qrels.getRelevanceGrade("51", "clueweb09-en0001-01-17957"));
   }
 
   @Test
   public void testWeb101To150() throws IOException {
-    assertWebQrels("web.101-150", 50, 19381, "101", "clueweb09-en0076-79-19134", 2);
+    Qrels qrels = assertQrels("web.101-150", 50, 19381);
+    assertEquals(2, qrels.getRelevanceGrade("101", "clueweb09-en0076-79-19134"));
   }
 
   @Test
   public void testWeb151To200() throws IOException {
-    assertWebQrels("web.151-200", 50, 16055, "151", "clueweb09-en0000-00-17600", 1);
+    Qrels qrels = assertQrels("web.151-200", 50, 16055);
+    assertEquals(1, qrels.getRelevanceGrade("151", "clueweb09-en0000-00-17600"));
   }
 
   @Test
   public void testWeb201To250() throws IOException {
-    assertWebQrels("web.201-250", 50, 14474, "201", "clueweb12-0000tw-05-12114", 1);
+    Qrels qrels = assertQrels("web.201-250", 50, 14474);
+    assertEquals(1, qrels.getRelevanceGrade("201", "clueweb12-0000tw-05-12114"));
   }
 
   @Test
   public void testWeb251To300() throws IOException {
-    assertWebQrels("web.251-300", 50, 14432, "251", "clueweb12-0000tw-34-04382", 1);
-  }
-
-  private void assertWebQrels(String name, int qids, int judgments, String qid, String docid, int grade) throws IOException {
-    Qrels qrels = Qrels.get(name);
-    assertNotNull(qrels);
-    assertEquals(qids, qrels.getQids().size());
-    assertEquals(judgments, getQrelsCount(qrels));
-    assertEquals(grade, qrels.getRelevanceGrade(qid, docid));
+    Qrels qrels = assertQrels("web.251-300", 50, 14432);
+    assertEquals(1, qrels.getRelevanceGrade("251", "clueweb12-0000tw-34-04382"));
   }
 
   @Test
   public void testRobust04() throws IOException {
-    Qrels qrels = Qrels.get("robust04");
-    assertNotNull(qrels);
-    assertEquals(249, qrels.getQids().size());
-    assertEquals(311410, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("robust04", 249, 311410);
     assertEquals(1, qrels.getRelevanceGrade("301", "FBIS3-10082"));
     assertEquals(0, qrels.getRelevanceGrade("700", "LA123090-0137"));
     assertEquals(0, qrels.getRelevanceGrade("700", "LA123090-0137x")); // non-existent docid
@@ -252,697 +232,417 @@ public class QrelsTest{
 
   @Test
   public void testRobust05() throws IOException {
-    Qrels qrels = Qrels.get("robust05");
-    assertNotNull(qrels);
-    assertEquals(50, qrels.getQids().size());
-    assertEquals(37798, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("robust05", 50, 37798);
     assertEquals(2, qrels.getRelevanceGrade("303", "APW19980609.1531"));
     assertEquals(0, qrels.getRelevanceGrade("689", "XIE20000925.0055"));
   }
 
   @Test
   public void testTrec19DLDoc() throws IOException {
-    Qrels qrels = Qrels.get("dl19-doc");
-    assertNotNull(qrels);
-    assertEquals(43, qrels.getQids().size());
-    assertEquals(16258, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("dl19-doc", 43, 16258);
     assertEquals(0, qrels.getRelevanceGrade("19335", "D1035833"));
     assertEquals(0, qrels.getRelevanceGrade("1133167", "D984590"));
   }
 
   @Test
   public void testTrec19DLPassage() throws IOException {
-    Qrels qrels = Qrels.get("dl19-passage");
-    assertNotNull(qrels);
-    assertEquals(43, qrels.getQids().size());
-    assertEquals(9260, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("dl19-passage", 43, 9260);
     assertEquals(0, qrels.getRelevanceGrade("19335", "1017759"));
     assertEquals(1, qrels.getRelevanceGrade("1133167", "8804478"));
   }
 
   @Test
   public void testTrec20DLDoc() throws IOException {
-    Qrels qrels = Qrels.get("dl20-doc");
-    assertNotNull(qrels);
-    assertEquals(45, qrels.getQids().size());
-    assertEquals(9098, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("dl20-doc", 45, 9098);
     assertEquals(3, qrels.getRelevanceGrade("42255", "D1884223"));
     assertEquals(3, qrels.getRelevanceGrade("1136962", "D96741"));
   }
 
   @Test
   public void testTrec20DLPassage() throws IOException {
-    Qrels qrels = Qrels.get("dl20-passage");
-    assertNotNull(qrels);
-    assertEquals(54, qrels.getQids().size());
-    assertEquals(11386, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("dl20-passage", 54, 11386);
     assertEquals(2, qrels.getRelevanceGrade("23849", "1020327"));
     assertEquals(1, qrels.getRelevanceGrade("1136962", "937258"));
   }
 
   @Test
   public void testTrec21DLDoc() throws IOException {
-    Qrels qrels = Qrels.get("dl21-doc");
-    assertNotNull(qrels);
-    assertEquals(57, qrels.getQids().size());
-    assertEquals(13058, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("dl21-doc", 57, 13058);
     assertEquals(2, qrels.getRelevanceGrade("2082", "msmarco_doc_01_1320020407"));
     assertEquals(1, qrels.getRelevanceGrade("1129560", "msmarco_doc_59_863449044"));
   }
 
   @Test
   public void testTrec21DLPassage() throws IOException {
-    Qrels qrels = Qrels.get("dl21-passage");
-    assertNotNull(qrels);
-    assertEquals(53, qrels.getQids().size());
-    assertEquals(10828, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("dl21-passage", 53, 10828);
     assertEquals(3, qrels.getRelevanceGrade("2082", "msmarco_passage_02_179207466"));
     assertEquals(1, qrels.getRelevanceGrade("1129560", "msmarco_passage_67_937656589"));
   }
 
   @Test
   public void testTrec21DLDocMsMarcoV21() throws IOException {
-    Qrels qrels = Qrels.get("dl21-doc-msmarco-v2.1");
-    assertNotNull(qrels);
-    assertEquals(57, qrels.getQids().size());
-    assertEquals(10973, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("dl21-doc-msmarco-v2.1", 57, 10973);
     assertEquals(2, qrels.getRelevanceGrade("2082", "msmarco_v2.1_doc_01_1281570012"));
     assertEquals(2, qrels.getRelevanceGrade("1128632", "msmarco_v2.1_doc_17_481617788"));
   }
 
   @Test
   public void testTrec22DLDoc() throws IOException {
-    Qrels qrels = Qrels.get("dl22-doc");
-    assertNotNull(qrels);
-    assertEquals(76, qrels.getQids().size());
-    assertEquals(369638, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("dl22-doc", 76, 369638);
     assertEquals(1, qrels.getRelevanceGrade("2000511", "msmarco_doc_00_928744703"));
     assertEquals(1, qrels.getRelevanceGrade("2056323", "msmarco_doc_59_419476385"));
   }
 
   @Test
   public void testTrec22DLPassage() throws IOException {
-    Qrels qrels = Qrels.get("dl22-passage");
-    assertNotNull(qrels);
-    assertEquals(76, qrels.getQids().size());
-    assertEquals(386416, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("dl22-passage", 76, 386416);
     assertEquals(1, qrels.getRelevanceGrade("2000511", "msmarco_passage_00_491585864"));
     assertEquals(1, qrels.getRelevanceGrade("2056323", "msmarco_passage_68_715747739"));
   }
 
   @Test
   public void testTrec22DLDocMsMarcoV21() throws IOException {
-    Qrels qrels = Qrels.get("dl22-doc-msmarco-v2.1");
-    assertNotNull(qrels);
-    assertEquals(76, qrels.getQids().size());
-    assertEquals(349541, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("dl22-doc-msmarco-v2.1", 76, 349541);
     assertEquals(1, qrels.getRelevanceGrade("2000511", "msmarco_v2.1_doc_00_896525856"));
     assertEquals(2, qrels.getRelevanceGrade("2056158", "msmarco_v2.1_doc_06_934688453"));
   }
 
   @Test
   public void testTrec23DLDoc() throws IOException {
-    Qrels qrels = Qrels.get("dl23-doc");
-    assertNotNull(qrels);
-    assertEquals(82, qrels.getQids().size());
-    assertEquals(18034, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("dl23-doc", 82, 18034);
     assertEquals(1, qrels.getRelevanceGrade("2001010", "msmarco_doc_00_1413652624"));
     assertEquals(3, qrels.getRelevanceGrade("3100922", "msmarco_doc_16_3928760942"));
   }
 
   @Test
   public void testTrec23DLPassage() throws IOException {
-    Qrels qrels = Qrels.get("dl23-passage");
-    assertNotNull(qrels);
-    assertEquals(82, qrels.getQids().size());
-    assertEquals(22327, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("dl23-passage", 82, 22327);
     assertEquals(1, qrels.getRelevanceGrade("2001010", "msmarco_passage_00_729315698"));
     assertEquals(2, qrels.getRelevanceGrade("3100922", "msmarco_passage_22_487548813"));
   }
 
   @Test
   public void testTrec23DLDocMsMarcoV21() throws IOException {
-    Qrels qrels = Qrels.get("dl23-doc-msmarco-v2.1");
-    assertNotNull(qrels);
-    assertEquals(82, qrels.getQids().size());
-    assertEquals(15995, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("dl23-doc-msmarco-v2.1", 82, 15995);
     assertEquals(1, qrels.getRelevanceGrade("2001010", "msmarco_v2.1_doc_00_1372241967"));
     assertEquals(2, qrels.getRelevanceGrade("3100922", "msmarco_v2.1_doc_19_1982402861"));
   }
 
   @Test
   public void testTREC24_RAG_RAGGY_DEV() throws IOException {
-    Qrels qrels = Qrels.get("rag24.raggy-dev");
-    assertNotNull(qrels);
-    assertEquals(120, qrels.getQids().size());
-    assertEquals(147328, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("rag24.raggy-dev", 120, 147328);
     assertEquals(1, qrels.getRelevanceGrade("2001010", "msmarco_v2.1_doc_00_1372241967"));
     assertEquals(1, qrels.getRelevanceGrade("253263", "msmarco_v2.1_doc_46_843492186"));
   }
 
   @Test
   public void testTREC24_RAG_UMBRELA() throws IOException {
-    Qrels qrels = Qrels.get("rag24.test-umbrela");
-    assertNotNull(qrels);
-    assertEquals(301, qrels.getQids().size());
-    assertEquals(108479, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("rag24.test-umbrela", 301, 108479);
     assertEquals(1, qrels.getRelevanceGrade("2024-145979", "msmarco_v2.1_doc_25_771726319#13_1477564195"));
     assertEquals(1, qrels.getRelevanceGrade("2024-216592", "msmarco_v2.1_doc_52_1092442741#3_2165187686"));
   }
 
   @Test
   public void testTREC24_RAG() throws IOException {
-    Qrels qrels = Qrels.get("rag24.test");
-    assertNotNull(qrels);
-    assertEquals(89, qrels.getQids().size());
-    assertEquals(20429, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("rag24.test", 89, 20429);
     assertEquals(0, qrels.getRelevanceGrade("2024-145979", "msmarco_v2.1_doc_00_125364462#6_229054655"));
     assertEquals(1, qrels.getRelevanceGrade("2024-96359", "msmarco_v2.1_doc_54_724887112#1_1700994504"));
   }
 
   @Test
   public void testTREC25_RAG_UMBRELA() throws IOException {
-    Qrels qrels = Qrels.get("rag25.test-umbrela2");
-    assertNotNull(qrels);
-    assertEquals(22, qrels.getQids().size());
-    assertEquals(10284, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("rag25.test-umbrela2", 22, 10284);
     assertEquals(1, qrels.getRelevanceGrade("200", "msmarco_v2.1_doc_10_1630045707#13_2668822206"));
     assertEquals(1, qrels.getRelevanceGrade("31", "msmarco_v2.1_doc_20_1589508824#12_3490034638"));
   }
 
   @Test
   public void testTREC25_RAG() throws IOException {
-    Qrels qrels = Qrels.get("rag25.test");
-    assertNotNull(qrels);
-    assertEquals(22, qrels.getQids().size());
-    assertEquals(10284, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("rag25.test", 22, 10284);
     assertEquals(2, qrels.getRelevanceGrade("200", "msmarco_v2.1_doc_10_1630045707#13_2668822206"));
     assertEquals(0, qrels.getRelevanceGrade("31", "msmarco_v2.1_doc_20_1589508824#12_3490034638"));
   }
 
   @Test
   public void testMsmarcoDocDev() throws IOException {
-    Qrels qrels = Qrels.get("msmarco-doc-dev");
-    assertNotNull(qrels);
-    assertEquals(5193, qrels.getQids().size());
-    assertEquals(5193, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("msmarco-doc-dev", 5193, 5193);
     assertEquals(1, qrels.getRelevanceGrade("2", "D1650436"));
     assertEquals(1, qrels.getRelevanceGrade("1102400", "D677570"));
   }
 
   @Test
   public void testMsmarcoDocDevAlias() throws IOException {
-    Qrels qrels = Qrels.get("msmarco-doc.dev");
-    assertNotNull(qrels);
+    Qrels qrels = assertQrels("msmarco-doc.dev", 5193, 5193);
     assertEquals("msmarco-doc.dev", qrels.name());
-    assertEquals(5193, qrels.getQids().size());
-    assertEquals(5193, getQrelsCount(qrels));
   }
 
   @Test
   public void testMsmarcoPassageDevSubset() throws IOException {
-    Qrels qrels = Qrels.get("msmarco-passage-dev");
-    assertNotNull(qrels);
-    assertEquals(6980, qrels.getQids().size());
-    assertEquals(7437, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("msmarco-passage-dev", 6980, 7437);
     assertEquals(1, qrels.getRelevanceGrade("300674", "7067032"));
     assertEquals(1, qrels.getRelevanceGrade("195199", "8009377"));
   }
 
   @Test
   public void testMsmarcoV2DocDevMsMarcoV21() throws IOException {
-    Qrels qrels = Qrels.get("msmarco-v2.1-doc.dev");
-    assertNotNull(qrels);
-    assertEquals(4552, qrels.getQids().size());
-    assertEquals(4702, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("msmarco-v2.1-doc.dev", 4552, 4702);
     assertEquals(1, qrels.getRelevanceGrade("1000000", "msmarco_v2.1_doc_17_1968189952"));
     assertEquals(1, qrels.getRelevanceGrade("999897", "msmarco_v2.1_doc_46_191673440"));
   }
 
   @Test
   public void testMsmarcoV2DocDev2MsMarcoV21() throws IOException {
-    Qrels qrels = Qrels.get("msmarco-v2.1-doc.dev2");
-    assertNotNull(qrels);
-    assertEquals(5000, qrels.getQids().size());
-    assertEquals(5177, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("msmarco-v2.1-doc.dev2", 5000, 5177);
     assertEquals(1, qrels.getRelevanceGrade("1000202", "msmarco_v2.1_doc_08_69146701"));
     assertEquals(1, qrels.getRelevanceGrade("999659", "msmarco_v2.1_doc_08_1247437925"));
   }
 
   @Test
   public void testMsmarcoV2DocPassage() throws IOException {
-    Qrels qrels = Qrels.get("msmarco-v2-passage-dev");
-    assertNotNull(qrels);
-    assertEquals(3903, qrels.getQids().size());
-    assertEquals(4009, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("msmarco-v2-passage-dev", 3903, 4009);
     assertEquals(1, qrels.getRelevanceGrade("763878", "msmarco_passage_33_459057644"));
     assertEquals(1, qrels.getRelevanceGrade("1091692", "msmarco_passage_23_330102695"));
   }
 
   @Test
   public void testMsmarcoV2DocPassageAlias() throws IOException {
-    Qrels qrels = Qrels.get("msmarco-v2-passage.dev");
-    assertNotNull(qrels);
+    Qrels qrels = assertQrels("msmarco-v2-passage.dev", 3903, 4009);
     assertEquals("msmarco-v2-passage.dev", qrels.name());
-    assertEquals(3903, qrels.getQids().size());
-    assertEquals(4009, getQrelsCount(qrels));
   }
 
   @Test
   public void testMsmarcoV2DocPassage2() throws IOException {
-    Qrels qrels = Qrels.get("msmarco-v2-passage-dev2");
-    assertNotNull(qrels);
-    assertEquals(4281, qrels.getQids().size());
-    assertEquals(4411, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("msmarco-v2-passage-dev2", 4281, 4411);
     assertEquals(1, qrels.getRelevanceGrade("419507", "msmarco_passage_04_254301507"));
     assertEquals(1, qrels.getRelevanceGrade("961297", "msmarco_passage_18_858458289"));
   }
 
   @Test
   public void testMsmarcoV2DocPassage2Alias() throws IOException {
-    Qrels qrels = Qrels.get("msmarco-v2-passage.dev2");
-    assertNotNull(qrels);
+    Qrels qrels = assertQrels("msmarco-v2-passage.dev2", 4281, 4411);
     assertEquals("msmarco-v2-passage.dev2", qrels.name());
-    assertEquals(4281, qrels.getQids().size());
-    assertEquals(4411, getQrelsCount(qrels));
   }
 
   @Test
   public void testMsmarcoV2DocDev() throws IOException {
-    Qrels qrels = Qrels.get("msmarco-v2-doc-dev");
-    assertNotNull(qrels);
-    assertEquals(4552, qrels.getQids().size());
-    assertEquals(4702, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("msmarco-v2-doc-dev", 4552, 4702);
     assertEquals(1, qrels.getRelevanceGrade("1000000", "msmarco_doc_17_2560009121"));
     assertEquals(1, qrels.getRelevanceGrade("999942", "msmarco_doc_06_956348348"));
   }
 
   @Test
   public void testMsmarcoV2DocDevAlias() throws IOException {
-    Qrels qrels = Qrels.get("msmarco-v2-doc.dev");
-    assertNotNull(qrels);
+    Qrels qrels = assertQrels("msmarco-v2-doc.dev", 4552, 4702);
     assertEquals("msmarco-v2-doc.dev", qrels.name());
-    assertEquals(4552, qrels.getQids().size());
-    assertEquals(4702, getQrelsCount(qrels));
   }
 
   @Test
   public void testMsmarcoV2DocDev2() throws IOException {
-    Qrels qrels = Qrels.get("msmarco-v2-doc-dev2");
-    assertNotNull(qrels);
-    assertEquals(5000, qrels.getQids().size());
-    assertEquals(5178, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("msmarco-v2-doc-dev2", 5000, 5178);
     assertEquals(1, qrels.getRelevanceGrade("1000202", "msmarco_doc_08_73026062"));
     assertEquals(1, qrels.getRelevanceGrade("999937", "msmarco_doc_05_319743607"));
   }
 
   @Test
   public void testMsmarcoV2DocDev2Alias() throws IOException {
-    Qrels qrels = Qrels.get("msmarco-v2-doc.dev2");
-    assertNotNull(qrels);
+    Qrels qrels = assertQrels("msmarco-v2-doc.dev2", 5000, 5178);
     assertEquals("msmarco-v2-doc.dev2", qrels.name());
-    assertEquals(5000, qrels.getQids().size());
-    assertEquals(5178, getQrelsCount(qrels));
   }
 
   @Test
   public void testCore17() throws IOException {
-    Qrels qrels = Qrels.get("core17");
-    assertNotNull(qrels);
-    assertEquals(50, qrels.getQids().size());
-    assertEquals(30030, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("core17", 50, 30030);
     assertEquals(1, qrels.getRelevanceGrade("307", "1001536"));
     assertEquals(0, qrels.getRelevanceGrade("690", "996059"));
   }
 
   @Test
   public void testCore18() throws IOException {
-    Qrels qrels = Qrels.get("core18");
-    assertNotNull(qrels);
-    assertEquals(50, qrels.getQids().size());
-    assertEquals(26233, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("core18", 50, 26233);
     assertEquals(0, qrels.getRelevanceGrade("321", "004c6120d0aa69da29cc045da0562168"));
     assertEquals(0, qrels.getRelevanceGrade("825", "ff3a25b0-0ba4-11e4-8341-b8072b1e7348"));
   }
 
   @Test
   public void testCar15() throws IOException {
-    Qrels qrels = Qrels.get("car17v1.5-benchmarkY1test");
-    assertNotNull(qrels);
-    assertEquals(2125, qrels.getQids().size());
-    assertEquals(5820, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("car17v1.5-benchmarkY1test", 2125, 5820);
     assertEquals(1, qrels.getRelevanceGrade("Aftertaste/Aftertaste%20processing%20in%20the%20cerebral%20cortex", "38c1bd25ddca2705164677a3f598c46df85afba7"));
     assertEquals(1, qrels.getRelevanceGrade("Yellowstone%20National%20Park/Recreation", "e80b5185da1493edde41bea19a389a3f62167369"));
   }
 
   @Test
   public void testCar20() throws IOException {
-    Qrels qrels = Qrels.get("car17v2.0-benchmarkY1test");
-    assertNotNull(qrels);
-    assertEquals(2254, qrels.getQids().size());
-    assertEquals(6192, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("car17v2.0-benchmarkY1test", 2254, 6192);
     assertEquals(1, qrels.getRelevanceGrade("enwiki:Aftertaste", "327cca6c4d38953196fa6789f615546f03287b25"));
     assertEquals(1, qrels.getRelevanceGrade("enwiki:Yellowstone%20National%20Park/Recreation", "b812fca195f74f8c563db4262260554fe3ff3731"));
   }
 
   @Test
   public void testTrec2018BL() throws IOException {
-    Qrels qrels = Qrels.get("trec2018-bl");
-    assertNotNull(qrels);
-    assertEquals(50, qrels.getQids().size());
-    assertEquals(8508, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("trec2018-bl", 50, 8508);
     assertEquals(16, qrels.getRelevanceGrade("321", "00f57310e5c8ec7833d6756ba637332e"));
     assertEquals(0, qrels.getRelevanceGrade("825", "f66b624ba8689d704872fa776fb52860"));
   }
 
   @Test
   public void testTrec2019BL() throws IOException {
-    Qrels qrels = Qrels.get("trec2019-bl");
-    assertNotNull(qrels);
-    assertEquals(57, qrels.getQids().size());
-    assertEquals(15655, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("trec2019-bl", 57, 15655);
     assertEquals(2, qrels.getRelevanceGrade("826", "0154349511cd8c49ab862d6cb0d8f6a8"));
     assertEquals(0, qrels.getRelevanceGrade("885", "fde80cb0-b4f0-11e2-bbf2-a6f9e9d79e19"));
   }
 
   @Test
   public void testTrec2020BL() throws IOException {
-    Qrels qrels = Qrels.get("trec2020-bl");
-    assertNotNull(qrels);
-    assertEquals(49, qrels.getQids().size());
-    assertEquals(17764, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("trec2020-bl", 49, 17764);
     assertEquals(0, qrels.getRelevanceGrade("886", "00183d98-741b-11e5-8248-98e0f5a2e830"));
     assertEquals(0, qrels.getRelevanceGrade("935", "ff0a760128ecdbcc096cafc8cd553255"));
   }
 
   @Test
   public void testCovidRound1() throws IOException {
-    Qrels qrels = Qrels.get("covid-round1");
-    assertNotNull(qrels);
-    assertEquals(30, qrels.getQids().size());
-    assertEquals(8691, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("covid-round1", 30, 8691);
     assertEquals(2, qrels.getRelevanceGrade("1", "010vptx3"));
     assertEquals(1, qrels.getRelevanceGrade("30", "zn87f1lk"));
   }
 
   @Test
   public void testCovidRound2() throws IOException {
-    Qrels qrels = Qrels.get("covid-round2");
-    assertNotNull(qrels);
-    assertEquals(35, qrels.getQids().size());
-    assertEquals(12037, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("covid-round2", 35, 12037);
     assertEquals(0, qrels.getRelevanceGrade("1", "08efpohc"));
     assertEquals(0, qrels.getRelevanceGrade("35", "zzmfhr2s"));
   }
 
   @Test
   public void testCovidRound3() throws IOException {
-    Qrels qrels = Qrels.get("covid-round3");
-    assertNotNull(qrels);
-    assertEquals(40, qrels.getQids().size());
-    assertEquals(12713, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("covid-round3", 40, 12713);
     assertEquals(1, qrels.getRelevanceGrade("1", "0194oljo"));
     assertEquals(1, qrels.getRelevanceGrade("40", "zsx7wfyj"));
   }
 
   @Test
   public void testCovidRound4() throws IOException {
-    Qrels qrels = Qrels.get("covid-round4");
-    assertNotNull(qrels);
-    assertEquals(45, qrels.getQids().size());
-    assertEquals(13262, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("covid-round4", 45, 13262);
     assertEquals(2, qrels.getRelevanceGrade("1", "1c47w4q5"));
     assertEquals(2, qrels.getRelevanceGrade("45", "zzrsk1ls"));
   }
 
   @Test
   public void testCovidRound5() throws IOException {
-    Qrels qrels = Qrels.get("covid-round5");
-    assertNotNull(qrels);
-    assertEquals(50, qrels.getQids().size());
-    assertEquals(23151, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("covid-round5", 50, 23151);
     assertEquals(2, qrels.getRelevanceGrade("1", "005b2j4b"));
     assertEquals(1, qrels.getRelevanceGrade("50", "zz8wvos9"));
   }
 
   @Test
   public void testCovidRound3Cumulative() throws IOException {
-    Qrels qrels = Qrels.get("covid-round3-cumulative");
-    assertNotNull(qrels);
-    assertEquals(40, qrels.getQids().size());
-    assertEquals(33068, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("covid-round3-cumulative", 40, 33068);
     assertEquals(2, qrels.getRelevanceGrade("1", "010vptx3"));
     assertEquals(1, qrels.getRelevanceGrade("40", "zsx7wfyj"));
   }
 
   @Test
   public void testCovidRound4Cumulative() throws IOException {
-    Qrels qrels = Qrels.get("covid-round4-cumulative");
-    assertNotNull(qrels);
-    assertEquals(45, qrels.getQids().size());
-    assertEquals(46203, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("covid-round4-cumulative", 45, 46203);
     assertEquals(1, qrels.getRelevanceGrade("1", "00fmeepz"));
     assertEquals(2, qrels.getRelevanceGrade("45", "zzrsk1ls"));
   }
 
   @Test
   public void testCovidComplete() throws IOException {
-    Qrels qrels = Qrels.get("covid-complete");
-    assertNotNull(qrels);
-    assertEquals(50, qrels.getQids().size());
-    assertEquals(69318, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("covid-complete", 50, 69318);
     assertEquals(2, qrels.getRelevanceGrade("1", "005b2j4b"));
     assertEquals(1, qrels.getRelevanceGrade("50", "zz8wvos9"));
   }
 
   @Test
   public void testNtcir8Zh() throws IOException {
-    Qrels qrels = Qrels.get("ntcir8-zh");
-    assertNotNull(qrels);
-    assertEquals(100, qrels.getQids().size());
-    assertEquals(110213, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("ntcir8-zh", 100, 110213);
     assertEquals(0, qrels.getRelevanceGrade("ACLIA2-CS-0001", "XIN_CMN_20020106.0118"));
     assertEquals(0, qrels.getRelevanceGrade("ACLIA2-CS-0001", "XIN_CMN_20020107.0140"));
   }
 
   @Test
   public void testClef2006Fr() throws IOException {
-    Qrels qrels = Qrels.get("clef2006-fr");
-    assertNotNull(qrels);
-    assertEquals(49, qrels.getQids().size());
-    assertEquals(17882, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("clef2006-fr", 49, 17882);
     assertEquals(0, qrels.getRelevanceGrade("301-AH", "ATS.940106.0082"));
     assertEquals(0, qrels.getRelevanceGrade("301-AH", "ATS.940112.0089"));
   }
 
   @Test
   public void testTrec2002Ar() throws IOException {
-    Qrels qrels = Qrels.get("trec2002-ar");
-    assertNotNull(qrels);
-    assertEquals(50, qrels.getQids().size());
-    assertEquals(38432, getQrelsCount(qrels));
+    Qrels qrels = assertQrels("trec2002-ar", 50, 38432);
     assertEquals(0, qrels.getRelevanceGrade("26", "19940515_AFP_ARB.0115"));
     assertEquals(1, qrels.getRelevanceGrade("26", "19941213_AFP_ARB.0159"));
   }
 
   @Test
   public void testMrTyDiAr() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("mrtydi-v1.1-arabic-train");
-    assertNotNull(qrels);
-    assertEquals(12377, qrels.getQids().size());
-    assertEquals(12377, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-arabic-dev");
-    assertNotNull(qrels);
-    assertEquals(3115, qrels.getQids().size());
-    assertEquals(3115, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-arabic-test");
-    assertNotNull(qrels);
-    assertEquals(1081, qrels.getQids().size());
-    assertEquals(1257, getQrelsCount(qrels));
+    assertQrels("mrtydi-v1.1-arabic-train", 12377, 12377);
+    assertQrels("mrtydi-v1.1-arabic-dev", 3115, 3115);
+    assertQrels("mrtydi-v1.1-arabic-test", 1081, 1257);
   }
 
   @Test
   public void testMrTyDiBn() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("mrtydi-v1.1-bengali-train");
-    assertNotNull(qrels);
-    assertEquals(1713, qrels.getQids().size());
-    assertEquals(1719, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-bengali-dev");
-    assertNotNull(qrels);
-    assertEquals(440, qrels.getQids().size());
-    assertEquals(443, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-bengali-test");
-    assertNotNull(qrels);
-    assertEquals(111, qrels.getQids().size());
-    assertEquals(130, getQrelsCount(qrels));
+    assertQrels("mrtydi-v1.1-bengali-train", 1713, 1719);
+    assertQrels("mrtydi-v1.1-bengali-dev", 440, 443);
+    assertQrels("mrtydi-v1.1-bengali-test", 111, 130);
   }
 
   @Test
   public void testMrTyDiEn() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("mrtydi-v1.1-english-train");
-    assertNotNull(qrels);
-    assertEquals(3547, qrels.getQids().size());
-    assertEquals(3547, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-english-dev");
-    assertNotNull(qrels);
-    assertEquals(878, qrels.getQids().size());
-    assertEquals(878, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-english-test");
-    assertNotNull(qrels);
-    assertEquals(744, qrels.getQids().size());
-    assertEquals(935, getQrelsCount(qrels));
+    assertQrels("mrtydi-v1.1-english-train", 3547, 3547);
+    assertQrels("mrtydi-v1.1-english-dev", 878, 878);
+    assertQrels("mrtydi-v1.1-english-test", 744, 935);
   }
 
   @Test
   public void testMrTyDiFi() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("mrtydi-v1.1-finnish-train");
-    assertNotNull(qrels);
-    assertEquals(6561, qrels.getQids().size());
-    assertEquals(6561, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-finnish-dev");
-    assertNotNull(qrels);
-    assertEquals(1738, qrels.getQids().size());
-    assertEquals(1738, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-finnish-test");
-    assertNotNull(qrels);
-    assertEquals(1254, qrels.getQids().size());
-    assertEquals(1451, getQrelsCount(qrels));
+    assertQrels("mrtydi-v1.1-finnish-train", 6561, 6561);
+    assertQrels("mrtydi-v1.1-finnish-dev", 1738, 1738);
+    assertQrels("mrtydi-v1.1-finnish-test", 1254, 1451);
   }
 
   @Test
   public void testMrTyDiId() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("mrtydi-v1.1-indonesian-train");
-    assertNotNull(qrels);
-    assertEquals(4902, qrels.getQids().size());
-    assertEquals(4902, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-indonesian-dev");
-    assertNotNull(qrels);
-    assertEquals(1224, qrels.getQids().size());
-    assertEquals(1224, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-indonesian-test");
-    assertNotNull(qrels);
-    assertEquals(829, qrels.getQids().size());
-    assertEquals(961, getQrelsCount(qrels));
+    assertQrels("mrtydi-v1.1-indonesian-train", 4902, 4902);
+    assertQrels("mrtydi-v1.1-indonesian-dev", 1224, 1224);
+    assertQrels("mrtydi-v1.1-indonesian-test", 829, 961);
   }
 
   @Test
   public void testMrTyDiJa() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("mrtydi-v1.1-japanese-train");
-    assertNotNull(qrels);
-    assertEquals(3697, qrels.getQids().size());
-    assertEquals(3697, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-japanese-dev");
-    assertNotNull(qrels);
-    assertEquals(928, qrels.getQids().size());
-    assertEquals(928, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-japanese-test");
-    assertNotNull(qrels);
-    assertEquals(720, qrels.getQids().size());
-    assertEquals(923, getQrelsCount(qrels));
+    assertQrels("mrtydi-v1.1-japanese-train", 3697, 3697);
+    assertQrels("mrtydi-v1.1-japanese-dev", 928, 928);
+    assertQrels("mrtydi-v1.1-japanese-test", 720, 923);
   }
 
   @Test
   public void testMrTyDiKo() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("mrtydi-v1.1-korean-train");
-    assertNotNull(qrels);
-    assertEquals(1295, qrels.getQids().size());
-    assertEquals(1317, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-korean-dev");
-    assertNotNull(qrels);
-    assertEquals(303, qrels.getQids().size());
-    assertEquals(307, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-korean-test");
-    assertNotNull(qrels);
-    assertEquals(421, qrels.getQids().size());
-    assertEquals(492, getQrelsCount(qrels));
+    assertQrels("mrtydi-v1.1-korean-train", 1295, 1317);
+    assertQrels("mrtydi-v1.1-korean-dev", 303, 307);
+    assertQrels("mrtydi-v1.1-korean-test", 421, 492);
   }
 
   @Test
   public void testMrTyDiRu() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("mrtydi-v1.1-russian-train");
-    assertNotNull(qrels);
-    assertEquals(5366, qrels.getQids().size());
-    assertEquals(5366, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-russian-dev");
-    assertNotNull(qrels);
-    assertEquals(1375, qrels.getQids().size());
-    assertEquals(1375, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-russian-test");
-    assertNotNull(qrels);
-    assertEquals(995, qrels.getQids().size());
-    assertEquals(1168, getQrelsCount(qrels));
+    assertQrels("mrtydi-v1.1-russian-train", 5366, 5366);
+    assertQrels("mrtydi-v1.1-russian-dev", 1375, 1375);
+    assertQrels("mrtydi-v1.1-russian-test", 995, 1168);
   }
 
   @Test
   public void testMrTyDiSw() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("mrtydi-v1.1-swahili-train");
-    assertNotNull(qrels);
-    assertEquals(2072, qrels.getQids().size());
-    assertEquals(2401, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-swahili-dev");
-    assertNotNull(qrels);
-    assertEquals(526, qrels.getQids().size());
-    assertEquals(623, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-swahili-test");
-    assertNotNull(qrels);
-    assertEquals(670, qrels.getQids().size());
-    assertEquals(743, getQrelsCount(qrels));
+    assertQrels("mrtydi-v1.1-swahili-train", 2072, 2401);
+    assertQrels("mrtydi-v1.1-swahili-dev", 526, 623);
+    assertQrels("mrtydi-v1.1-swahili-test", 670, 743);
   }
 
   @Test
   public void testMrTyDiTe() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("mrtydi-v1.1-telugu-train");
-    assertNotNull(qrels);
-    assertEquals(3880, qrels.getQids().size());
-    assertEquals(3880, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-telugu-dev");
-    assertNotNull(qrels);
-    assertEquals(983, qrels.getQids().size());
-    assertEquals(983, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-telugu-test");
-    assertNotNull(qrels);
-    assertEquals(646, qrels.getQids().size());
-    assertEquals(677, getQrelsCount(qrels));
+    assertQrels("mrtydi-v1.1-telugu-train", 3880, 3880);
+    assertQrels("mrtydi-v1.1-telugu-dev", 983, 983);
+    assertQrels("mrtydi-v1.1-telugu-test", 646, 677);
     // The value 677 differs from Mr. TyDi paper.
     // The paper reported 664, which is the qrel size before fixing the document slicing bug.
     // 677 should be the correct number.
@@ -950,628 +650,158 @@ public class QrelsTest{
 
   @Test
   public void testMrTyDiTh() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("mrtydi-v1.1-thai-train");
-    assertNotNull(qrels);
-    assertEquals(3319, qrels.getQids().size());
-    assertEquals(3360, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-thai-dev");
-    assertNotNull(qrels);
-    assertEquals(807, qrels.getQids().size());
-    assertEquals(817, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mrtydi-v1.1-thai-test");
-    assertNotNull(qrels);
-    assertEquals(1190, qrels.getQids().size());
-    assertEquals(1368, getQrelsCount(qrels));
+    assertQrels("mrtydi-v1.1-thai-train", 3319, 3360);
+    assertQrels("mrtydi-v1.1-thai-dev", 807, 817);
+    assertQrels("mrtydi-v1.1-thai-test", 1190, 1368);
   }
 
   @Test
   public void testBRIGHT() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("bright-biology");
-    assertNotNull(qrels);
-    assertEquals(103, qrels.getQids().size());
-    assertEquals(372, getQrelsCount(qrels));
-
-    qrels = Qrels.get("bright-earth-science");
-    assertNotNull(qrels);
-    assertEquals(116, qrels.getQids().size());
-    assertEquals(585, getQrelsCount(qrels));
-
-    qrels = Qrels.get("bright-economics");
-    assertNotNull(qrels);
-    assertEquals(103, qrels.getQids().size());
-    assertEquals(800, getQrelsCount(qrels));
-
-    qrels = Qrels.get("bright-psychology");
-    assertNotNull(qrels);
-    assertEquals(101, qrels.getQids().size());
-    assertEquals(692, getQrelsCount(qrels));
-
-    qrels = Qrels.get("bright-robotics");
-    assertNotNull(qrels);
-    assertEquals(101, qrels.getQids().size());
-    assertEquals(520, getQrelsCount(qrels));
-
-    qrels = Qrels.get("bright-stackoverflow");
-    assertNotNull(qrels);
-    assertEquals(117, qrels.getQids().size());
-    assertEquals(478, getQrelsCount(qrels));
-
-    qrels = Qrels.get("bright-sustainable-living");
-    assertNotNull(qrels);
-    assertEquals(108, qrels.getQids().size());
-    assertEquals(576, getQrelsCount(qrels));
-
-    qrels = Qrels.get("bright-pony");
-    assertNotNull(qrels);
-    assertEquals(112, qrels.getQids().size());
-    assertEquals(2219, getQrelsCount(qrels));
-
-    qrels = Qrels.get("bright-leetcode");
-    assertNotNull(qrels);
-    assertEquals(142, qrels.getQids().size());
-    assertEquals(262, getQrelsCount(qrels));
-
-    qrels = Qrels.get("bright-aops");
-    assertNotNull(qrels);
-    assertEquals(111, qrels.getQids().size());
-    assertEquals(524, getQrelsCount(qrels));
-
-    qrels = Qrels.get("bright-theoremqa-theorems");
-    assertNotNull(qrels);
-    assertEquals(76, qrels.getQids().size());
-    assertEquals(151, getQrelsCount(qrels));
-
-    qrels = Qrels.get("bright-theoremqa-questions");
-    assertNotNull(qrels);
-    assertEquals(194, qrels.getQids().size());
-    assertEquals(439, getQrelsCount(qrels));
+    assertQrels("bright-biology", 103, 372);
+    assertQrels("bright-earth-science", 116, 585);
+    assertQrels("bright-economics", 103, 800);
+    assertQrels("bright-psychology", 101, 692);
+    assertQrels("bright-robotics", 101, 520);
+    assertQrels("bright-stackoverflow", 117, 478);
+    assertQrels("bright-sustainable-living", 108, 576);
+    assertQrels("bright-pony", 112, 2219);
+    assertQrels("bright-leetcode", 142, 262);
+    assertQrels("bright-aops", 111, 524);
+    assertQrels("bright-theoremqa-theorems", 76, 151);
+    assertQrels("bright-theoremqa-questions", 194, 439);
   }
 
   @Test
   public void testBEIR() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("beir-v1.0.0-trec-covid-test");
-    assertNotNull(qrels);
-    assertEquals(50, qrels.getQids().size());
-    assertEquals(66334, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-bioasq-test");
-    assertNotNull(qrels);
-    assertEquals(500, qrels.getQids().size());
-    assertEquals(2359, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-nfcorpus-test");
-    assertNotNull(qrels);
-    assertEquals(323, qrels.getQids().size());
-    assertEquals(12334, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-nq-test");
-    assertNotNull(qrels);
-    assertEquals(3452, qrels.getQids().size());
-    assertEquals(4201, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-hotpotqa-test");
-    assertNotNull(qrels);
-    assertEquals(7405, qrels.getQids().size());
-    assertEquals(14810, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-fiqa-test");
-    assertNotNull(qrels);
-    assertEquals(648, qrels.getQids().size());
-    assertEquals(1706, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-signal1m-test");
-    assertNotNull(qrels);
-    assertEquals(97, qrels.getQids().size());
-    assertEquals(1899, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-trec-news-test");
-    assertNotNull(qrels);
-    assertEquals(57, qrels.getQids().size());
-    assertEquals(15655, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-robust04-test");
-    assertNotNull(qrels);
-    assertEquals(249, qrels.getQids().size());
-    assertEquals(311410, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-arguana-test");
-    assertNotNull(qrels);
-    assertEquals(1406, qrels.getQids().size());
-    assertEquals(1406, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-webis-touche2020-test");
-    assertNotNull(qrels);
-    assertEquals(49, qrels.getQids().size());
-    assertEquals(932, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-cqadupstack-android-test");
-    assertNotNull(qrels);
-    assertEquals(699, qrels.getQids().size());
-    assertEquals(1696, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-cqadupstack-english-test");
-    assertNotNull(qrels);
-    assertEquals(1570, qrels.getQids().size());
-    assertEquals(3765, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-cqadupstack-gaming-test");
-    assertNotNull(qrels);
-    assertEquals(1595, qrels.getQids().size());
-    assertEquals(2263, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-cqadupstack-gis-test");
-    assertNotNull(qrels);
-    assertEquals(885, qrels.getQids().size());
-    assertEquals(1114, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-cqadupstack-mathematica-test");
-    assertNotNull(qrels);
-    assertEquals(804, qrels.getQids().size());
-    assertEquals(1358, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-cqadupstack-physics-test");
-    assertNotNull(qrels);
-    assertEquals(1039, qrels.getQids().size());
-    assertEquals(1933, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-cqadupstack-programmers-test");
-    assertNotNull(qrels);
-    assertEquals(876, qrels.getQids().size());
-    assertEquals(1675, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-cqadupstack-stats-test");
-    assertNotNull(qrels);
-    assertEquals(652, qrels.getQids().size());
-    assertEquals(913, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-cqadupstack-tex-test");
-    assertNotNull(qrels);
-    assertEquals(2906, qrels.getQids().size());
-    assertEquals(5154, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-cqadupstack-unix-test");
-    assertNotNull(qrels);
-    assertEquals(1072, qrels.getQids().size());
-    assertEquals(1693, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-cqadupstack-webmasters-test");
-    assertNotNull(qrels);
-    assertEquals(506, qrels.getQids().size());
-    assertEquals(1395, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-cqadupstack-wordpress-test");
-    assertNotNull(qrels);
-    assertEquals(541, qrels.getQids().size());
-    assertEquals(744, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-quora-test");
-    assertNotNull(qrels);
-    assertEquals(10000, qrels.getQids().size());
-    assertEquals(15675, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-dbpedia-entity-test");
-    assertNotNull(qrels);
-    assertEquals(400, qrels.getQids().size());
-    assertEquals(43515, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-scidocs-test");
-    assertNotNull(qrels);
-    assertEquals(1000, qrels.getQids().size());
-    assertEquals(29928, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-fever-test");
-    assertNotNull(qrels);
-    assertEquals(6666, qrels.getQids().size());
-    assertEquals(7937, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-climate-fever-test");
-    assertNotNull(qrels);
-    assertEquals(1535, qrels.getQids().size());
-    assertEquals(4681, getQrelsCount(qrels));
-
-    qrels = Qrels.get("beir-v1.0.0-scifact-test");
-    assertNotNull(qrels);
-    assertEquals(300, qrels.getQids().size());
-    assertEquals(339, getQrelsCount(qrels));
+    assertQrels("beir-v1.0.0-trec-covid-test", 50, 66334);
+    assertQrels("beir-v1.0.0-bioasq-test", 500, 2359);
+    assertQrels("beir-v1.0.0-nfcorpus-test", 323, 12334);
+    assertQrels("beir-v1.0.0-nq-test", 3452, 4201);
+    assertQrels("beir-v1.0.0-hotpotqa-test", 7405, 14810);
+    assertQrels("beir-v1.0.0-fiqa-test", 648, 1706);
+    assertQrels("beir-v1.0.0-signal1m-test", 97, 1899);
+    assertQrels("beir-v1.0.0-trec-news-test", 57, 15655);
+    assertQrels("beir-v1.0.0-robust04-test", 249, 311410);
+    assertQrels("beir-v1.0.0-arguana-test", 1406, 1406);
+    assertQrels("beir-v1.0.0-webis-touche2020-test", 49, 932);
+    assertQrels("beir-v1.0.0-cqadupstack-android-test", 699, 1696);
+    assertQrels("beir-v1.0.0-cqadupstack-english-test", 1570, 3765);
+    assertQrels("beir-v1.0.0-cqadupstack-gaming-test", 1595, 2263);
+    assertQrels("beir-v1.0.0-cqadupstack-gis-test", 885, 1114);
+    assertQrels("beir-v1.0.0-cqadupstack-mathematica-test", 804, 1358);
+    assertQrels("beir-v1.0.0-cqadupstack-physics-test", 1039, 1933);
+    assertQrels("beir-v1.0.0-cqadupstack-programmers-test", 876, 1675);
+    assertQrels("beir-v1.0.0-cqadupstack-stats-test", 652, 913);
+    assertQrels("beir-v1.0.0-cqadupstack-tex-test", 2906, 5154);
+    assertQrels("beir-v1.0.0-cqadupstack-unix-test", 1072, 1693);
+    assertQrels("beir-v1.0.0-cqadupstack-webmasters-test", 506, 1395);
+    assertQrels("beir-v1.0.0-cqadupstack-wordpress-test", 541, 744);
+    assertQrels("beir-v1.0.0-quora-test", 10000, 15675);
+    assertQrels("beir-v1.0.0-dbpedia-entity-test", 400, 43515);
+    assertQrels("beir-v1.0.0-scidocs-test", 1000, 29928);
+    assertQrels("beir-v1.0.0-fever-test", 6666, 7937);
+    assertQrels("beir-v1.0.0-climate-fever-test", 1535, 4681);
+    assertQrels("beir-v1.0.0-scifact-test", 300, 339);
   }
-  
+
   @Test
   public void testHC4() throws IOException {
-    Qrels qrels;
-    
-    qrels = Qrels.get("hc4-v1.0-ru-dev");
-    assertNotNull(qrels);
-    assertEquals(4, qrels.getQids().size());
-    assertEquals(265, getQrelsCount(qrels));
-
-    qrels = Qrels.get("hc4-v1.0-ru-test");
-    assertNotNull(qrels);
-    assertEquals(50, qrels.getQids().size());
-    assertEquals(2970, getQrelsCount(qrels));
-  
-    qrels = Qrels.get("hc4-v1.0-fa-dev");
-    assertNotNull(qrels);
-    assertEquals(10, qrels.getQids().size());
-    assertEquals(565, getQrelsCount(qrels));
-
-    qrels = Qrels.get("hc4-v1.0-fa-test");
-    assertNotNull(qrels);
-    assertEquals(50, qrels.getQids().size());
-    assertEquals(2522, getQrelsCount(qrels));
-
-    qrels = Qrels.get("hc4-v1.0-zh-dev");
-    assertNotNull(qrels);
-    assertEquals(10, qrels.getQids().size());
-    assertEquals(466, getQrelsCount(qrels));
-
-    qrels = Qrels.get("hc4-v1.0-zh-test");
-    assertNotNull(qrels);
-    assertEquals(50, qrels.getQids().size());
-    assertEquals(2751, getQrelsCount(qrels));
+    assertQrels("hc4-v1.0-ru-dev", 4, 265);
+    assertQrels("hc4-v1.0-ru-test", 50, 2970);
+    assertQrels("hc4-v1.0-fa-dev", 10, 565);
+    assertQrels("hc4-v1.0-fa-test", 50, 2522);
+    assertQrels("hc4-v1.0-zh-dev", 10, 466);
+    assertQrels("hc4-v1.0-zh-test", 50, 2751);
   }
 
   @Test
   public void testNeuClir2022() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("neuclir22-fa");
-    assertNotNull(qrels);
-    assertEquals(46, qrels.getQids().size());
-    assertEquals(34174, getQrelsCount(qrels));
-
-    qrels = Qrels.get("neuclir22-ru");
-    assertNotNull(qrels);
-    assertEquals(45, qrels.getQids().size());
-    assertEquals(33006, getQrelsCount(qrels));
-
-    qrels = Qrels.get("neuclir22-zh");
-    assertNotNull(qrels);
-    assertEquals(49, qrels.getQids().size());
-    assertEquals(36575, getQrelsCount(qrels));
+    assertQrels("neuclir22-fa", 46, 34174);
+    assertQrels("neuclir22-ru", 45, 33006);
+    assertQrels("neuclir22-zh", 49, 36575);
   }
 
   @Test
   public void testHc4NeuClir2022() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("hc4-neuclir22-fa-test");
-    assertNotNull(qrels);
-    assertEquals(50, qrels.getQids().size());
-    assertEquals(2041, getQrelsCount(qrels));
-
-    qrels = Qrels.get("hc4-neuclir22-ru-test");
-    assertNotNull(qrels);
-    assertEquals(50, qrels.getQids().size());
-    assertEquals(625, getQrelsCount(qrels));
-
-    qrels = Qrels.get("hc4-neuclir22-zh-test");
-    assertNotNull(qrels);
-    assertEquals(60, qrels.getQids().size());
-    assertEquals(2573, getQrelsCount(qrels));
+    assertQrels("hc4-neuclir22-fa-test", 50, 2041);
+    assertQrels("hc4-neuclir22-ru-test", 50, 625);
+    assertQrels("hc4-neuclir22-zh-test", 60, 2573);
   }
 
   @Test
   public void testMIRACL() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("miracl-v1.0-ar-dev");
-    assertNotNull(qrels);
-    assertEquals(2896, qrels.getQids().size());
-    assertEquals(29197, getQrelsCount(qrels));
-
-    qrels = Qrels.get("miracl-v1.0-bn-dev");
-    assertNotNull(qrels);
-    assertEquals(411, qrels.getQids().size());
-    assertEquals(4206, getQrelsCount(qrels));
-
-    qrels = Qrels.get("miracl-v1.0-en-dev");
-    assertNotNull(qrels);
-    assertEquals(799, qrels.getQids().size());
-    assertEquals(8350, getQrelsCount(qrels));
-
-    qrels = Qrels.get("miracl-v1.0-es-dev");
-    assertNotNull(qrels);
-    assertEquals(648, qrels.getQids().size());
-    assertEquals(6443, getQrelsCount(qrels));
-
-    qrels = Qrels.get("miracl-v1.0-fa-dev");
-    assertNotNull(qrels);
-    assertEquals(632, qrels.getQids().size());
-    assertEquals(6571, getQrelsCount(qrels));
-
-    qrels = Qrels.get("miracl-v1.0-fi-dev");
-    assertNotNull(qrels);
-    assertEquals(1271, qrels.getQids().size());
-    assertEquals(12008, getQrelsCount(qrels));
-
-    qrels = Qrels.get("miracl-v1.0-fr-dev");
-    assertNotNull(qrels);
-    assertEquals(343, qrels.getQids().size());
-    assertEquals(3429, getQrelsCount(qrels));
-
-    qrels = Qrels.get("miracl-v1.0-hi-dev");
-    assertNotNull(qrels);
-    assertEquals(350, qrels.getQids().size());
-    assertEquals(3494, getQrelsCount(qrels));
-
-    qrels = Qrels.get("miracl-v1.0-id-dev");
-    assertNotNull(qrels);
-    assertEquals(960, qrels.getQids().size());
-    assertEquals(9668, getQrelsCount(qrels));
-
-    qrels = Qrels.get("miracl-v1.0-ja-dev");
-    assertNotNull(qrels);
-    assertEquals(860, qrels.getQids().size());
-    assertEquals(8354, getQrelsCount(qrels));
-
-    qrels = Qrels.get("miracl-v1.0-ko-dev");
-    assertNotNull(qrels);
-    assertEquals(213, qrels.getQids().size());
-    assertEquals(3057, getQrelsCount(qrels));
-
-    qrels = Qrels.get("miracl-v1.0-ru-dev");
-    assertNotNull(qrels);
-    assertEquals(1252, qrels.getQids().size());
-    assertEquals(13100, getQrelsCount(qrels));
-
-    qrels = Qrels.get("miracl-v1.0-sw-dev");
-    assertNotNull(qrels);
-    assertEquals(482, qrels.getQids().size());
-    assertEquals(5092, getQrelsCount(qrels));
-
-    qrels = Qrels.get("miracl-v1.0-te-dev");
-    assertNotNull(qrels);
-    assertEquals(828, qrels.getQids().size());
-    assertEquals(1606, getQrelsCount(qrels));
-
-    qrels = Qrels.get("miracl-v1.0-th-dev");
-    assertNotNull(qrels);
-    assertEquals(733, qrels.getQids().size());
-    assertEquals(7573, getQrelsCount(qrels));
-
-    qrels = Qrels.get("miracl-v1.0-zh-dev");
-    assertNotNull(qrels);
-    assertEquals(393, qrels.getQids().size());
-    assertEquals(3928, getQrelsCount(qrels));
+    assertQrels("miracl-v1.0-ar-dev", 2896, 29197);
+    assertQrels("miracl-v1.0-bn-dev", 411, 4206);
+    assertQrels("miracl-v1.0-en-dev", 799, 8350);
+    assertQrels("miracl-v1.0-es-dev", 648, 6443);
+    assertQrels("miracl-v1.0-fa-dev", 632, 6571);
+    assertQrels("miracl-v1.0-fi-dev", 1271, 12008);
+    assertQrels("miracl-v1.0-fr-dev", 343, 3429);
+    assertQrels("miracl-v1.0-hi-dev", 350, 3494);
+    assertQrels("miracl-v1.0-id-dev", 960, 9668);
+    assertQrels("miracl-v1.0-ja-dev", 860, 8354);
+    assertQrels("miracl-v1.0-ko-dev", 213, 3057);
+    assertQrels("miracl-v1.0-ru-dev", 1252, 13100);
+    assertQrels("miracl-v1.0-sw-dev", 482, 5092);
+    assertQrels("miracl-v1.0-te-dev", 828, 1606);
+    assertQrels("miracl-v1.0-th-dev", 733, 7573);
+    assertQrels("miracl-v1.0-zh-dev", 393, 3928);
   }
 
   @Test
   public void testCIRAL() throws IOException {
-    Qrels qrels;
-
-    qrels = Qrels.get("ciral-v1.0-ha-dev");
-    assertNotNull(qrels);
-    assertEquals(10, qrels.getQids().size());
-    assertEquals(165, getQrelsCount(qrels));
-
-    qrels = Qrels.get("ciral-v1.0-so-dev");
-    assertNotNull(qrels);
-    assertEquals(10, qrels.getQids().size());
-    assertEquals(187, getQrelsCount(qrels));
-
-    qrels = Qrels.get("ciral-v1.0-sw-dev");
-    assertNotNull(qrels);
-    assertEquals(10, qrels.getQids().size());
-    assertEquals(196, getQrelsCount(qrels));
-
-    qrels = Qrels.get("ciral-v1.0-yo-dev");
-    assertNotNull(qrels);
-    assertEquals(10, qrels.getQids().size());
-    assertEquals(185, getQrelsCount(qrels));
-
-    qrels = Qrels.get("ciral-v1.0-ha-test-a");
-    assertNotNull(qrels);
-    assertEquals(80, qrels.getQids().size());
-    assertEquals(1447, getQrelsCount(qrels));
-
-    qrels = Qrels.get("ciral-v1.0-so-test-a");
-    assertNotNull(qrels);
-    assertEquals(99, qrels.getQids().size());
-    assertEquals(1798, getQrelsCount(qrels));
-
-    qrels = Qrels.get("ciral-v1.0-sw-test-a");
-    assertNotNull(qrels);
-    assertEquals(85, qrels.getQids().size());
-    assertEquals(1656, getQrelsCount(qrels));
-
-    qrels = Qrels.get("ciral-v1.0-yo-test-a");
-    assertNotNull(qrels);
-    assertEquals(100, qrels.getQids().size());
-    assertEquals(1921, getQrelsCount(qrels));
-
-    qrels = Qrels.get("ciral-v1.0-ha-test-a-pools");
-    assertNotNull(qrels);
-    assertEquals(80, qrels.getQids().size());
-    assertEquals(7288, getQrelsCount(qrels));
-
-    qrels = Qrels.get("ciral-v1.0-so-test-a-pools");
-    assertNotNull(qrels);
-    assertEquals(99, qrels.getQids().size());
-    assertEquals(9094, getQrelsCount(qrels));
-
-    qrels = Qrels.get("ciral-v1.0-sw-test-a-pools");
-    assertNotNull(qrels);
-    assertEquals(85, qrels.getQids().size());
-    assertEquals(8079, getQrelsCount(qrels));
-
-    qrels = Qrels.get("ciral-v1.0-yo-test-a-pools");
-    assertNotNull(qrels);
-    assertEquals(100, qrels.getQids().size());
-    assertEquals(8311, getQrelsCount(qrels));
-
-    qrels = Qrels.get("ciral-v1.0-ha-test-b");
-    assertNotNull(qrels);
-    assertEquals(312, qrels.getQids().size());
-    assertEquals(5930, getQrelsCount(qrels));
-
-    qrels = Qrels.get("ciral-v1.0-so-test-b");
-    assertNotNull(qrels);
-    assertEquals(239, qrels.getQids().size());
-    assertEquals(4324, getQrelsCount(qrels));
-
-    qrels = Qrels.get("ciral-v1.0-sw-test-b");
-    assertNotNull(qrels);
-    assertEquals(114, qrels.getQids().size());
-    assertEquals(2175, getQrelsCount(qrels));
-
-    qrels = Qrels.get("ciral-v1.0-yo-test-b");
-    assertNotNull(qrels);
-    assertEquals(554, qrels.getQids().size());
-    assertEquals(10569, getQrelsCount(qrels));
+    assertQrels("ciral-v1.0-ha-dev", 10, 165);
+    assertQrels("ciral-v1.0-so-dev", 10, 187);
+    assertQrels("ciral-v1.0-sw-dev", 10, 196);
+    assertQrels("ciral-v1.0-yo-dev", 10, 185);
+    assertQrels("ciral-v1.0-ha-test-a", 80, 1447);
+    assertQrels("ciral-v1.0-so-test-a", 99, 1798);
+    assertQrels("ciral-v1.0-sw-test-a", 85, 1656);
+    assertQrels("ciral-v1.0-yo-test-a", 100, 1921);
+    assertQrels("ciral-v1.0-ha-test-a-pools", 80, 7288);
+    assertQrels("ciral-v1.0-so-test-a-pools", 99, 9094);
+    assertQrels("ciral-v1.0-sw-test-a-pools", 85, 8079);
+    assertQrels("ciral-v1.0-yo-test-a-pools", 100, 8311);
+    assertQrels("ciral-v1.0-ha-test-b", 312, 5930);
+    assertQrels("ciral-v1.0-so-test-b", 239, 4324);
+    assertQrels("ciral-v1.0-sw-test-b", 114, 2175);
+    assertQrels("ciral-v1.0-yo-test-b", 554, 10569);
   }
 
   @Test
   public void testDseQrels() throws IOException {
-    Qrels qrels = Qrels.get("slidevqa");
-    assertNotNull(qrels);
-    assertEquals(2214, qrels.getQids().size());
-    assertEquals(2786, getQrelsCount(qrels));
+    assertQrels("slidevqa", 2214, 2786);
   }
 
   @Test
   public void testMMEBVisDocQrels() throws IOException {
-    Qrels qrels = Qrels.get("mmeb-visdoc-ViDoRe_arxivqa-test");
-    assertNotNull(qrels);
-    assertEquals(500, qrels.getQids().size());
-    assertEquals(500, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoRe_docvqa-test");
-    assertNotNull(qrels);
-    assertEquals(451, qrels.getQids().size());
-    assertEquals(500, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoRe_infovqa-test");
-    assertNotNull(qrels);
-    assertEquals(494, qrels.getQids().size());
-    assertEquals(500, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoRe_shiftproject-test");
-    assertNotNull(qrels);
-    assertEquals(100, qrels.getQids().size());
-    assertEquals(100, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoRe_syntheticDocQA_artificial_intelligence-test");
-      assertNotNull(qrels);
-      assertEquals(100, qrels.getQids().size());
-      assertEquals(100, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoRe_syntheticDocQA_energy-test");
-    assertNotNull(qrels);
-    assertEquals(100, qrels.getQids().size());
-    assertEquals(100, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoRe_syntheticDocQA_government_reports-test");
-    assertNotNull(qrels);
-    assertEquals(100, qrels.getQids().size());
-    assertEquals(100, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoRe_syntheticDocQA_healthcare_industry-test");
-    assertNotNull(qrels);
-    assertEquals(100, qrels.getQids().size());
-    assertEquals(100, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoRe_tabfquad-test");
-    assertNotNull(qrels);
-    assertEquals(280, qrels.getQids().size());
-    assertEquals(280, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoRe_tatdqa-test");
-    assertNotNull(qrels);
-    assertEquals(1646, qrels.getQids().size());
-    assertEquals(1663, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoRe_biomedical_lectures_v2-test");
-    assertNotNull(qrels);
-    assertEquals(640, qrels.getQids().size());
-    assertEquals(2060, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoRe_biomedical_lectures_v2_multilingual-test");
-    assertNotNull(qrels);
-    assertEquals(640, qrels.getQids().size());
-    assertEquals(2060, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoRe_economics_reports_v2-test");
-    assertNotNull(qrels);
-    assertEquals(232, qrels.getQids().size());
-    assertEquals(3628, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoRe_economics_reports_v2_multilingual-test");
-    assertNotNull(qrels);
-    assertEquals(232, qrels.getQids().size());
-    assertEquals(3628, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoRe_esg_reports_human_labeled_v2-test");
-    assertNotNull(qrels);
-    assertEquals(52, qrels.getQids().size());
-    assertEquals(128, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoRe_esg_reports_v2-test");
-    assertNotNull(qrels);
-    assertEquals(228, qrels.getQids().size());
-    assertEquals(888, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoRe_esg_reports_v2_multilingual-test");
-    assertNotNull(qrels);
-    assertEquals(228, qrels.getQids().size());
-    assertEquals(888, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-VisRAG_ArxivQA-train");
-    assertNotNull(qrels);
-    assertEquals(816, qrels.getQids().size());
-    assertEquals(816, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-VisRAG_ChartQA-train");
-    assertNotNull(qrels);
-    assertEquals(63, qrels.getQids().size());
-    assertEquals(63, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-VisRAG_InfoVQA-train");
-    assertNotNull(qrels);
-    assertEquals(718, qrels.getQids().size());
-    assertEquals(718, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-VisRAG_MP-DocVQA-train");
-    assertNotNull(qrels);
-    assertEquals(591, qrels.getQids().size());
-    assertEquals(591, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-VisRAG_PlotQA-train");
-    assertNotNull(qrels);
-    assertEquals(863, qrels.getQids().size());
-    assertEquals(863, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-VisRAG_SlideVQA-train");
-    assertNotNull(qrels);
-    assertEquals(556, qrels.getQids().size());
-    assertEquals(702, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoSeek-doc-test");
-    assertNotNull(qrels);
-    assertEquals(1142, qrels.getQids().size());
-    assertEquals(21190, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-ViDoSeek-page-test");
-    assertNotNull(qrels);
-    assertEquals(1142, qrels.getQids().size());
-    assertEquals(1142, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-MMLongBench-doc-test");
-    assertNotNull(qrels);
-    assertEquals(838, qrels.getQids().size());
-    assertEquals(40850, getQrelsCount(qrels));
-
-    qrels = Qrels.get("mmeb-visdoc-MMLongBench-page-test");
-    assertNotNull(qrels);
-    assertEquals(838, qrels.getQids().size());
-    assertEquals(1574, getQrelsCount(qrels));
+    assertQrels("mmeb-visdoc-ViDoRe_arxivqa-test", 500, 500);
+    assertQrels("mmeb-visdoc-ViDoRe_docvqa-test", 451, 500);
+    assertQrels("mmeb-visdoc-ViDoRe_infovqa-test", 494, 500);
+    assertQrels("mmeb-visdoc-ViDoRe_shiftproject-test", 100, 100);
+    assertQrels("mmeb-visdoc-ViDoRe_syntheticDocQA_artificial_intelligence-test", 100, 100);
+    assertQrels("mmeb-visdoc-ViDoRe_syntheticDocQA_energy-test", 100, 100);
+    assertQrels("mmeb-visdoc-ViDoRe_syntheticDocQA_government_reports-test", 100, 100);
+    assertQrels("mmeb-visdoc-ViDoRe_syntheticDocQA_healthcare_industry-test", 100, 100);
+    assertQrels("mmeb-visdoc-ViDoRe_tabfquad-test", 280, 280);
+    assertQrels("mmeb-visdoc-ViDoRe_tatdqa-test", 1646, 1663);
+    assertQrels("mmeb-visdoc-ViDoRe_biomedical_lectures_v2-test", 640, 2060);
+    assertQrels("mmeb-visdoc-ViDoRe_biomedical_lectures_v2_multilingual-test", 640, 2060);
+    assertQrels("mmeb-visdoc-ViDoRe_economics_reports_v2-test", 232, 3628);
+    assertQrels("mmeb-visdoc-ViDoRe_economics_reports_v2_multilingual-test", 232, 3628);
+    assertQrels("mmeb-visdoc-ViDoRe_esg_reports_human_labeled_v2-test", 52, 128);
+    assertQrels("mmeb-visdoc-ViDoRe_esg_reports_v2-test", 228, 888);
+    assertQrels("mmeb-visdoc-ViDoRe_esg_reports_v2_multilingual-test", 228, 888);
+    assertQrels("mmeb-visdoc-VisRAG_ArxivQA-train", 816, 816);
+    assertQrels("mmeb-visdoc-VisRAG_ChartQA-train", 63, 63);
+    assertQrels("mmeb-visdoc-VisRAG_InfoVQA-train", 718, 718);
+    assertQrels("mmeb-visdoc-VisRAG_MP-DocVQA-train", 591, 591);
+    assertQrels("mmeb-visdoc-VisRAG_PlotQA-train", 863, 863);
+    assertQrels("mmeb-visdoc-VisRAG_SlideVQA-train", 556, 702);
+    assertQrels("mmeb-visdoc-ViDoSeek-doc-test", 1142, 21190);
+    assertQrels("mmeb-visdoc-ViDoSeek-page-test", 1142, 1142);
+    assertQrels("mmeb-visdoc-MMLongBench-doc-test", 838, 40850);
+    assertQrels("mmeb-visdoc-MMLongBench-page-test", 838, 1574);
   }
 
   @Test
@@ -1652,11 +882,12 @@ public class QrelsTest{
     assertQrels("terabyte06.801-850", 50, 31984);
   }
 
-  private void assertQrels(String name, int qids, int judgments) throws IOException {
+  private Qrels assertQrels(String name, int qids, int judgments) throws IOException {
     Qrels qrels = Qrels.get(name);
     assertNotNull(qrels);
     assertEquals(qids, qrels.getQids().size());
     assertEquals(judgments, getQrelsCount(qrels));
+    return qrels;
   }
 
   @Test
@@ -1693,7 +924,7 @@ public class QrelsTest{
     produced = Qrels.resolveQrelsPath("qrels.covid-round3.txt");
     assertNotNull(produced);
     assertEquals(expected, produced);
-    
+
     expected = CacheDirectoryResolver.getQrelsCachePath().resolve("qrels.ciral-v1.0-yo-test-a-pools.tsv");
     produced = Qrels.resolveQrelsPath("qrels.ciral-v1.0-yo-test-a-pools.tsv");
     assertNotNull(produced);

--- a/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicReaderTest.java
@@ -791,6 +791,16 @@ public class TopicReaderTest {
     assertEquals("[-0.010772705", topics.get(topics.firstKey()).get("vector").split(",")[0]);
     assertEquals(1133167, (int) topics.lastKey());
     assertEquals("[0.016159058", topics.get(topics.lastKey()).get("vector").split(",")[0]);
+
+    assertEquals(43, TopicReader.load(Topics.get("dl19-doc.unicoil-noexp.0shot")).size());
+    assertEquals(43, TopicReader.load(Topics.get("dl19-doc.unicoil.0shot")).size());
+    assertEquals(43, TopicReader.load(Topics.get("dl19-passage.cos-dpr-distil")).size());
+    assertEquals(43, TopicReader.load(Topics.get("dl19-passage.splade-pp-ed")).size());
+    assertEquals(43, TopicReader.load(Topics.get("dl19-passage.splade-pp-sd")).size());
+    assertEquals(43, TopicReader.load(Topics.get("dl19-passage.splade-v3")).size());
+    assertEquals(43, TopicReader.load(Topics.get("dl19-passage.splade_distil_cocodenser_medium")).size());
+    assertEquals(43, TopicReader.load(Topics.get("dl19-passage.unicoil-noexp.0shot")).size());
+    assertEquals(43, TopicReader.load(Topics.get("dl19-passage.unicoil.0shot")).size());
   }
 
   @Test
@@ -822,6 +832,14 @@ public class TopicReaderTest {
     assertEquals("[0.008285522", topics.get(topics.firstKey()).get("vector").split(",")[0]);
     assertEquals(1136962, (int) topics.lastKey());
     assertEquals("[0.0056495667", topics.get(topics.lastKey()).get("vector").split(",")[0]);
+
+    assertEquals(200, TopicReader.load(Topics.get("dl20.cos-dpr-distil")).size());
+    assertEquals(200, TopicReader.load(Topics.get("dl20.splade-pp-ed")).size());
+    assertEquals(200, TopicReader.load(Topics.get("dl20.splade-pp-sd")).size());
+    assertEquals(200, TopicReader.load(Topics.get("dl20.splade-v3")).size());
+    assertEquals(54, TopicReader.load(Topics.get("dl20.splade_distil_cocodenser_medium")).size());
+    assertEquals(200, TopicReader.load(Topics.get("dl20.unicoil-noexp.0shot")).size());
+    assertEquals(200, TopicReader.load(Topics.get("dl20.unicoil.0shot")).size());
   }
 
   @Test
@@ -844,6 +862,9 @@ public class TopicReaderTest {
     assertEquals("[-0.0054801227524876595", topics.get(topics.firstKey()).get("vector").split(",")[0]);
     assertEquals(1136769, (int) topics.lastKey());
     assertEquals("[0.0038787610828876495", topics.get(topics.lastKey()).get("vector").split(",")[0]);
+
+    assertEquals(477, TopicReader.load(Topics.get("dl21.unicoil-noexp.0shot")).size());
+    assertEquals(477, TopicReader.load(Topics.get("dl21.unicoil.0shot")).size());
   }
 
   @Test
@@ -866,6 +887,9 @@ public class TopicReaderTest {
     assertEquals("[0.020797204226255417", topics.get(topics.firstKey()).get("vector").split(",")[0]);
     assertEquals(2056473, (int) topics.lastKey());
     assertEquals("[0.005524440202862024", topics.get(topics.lastKey()).get("vector").split(",")[0]);
+
+    assertEquals(500, TopicReader.load(Topics.get("dl22.unicoil-noexp.0shot")).size());
+    assertEquals(500, TopicReader.load(Topics.get("dl22.unicoil.0shot")).size());
   }
 
   @Test
@@ -888,6 +912,9 @@ public class TopicReaderTest {
     assertEquals("[0.001558756805025041", topics.get(topics.firstKey()).get("vector").split(",")[0]);
     assertEquals(3100949, (int) topics.lastKey());
     assertEquals("[0.014963677152991295", topics.get(topics.lastKey()).get("vector").split(",")[0]);
+
+    assertEquals(700, TopicReader.load(Topics.get("dl23.unicoil-noexp.0shot")).size());
+    assertEquals(700, TopicReader.load(Topics.get("dl23.unicoil.0shot")).size());
   }
 
   @Test
@@ -998,6 +1025,18 @@ public class TopicReaderTest {
     assertEquals(1136966, (int) topics.lastKey());
     assertEquals("#ffffff color code", topics.get(topics.lastKey()).get("title"));
 
+    assertEquals(5193, TopicReader.load(Topics.get("msmarco-doc.dev.unicoil")).size());
+    assertEquals(5193, TopicReader.load(Topics.get("msmarco-doc.dev.unicoil-noexp")).size());
+    assertEquals(6980, TopicReader.load(Topics.get("msmarco-passage.dev-subset.cos-dpr-distil")).size());
+    assertEquals(6980, TopicReader.load(Topics.get("msmarco-passage.dev-subset.distill-splade-max")).size());
+    assertEquals(6980, TopicReader.load(Topics.get("msmarco-passage.dev-subset.splade-pp-ed")).size());
+    assertEquals(6980, TopicReader.load(Topics.get("msmarco-passage.dev-subset.splade-pp-sd")).size());
+    assertEquals(6980, TopicReader.load(Topics.get("msmarco-passage.dev-subset.splade-v3")).size());
+    assertEquals(6980, TopicReader.load(Topics.get("msmarco-passage.dev-subset.splade_distil_cocodenser_medium")).size());
+    assertEquals(6980, TopicReader.load(Topics.get("msmarco-passage.dev-subset.unicoil")).size());
+    assertEquals(6980, TopicReader.load(Topics.get("msmarco-passage.dev-subset.unicoil-noexp")).size());
+    assertEquals(6980, TopicReader.load(Topics.get("msmarco-passage.dev-subset.unicoil-tilde-expansion")).size());
+
     topics = TopicReader.load(Topics.get("msmarco-passage.dev-subset"));
     assertNotNull(topics);
     assertEquals(6980, topics.size());
@@ -1066,6 +1105,15 @@ public class TopicReaderTest {
     assertEquals(". irritability medical definition", topics.get(topics.firstKey()).get("title"));
     assertEquals(1102413, (int) topics.lastKey());
     assertEquals("why do a ferritin level", topics.get(topics.lastKey()).get("title"));
+
+    assertEquals(4552, TopicReader.load(Topics.get("msmarco-v2-doc.dev.unicoil-noexp.0shot")).size());
+    assertEquals(4552, TopicReader.load(Topics.get("msmarco-v2-doc.dev.unicoil.0shot")).size());
+    assertEquals(5000, TopicReader.load(Topics.get("msmarco-v2-doc.dev2.unicoil-noexp.0shot")).size());
+    assertEquals(5000, TopicReader.load(Topics.get("msmarco-v2-doc.dev2.unicoil.0shot")).size());
+    assertEquals(3903, TopicReader.load(Topics.get("msmarco-v2-passage.dev.unicoil-noexp.0shot")).size());
+    assertEquals(3903, TopicReader.load(Topics.get("msmarco-v2-passage.dev.unicoil.0shot")).size());
+    assertEquals(4281, TopicReader.load(Topics.get("msmarco-v2-passage.dev2.unicoil-noexp.0shot")).size());
+    assertEquals(4281, TopicReader.load(Topics.get("msmarco-v2-passage.dev2.unicoil.0shot")).size());
 
     topics = TopicReader.load(Topics.get("msmarco-v2-doc.dev2.snowflake-arctic-embed-l"));
     assertNotNull(topics);
@@ -1595,6 +1643,61 @@ public class TopicReaderTest {
     assertEquals(111, TopicReader.load(Topics.get("bright-aops")).keySet().size());
     assertEquals(76,  TopicReader.load(Topics.get("bright-theoremqa-theorems")).keySet().size());
     assertEquals(194, TopicReader.load(Topics.get("bright-theoremqa-questions")).keySet().size());
+
+    assertEquals(103, TopicReader.load(Topics.get("bright-biology.bge-large-en-v1.5")).size());
+    assertEquals(103, TopicReader.load(Topics.get("bright-biology.splade-v3")).size());
+    assertEquals(116, TopicReader.load(Topics.get("bright-earth-science.bge-large-en-v1.5")).size());
+    assertEquals(116, TopicReader.load(Topics.get("bright-earth-science.splade-v3")).size());
+    assertEquals(103, TopicReader.load(Topics.get("bright-economics.bge-large-en-v1.5")).size());
+    assertEquals(103, TopicReader.load(Topics.get("bright-economics.splade-v3")).size());
+    assertEquals(101, TopicReader.load(Topics.get("bright-psychology.bge-large-en-v1.5")).size());
+    assertEquals(101, TopicReader.load(Topics.get("bright-psychology.splade-v3")).size());
+    assertEquals(101, TopicReader.load(Topics.get("bright-robotics.bge-large-en-v1.5")).size());
+    assertEquals(101, TopicReader.load(Topics.get("bright-robotics.splade-v3")).size());
+    assertEquals(117, TopicReader.load(Topics.get("bright-stackoverflow.bge-large-en-v1.5")).size());
+    assertEquals(117, TopicReader.load(Topics.get("bright-stackoverflow.splade-v3")).size());
+    assertEquals(108, TopicReader.load(Topics.get("bright-sustainable-living.bge-large-en-v1.5")).size());
+    assertEquals(108, TopicReader.load(Topics.get("bright-sustainable-living.splade-v3")).size());
+    assertEquals(112, TopicReader.load(Topics.get("bright-pony.bge-large-en-v1.5")).size());
+    assertEquals(112, TopicReader.load(Topics.get("bright-pony.splade-v3")).size());
+    assertEquals(142, TopicReader.load(Topics.get("bright-leetcode.bge-large-en-v1.5")).size());
+    assertEquals(142, TopicReader.load(Topics.get("bright-leetcode.splade-v3")).size());
+    assertEquals(111, TopicReader.load(Topics.get("bright-aops.bge-large-en-v1.5")).size());
+    assertEquals(111, TopicReader.load(Topics.get("bright-aops.splade-v3")).size());
+    assertEquals(76, TopicReader.load(Topics.get("bright-theoremqa-theorems.bge-large-en-v1.5")).size());
+    assertEquals(76, TopicReader.load(Topics.get("bright-theoremqa-theorems.splade-v3")).size());
+    assertEquals(194, TopicReader.load(Topics.get("bright-theoremqa-questions.bge-large-en-v1.5")).size());
+    assertEquals(194, TopicReader.load(Topics.get("bright-theoremqa-questions.splade-v3")).size());
+  }
+
+  @Test
+  public void testAtomicValidationTopics() throws IOException {
+    String[] models = {
+        "Salesforce.blip-itm-base-coco",
+        "Salesforce.blip-itm-large-coco",
+        "ViT-B-32.laion2b_e16",
+        "ViT-B-32.laion400m_e32",
+        "ViT-H-14.laion2b_s32b_b79k",
+        "ViT-L-14.laion2b_s32b_b82k",
+        "ViT-bigG-14.laion2b_s39b_b160k",
+        "facebook.flava-full",
+        "openai.clip-vit-base-patch32",
+        "openai.clip-vit-large-patch14"
+    };
+
+    for (String model : models) {
+      assertEquals(16131, TopicReader.load(Topics.get("atomic.validation.image." + model)).size());
+      assertEquals(17173, TopicReader.load(Topics.get("atomic.validation.text." + model)).size());
+    }
+  }
+
+  @Test
+  public void testLegacyTopics() throws IOException {
+    assertEquals(73, TopicReader.load(Topics.get("ntcir8en.eval")).size());
+    assertEquals(50000, TopicReader.load(Topics.get("terabyte05.efficiency")).size());
+    assertEquals(50, TopicReader.load(Topics.get("web.1-50")).size());
+    assertEquals(100, TopicReader.load(Topics.get("www1.english")).size());
+    assertEquals(80, TopicReader.load(Topics.get("www2.english")).size());
   }
 
   @Test
@@ -1834,6 +1937,10 @@ public class TopicReaderTest {
 
   @Test
   public void testNeuCLIR22SpladeTopics() throws IOException {
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-en.splade.original-title")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-en.splade.original-desc")).keySet().size());
+    assertEquals(114, TopicReader.load(Topics.get("neuclir22-en.splade.original-desc_title")).keySet().size());
+
     assertEquals(114, TopicReader.load(Topics.get("neuclir22-fa.splade.ht-title")).keySet().size());
     assertEquals(114, TopicReader.load(Topics.get("neuclir22-fa.splade.ht-desc")).keySet().size());
     assertEquals(114, TopicReader.load(Topics.get("neuclir22-fa.splade.ht-desc_title")).keySet().size());
@@ -1879,6 +1986,23 @@ public class TopicReaderTest {
     assertEquals(393,  TopicReader.load(Topics.get("miracl-v1.0-zh-dev")).keySet().size());
     assertEquals(305,  TopicReader.load(Topics.get("miracl-v1.0-de-dev")).keySet().size());
     assertEquals(119,  TopicReader.load(Topics.get("miracl-v1.0-yo-dev")).keySet().size());
+
+    assertEquals(3495, TopicReader.load(Topics.get("miracl-v1.0-ar-train")).size());
+    assertEquals(1631, TopicReader.load(Topics.get("miracl-v1.0-bn-train")).size());
+    assertEquals(2863, TopicReader.load(Topics.get("miracl-v1.0-en-train")).size());
+    assertEquals(2162, TopicReader.load(Topics.get("miracl-v1.0-es-train")).size());
+    assertEquals(2107, TopicReader.load(Topics.get("miracl-v1.0-fa-train")).size());
+    assertEquals(2897, TopicReader.load(Topics.get("miracl-v1.0-fi-train")).size());
+    assertEquals(1143, TopicReader.load(Topics.get("miracl-v1.0-fr-train")).size());
+    assertEquals(1169, TopicReader.load(Topics.get("miracl-v1.0-hi-train")).size());
+    assertEquals(4071, TopicReader.load(Topics.get("miracl-v1.0-id-train")).size());
+    assertEquals(3477, TopicReader.load(Topics.get("miracl-v1.0-ja-train")).size());
+    assertEquals(868, TopicReader.load(Topics.get("miracl-v1.0-ko-train")).size());
+    assertEquals(4683, TopicReader.load(Topics.get("miracl-v1.0-ru-train")).size());
+    assertEquals(1901, TopicReader.load(Topics.get("miracl-v1.0-sw-train")).size());
+    assertEquals(3452, TopicReader.load(Topics.get("miracl-v1.0-te-train")).size());
+    assertEquals(2972, TopicReader.load(Topics.get("miracl-v1.0-th-train")).size());
+    assertEquals(1312, TopicReader.load(Topics.get("miracl-v1.0-zh-train")).size());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- add loading and exact size checks for previously uncovered registered topics
- add exact qid and judgment-count checks for previously uncovered registered qrels
- cover Atomic, BRIGHT, FIRE, M-BEIR, MIRACL, MS MARCO, TREC, and legacy collections

## Validation

- `mvn -Dtest=TopicReaderTest test`
- `mvn -Dtest=QrelsTest test`
- `git diff --check`

`TopicReaderTest`: 66 tests passed.
`QrelsTest`: 98 tests passed.
