### PR TITLE
[codex] Fix Lucene 10.5 compatibility issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <configuration>
           <!-- Need to add @{argLine} for JaCoCo to work; see
           https://stackoverflow.com/questions/71568474/getting-skipping-jacoco-execution-due-to-missing-execution-data-file-with-jaco -->
-          <argLine>@{argLine} -Xmx8192m --enable-native-access=ALL-UNNAMED</argLine>
+          <argLine>@{argLine} -Xmx8192m --enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/io/anserini/index/IndexReaderUtils.java
+++ b/src/main/java/io/anserini/index/IndexReaderUtils.java
@@ -37,6 +37,7 @@ import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiTerms;
 import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
@@ -49,7 +50,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TotalHitCountCollector;
 import org.apache.lucene.search.similarities.BM25Similarity;
 import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.store.Directory;
@@ -208,15 +208,12 @@ public class IndexReaderUtils {
    * @return df (+cf if only one term) of the phrase
    * @throws IOException if error encountered during access to index
    */
-  public static Map<String, Long> getTermCountsWithAnalyzer(IndexReader reader, String termStr, Analyzer analyzer)
-      throws IOException {
+  public static Map<String, Long> getTermCountsWithAnalyzer(IndexReader reader, String termStr, Analyzer analyzer) throws IOException {
     if (AnalyzerUtils.analyze(analyzer, termStr).size() > 1) {
       Query query = new PhraseQueryGenerator().buildQuery(Constants.CONTENTS, analyzer, termStr);
       IndexSearcher searcher = new IndexSearcher(reader);
-      TotalHitCountCollector totalHitCountCollector = new TotalHitCountCollector();
-      searcher.search(query, totalHitCountCollector);
       return Map.ofEntries(
-        Map.entry("docFreq", (long) totalHitCountCollector.getTotalHits())
+        Map.entry("docFreq", (long) searcher.count(query))
       );
     }
 
@@ -426,8 +423,7 @@ public class IndexReaderUtils {
    *
    * @param reader index reader
    * @param docid collection docid
-   * @return the document vector for a particular document as a map of terms to term frequencies or {@code null} if
-   * document does not exist.
+   * @return the document vector for a particular document as a map of terms to term frequencies or {@code null} if document does not exist.
    * @throws IOException if error encountered during query
    * @throws NotStoredException if the term vector is not stored
    */
@@ -497,7 +493,7 @@ public class IndexReaderUtils {
 
   /**
    * Returns the Lucene {@link Document} based on a collection docid. The method is named to be consistent with Lucene's
-   * {@link IndexReader#document(int)}, contra Java's standard method naming conventions.
+   * {@link StoredFields#document(int)}, contra Java's standard method naming conventions.
    *
    * @param reader index reader
    * @param docid collection docid
@@ -515,7 +511,7 @@ public class IndexReaderUtils {
   /**
    * Fetches the Lucene {@link Document} based on some field other than its unique collection docid. For example,
    * scientific articles might have DOIs. The method is named to be consistent with Lucene's
-   * {@link IndexReader#document(int)}, contra Java's standard method naming conventions.
+   * {@link StoredFields#document(int)}, contra Java's standard method naming conventions.
    *
    * @param reader index reader
    * @param field field
@@ -543,7 +539,7 @@ public class IndexReaderUtils {
 
   /**
    * Returns the "raw" field of a document based on a collection docid. The method is named to be consistent with
-   * Lucene's {@link IndexReader#document(int)}, contra Java's standard method naming conventions.
+   * Lucene's {@link StoredFields#document(int)}, contra Java's standard method naming conventions.
    *
    * @param reader index reader
    * @param docid collection docid
@@ -560,7 +556,7 @@ public class IndexReaderUtils {
 
   /**
    * Returns the "contents" field of a document based on a collection docid. The method is named to be consistent with
-   * Lucene's {@link IndexReader#document(int)}, contra Java's standard method naming conventions.
+   * Lucene's {@link StoredFields#document(int)}, contra Java's standard method naming conventions.
    *
    * @param reader index reader
    * @param docid collection docid
@@ -934,8 +930,6 @@ public class IndexReaderUtils {
     }
     return String.format(Locale.US, "%.1f %s", size, units[unitIndex]);
   }
-
-    // This is needed by src/main/python/run_regression.py
 
   public static final class Args {
     @Option(name = "-index", metaVar = "[Path]", required = true, usage = "index path")

--- a/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
@@ -212,6 +212,7 @@ public class ReproduceFromPrebuiltIndexes {
       }
 
       // Compute dynamic widths for first and last columns.
+      @SuppressWarnings("null")
       int nameWidth = Math.max("name".length(), uniqueIndexNames.stream().mapToInt(String::length).max().orElse(4));
       nameWidth = Math.max(nameWidth, "total".length());
       int pathWidth = "local path".length();

--- a/src/main/java/io/anserini/util/FeatureVector.java
+++ b/src/main/java/io/anserini/util/FeatureVector.java
@@ -116,6 +116,7 @@ public class FeatureVector {
     return getOrderedFeatures(Order.VALUE_DESCENDING);
   }
 
+  @SuppressWarnings("null")
   private List<FeatureValuePair> getOrderedFeatures(Order order) {
     List<FeatureValuePair> pairs = new ArrayList<>(features.size());
     Iterator<String> featureIterator = features.keySet().iterator();


### PR DESCRIPTION
## Summary

- Enable the incubating vector module during Maven test execution.
- Replace `TotalHitCountCollector` with `IndexSearcher.count`.
- Update stored-fields API references and suppress validated nullness warnings.
- Remove obsolete comments and tidy affected formatting.

## Validation

- `git diff --check`
- `bin/qbuild.sh`

The quick build completed successfully; tests are intentionally skipped by `bin/qbuild.sh`.