### PR TITLE
Use OKish in reproduction status output

### DIFF
--- a/src/main/java/io/anserini/reproduce/ReproductionUtils.java
+++ b/src/main/java/io/anserini/reproduce/ReproductionUtils.java
@@ -59,8 +59,12 @@ public final class ReproductionUtils {
     // ANSI escape code to reset to the default text color
     private static final String RESET = "\u001B[0m";
 
+    public static final String OKISH_LABEL = "[OKish]";
+    public static final String LEGACY_OKISH_LABEL = "[OK*]";
+
     public static final String OK = GREEN + "   [OK] " + RESET;
-    public static final String OKISH = BLUE + "  [OK*] " + RESET;
+    public static final String OKISH = BLUE + OKISH_LABEL + " " + RESET;
+    public static final String LEGACY_OKISH = BLUE + "  " + LEGACY_OKISH_LABEL + " " + RESET;
     public static final String FAIL = RED + " [FAIL] " + RESET;
 
     public static final String DEFAULT_RUNS_DIRECTORY = "runs";

--- a/src/main/java/io/anserini/reproduce/SummarizeLogsFromDocumentCollection.java
+++ b/src/main/java/io/anserini/reproduce/SummarizeLogsFromDocumentCollection.java
@@ -103,7 +103,8 @@ public class SummarizeLogsFromDocumentCollection {
     Path logsDir = Paths.get(args.logsDirectory);
     int totalRegressions = 0;
     String[] statusLabels = {ReproductionUtils.Constants.OK, ReproductionUtils.Constants.OKISH, ReproductionUtils.Constants.FAIL};
-    String[] rawStatusLabels = {"[OK]", "[OK*]", "[FAIL]"};
+    String[] rawStatusLabels = {"[OK]", ReproductionUtils.Constants.OKISH_LABEL, "[FAIL]"};
+    String[] jsonStatusLabels = {"[OK]", ReproductionUtils.Constants.LEGACY_OKISH_LABEL, "[FAIL]"};
     int[] statusCounters = new int[statusLabels.length];
 
     Instant startTime = null;
@@ -145,7 +146,11 @@ public class SummarizeLogsFromDocumentCollection {
         }
 
         for (int i = 0; i < statusLabels.length; i++) {
-          if (lastRunRegressionsLine.contains(statusLabels[i])) {
+          boolean containsStatus = i == 1
+              ? lastRunRegressionsLine.contains(ReproductionUtils.Constants.OKISH_LABEL)
+                  || lastRunRegressionsLine.contains(ReproductionUtils.Constants.LEGACY_OKISH_LABEL)
+              : lastRunRegressionsLine.contains(statusLabels[i]);
+          if (containsStatus) {
             statusCounters[i]++;
           }
         }
@@ -168,7 +173,8 @@ public class SummarizeLogsFromDocumentCollection {
     }
 
     if (args.json) {
-      printSummaryJson(totalRegressions, statusCounters, rawStatusLabels, startTime, endTime, duration);
+      // Keep the established JSON key for downstream consumers.
+      printSummaryJson(totalRegressions, statusCounters, jsonStatusLabels, startTime, endTime, duration);
     } else if (args.markdown) {
       printSummaryMarkdown(totalRegressions, statusCounters, rawStatusLabels, startTime, endTime, duration);
     } else {

--- a/src/main/java/io/anserini/reproduce/SummarizeLogsFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/SummarizeLogsFromPrebuiltIndexes.java
@@ -110,7 +110,8 @@ public class SummarizeLogsFromPrebuiltIndexes {
 
         try (var lines = Files.lines(logFile, StandardCharsets.UTF_8)) {
           for (String line : (Iterable<String>) lines::iterator) {
-            if (line.contains("[OK*]")) {
+            if (line.contains(ReproductionUtils.Constants.OKISH_LABEL)
+                || line.contains(ReproductionUtils.Constants.LEGACY_OKISH_LABEL)) {
               okishCount++;
             } else if (line.contains("[OK]")) {
               okCount++;
@@ -149,7 +150,7 @@ public class SummarizeLogsFromPrebuiltIndexes {
 
     rows.sort((left, right) -> left[0].compareTo(right[0]));
 
-    final String[] headers = {"run", "[OK]", "[OK*]", "[FAIL]", "elapsed"};
+    final String[] headers = {"run", "[OK]", ReproductionUtils.Constants.OKISH_LABEL, "[FAIL]", "elapsed"};
     int[] widths = new int[headers.length];
     for (int i = 0; i < headers.length; i++) {
       widths[i] = headers[i].length();
@@ -244,7 +245,8 @@ public class SummarizeLogsFromPrebuiltIndexes {
       sb.append("  {\n")
           .append("    \"run\": \"").append(ReproductionUtils.escapeJson(row[0])).append("\",\n")
           .append("    \"[OK]\": ").append(row[1]).append(",\n")
-          .append("    \"[OK*]\": ").append(row[2]).append(",\n")
+          // Keep the established JSON key for downstream consumers.
+          .append("    \"").append(ReproductionUtils.Constants.LEGACY_OKISH_LABEL).append("\": ").append(row[2]).append(",\n")
           .append("    \"[FAIL]\": ").append(row[3]).append(",\n")
           .append("    \"elapsed\": \"").append(ReproductionUtils.escapeJson(row[4])).append("\"\n")
           .append("  }");

--- a/src/test/java/io/anserini/reproduce/SummarizeLogsFromDocumentCollectionTest.java
+++ b/src/test/java/io/anserini/reproduce/SummarizeLogsFromDocumentCollectionTest.java
@@ -133,6 +133,30 @@ public class SummarizeLogsFromDocumentCollectionTest {
   }
 
   @Test
+  public void testCurrentAndLegacyOkishLabels() throws Exception {
+    Path logsDir = temporaryWorkingDirectory.resolve("logs");
+    Files.createDirectory(logsDir);
+
+    writeLog(logsDir.resolve("log.from-document-collection.current"), List.of(
+        "2026-03-01 10:00:00,100 Starting ReproduceFromDocumentCollection for current",
+        "2026-03-01 10:00:01,200 ReproduceFromDocumentCollection" + ReproductionUtils.Constants.OKISH + " completed current"));
+
+    writeLog(logsDir.resolve("log.from-document-collection.legacy"), List.of(
+        "2026-03-01 10:00:02,300 Starting ReproduceFromDocumentCollection for legacy",
+        "2026-03-01 10:00:03,400 ReproduceFromDocumentCollection" + ReproductionUtils.Constants.LEGACY_OKISH + " completed legacy"));
+
+    String output = runInTempDirectory();
+    assertEquals(2, countForStatusLine(output, ReproductionUtils.Constants.OKISH));
+
+    output = runInTempDirectory("--md");
+    assertTrue(Pattern.compile("\\| \\[OKish\\]\\s+\\|\\s+2 \\|").matcher(output).find());
+
+    output = runInTempDirectory("--json");
+    assertTrue(output.contains("\"[OK*]\": 2"));
+    assertTrue(!output.contains("\"[OKish]\":"));
+  }
+
+  @Test
   public void testSummarizeLogsMarkdown() throws Exception {
     Path logsDir = temporaryWorkingDirectory.resolve("logs");
     Files.createDirectory(logsDir);
@@ -148,10 +172,10 @@ public class SummarizeLogsFromDocumentCollectionTest {
     String output = runInTempDirectory("--md");
 
     assertTrue(Pattern.compile("Total regressions:\\s+2").matcher(output).find());
-    assertTrue(output.contains("| status | count |"));
-    assertTrue(output.contains("| ------ | ----: |"));
+    assertTrue(output.contains("| status  | count |"));
+    assertTrue(output.contains("| ------- | ----: |"));
     assertTrue(Pattern.compile("\\| \\[OK\\]\\s+\\|\\s+1 \\|").matcher(output).find());
-    assertTrue(Pattern.compile("\\| \\[OK\\*\\]\\s+\\|\\s+0 \\|").matcher(output).find());
+    assertTrue(Pattern.compile("\\| \\[OKish\\]\\s+\\|\\s+0 \\|").matcher(output).find());
     assertTrue(Pattern.compile("\\| \\[FAIL\\]\\s+\\|\\s+1 \\|").matcher(output).find());
     assertTrue(Pattern.compile("(?m)^Start time:").matcher(output).find());
     assertTrue(Pattern.compile("(?m)^End time:").matcher(output).find());

--- a/src/test/java/io/anserini/reproduce/SummarizeLogsFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/reproduce/SummarizeLogsFromPrebuiltIndexesTest.java
@@ -73,7 +73,8 @@ public class SummarizeLogsFromPrebuiltIndexesTest {
 
     Files.write(logsDir.resolve("log.from-prebuilt-indexes.betaset.txt"), List.of(
         "Run for beta [OK]",
-        "Second line [OK*]",
+        "Current label [OKish]",
+        "Historical label [OK*]",
         "Duration: done (01:03:04)"));
 
     Files.write(logsDir.resolve("log.from-prebuilt-indexes.alpha.txt"), List.of(
@@ -93,7 +94,8 @@ public class SummarizeLogsFromPrebuiltIndexesTest {
     assertTrue(output.contains("\"elapsed\": \"00:00:01\""));
 
     assertTrue(output.contains("\"[OK]\": 1"));
-    assertTrue(output.contains("\"[OK*]\": 1"));
+    assertTrue(output.contains("\"[OK*]\": 2"));
+    assertTrue(!output.contains("\"[OKish]\":"));
     assertTrue(output.contains("\"[FAIL]\": 0"));
     assertTrue(output.contains("\"elapsed\": \"01:03:04\""));
   }
@@ -105,7 +107,8 @@ public class SummarizeLogsFromPrebuiltIndexesTest {
 
     Files.write(logsDir.resolve("log.from-prebuilt-indexes.betaset.txt"), List.of(
         "Run for beta [OK]",
-        "Second line [OK*]",
+        "Current label [OKish]",
+        "Historical label [OK*]",
         "Duration: done (01:03:04)"));
 
     Files.write(logsDir.resolve("log.from-prebuilt-indexes.alpha.txt"), List.of(
@@ -117,9 +120,10 @@ public class SummarizeLogsFromPrebuiltIndexesTest {
 
     String[] lines = output.strip().split("\\R");
     assertTrue(lines[0].startsWith("| run"));
-    assertTrue(lines[1].contains("| -----:"));
+    assertTrue(lines[1].contains("| ------:"));
     assertTrue(lines[2].matches("\\|\\s*alpha\\s+\\|\\s+0\\s+\\|\\s+0\\s+\\|\\s+2\\s+\\|\\s+00:00:01\\s+\\|"));
-    assertTrue(lines[3].matches("\\|\\s*betaset\\s+\\|\\s+1\\s+\\|\\s+1\\s+\\|\\s+0\\s+\\|\\s+01:03:04\\s+\\|"));
+    assertTrue(lines[3].matches("\\|\\s*betaset\\s+\\|\\s+1\\s+\\|\\s+2\\s+\\|\\s+0\\s+\\|\\s+01:03:04\\s+\\|"));
+    assertTrue(lines[0].contains("[OKish]"));
     assertTrue(output.indexOf("alpha") < output.indexOf("betaset"));
   }
 
@@ -130,7 +134,8 @@ public class SummarizeLogsFromPrebuiltIndexesTest {
 
     Files.write(logsDir.resolve("log.from-prebuilt-indexes.betaset.txt"), List.of(
         "Run for beta [OK]",
-        "Second line [OK*]",
+        "Current label [OKish]",
+        "Historical label [OK*]",
         "Duration: done (01:03:04)"));
 
     Files.write(logsDir.resolve("log.from-prebuilt-indexes.alpha.txt"), List.of(
@@ -144,9 +149,9 @@ public class SummarizeLogsFromPrebuiltIndexesTest {
     assertTrue(lines.length >= 4);
     assertTrue(!lines[0].contains("|"));
     assertTrue(!lines[1].contains("|"));
-    assertTrue(lines[0].matches("\\s*run\\s+\\[OK\\]\\s+\\[OK\\*\\]\\s+\\[FAIL\\]\\s+elapsed\\s*"));
+    assertTrue(lines[0].matches("\\s*run\\s+\\[OK\\]\\s+\\[OKish\\]\\s+\\[FAIL\\]\\s+elapsed\\s*"));
     assertTrue(lines[2].matches("\\s*alpha\\s+0\\s+0\\s+2\\s+00:00:01\\s*"));
-    assertTrue(lines[3].matches("\\s*betaset\\s+1\\s+1\\s+0\\s+01:03:04\\s*"));
+    assertTrue(lines[3].matches("\\s*betaset\\s+1\\s+2\\s+0\\s+01:03:04\\s*"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- emit `[OKish]` in new reproduction logs and human-readable summaries
- recognize both `[OKish]` and historical `[OK*]` entries
- keep the established `[OK*]` JSON key for compatibility
- cover current, historical, and mixed logs in both summarizers

## Testing

- 19 targeted tests passed

Fixes #3420