### PR TITLE
Add reproduction log entries for MS MARCO passage exercises

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -708,6 +708,7 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@Rex-fortune](https://github.com/Rex-fortune) on 2026-08-12 (commit [`b99e095`](https://github.com/castorini/anserini/commit/b99e09582d3c3880c87e43eb0e1040adb4cfa0ac))
 + Results reproduced by [@Evan-Lowry](https://github.com/Evan-Lowry) on 2026-08-13 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
 + Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-14 (commit [`1272378`](https://github.com/castorini/anserini/commit/127237835c675272668f0d65420602117fe50d09))
++ Results reproduced by [@taherb22](https://github.com/taherb22) on 2026-08-16 (commit [`9bfc04b`](https://github.com/castorini/anserini/commit/9bfc04b2d5f22e3acf56edf43d06c1efa5fe2783))
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`d02b3dd`](https://github.com/castorini/anserini/commit/d02b3dd3c85c81a675c4f5a7dc721ab249170817))
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`efb96dd`](https://github.com/castorini/anserini/commit/efb96ddf50857058c68298efb4a5430d1af1f95e))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d178a77`](https://github.com/castorini/anserini/commit/d178a7748b5b25b7c9238df6cb1eac134e2e6b58))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -263,6 +263,7 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Rex-fortune](https://github.com/Rex-fortune) on 2026-08-12 (commit [`b99e095`](https://github.com/castorini/anserini/commit/b99e09582d3c3880c87e43eb0e1040adb4cfa0ac))
 + Results reproduced by [@Evan-Lowry](https://github.com/Evan-Lowry) on 2026-08-13 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
 + Results reproduced by [@AhmadT198](https://github.com/AhmadT198) on 2026-08-15 (commit [`9bfc04b`](https://github.com/castorini/anserini/commit/9bfc04b2d5f22e3acf56edf43d06c1efa5fe2783))
++ Results reproduced by [@taherb22](https://github.com/taherb22) on 2026-08-16 (commit [`9bfc04b`](https://github.com/castorini/anserini/commit/9bfc04b2d5f22e3acf56edf43d06c1efa5fe2783))
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`d02b3dd`](https://github.com/castorini/anserini/commit/d02b3dd3c85c81a675c4f5a7dc721ab249170817))
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`efb96dd`](https://github.com/castorini/anserini/commit/efb96ddf50857058c68298efb4a5430d1af1f95e))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d178a77`](https://github.com/castorini/anserini/commit/d178a7748b5b25b7c9238df6cb1eac134e2e6b58))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -615,6 +615,7 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@mehra-es](https://github.com/mehra-es) on 2026-08-11 (commit [`4179733`](https://github.com/castorini/anserini/commit/4179733cc8aabefd22a7cb1f3e674cbc347a3953))
 + Results reproduced by [@Rex-fortune](https://github.com/Rex-fortune) on 2026-08-12 (commit [`b99e095`](https://github.com/castorini/anserini/commit/b99e09582d3c3880c87e43eb0e1040adb4cfa0ac))
 + Results reproduced by [@Evan-Lowry](https://github.com/Evan-Lowry) on 2026-08-13 (commit [`ff848cb`](https://github.com/castorini/anserini/commit/ff848cb5872b42ee5305dbb1e27d72d2602aeade))
++ Results reproduced by [@taherb22](https://github.com/taherb22) on 2026-08-16 (commit [`9bfc04b`](https://github.com/castorini/anserini/commit/9bfc04b2d5f22e3acf56edf43d06c1efa5fe2783))
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`d02b3dd`](https://github.com/castorini/anserini/commit/d02b3dd3c85c81a675c4f5a7dc721ab249170817))
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`efb96dd`](https://github.com/castorini/anserini/commit/efb96ddf50857058c68298efb4a5430d1af1f95e))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d178a77`](https://github.com/castorini/anserini/commit/d178a7748b5b25b7c9238df6cb1eac134e2e6b58))


### PR DESCRIPTION
## Summary

Reproduction log entries for the two MS MARCO passage onboarding exercises.

**Setup:** WSL2/Ubuntu (Windows host), Java 21, Maven 3.9+.

## Memory issues encountered (WSL2)

Indexing/retrieval with the default `bin/run.sh` and `-threads 9` repeatedly crashed the whole WSL2 VM with `Wsl/Service/CreateInstance/E_UNEXPECTED`. This is a VM-level crash, not a Java/Lucene error — nothing gets logged on the Java side because the entire VM dies. Confirmed via the Windows Task Manager memory graph: memory climbs steadily through the run, plateaus, then drops sharply, consistent with the VM being killed and Windows reclaiming its memory.

What actually fixed it was tuning the JVM's max heap (`-Xmx`) down to a size the WSL2 VM could reliably back, rather than leaving Java free to grow unbounded — ran indexing via `bin/run-memsafe.sh` (which pins `-Xmx15000m`) instead of the default `bin/run.sh`. Once the heap was capped, indexing and retrieval completed cleanly and repeatably.

**`docs/experiments-msmarco-passage.md`** (BM25 baseline, commit `9bfc04b`):
- Indexed 8,841,823 documents in 00:03:37.
- Retrieval (BM25 k1=0.82, b=0.68) over 6,980 dev queries in 00:01:08.
- MRR@10: 0.18741227770955546 (matches guide).
- `trec_eval`: map 0.1957, recall@1000 0.8573, MRR@10 0.1874 — all match expected values.
- Everything worked as documented.

**`docs/experiments-msmarco-passage2.md`** (prebuilt-index + dense retrieval, commit `9bfc04b`):
- Prebuilt-index BM25 retrieval: `trec_eval` MRR@10 0.1875, matches guide exactly.
- Dense HNSW retrieval (`SearchHnswDenseVectors`, `msmarco-v1-passage.bge-base-en-v1.5.hnsw`): MRR@10 ~0.3521, matches guide.
- Everything worked.

**Other notes from the exercise** (not part of the diff, sharing in case they're useful):
- Pyserini needs Anserini's fatjar copied/symlinked into `pyserini/pyserini/resources/jars/` (package-internal path), not a top-level `resources/jars` — most Pyserini import failures trace back to this being missing.
- Found and root-caused an upstream Pyserini regression: PR #2644 swapped the argument order in `pyserini/search/_base.py`'s calls to `TopicReader.getTopicsWithStringIdsFromFileWithTopicReaderClass`, breaking topic loading for every collection (verified via direct pyjnius calls with both argument orders). Worth a separate PR against `castorini/pyserini`