### PR TITLE
Add onboarding reproduction log entries

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -712,5 +712,6 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`d02b3dd`](https://github.com/castorini/anserini/commit/d02b3dd3c85c81a675c4f5a7dc721ab249170817))
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`efb96dd`](https://github.com/castorini/anserini/commit/efb96ddf50857058c68298efb4a5430d1af1f95e))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d178a77`](https://github.com/castorini/anserini/commit/d178a7748b5b25b7c9238df6cb1eac134e2e6b58))
++ Results reproduced by [@sliverdancer](https://github.com/sliverdancer) on 2026-08-27 (commit [`d178a77`](https://github.com/castorini/anserini/commit/d178a7748b5b25b7c9238df6cb1eac134e2e6b58))
 + Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-29 (commit [`843af42`](https://github.com/castorini/anserini/commit/843af42914a62542053a5519ea92a1fc55f0ec0a))
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-29 (commit [`b228451`](https://github.com/castorini/anserini/commit/b228451f07ac86a59b3b93d35287e36a4c69fb4b))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -269,3 +269,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d178a77`](https://github.com/castorini/anserini/commit/d178a7748b5b25b7c9238df6cb1eac134e2e6b58))
 + Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-29 (commit [`843af42`](https://github.com/castorini/anserini/commit/843af42914a62542053a5519ea92a1fc55f0ec0a))
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-29 (commit [`b228451`](https://github.com/castorini/anserini/commit/b228451f07ac86a59b3b93d35287e36a4c69fb4b))
++ Results reproduced by [@sliverdancer](https://github.com/sliverdancer) on 2026-08-29 (commit [`d178a77`](https://github.com/castorini/anserini/commit/d178a7748b5b25b7c9238df6cb1eac134e2e6b58))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -619,5 +619,6 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@sattipraveena3-sudo](https://github.com/sattipraveena3-sudo) on 2026-08-21 (commit [`d02b3dd`](https://github.com/castorini/anserini/commit/d02b3dd3c85c81a675c4f5a7dc721ab249170817))
 + Results reproduced by [@Ali-Sherazii](https://github.com/Ali-Sherazii) on 2026-08-25 (commit [`efb96dd`](https://github.com/castorini/anserini/commit/efb96ddf50857058c68298efb4a5430d1af1f95e))
 + Results reproduced by [@seangebob](https://github.com/seangebob) on 2026-08-26 (commit [`d178a77`](https://github.com/castorini/anserini/commit/d178a7748b5b25b7c9238df6cb1eac134e2e6b58))
++ Results reproduced by [@sliverdancer](https://github.com/sliverdancer) on 2026-08-27 (commit [`d178a77`](https://github.com/castorini/anserini/commit/d178a7748b5b25b7c9238df6cb1eac134e2e6b58))
 + Results reproduced by [@nointro3493](https://github.com/nointro3493) on 2026-08-28 (commit [`843af42`](https://github.com/castorini/anserini/commit/843af42914a62542053a5519ea92a1fc55f0ec0a))
 + Results reproduced by [@iwis19](https://github.com/iwis19) on 2026-08-29 (commit [`b228451`](https://github.com/castorini/anserini/commit/b228451f07ac86a59b3b93d35287e36a4c69fb4b))


### PR DESCRIPTION
I completed the three Anserini exercises in the Foundations of Retrieval onboarding path and added a Reproduction Log entry to each page. I ran the experiments at commit `d178a7748b5b25b7c9238df6cb1eac134e2e6b58`.

Environment:
- Windows 11 with WSL2 Ubuntu 24.04
- OpenJDK 21.0.12
- Maven 3.9.16
- 16 GB RAM

Results:
- Local BM25 index: 8,841,823 documents, with no skipped or failed documents
- BM25: MRR@10 0.1874, MAP 0.1957, Recall@1000 0.8573
- Prebuilt BM25: MRR@10 0.1875
- BGE-base-en-v1.5 HNSW: MRR@10 0.3521

I also manually checked the query, qrels, and document relationships in the first exercise.

Most of the problems I ran into were related to my WSL setup. Downloads from GitHub, Maven Central, JitPack, and Hugging Face occasionally failed, so I used my Windows proxy and retried them. Java was also trying to reserve too much memory for my 16 GB laptop; setting the heap limit to 6 GB allowed the search to finish. The HNSW archive and ONNX model were incomplete after their first downloads, so I downloaded them again and verified their checksums before rerunning the experiment.

This PR only contains the three Reproduction Log entries. The proxy, memory, and download fixes were local setup changes and are not included.