### PR TITLE
[codex] Add qrels registry and registry metadata

### DIFF
--- a/.agents/skills/anserini-cli/SKILL.md
+++ b/.agents/skills/anserini-cli/SKILL.md
@@ -2,7 +2,7 @@
 name: anserini-cli
 description: Run Anserini command-line and REST workflows from either a built fatjar or an Anserini source checkout. Use for PrebuiltIndexRegistry, TopicsRegistry, ad hoc search, interactive search, output formats, and RestServer examples.
 metadata:
-  version: v0.2.0
+  version: v0.3.0
 ---
 
 # Use Anserini CLI

--- a/.agents/skills/anserini-cli/SKILL.md
+++ b/.agents/skills/anserini-cli/SKILL.md
@@ -116,6 +116,12 @@ To print all topics for a specific set, run:
 java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsRegistry --get <set>
 ```
 
+To print metadata, including the downloaded local path, run:
+
+```bash
+java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsRegistry --metadata <set>
+```
+
 For the standard MS MARCO V1 passage queries that pair with the
 `msmarco-v1-passage` prebuilt index, use `msmarco-v1-passage.dev`.
 
@@ -130,6 +136,20 @@ java -cp "$ANSERINI_JAR" \
 
 Use `--list` first to discover the exact set name, then `--get` to inspect its
 contents.
+
+## Qrels Registry
+
+To list available qrels, print raw qrels, or print metadata including the
+downloaded local path, run:
+
+```bash
+java -cp "$ANSERINI_JAR" io.anserini.cli.QrelsRegistry --list
+java -cp "$ANSERINI_JAR" io.anserini.cli.QrelsRegistry --get <set>
+java -cp "$ANSERINI_JAR" io.anserini.cli.QrelsRegistry --metadata <set>
+```
+
+`--list` supports `--filter <regexp>`. Both `--get` and `--metadata` download
+the registered qrels when it is not already available locally.
 
 ## Search CLI
 

--- a/.agents/skills/anserini-cli/SKILL.md
+++ b/.agents/skills/anserini-cli/SKILL.md
@@ -125,17 +125,12 @@ java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsRegistry --metadata <name>
 For the standard MS MARCO V1 passage queries that pair with the
 `msmarco-v1-passage` prebuilt index, use `msmarco-v1-passage.dev`.
 
-Recommended lookup:
+To inspect its metadata and resolve the topics to a local path:
 
 ```bash
-java -cp "$ANSERINI_JAR" \
-  io.anserini.cli.TopicsRegistry \
-  --list --filter '^msmarco(-v1)?-passage(\\.dev|-dev)$' \
-| jq '.'
+java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsRegistry \
+  --metadata msmarco-v1-passage.dev | jq '.'
 ```
-
-Use `--list` first to discover the exact set name, then `--get` to inspect its
-contents.
 
 ## Qrels Registry
 

--- a/.agents/skills/anserini-cli/SKILL.md
+++ b/.agents/skills/anserini-cli/SKILL.md
@@ -183,13 +183,13 @@ index path or a prebuilt index name.
 Example using the popular `msmarco-v1-passage` prebuilt index:
 
 ```bash
-java -cp "$ANSERINI_JAR" io.anserini.cli.Search --index msmarco-v1-passage --query "what is a lobster roll" --hits 10
+java -cp "$ANSERINI_JAR" io.anserini.cli.Search --index msmarco-v1-passage --query "what is a lobster roll" --hits 10 --json
 ```
 
 Interactive mode:
 
 ```bash
-java -cp "$ANSERINI_JAR" io.anserini.cli.Search --index msmarco-v1-passage --interactive
+java -cp "$ANSERINI_JAR" io.anserini.cli.Search --index msmarco-v1-passage --interactive --json
 ```
 
 Useful output variants:
@@ -260,8 +260,8 @@ java -cp "$ANSERINI_JAR" io.anserini.eval.TrecEval \
   cacm \
   run.cacm.bm25.txt | tee eval.cacm.bm25.txt
 
-grep -q $'map\tall\t0.3123' eval.cacm.bm25.txt
-grep -q $'P_30\tall\t0.1942' eval.cacm.bm25.txt
+grep -Eq '^map[[:space:]]+all[[:space:]]+0\.3123$' eval.cacm.bm25.txt
+grep -Eq '^P_30[[:space:]]+all[[:space:]]+0\.1942$' eval.cacm.bm25.txt
 ```
 
 ## REST API Server

--- a/.agents/skills/anserini-cli/SKILL.md
+++ b/.agents/skills/anserini-cli/SKILL.md
@@ -113,13 +113,13 @@ installed before relying on `jq` examples.
 To print all topics for a specific set, run:
 
 ```bash
-java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsRegistry --get <set>
+java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsRegistry --get <name>
 ```
 
 To print metadata, including the downloaded local path, run:
 
 ```bash
-java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsRegistry --metadata <set>
+java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsRegistry --metadata <name>
 ```
 
 For the standard MS MARCO V1 passage queries that pair with the
@@ -144,8 +144,8 @@ downloaded local path, run:
 
 ```bash
 java -cp "$ANSERINI_JAR" io.anserini.cli.QrelsRegistry --list
-java -cp "$ANSERINI_JAR" io.anserini.cli.QrelsRegistry --get <set>
-java -cp "$ANSERINI_JAR" io.anserini.cli.QrelsRegistry --metadata <set>
+java -cp "$ANSERINI_JAR" io.anserini.cli.QrelsRegistry --get <name>
+java -cp "$ANSERINI_JAR" io.anserini.cli.QrelsRegistry --metadata <name>
 ```
 
 `--list` supports `--filter <regexp>`. Both `--get` and `--metadata` download

--- a/.agents/skills/anserini-cli/SKILL.md
+++ b/.agents/skills/anserini-cli/SKILL.md
@@ -81,10 +81,8 @@ about available prebuilt indexes or MS MARCO passage retrieval setup.
 Recommended lookup for the standard MS MARCO V1 passage inverted index:
 
 ```bash
-java -cp "$ANSERINI_JAR" \
-  io.anserini.cli.PrebuiltIndexRegistry \
-  --list --filter '^msmarco-v1-passage$' \
-| jq '.[0] | {name, type, description, filename}'
+java -cp "$ANSERINI_JAR" io.anserini.cli.PrebuiltIndexRegistry --list --filter '^msmarco-v1-passage$' \
+  | jq '.[0] | {name, type, description, filename}'
 ```
 
 Useful variants:
@@ -106,45 +104,76 @@ To inspect topics exposed by `io.anserini.cli.TopicsRegistry`, run:
 java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsRegistry --list
 ```
 
-`--list` emits JSON in current jars, so prefer `--filter` and `jq` to locate the
-exact symbol. If `jq` is not available, ask the user whether it should be
-installed before relying on `jq` examples.
+`--list` emits canonical topic names as JSON. Use `--filter <regexp>` to narrow
+the registry with a regular expression:
 
-To print all topics for a specific set, run:
+```bash
+java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsRegistry --list --filter 'msmarco' | jq '.'
+```
+
+`--get` writes parsed topics as JSON to stdout:
 
 ```bash
 java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsRegistry --get <name>
 ```
 
-To print metadata, including the downloaded local path, run:
+`--metadata` writes the canonical name, aliases, registered path, reader class,
+and downloaded local path as JSON to stdout:
 
 ```bash
 java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsRegistry --metadata <name>
 ```
 
-For the standard MS MARCO V1 passage queries that pair with the
-`msmarco-v1-passage` prebuilt index, use `msmarco-v1-passage.dev`.
+Both `--get` and `--metadata` download the registered topics when needed.
 
-To inspect its metadata and resolve the topics to a local path:
+For the standard MS MARCO V1 passage queries that pair with the
+`msmarco-v1-passage` prebuilt index, use the canonical name
+`msmarco-passage.dev-subset`:
 
 ```bash
-java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsRegistry \
-  --metadata msmarco-v1-passage.dev | jq '.'
+java -cp "$ANSERINI_JAR" io.anserini.cli.TopicsRegistry --metadata msmarco-passage.dev-subset | jq '.'
 ```
+
+Aliases such as `msmarco-v1-passage.dev` are also accepted by `--get` and
+`--metadata`.
 
 ## Qrels Registry
 
-To list available qrels, print raw qrels, or print metadata including the
-downloaded local path, run:
+To inspect qrels exposed by `io.anserini.cli.QrelsRegistry`, run:
 
 ```bash
 java -cp "$ANSERINI_JAR" io.anserini.cli.QrelsRegistry --list
+```
+
+`--list` emits canonical qrels names as JSON. Use `--filter <regexp>` to narrow
+the registry with a regular expression:
+
+```bash
+java -cp "$ANSERINI_JAR" io.anserini.cli.QrelsRegistry --list --filter 'msmarco' | jq '.'
+```
+
+`--get` writes raw qrels to stdout:
+
+```bash
 java -cp "$ANSERINI_JAR" io.anserini.cli.QrelsRegistry --get <name>
+```
+
+`--metadata` writes the canonical name, aliases, registered path, and downloaded
+local path as JSON to stdout:
+
+```bash
 java -cp "$ANSERINI_JAR" io.anserini.cli.QrelsRegistry --metadata <name>
 ```
 
-`--list` supports `--filter <regexp>`. Both `--get` and `--metadata` download
-the registered qrels when it is not already available locally.
+Both `--get` and `--metadata` download the registered qrels when needed.
+
+For the standard MS MARCO V1 passage relevance judgments that pair with the
+`msmarco-v1-passage` prebuilt index, use the canonical name
+`msmarco-passage.dev-subset`:
+
+```bash
+java -cp "$ANSERINI_JAR" io.anserini.cli.QrelsRegistry --metadata msmarco-passage.dev-subset | jq '.'
+```
 
 ## Search CLI
 

--- a/src/main/java/io/anserini/cli/QrelsRegistry.java
+++ b/src/main/java/io/anserini/cli/QrelsRegistry.java
@@ -1,0 +1,144 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.cli;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.ParserProperties;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.anserini.eval.Qrels;
+import io.anserini.util.LoggingBootstrap;
+
+public final class QrelsRegistry {
+  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+  public static class Args {
+    @Option(name = "--list", usage = "List available qrels.")
+    public boolean list = false;
+
+    @Option(name = "--filter", metaVar = "[regexp]", usage = "Filter qrels by regular expression.")
+    public String filter = null;
+
+    @Option(name = "--get", metaVar = "[qrels]", usage = "Print qrels.")
+    public String get = null;
+
+    @Option(name = "--metadata", metaVar = "[qrels]", usage = "Print qrels metadata.")
+    public String metadata = null;
+
+    @Option(name = "--help", help = true, usage = "Print this help message and exit.")
+    public boolean help = false;
+  }
+
+  private static final String[] argsOrdering = new String[] {"--list", "--filter", "--get", "--metadata", "--help"};
+
+  public static void main(String[] args) {
+    LoggingBootstrap.installJulToSlf4jBridge();
+
+    Args parsedArgs = new Args();
+    CmdLineParser parser = new CmdLineParser(parsedArgs, ParserProperties.defaults().withUsageWidth(120));
+
+    try {
+      parser.parseArgument(args);
+    } catch (CmdLineException e) {
+      System.err.println(String.format("Error: %s", e.getMessage()));
+      CliUtils.printUsage(parser, QrelsRegistry.class, argsOrdering);
+      return;
+    }
+
+    if (parsedArgs.help) {
+      CliUtils.printUsage(parser, QrelsRegistry.class, argsOrdering);
+      return;
+    }
+
+    int actions = (parsedArgs.list ? 1 : 0) + (parsedArgs.get != null ? 1 : 0) + (parsedArgs.metadata != null ? 1 : 0);
+    if (actions != 1) {
+      System.err.println("Error: exactly one of --list, --get, or --metadata must be specified");
+      CliUtils.printUsage(parser, QrelsRegistry.class, argsOrdering);
+      return;
+    }
+
+    if (!parsedArgs.list && parsedArgs.filter != null) {
+      System.err.println("Error: --filter only works with --list");
+      CliUtils.printUsage(parser, QrelsRegistry.class, argsOrdering);
+      return;
+    }
+
+    run(parsedArgs);
+  }
+
+  private static void run(Args args) {
+    if (args.list) {
+      TreeSet<String> names = new TreeSet<>(Qrels.names());
+
+      if (args.filter != null) {
+        Pattern pattern;
+        try {
+          pattern = Pattern.compile(args.filter);
+        } catch (PatternSyntaxException e) {
+          System.err.printf("Error: invalid regular expression \"%s\": %s%n", args.filter, e.getMessage());
+          return;
+        }
+
+        names.removeIf(name -> !pattern.matcher(name).find());
+      }
+
+      try {
+        System.out.println(JSON_MAPPER.writeValueAsString(List.copyOf(names)));
+      } catch (JsonProcessingException e) {
+        System.err.printf("Error: %s%n", e.getMessage());
+      }
+    } else if (args.get != null) {
+      try {
+        Path path = Qrels.resolveRegisteredQrelsPath(args.get);
+        Files.copy(path, System.out);
+        System.out.flush();
+      } catch (IllegalArgumentException e) {
+        System.err.printf("Error: unknown qrels \"%s\"%n", args.get);
+      } catch (IOException e) {
+        System.err.printf("Error: unable to read qrels \"%s\": %s%n", args.get, e.getMessage());
+      }
+    } else {
+      try {
+        Path localPath = Qrels.resolveRegisteredQrelsPath(args.metadata);
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("name", Qrels.getCanonicalName(args.metadata));
+        metadata.put("path", Qrels.getRegisteredPath(args.metadata));
+        metadata.put("local_path", localPath.toAbsolutePath().toString());
+        metadata.put("aliases", Qrels.aliases(args.metadata));
+        System.out.println(JSON_MAPPER.writeValueAsString(metadata));
+      } catch (IllegalArgumentException e) {
+        System.err.printf("Error: unknown qrels \"%s\"%n", args.metadata);
+      } catch (IOException e) {
+        System.err.printf("Error: unable to read qrels \"%s\": %s%n", args.metadata, e.getMessage());
+      }
+    }
+  }
+}

--- a/src/main/java/io/anserini/cli/TopicsRegistry.java
+++ b/src/main/java/io/anserini/cli/TopicsRegistry.java
@@ -16,6 +16,7 @@
 
 package io.anserini.cli;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -48,12 +49,14 @@ public final class TopicsRegistry {
     @Option(name = "--get", metaVar = "[topics]", usage = "Enumerate topics.")
     public String get = null;
 
+    @Option(name = "--metadata", metaVar = "[topics]", usage = "Print topics metadata.")
+    public String metadata = null;
+
     @Option(name = "--help", help = true, usage = "Print this help message and exit.")
     public boolean help = false;
   }
 
-  private static final String[] argsOrdering = new String[] {
-      "--list", "--filter", "--get", "--help"};
+  private static final String[] argsOrdering = new String[] {"--list", "--filter", "--get", "--metadata", "--help"};
 
   public static void main(String[] args) {
     LoggingBootstrap.installJulToSlf4jBridge();
@@ -74,8 +77,9 @@ public final class TopicsRegistry {
       return;
     }
 
-    if (parsedArgs.list == (parsedArgs.get != null)) {
-      System.err.println("Error: exactly one of --list or --get must be specified");
+    int actions = (parsedArgs.list ? 1 : 0) + (parsedArgs.get != null ? 1 : 0) + (parsedArgs.metadata != null ? 1 : 0);
+    if (actions != 1) {
+      System.err.println("Error: exactly one of --list, --get, or --metadata must be specified");
       CliUtils.printUsage(parser, TopicsRegistry.class, argsOrdering);
       return;
     }
@@ -107,7 +111,7 @@ public final class TopicsRegistry {
         }
 
         System.out.println(JSON_MAPPER.writeValueAsString(List.copyOf(names)));
-      } else {
+      } else if (args.get != null) {
         SortedMap<?, Map<String, String>> queries = getAllQueriesForTopic(args.get);
         if (queries == null) {
           if (Topics.get(args.get) == null) {
@@ -117,9 +121,25 @@ public final class TopicsRegistry {
         }
 
         System.out.println(JSON_MAPPER.writeValueAsString(queries));
+      } else {
+        Topics topic = Topics.get(args.metadata);
+        if (topic == null) {
+          System.err.printf("Error: unknown topics \"%s\"%n", args.metadata);
+          return;
+        }
+
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("name", topic.name());
+        metadata.put("path", topic.path);
+        metadata.put("reader_class", topic.readerClass.getName());
+        metadata.put("local_path", Topics.resolveRegisteredTopicPath(args.metadata).toAbsolutePath().toString());
+        metadata.put("aliases", Topics.aliases(args.metadata));
+        System.out.println(JSON_MAPPER.writeValueAsString(metadata));
       }
     } catch (JsonProcessingException e) {
       System.err.printf("Error: %s%n", e.getMessage());
+    } catch (Exception e) {
+      System.err.printf("Error: unable to read topics \"%s\": %s%n", args.metadata, e.getMessage());
     }
   }
 

--- a/src/main/java/io/anserini/eval/Qrels.java
+++ b/src/main/java/io/anserini/eval/Qrels.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -98,6 +99,32 @@ public class Qrels {
     return new Qrels(name, Path.of(path));
   }
 
+  public static Path resolveRegisteredQrelsPath(String name) throws IOException {
+    String path = getRegisteredPath(name);
+    return resolveQrelsPath(path);
+  }
+
+  public static String getRegisteredPath(String name) {
+    String path = registry().lookup.get(name);
+    if (path == null) {
+      throw new IllegalArgumentException("Unknown qrels name: " + name);
+    }
+    return path;
+  }
+
+  public static String getCanonicalName(String name) {
+    String path = getRegisteredPath(name);
+    return registry().canonical.entrySet().stream()
+        .filter(entry -> entry.getValue().equals(path))
+        .map(Map.Entry::getKey)
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("No canonical qrels name for: " + name));
+  }
+
+  public static List<String> aliases(String name) {
+    return registry().aliases.getOrDefault(getCanonicalName(name), List.of());
+  }
+
   public static Qrels loadFromFile(String file) throws IOException {
     return new Qrels(file);
   }
@@ -124,17 +151,25 @@ public class Qrels {
     try (InputStream inputStream = new URI(QRELS_URL).toURL().openStream()) {
       Map<String, String> registry = mapper.readValue(inputStream, new TypeReference<>() {});
       registry.putAll(loadLocalMetadata());
+      Map<String, List<String>> aliases = new LinkedHashMap<>();
+      mergeAliases(aliases, loadAliasesMetadata(QREL_ALIASES_URL));
       Map<String, List<String>> localAliases = loadLocalAliasesMetadata();
+      mergeAliases(aliases, localAliases);
       Map<String, String> canonicalRegistry = new LinkedHashMap<>(registry);
-      localAliases.values().forEach(aliases -> aliases.forEach(canonicalRegistry::remove));
+      localAliases.values().forEach(aliasValues -> aliasValues.forEach(canonicalRegistry::remove));
       Map<String, String> canonical = Collections.unmodifiableMap(canonicalRegistry);
       Map<String, String> lookup = new LinkedHashMap<>(registry);
-      addAliasesToRegistry(lookup, loadAliasesMetadata(QREL_ALIASES_URL));
-      addAliasesToRegistry(lookup, localAliases);
-      return new Registry(canonical, Collections.unmodifiableMap(lookup));
+      addAliasesToRegistry(lookup, aliases);
+      aliases.replaceAll((name, values) -> List.copyOf(values));
+      return new Registry(canonical, Collections.unmodifiableMap(lookup), Collections.unmodifiableMap(aliases));
     } catch (Exception e) {
       throw new IllegalStateException("Failed to load qrels metadata from " + QRELS_URL, e);
     }
+  }
+
+  private static void mergeAliases(Map<String, List<String>> destination, Map<String, List<String>> source) {
+    source.forEach((name, aliases) ->
+        destination.computeIfAbsent(name, ignored -> new ArrayList<>()).addAll(aliases));
   }
 
   private static Map<String, String> loadLocalMetadata() {
@@ -276,7 +311,7 @@ public class Qrels {
 
   public static Path downloadQrels(Path qrelsPath) throws IOException {
     String qrelsURL = URL + qrelsPath.getFileName().toString();
-    System.out.println("Downloading qrels from " + qrelsURL);
+    System.err.println("Downloading qrels from " + qrelsURL);
     Path localQrelsPath = CacheDirectoryResolver.getQrelsCachePath().resolve(qrelsPath.getFileName());
 
     try {
@@ -290,10 +325,12 @@ public class Qrels {
   private static final class Registry {
     private final Map<String, String> canonical;
     private final Map<String, String> lookup;
+    private final Map<String, List<String>> aliases;
 
-    private Registry(Map<String, String> canonical, Map<String, String> lookup) {
+    private Registry(Map<String, String> canonical, Map<String, String> lookup, Map<String, List<String>> aliases) {
       this.canonical = canonical;
       this.lookup = lookup;
+      this.aliases = aliases;
     }
   }
 }

--- a/src/main/java/io/anserini/eval/Qrels.java
+++ b/src/main/java/io/anserini/eval/Qrels.java
@@ -112,6 +112,7 @@ public class Qrels {
     return path;
   }
 
+  @SuppressWarnings("null")
   public static String getCanonicalName(String name) {
     String path = getRegisteredPath(name);
     return registry().canonical.entrySet().stream()

--- a/src/main/java/io/anserini/search/topicreader/Topics.java
+++ b/src/main/java/io/anserini/search/topicreader/Topics.java
@@ -16,9 +16,11 @@
 
 package io.anserini.search.topicreader;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -50,6 +52,7 @@ public final class Topics {
 
   // Contains every accepted lookup key, including canonical names, aliases, paths, and filenames; used by get().
   private static volatile Map<String, Topics> registryCache;
+  private static volatile Map<String, List<String>> aliasesCache;
 
   public final String path;
   public final Class<? extends TopicReader<?>> readerClass;
@@ -70,6 +73,14 @@ public final class Topics {
     return registry().get(name);
   }
 
+  public static Path resolveRegisteredTopicPath(String name) throws IOException {
+    Topics topics = get(name);
+    if (topics == null) {
+      throw new IllegalArgumentException("Unknown topics name: " + name);
+    }
+    return TopicReader.getTopicPath(Path.of(topics.path));
+  }
+
   public static Map<String, Topics> entries() {
     registry();
     return canonicalRegistryCache;
@@ -77,6 +88,14 @@ public final class Topics {
 
   public static Set<String> names() {
     return entries().keySet();
+  }
+
+  public static List<String> aliases(String name) {
+    Topics topics = get(name);
+    if (topics == null) {
+      throw new IllegalArgumentException("Unknown topics name: " + name);
+    }
+    return aliasesCache.getOrDefault(topics.name(), List.of());
   }
 
   public static Class<? extends TopicReader<?>> getTopicReaderClassForPath(String path) {
@@ -140,13 +159,22 @@ public final class Topics {
       addLookupEntry(lookup, Path.of(value.path).getFileName().toString(), topic);
     }
 
-    addAliasesToRegistry(canonical, lookup, loadAliasesMetadata(TOPICS_ALIASES_URL));
+    Map<String, List<String>> aliases = new LinkedHashMap<>();
+    mergeAliases(aliases, loadAliasesMetadata(TOPICS_ALIASES_URL));
     Map<String, List<String>> localAliases = loadLocalAliasesMetadata();
-    addAliasesToRegistry(canonical, lookup, localAliases);
-    localAliases.values().forEach(aliases -> aliases.forEach(canonical::remove));
+    mergeAliases(aliases, localAliases);
+    addAliasesToRegistry(canonical, lookup, aliases);
+    localAliases.values().forEach(aliasValues -> aliasValues.forEach(canonical::remove));
 
     canonicalRegistryCache = Collections.unmodifiableMap(canonical);
+    aliases.replaceAll((name, values) -> List.copyOf(values));
+    aliasesCache = Collections.unmodifiableMap(aliases);
     return Collections.unmodifiableMap(lookup);
+  }
+
+  private static void mergeAliases(Map<String, List<String>> destination, Map<String, List<String>> source) {
+    source.forEach((name, aliases) ->
+        destination.computeIfAbsent(name, ignored -> new ArrayList<>()).addAll(aliases));
   }
 
   private static void addAliasesToRegistry(Map<String, Topics> canonical, Map<String, Topics> lookup,

--- a/src/test/java/io/anserini/cli/QrelsRegistryTest.java
+++ b/src/test/java/io/anserini/cli/QrelsRegistryTest.java
@@ -32,14 +32,12 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
-import io.anserini.search.topicreader.Topics;
+import io.anserini.eval.Qrels;
 
-public class TopicsRegistryTest extends StdOutStdErrRedirectableLuceneTestCase {
+public class QrelsRegistryTest extends StdOutStdErrRedirectableLuceneTestCase {
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final TypeReference<List<String>> NAME_LIST_TYPE =
       new TypeReference<List<String>>() {};
-  private static final TypeReference<Map<String, Map<String, String>>> QUERY_MAP_TYPE =
-      new TypeReference<Map<String, Map<String, String>>>() {};
   private static final TypeReference<Map<String, Object>> METADATA_TYPE =
       new TypeReference<Map<String, Object>>() {};
 
@@ -59,113 +57,98 @@ public class TopicsRegistryTest extends StdOutStdErrRedirectableLuceneTestCase {
 
   @Test
   public void testInvalidOption() {
-    TopicsRegistry.main(new String[] {"--invalid"});
+    QrelsRegistry.main(new String[] {"--invalid"});
     assertTrue(err.toString().contains("Error:"));
     assertTrue(err.toString().contains("--invalid"));
-    assertTrue(err.toString().contains("Options for TopicsRegistry:"));
+    assertTrue(err.toString().contains("Options for QrelsRegistry:"));
   }
 
   @Test
   public void testHelp() {
-    TopicsRegistry.main(new String[] {"--help"});
-    assertTrue(err.toString().contains("Options for TopicsRegistry:"));
+    QrelsRegistry.main(new String[] {"--help"});
+    assertTrue(err.toString().contains("Options for QrelsRegistry:"));
     assertTrue(err.toString().contains("--help"));
     assertFalse(err.toString().contains("Error:"));
   }
 
   @Test
   public void testFilterRequiresList() {
-    TopicsRegistry.main(new String[] {"--get", "TREC2019_DL_PASSAGE", "--filter", "DL"});
+    QrelsRegistry.main(new String[] {"--get", "dummy", "--filter", "dummy"});
     assertTrue(err.toString().contains("Error: --filter only works with --list"));
   }
 
   @Test
   public void testListWithFilter() throws Exception {
-    TopicsRegistry.main(new String[] {"--list", "--filter", "msmarco"});
-
+    QrelsRegistry.main(new String[] {"--list", "--filter", "^dummy$"});
     List<String> names = MAPPER.readValue(out.toString(), NAME_LIST_TYPE);
-
-    Set<String> expectedNames = new TreeSet<>(Topics.names());
-    expectedNames.removeIf(name -> !name.contains("msmarco"));
-
-    assertEquals(expectedNames.size(), names.size());
-    assertEquals(expectedNames, new TreeSet<>(names));
-    assertTrue(names.contains("msmarco-passage.dev-subset"));
-    assertFalse(names.contains("topics.msmarco-passage.dev-subset.txt"));
+    assertEquals(List.of("dummy"), names);
   }
 
   @Test
   public void testListWithInvalidFilterRegex() {
-    TopicsRegistry.main(new String[] {"--list", "--filter", "["});
+    QrelsRegistry.main(new String[] {"--list", "--filter", "["});
     assertTrue(err.toString().contains("Error: invalid regular expression \"[\""));
     assertEquals("", out.toString());
   }
 
   @Test
   public void testMissingRequiredOption() {
-    TopicsRegistry.main(new String[] {});
+    QrelsRegistry.main(new String[] {});
     assertTrue(err.toString().contains("Error: exactly one of --list, --get, or --metadata must be specified"));
   }
 
   @Test
   public void testList() throws Exception {
-    TopicsRegistry.main(new String[] {"--list"});
-
+    QrelsRegistry.main(new String[] {"--list"});
     List<String> names = MAPPER.readValue(out.toString(), NAME_LIST_TYPE);
-
-    Set<String> expectedNames = new TreeSet<>(Topics.names());
-
-    assertEquals(expectedNames.size(), names.size());
+    Set<String> expectedNames = new TreeSet<>(Qrels.names());
     assertEquals(expectedNames, new TreeSet<>(names));
-    assertTrue(names.contains("dl19-passage"));
-    assertFalse(names.contains("topics.dl19-passage.txt"));
+    assertTrue(names.contains("dummy"));
+    assertFalse(names.contains("dummy.1"));
   }
 
   @Test
-  public void testGet() throws Exception {
-    Path topicFile = Path.of("topics.dl19-passage.txt");
-    Files.writeString(topicFile, "1\tquery one\n2\tquery two\n", StandardCharsets.UTF_8);
+  public void testGetRawContents() throws Exception {
+    Path qrelsFile = Path.of("qrels.dummy.txt");
+    String contents = "1 0 DOC1 1\n1 0 DOC2 0\n2 0 DOC3 1\n2 0 DOC4 0\n";
+    Files.writeString(qrelsFile, contents, StandardCharsets.UTF_8);
 
     try {
-      TopicsRegistry.main(new String[] {"--get", "dl19-passage"});
-
-      Map<String, Map<String, String>> queries = MAPPER.readValue(out.toString(), QUERY_MAP_TYPE);
-
-      assertEquals(2, queries.size());
-      assertEquals("query one", queries.get("1").get("title"));
-      assertEquals("query two", queries.get("2").get("title"));
+      QrelsRegistry.main(new String[] {"--get", "dummy"});
+      assertEquals(contents, out.toString());
+      assertEquals("", err.toString());
     } finally {
-      Files.deleteIfExists(topicFile);
+      Files.deleteIfExists(qrelsFile);
     }
   }
 
   @Test
-  public void testGetInvalidTopic() {
-    TopicsRegistry.main(new String[] {"--get", "NOT_A_TOPIC"});
-    assertTrue(err.toString().contains("Error: unknown topics \"NOT_A_TOPIC\""));
+  public void testGetInvalidQrels() {
+    QrelsRegistry.main(new String[] {"--get", "NOT_A_QRELS"});
+    assertTrue(err.toString().contains("Error: unknown qrels \"NOT_A_QRELS\""));
+    assertEquals("", out.toString());
   }
 
   @Test
   public void testMetadata() throws Exception {
-    Path topicFile = Path.of("topics.dummy.tsv");
-    Files.writeString(topicFile, "1\tquery one\n", StandardCharsets.UTF_8);
+    Path qrelsFile = Path.of("qrels.dummy.txt");
+    Files.writeString(qrelsFile, "1 0 DOC1 1\n", StandardCharsets.UTF_8);
 
     try {
-      TopicsRegistry.main(new String[] {"--metadata", "dummy"});
+      QrelsRegistry.main(new String[] {"--metadata", "dummy"});
       Map<String, Object> metadata = MAPPER.readValue(out.toString(), METADATA_TYPE);
       assertEquals("dummy", metadata.get("name"));
-      assertEquals("topics.dummy.tsv", metadata.get("path"));
-      assertEquals("io.anserini.search.topicreader.TsvStringTopicReader", metadata.get("reader_class"));
-      assertEquals(topicFile.toAbsolutePath().toString(), metadata.get("local_path"));
+      assertEquals("qrels.dummy.txt", metadata.get("path"));
+      assertEquals(qrelsFile.toAbsolutePath().toString(), metadata.get("local_path"));
       assertEquals(List.of("dummy.1", "dummy.2"), metadata.get("aliases"));
     } finally {
-      Files.deleteIfExists(topicFile);
+      Files.deleteIfExists(qrelsFile);
     }
   }
 
   @Test
-  public void testMetadataInvalidTopic() {
-    TopicsRegistry.main(new String[] {"--metadata", "NOT_A_TOPIC"});
-    assertTrue(err.toString().contains("Error: unknown topics \"NOT_A_TOPIC\""));
+  public void testMetadataInvalidQrels() {
+    QrelsRegistry.main(new String[] {"--metadata", "NOT_A_QRELS"});
+    assertTrue(err.toString().contains("Error: unknown qrels \"NOT_A_QRELS\""));
   }
 }

--- a/src/test/java/io/anserini/eval/QrelsTest.java
+++ b/src/test/java/io/anserini/eval/QrelsTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -54,6 +55,9 @@ public class QrelsTest{
     // Aliases shouldn't be in names().
     assertFalse(Qrels.names().contains("dummy.1"));
     assertFalse(Qrels.names().contains("dummy.2"));
+
+    assertEquals(List.of("dummy.1", "dummy.2"), Qrels.aliases("dummy"));
+    assertEquals(List.of("dummy.1", "dummy.2"), Qrels.aliases("dummy.1"));
 
     // But they should be available via get.
     assertDummyQrels("dummy.1");

--- a/src/test/java/io/anserini/search/topicreader/TopicsTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicsTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -151,6 +152,30 @@ public class TopicsTest {
       fail("Expected IllegalArgumentException to be thrown");
     } catch (IllegalArgumentException e) {
       assertEquals("\"" + invalidTopics + "\" does not refer to valid topics.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testResolveRegisteredTopicPathWithUnknownName() throws IOException {
+    String invalidTopics = "this-topic-name-does-not-exist";
+
+    try {
+      Topics.resolveRegisteredTopicPath(invalidTopics);
+      fail("Expected IllegalArgumentException to be thrown");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Unknown topics name: " + invalidTopics, e.getMessage());
+    }
+  }
+
+  @Test
+  public void testAliasesWithUnknownName() {
+    String invalidTopics = "this-topic-name-does-not-exist";
+
+    try {
+      Topics.aliases(invalidTopics);
+      fail("Expected IllegalArgumentException to be thrown");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Unknown topics name: " + invalidTopics, e.getMessage());
     }
   }
 }

--- a/src/test/java/io/anserini/search/topicreader/TopicsTest.java
+++ b/src/test/java/io/anserini/search/topicreader/TopicsTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 
@@ -87,6 +88,9 @@ public class TopicsTest {
     // Aliases shouldn't be in names().
     assertFalse(Topics.names().contains("dummy.1"));
     assertFalse(Topics.names().contains("dummy.2"));
+
+    assertEquals(List.of("dummy.1", "dummy.2"), Topics.aliases("dummy"));
+    assertEquals(List.of("dummy.1", "dummy.2"), Topics.aliases("dummy.1"));
 
     // But they should be available via get.
     assertDummyTopics("dummy.1");


### PR DESCRIPTION
## Summary

- add a `QrelsRegistry` CLI with canonical listing, filtering, and raw qrels output
- add downloadable JSON metadata output to the topics and qrels registries
- expose canonical names, local paths, and explicit aliases in registry metadata
- keep registry listings restricted to canonical names
- document the new CLI invocations

## Validation

- `mvn -Dtest=TopicsRegistryTest,QrelsRegistryTest,TopicsTest,QrelsTest test`
- `git diff --check`

All 130 focused tests passed with zero failures.
