### PR TITLE
Add reproduction log entries for onboarding lessons 1-3

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -719,3 +719,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-08-31 (commit [`b228451`](https://github.com/castorini/anserini/commit/b228451f07ac86a59b3b93d35287e36a4c69fb4b))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`b228451`](https://github.com/castorini/anserini/commit/b228451f07ac86a59b3b93d35287e36a4c69fb4b))
 + Results reproduced by [@ParsaA2006](https://github.com/ParsaA2006) on 2026-09-04 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))
++ Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -274,3 +274,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-08-31 (commit [`b228451`](https://github.com/castorini/anserini/commit/b228451f07ac86a59b3b93d35287e36a4c69fb4b))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`b228451`](https://github.com/castorini/anserini/commit/b228451f07ac86a59b3b93d35287e36a4c69fb4b))
 + Results reproduced by [@ParsaA2006](https://github.com/ParsaA2006) on 2026-09-04 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))
++ Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -625,3 +625,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@Ben-geo](https://github.com/Ben-geo) on 2026-08-31 (commit [`b228451`](https://github.com/castorini/anserini/commit/b228451f07ac86a59b3b93d35287e36a4c69fb4b))
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`b228451`](https://github.com/castorini/anserini/commit/b228451f07ac86a59b3b93d35287e36a4c69fb4b))
 + Results reproduced by [@ParsaA2006](https://github.com/ParsaA2006) on 2026-09-04 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))
++ Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))


### PR DESCRIPTION
Working through the [Foundations of Retrieval](https://github.com/castorini/onboarding/blob/master/ura.md) onboarding path. This PR adds reproduction log entries for the three Anserini lessons (1-3), consolidated into a single pull request as the guide asks.

### Environment

| | |
| --- | --- |
| Host | Windows, 64 GB RAM, 16 logical CPUs (AMD EPYC 7763), no CUDA GPU |
| OS | Ubuntu 24.04.4 LTS on WSL2 |
| JDK | OpenJDK 21.0.12 |
| Maven | 3.9.16 |
| Python | 3.12.3 |
| Anserini | built from source at `8af8d25` → `anserini-2.3.1-SNAPSHOT-fatjar.jar` |

### Results

**Lesson 1 — `start-here.md`** (data prep only)

| Check | Expected | Actual |
| --- | --- | --- |
| `collectionandqueries.tar.gz` MD5 | `31644046b18952c1386cd4564ba2ae69` | match |
| JSONL files / total passages | 9 / 8,841,823 | 9 / 8,841,823 |
| `queries.dev.small.tsv` | 6,980 | 6,980 |
| `qrels.dev.small.tsv` / `qrels.train.tsv` | 7,437 / 532,761 | 7,437 / 532,761 |

**Lesson 2 — `experiments-msmarco-passage.md`** (BM25, `k1=0.82`, `b=0.68`)

| Metric | Expected | Actual |
| --- | --- | --- |
| Documents indexed | 8,841,823 | 8,841,823 |
| MRR@10 | 0.18741227770955546 | 0.18741227770955546 |
| MAP | 0.1957 | 0.1957 |
| recall@1000 | 0.8573 | 0.8573 |
| `recip_rank` for qid 1048585 | 1.0000 | 1.0000 |

**Lesson 3 — `experiments-msmarco-passage2.md`** (prebuilt indexes)

| Run | Metric | Expected | Actual |
| --- | --- | --- | --- |
| BM25, prebuilt inverted index | MRR@10 | 0.1875 | 0.1875 |
| BGE-base-en-v1.5, prebuilt HNSW index | MRR@10 | 0.3521 | 0.3521 |

### Notes

Everything worked; every documented number matched exactly, and no issues were encountered with Anserini itself.

Dense retrieval ran at ~68.9 q/s on 4 threads (1 min 41 s for all 6,980 queries) — the 24.2 GB index download dominated wall-clock time, not the search. The MD5 and size verification that `PrebuiltIndexHandler` performs after downloading was a nice touch to see in the logs.

The tie-breaking explanation in lesson 3 is worth calling out as genuinely useful: it made the 0.1875 vs 0.1874 difference from lesson 2 predictable rather than alarming, and it came up again later in the Pyserini path for MAP.
