### PR TITLE
Copy MS MARCO scripts into repo, drop tools/ submodule references

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -52,7 +52,7 @@ To confirm, `collectionandqueries.tar.gz` is around 1 GB and should have MD5 che
 Next, we need to convert the MS MARCO tsv collection into Anserini's jsonl files (which have one json object per line):
 
 ```bash
-python tools/scripts/msmarco/convert_collection_to_jsonl.py \
+python src/main/python/msmarco/convert_collection_to_jsonl.py \
   --collection-path collections/msmarco-passage/collection.tsv \
   --output-folder collections/msmarco-passage/collection_jsonl
 ```
@@ -64,7 +64,7 @@ There are queries in the dev set that don't have relevance judgments.
 Let's discard them:
 
 ```bash
-python tools/scripts/msmarco/filter_queries.py \
+python src/main/python/msmarco/filter_queries.py \
   --qrels collections/msmarco-passage/qrels.dev.small.tsv \
   --queries collections/msmarco-passage/queries.dev.tsv \
   --output collections/msmarco-passage/queries.dev.small.tsv
@@ -207,7 +207,7 @@ Since the first column indicates the `qid`, it means that the file contains rank
 Finally, we can evaluate the retrieved documents using the official MS MARCO evaluation script:
 
 ```bash
-python tools/scripts/msmarco/msmarco_passage_eval.py \
+python src/main/python/msmarco/msmarco_passage_eval.py \
  collections/msmarco-passage/qrels.dev.small.tsv runs/run.msmarco-passage.dev.bm25.tsv
 ```
 
@@ -245,11 +245,11 @@ We can also use the official [TREC](https://trec.nist.gov/) evaluation tool, `tr
 For that we first need to convert runs and qrels files to the TREC format:
 
 ```bash
-python tools/scripts/msmarco/convert_msmarco_to_trec_run.py \
+python src/main/python/msmarco/convert_msmarco_to_trec_run.py \
   --input runs/run.msmarco-passage.dev.bm25.tsv \
   --output runs/run.msmarco-passage.dev.bm25.trec
 
-python tools/scripts/msmarco/convert_msmarco_to_trec_qrels.py \
+python src/main/python/msmarco/convert_msmarco_to_trec_qrels.py \
   --input collections/msmarco-passage/qrels.dev.small.tsv \
   --output collections/msmarco-passage/qrels.dev.small.trec
 ```
@@ -334,7 +334,7 @@ This section is **not** part of the onboarding path, so feel free to skip.
 
 Note that this figure differs slightly from the value reported in [Document Expansion by Query Prediction](https://arxiv.org/abs/1904.08375), which uses the Anserini (system-wide) default of `k1=0.9`, `b=0.4`.
 
-Tuning was accomplished with `tools/scripts/msmarco/tune_bm25.py`, using the queries found [here](https://github.com/castorini/Anserini-data/tree/master/MSMARCO); the basic approach is grid search of parameter values in tenth increments.
+Tuning was accomplished with `src/main/python/msmarco/tune_bm25.py`, using the queries found [here](https://github.com/castorini/Anserini-data/tree/master/MSMARCO); the basic approach is grid search of parameter values in tenth increments.
 There are five different sets of 10k samples (using the `shuf` command).
 We tuned on each individual set and then averaged parameter values across all five sets (this has the effect of regularization).
 In separate trials, we optimized for:

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -202,7 +202,7 @@ the first column contains a unique identifier for the passage (called the `docid
 Next, we need to do a bit of data munging to get the collection into something Anserini can easily work with, which is a jsonl format (where we have one json object per line):
 
 ```bash
-python tools/scripts/msmarco/convert_collection_to_jsonl.py \
+python src/main/python/msmarco/convert_collection_to_jsonl.py \
   --collection-path collections/msmarco-passage/collection.tsv \
   --output-folder collections/msmarco-passage/collection_jsonl
 ```
@@ -247,7 +247,7 @@ Similarly, we'll also have to do a bit of data munging of the queries and the qr
 We're going to retain only the queries that are in the qrels file:
 
 ```bash
-python tools/scripts/msmarco/filter_queries.py \
+python src/main/python/msmarco/filter_queries.py \
   --qrels collections/msmarco-passage/qrels.dev.small.tsv \
   --queries collections/msmarco-passage/queries.dev.tsv \
   --output collections/msmarco-passage/queries.dev.small.tsv

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -157,12 +157,11 @@ Bringing together everything we've discussed so far, a test collection consists 
 
 Here, we're going to introduce the [MS MARCO passage ranking test collection](https://microsoft.github.io/msmarco/).
 
-If you haven't cloned the [anserini](https://github.com/castorini/anserini) repository already, clone it and get its `tools` submodule:
+If you haven't cloned the [anserini](https://github.com/castorini/anserini) repository already, clone it:
 
 ```bash
 git clone https://github.com/castorini/anserini.git
 cd anserini
-git submodule update --init --recursive
 ```
 
 In these instructions we're going to use Anserini's root directory as the working directory.

--- a/src/main/python/msmarco/convert_collection_to_jsonl.py
+++ b/src/main/python/msmarco/convert_collection_to_jsonl.py
@@ -1,0 +1,57 @@
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import os
+import argparse
+
+
+def convert_collection(args):
+    print('Converting collection...')
+    file_index = 0
+    with open(args.collection_path, encoding='utf-8') as f:
+        for i, line in enumerate(f):
+            doc_id, doc_text = line.rstrip().split('\t')
+
+            if i % args.max_docs_per_file == 0:
+                if i > 0:
+                    output_jsonl_file.close()
+                output_path = os.path.join(args.output_folder, 'docs{:02d}.json'.format(file_index))
+                output_jsonl_file = open(output_path, 'w', encoding='utf-8', newline='\n')
+                file_index += 1
+            output_dict = {'id': doc_id, 'contents': doc_text}
+            output_jsonl_file.write(json.dumps(output_dict) + '\n')
+
+            if i % 100000 == 0:
+                print(f'Converted {i:,} docs, writing into file {file_index}')
+
+    output_jsonl_file.close()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Convert MSMARCO tsv passage collection into jsonl files for Anserini.')
+    parser.add_argument('--collection-path', required=True, help='Path to MS MARCO tsv collection.')
+    parser.add_argument('--output-folder', required=True, help='Output folder.')
+    parser.add_argument('--max-docs-per-file', default=1000000, type=int,
+                        help='Maximum number of documents in each jsonl file.')
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.output_folder):
+        os.makedirs(args.output_folder)
+
+    convert_collection(args)
+    print('Done!')

--- a/src/main/python/msmarco/convert_msmarco_to_trec_qrels.py
+++ b/src/main/python/msmarco/convert_msmarco_to_trec_qrels.py
@@ -1,0 +1,31 @@
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Convert MS MARCO qrels to TREC qrels.')
+    parser.add_argument('--input', required=True, default='', help='Input MS MARCO qrels file.')
+    parser.add_argument('--output', required=True, default='', help='Output TREC qrels file.')
+
+    args = parser.parse_args()
+
+    with open(args.output, 'w') as fout:
+        for line in open(args.input):
+            fout.write(line.replace('\t', ' '))
+
+    print('Done!')

--- a/src/main/python/msmarco/convert_msmarco_to_trec_run.py
+++ b/src/main/python/msmarco/convert_msmarco_to_trec_run.py
@@ -1,0 +1,34 @@
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Convert an MS MARCO run file to a TREC run file.')
+    parser.add_argument('--input', required=True, default='', help='Input MS MARCO run file.')
+    parser.add_argument('--output', required=True, default='', help='Output TREC run file.')
+
+    args = parser.parse_args()
+
+    with open(args.output, 'w') as fout:
+        for line in open(args.input):
+            query_id, doc_id, rank = line.strip().split('\t')
+            score = 1.0 / int(rank)
+            fout.write('{} Q0 {} {} {} anserini\n'.format(
+                query_id, doc_id, rank, score))
+
+    print('Done!')

--- a/src/main/python/msmarco/filter_queries.py
+++ b/src/main/python/msmarco/filter_queries.py
@@ -1,0 +1,40 @@
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Keeps only queries in a qrels file.')
+    parser.add_argument('--qrels', required=True, help='MS MARCO tsv qrels file.')
+    parser.add_argument('--queries', required=True, help='Queries file.')
+    parser.add_argument('--output', required=True, help='Output queries file.')
+
+    args = parser.parse_args()
+
+    qrels = set()
+    with open(args.qrels) as f:
+        for line in f:
+            query_id, _, _, _ = line.rstrip().split('\t')
+            qrels.add(query_id)
+
+    with open(args.output, 'w', encoding='utf-8', newline='\n') as fout:
+        with open(args.queries, encoding='utf-8') as f:
+            for line in f:
+                query_id, _ = line.rstrip().split('\t')
+                if query_id in qrels:
+                    fout.write(line)
+
+    print('Done!')

--- a/src/main/python/msmarco/msmarco_passage_eval.py
+++ b/src/main/python/msmarco/msmarco_passage_eval.py
@@ -1,0 +1,185 @@
+"""
+This module computes evaluation metrics for MSMARCO dataset on the ranking task.
+Command line:
+python msmarco_eval_ranking.py <path_to_reference_file> <path_to_candidate_file>
+
+Creation Date : 06/12/2018
+Last Modified : 1/21/2019
+Authors : Daniel Campos <dacamp@microsoft.com>, Rutger van Haasteren <ruvanh@microsoft.com>
+"""
+import re
+import sys
+import statistics
+
+from collections import Counter
+
+MaxMRRRank = 10
+
+def load_reference_from_stream(f):
+    """Load Reference reference relevant passages
+    Args:f (stream): stream to load.
+    Returns:qids_to_relevant_passageids (dict): dictionary mapping from query_id (int) to relevant passages (list of ints). 
+    """
+    qids_to_relevant_passageids = {}
+    for l in f:
+        try:
+            l = re.split('[\t\s]', l.strip())
+            qid = int(l[0])
+            if qid in qids_to_relevant_passageids:
+                pass
+            else:
+                qids_to_relevant_passageids[qid] = []
+            qids_to_relevant_passageids[qid].append(int(l[2]))
+        except:
+            raise IOError('\"%s\" is not valid format' % l)
+    return qids_to_relevant_passageids
+
+def load_reference(path_to_reference):
+    """Load Reference reference relevant passages
+    Args:path_to_reference (str): path to a file to load.
+    Returns:qids_to_relevant_passageids (dict): dictionary mapping from query_id (int) to relevant passages (list of ints). 
+    """
+    with open(path_to_reference,'r') as f:
+        qids_to_relevant_passageids = load_reference_from_stream(f)
+    return qids_to_relevant_passageids
+
+def load_candidate_from_stream(f):
+    """Load candidate data from a stream.
+    Args:f (stream): stream to load.
+    Returns:qid_to_ranked_candidate_passages (dict): dictionary mapping from query_id (int) to a list of 1000 passage ids(int) ranked by relevance and importance
+    """
+    qid_to_ranked_candidate_passages = {}
+    for l in f:
+        try:
+            l = l.strip().split('\t')
+            qid = int(l[0])
+            pid = int(l[1])
+            rank = int(l[2])
+            if qid in qid_to_ranked_candidate_passages:
+                pass    
+            else:
+                # By default, all PIDs in the list of 1000 are 0. Only override those that are given
+                tmp = [0] * 1000
+                qid_to_ranked_candidate_passages[qid] = tmp
+            qid_to_ranked_candidate_passages[qid][rank-1]=pid
+        except:
+            raise IOError('\"%s\" is not valid format' % l)
+    return qid_to_ranked_candidate_passages
+                
+def load_candidate(path_to_candidate):
+    """Load candidate data from a file.
+    Args:path_to_candidate (str): path to file to load.
+    Returns:qid_to_ranked_candidate_passages (dict): dictionary mapping from query_id (int) to a list of 1000 passage ids(int) ranked by relevance and importance
+    """
+    
+    with open(path_to_candidate,'r') as f:
+        qid_to_ranked_candidate_passages = load_candidate_from_stream(f)
+    return qid_to_ranked_candidate_passages
+
+def quality_checks_qids(qids_to_relevant_passageids, qids_to_ranked_candidate_passages):
+    """Perform quality checks on the dictionaries
+
+    Args:
+    p_qids_to_relevant_passageids (dict): dictionary of query-passage mapping
+        Dict as read in with load_reference or load_reference_from_stream
+    p_qids_to_ranked_candidate_passages (dict): dictionary of query-passage candidates
+    Returns:
+        bool,str: Boolean whether allowed, message to be shown in case of a problem
+    """
+    message = ''
+    allowed = True
+
+    # Create sets of the QIDs for the submitted and reference queries
+    candidate_set = set(qids_to_ranked_candidate_passages.keys())
+    ref_set = set(qids_to_relevant_passageids.keys())
+
+    # Check that we do not have multiple passages per query
+    for qid in qids_to_ranked_candidate_passages:
+        # Remove all zeros from the candidates
+        duplicate_pids = set([item for item, count in Counter(qids_to_ranked_candidate_passages[qid]).items() if count > 1])
+
+        if len(duplicate_pids-set([0])) > 0:
+            message = "Cannot rank a passage multiple times for a single query. QID={qid}, PID={pid}".format(
+                    qid=qid, pid=list(duplicate_pids)[0])
+            allowed = False
+
+    return allowed, message
+
+def compute_metrics(qids_to_relevant_passageids, qids_to_ranked_candidate_passages):
+    """Compute MRR metric
+    Args:    
+    p_qids_to_relevant_passageids (dict): dictionary of query-passage mapping
+        Dict as read in with load_reference or load_reference_from_stream
+    p_qids_to_ranked_candidate_passages (dict): dictionary of query-passage candidates
+    Returns:
+        dict: dictionary of metrics {'MRR': <MRR Score>}
+    """
+    all_scores = {}
+    MRR = 0
+    qids_with_relevant_passages = 0
+    ranking = []
+    for qid in qids_to_ranked_candidate_passages:
+        if qid in qids_to_relevant_passageids:
+            ranking.append(0)
+            target_pid = qids_to_relevant_passageids[qid]
+            candidate_pid = qids_to_ranked_candidate_passages[qid]
+            for i in range(0,MaxMRRRank):
+                if candidate_pid[i] in target_pid:
+                    MRR += 1/(i + 1)
+                    ranking.pop()
+                    ranking.append(i+1)
+                    break
+    if len(ranking) == 0:
+        raise IOError("No matching QIDs found. Are you sure you are scoring the evaluation set?")
+    
+    MRR = MRR/len(qids_to_relevant_passageids)
+    all_scores['MRR @10'] = MRR
+    all_scores['QueriesRanked'] = len(qids_to_ranked_candidate_passages)
+    return all_scores
+                
+def compute_metrics_from_files(path_to_reference, path_to_candidate, perform_checks=True):
+    """Compute MRR metric
+    Args:    
+    p_path_to_reference_file (str): path to reference file.
+        Reference file should contain lines in the following format:
+            QUERYID\tPASSAGEID
+            Where PASSAGEID is a relevant passage for a query. Note QUERYID can repeat on different lines with different PASSAGEIDs
+    p_path_to_candidate_file (str): path to candidate file.
+        Candidate file sould contain lines in the following format:
+            QUERYID\tPASSAGEID1\tRank
+            If a user wishes to use the TREC format please run the script with a -t flag at the end. If this flag is used the expected format is 
+            QUERYID\tITER\tDOCNO\tRANK\tSIM\tRUNID 
+            Where the values are separated by tabs and ranked in order of relevance 
+    Returns:
+        dict: dictionary of metrics {'MRR': <MRR Score>}
+    """
+    
+    qids_to_relevant_passageids = load_reference(path_to_reference)
+    qids_to_ranked_candidate_passages = load_candidate(path_to_candidate)
+    if perform_checks:
+        allowed, message = quality_checks_qids(qids_to_relevant_passageids, qids_to_ranked_candidate_passages)
+        if message != '': print(message)
+
+    return compute_metrics(qids_to_relevant_passageids, qids_to_ranked_candidate_passages)
+
+def main():
+    """Command line:
+    python msmarco_eval_ranking.py <path_to_reference_file> <path_to_candidate_file>
+    """
+
+    if len(sys.argv) == 3:
+        path_to_reference = sys.argv[1]
+        path_to_candidate = sys.argv[2]
+        metrics = compute_metrics_from_files(path_to_reference, path_to_candidate)
+        print('#####################')
+        for metric in sorted(metrics):
+            print('{}: {}'.format(metric, metrics[metric]))
+        print('#####################')
+
+    else:
+        print('Usage: msmarco_eval_ranking.py <reference ranking> <candidate ranking>')
+        exit()
+    
+if __name__ == '__main__':
+    main()
+

--- a/src/main/python/msmarco/tune_bm25.py
+++ b/src/main/python/msmarco/tune_bm25.py
@@ -1,0 +1,92 @@
+#
+# Pyserini: Python interface to the Anserini IR toolkit built on Lucene
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Simple script for tuning BM25 parameters (k1 and b) for MS MARCO
+
+import argparse
+import os
+import re
+import subprocess
+
+parser = argparse.ArgumentParser(description='Tunes BM25 parameters for MS MARCO Passages')
+parser.add_argument('--base-directory', required=True, help='base directory for storing runs')
+parser.add_argument('--index', required=True, help='index to use')
+parser.add_argument('--queries', required=True, help='queries for evaluation')
+parser.add_argument('--qrels-trec', required=True, help='qrels for evaluation (TREC format)')
+parser.add_argument('--qrels-tsv', required=True, help='qrels for evaluation (MS MARCO format)')
+
+args = parser.parse_args()
+
+base_directory = args.base_directory
+index = args.index
+queries = args.queries
+qrels_trec = args.qrels_trec
+qrels_tsv = args.qrels_tsv
+
+if not os.path.exists(base_directory):
+    os.makedirs(base_directory)
+
+print('# Settings')
+print(f'base directory: {base_directory}')
+print(f'index: {index}')
+print(f'queries: {queries}')
+print(f'qrels (TREC): {qrels_trec}')
+print(f'qrels (MS MARCO): {qrels_tsv}')
+print('\n')
+
+for k1 in [0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2]:
+    for b in [0.5, 0.6, 0.7, 0.8, 0.9]:
+        print(f'Trying... k1 = {k1}, b = {b}')
+        filename = f'run.bm25.k1_{k1}.b_{b}.txt'
+        if os.path.isfile(f'{base_directory}/{filename}'):
+            print('Run already exists, skipping!')
+        else:
+            subprocess.call(f'python tools/scripts/msmarco/retrieve.py --index {index} --queries {queries} \
+                --output {base_directory}/{filename} --k1 {k1} --b {b} --hits 1000', shell=True)
+
+print('\n\nStarting evaluation...')
+
+# We're going to be tuning to maximize recall, although we'll compute MRR and MAP also just for reference.
+max_score = 0
+max_file = ''
+
+for filename in sorted(os.listdir(base_directory)):
+    # TREC output run file, perhaps left over from a previous tuning run: skip.
+    if filename.endswith('trec'):
+        continue
+
+    # Convert to a TREC run and evaluate with trec_eval:
+    subprocess.call(f'python tools/scripts/msmarco/convert_msmarco_to_trec_run.py \
+        --input {base_directory}/{filename} --output {base_directory}/{filename}.trec', shell=True)
+    results = subprocess.check_output(['tools/eval/trec_eval.9.0.4/trec_eval', qrels_trec,
+                                       f'{base_directory}/{filename}.trec', '-mrecall.1000', '-mmap'])
+    match = re.search('map +\tall\t([0-9.]+)', results.decode('utf-8'))
+    ap = float(match.group(1))
+    match = re.search('recall_1000 +\tall\t([0-9.]+)', results.decode('utf-8'))
+    recall = float(match.group(1))
+
+    # Evaluate with official scoring script
+    results = subprocess.check_output(['python', 'tools/scripts/msmarco/msmarco_passage_eval.py',
+                                       'collections/msmarco-passage/qrels.train.tsv',
+                                       f'{base_directory}/{filename}'])
+    match = re.search(r'MRR @10: ([\d.]+)', results.decode('utf-8'))
+    rr = float(match.group(1))
+    print(f'{filename}: MRR@10 = {rr}, MAP = {ap}, R@1000 = {recall}')
+    if recall > max_score:
+        max_score = recall
+        max_file = filename
+
+print(f'\n\nBest parameters: {max_file}: R@1000 = {max_score}')


### PR DESCRIPTION
Closes #3403 

1. **Removed** `git submodule update --init --recursive` from `docs/start-here.md`
   (the `tools/` submodule was removed in #3382 , so it's a no-op).
2. **Copied** the scripts that `docs/start-here.md` and
   `docs/experiments-msmarco-passage.md` invoke into `src/main/python/msmarco/`,
   and repointed the doc paths from `tools/scripts/msmarco/` to
   `src/main/python/msmarco/`:
   - convert_collection_to_jsonl.py
   - filter_queries.py
   - msmarco_passage_eval.py
   - convert_msmarco_to_trec_run.py
   - convert_msmarco_to_trec_qrels.py
   - tune_bm25.py

Scripts are copied verbatim from `castorini/eval@master`.

### Validation

Ran each script from the new location against the MS MARCO passage data while
reproducing the start-here / experiments-msmarco-passage guides
(Windows 11 + WSL2, OpenJDK 21):

- `filter_queries.py` → 6980 queries
- `msmarco_passage_eval.py` → `MRR @10: 0.18741227770955546`
- `convert_msmarco_to_trec_run.py` / `convert_msmarco_to_trec_qrels.py` →
  `trec_eval` gives map 0.1957, recall@1000 0.8573
- `convert_collection_to_jsonl.py` → expected jsonl output
