### PR TITLE
Add reproduction logs for MS MARCO passage BM25 and BGE dense retrieval

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -720,3 +720,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`b228451`](https://github.com/castorini/anserini/commit/b228451f07ac86a59b3b93d35287e36a4c69fb4b))
 + Results reproduced by [@ParsaA2006](https://github.com/ParsaA2006) on 2026-09-04 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))
 + Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))
++ Results reproduced by [@kamrankhoxa](https://github.com/kamrankhoxa) on 2026-09-07 (commit [`30e0b11`](https://github.com/castorini/anserini/commit/30e0b113a5bbc5e4d5b7d573ee9ed5c903e6a204))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -275,3 +275,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`b228451`](https://github.com/castorini/anserini/commit/b228451f07ac86a59b3b93d35287e36a4c69fb4b))
 + Results reproduced by [@ParsaA2006](https://github.com/ParsaA2006) on 2026-09-04 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))
 + Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))
++ Results reproduced by [@kamrankhoxa](https://github.com/kamrankhoxa) on 2026-09-07 (commit [`30e0b11`](https://github.com/castorini/anserini/commit/30e0b113a5bbc5e4d5b7d573ee9ed5c903e6a204))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -626,3 +626,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@jnx01](https://github.com/jnx01) on 2026-08-31 (commit [`b228451`](https://github.com/castorini/anserini/commit/b228451f07ac86a59b3b93d35287e36a4c69fb4b))
 + Results reproduced by [@ParsaA2006](https://github.com/ParsaA2006) on 2026-09-04 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))
 + Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))
++ Results reproduced by [@kamrankhoxa](https://github.com/kamrankhoxa) on 2026-09-07 (commit [`30e0b11`](https://github.com/castorini/anserini/commit/30e0b113a5bbc5e4d5b7d573ee9ed5c903e6a204))


### PR DESCRIPTION
## Summary

Added reproduction log entries for the Foundations of Retrieval onboarding exercises.

## Environment specifications

- **Operating system:** Windows 11 Home/Pro 64-bit (native, no WSL)
- **Host device:** Acer Predator PHN14-51
- **CPU:** Intel Core Ultra 7 155H (16 cores, 22 threads @ 1.40 GHz)
- **Memory:** 16 GB RAM
- **GPU:** NVIDIA GeForce RTX 4070 Laptop GPU (8 GB VRAM, native CUDA 12.6)
- **Java runtime:** OpenJDK 21.0.2 (Eclipse Temurin 64-Bit Server VM)
- **Python / frameworks:** Python 3.12, PyTorch (CUDA cu126), Faiss-CPU
- **Terminal:** Windows PowerShell

## Reproduction verification

- MS MARCO Passage BM25: MRR@10 = 0.1874 (reproduced)
- MS MARCO Passage BGE HNSW: MRR@10 = 0.3521 (reproduced)
- NFCorpus Contriever Faiss: nDCG@10 = 0.3306 (reproduced)