### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -711,3 +711,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`d02b3dd`](https://github.com/castorini/anserini/commit/d02b3dd3c85c81a675c4f5a7dc721ab249170817))
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`efb96dd`](https://github.com/castorini/anserini/commit/efb96ddf50857058c68298efb4a5430d1af1f95e))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d178a77`](https://github.com/castorini/anserini/commit/d178a7748b5b25b7c9238df6cb1eac134e2e6b58))
++ Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-29 (commit [`843af42`](https://github.com/castorini/anserini/commit/843af42914a62542053a5519ea92a1fc55f0ec0a))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -266,3 +266,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`d02b3dd`](https://github.com/castorini/anserini/commit/d02b3dd3c85c81a675c4f5a7dc721ab249170817))
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`efb96dd`](https://github.com/castorini/anserini/commit/efb96ddf50857058c68298efb4a5430d1af1f95e))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d178a77`](https://github.com/castorini/anserini/commit/d178a7748b5b25b7c9238df6cb1eac134e2e6b58))
++ Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-29 (commit [`843af42`](https://github.com/castorini/anserini/commit/843af42914a62542053a5519ea92a1fc55f0ec0a))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -618,3 +618,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`d02b3dd`](https://github.com/castorini/anserini/commit/d02b3dd3c85c81a675c4f5a7dc721ab249170817))
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`efb96dd`](https://github.com/castorini/anserini/commit/efb96ddf50857058c68298efb4a5430d1af1f95e))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d178a77`](https://github.com/castorini/anserini/commit/d178a7748b5b25b7c9238df6cb1eac134e2e6b58))
++ Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-28 (commit [`843af42`](https://github.com/castorini/anserini/commit/843af42914a62542053a5519ea92a1fc55f0ec0a))


### PR DESCRIPTION
Reproduced the first three lessons of the onboarding path (`start-here.md`, `experiments-msmarco-passage.md`, `experiments-msmarco-passage2.md`), all at commit `843af42`.

**Lessons 1-2 (local):**
MacBook Air M4 (macOS 26.3.1)
Python 3.9.6
Java openJDK 21.0.12.1
Maven 3.9.16

**Lesson 3 (UWaterloo student teaching host `ubuntu2404-002`):**
Ubuntu 24.04, 64 vCPU / 982 GB RAM
Python 3.12.3
Java openJDK 21.0.12
Maven 3.8.7

All results were reproduced exactly: 8,841,823 documents indexed (0 errors), MRR@10 0.18741227770955546, MAP 0.1957, Recall@1000 0.8573 for BM25; MRR@10 0.1875 with the prebuilt index and 0.3521 with BGE-base-en-v1.5 HNSW.

However, I ran into two issues.

**1. Indexing was killed on a 16 GB laptop because `bin/run.sh` hardcodes `-Xmx192G`.** With a 192 GB ceiling the JVM never came under GC pressure, grew past physical RAM, pushed the machine into swap, and was SIGKILL'd by the macOS OOM killer partway through `IndexCollection` (5,030,000 of 8,841,823 documents, exit code 137). The symptom is an opaque `Killed: 9` rather than a Java OOM, so it isn't obvious that heap settings are the cause. Re-running with `-Xmx8G` and otherwise identical arguments completed in 1:46 with 0 errors and the documented 4.3 GB index. `experiments-msmarco-passage.md` does suggest tweaking `-Xms`/`-Xmx` on OOM; a note that `Killed: 9` is the symptom on macOS would make the connection easier to find.

**2. The 26 GB HNSW index in lesson 3 is impractical on a slow connection.** On residential bandwidth (~0.2 MB/s, measured with both Anserini and `curl`) the download projected to roughly 32 hours. `PrebuiltIndexHandler` deletes partial downloads on failure, so an interrupted transfer restarts from zero rather than resuming, which I hit once after ~100 MB. I finished lesson 3 on a UWaterloo teaching host, where the same download took about 12 minutes. Mentioning the teaching hosts near the 26 GB warning in `experiments-msmarco-passage2.md` might save students time.

Minor observation, not a problem: `SearchHnswDenseVectors` with `-hits 1000` returns 100 hits per query, since HNSW search is bounded by the default `efSearch` of 100. This does not affect MRR@10.
