### PR TITLE
[codex] Unify reproduction score comparison rules

### DIFF
--- a/src/main/java/io/anserini/reproduce/ReproduceFromDocumentCollection.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromDocumentCollection.java
@@ -578,7 +578,7 @@ public class ReproduceFromDocumentCollection {
           boolean usingHnsw = "hnsw".equals(modelType);
           boolean usingFlat = "flat".equals(modelType);
 
-          double toleranceOk = 0.0;
+          Double toleranceOk = null;
           JsonNode tolerance = model.get("tolerance");
           if (tolerance != null && tolerance.has(metricName)) {
             toleranceOk = tolerance.get(metricName).get(i).asDouble();
@@ -588,7 +588,7 @@ public class ReproduceFromDocumentCollection {
           if (usingFlat || usingHnsw) {
             resultStr = String.format(Locale.ROOT,
                 "expected: %.4f actual: %.4f (delta=%.4f, tolerance=%.4f) - metric: %-8s model: %s topics: %s",
-                expected, actual, expected - actual, toleranceOk, metricName, model.get("name").asText(),
+                expected, actual, expected - actual, toleranceOk == null ? 0.0 : toleranceOk, metricName, model.get("name").asText(),
                 topic.get("id").asText());
           } else {
             resultStr = String.format(Locale.ROOT,

--- a/src/main/java/io/anserini/reproduce/ReproduceFromDocumentCollection.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromDocumentCollection.java
@@ -347,10 +347,6 @@ public class ReproduceFromDocumentCollection {
     }
   }
 
-  private static boolean isClose(double a, double b, double relTol, double absTol) {
-    return Math.abs(a - b) <= Math.max(relTol * Math.max(Math.abs(a), Math.abs(b)), absTol);
-  }
-
   private static String constructIndexPath(JsonNode yaml) {
     String indexPath = Objects.requireNonNull(yaml.get("index_path")).asText();
 
@@ -601,17 +597,16 @@ public class ReproduceFromDocumentCollection {
                 topic.get("id").asText());
           }
 
-          if (isClose(expected, actual, 1e-9, 0.0) || actual > expected ||
-              (usingFlat && isClose(expected, actual, 1e-9, toleranceOk)) ||
-              (usingHnsw && isClose(expected, actual, 1e-9, toleranceOk))) {
-            LOG.info(ReproductionUtils.Constants.OK + resultStr);
-          } else if ((usingFlat && isClose(expected, actual, 1e-9, toleranceOk * 1.5)) ||
-              (usingHnsw && isClose(expected, actual, 1e-9, toleranceOk * 1.5))) {
-            LOG.info(ReproductionUtils.Constants.OKISH + resultStr);
-            okish = true;
-          } else {
-            LOG.error(ReproductionUtils.Constants.FAIL + resultStr);
-            failures = true;
+          switch (ReproductionUtils.compareScores(expected, actual, toleranceOk)) {
+            case OK -> LOG.info(ReproductionUtils.Constants.OK + resultStr);
+            case OKISH -> {
+              LOG.info(ReproductionUtils.Constants.OKISH + resultStr);
+              okish = true;
+            }
+            case FAIL -> {
+              LOG.error(ReproductionUtils.Constants.FAIL + resultStr);
+              failures = true;
+            }
           }
         }
       }

--- a/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
@@ -307,17 +307,7 @@ public class ReproduceFromPrebuiltIndexes {
           if (!dryRun) {
             try {
               double score = runTrecEvalAndGetScore(metricDefinitions.get(metric), topic.eval_key, output);
-              double delta = Math.abs(score - expected.get(metric));
-
-              if (score > expected.get(metric)) {
-                System.out.printf(Locale.ROOT, "    %8s: %.4f %s expected %.4f%n", metric, score, ReproductionUtils.Constants.OKISH, expected.get(metric));
-              } else if (delta < 0.00001) {
-                System.out.printf(Locale.ROOT, "    %8s: %.4f %s%n", metric, score, ReproductionUtils.Constants.OK);
-              } else if (delta < 0.0002) {
-                System.out.printf(Locale.ROOT, "    %8s: %.4f %s expected %.4f%n", metric, score, ReproductionUtils.Constants.OKISH, expected.get(metric));
-              } else {
-                System.out.printf(Locale.ROOT, "    %8s: %.4f %s expected %.4f%n", metric, score, ReproductionUtils.Constants.FAIL, expected.get(metric));
-              }
+              printMetricResult(topic, metric, score);
             } catch (RuntimeException e) {
               System.out.println("    Evaluation command failed for metric: " + metric);
               System.out.println("    " + e.getMessage());
@@ -467,6 +457,16 @@ public class ReproduceFromPrebuiltIndexes {
     return summary.toString();
   }
 
+  static void printMetricResult(Topic topic, String metric, double score) {
+    double expected = topic.expected_scores.get(metric);
+    double tolerance = topic.tolerance == null ? 0.0 : topic.tolerance.getOrDefault(metric, 0.0);
+    switch (ReproductionUtils.compareScores(expected, score, tolerance)) {
+      case OK -> System.out.printf(Locale.ROOT, "    %8s: %.4f %s%n", metric, score, ReproductionUtils.Constants.OK);
+      case OKISH -> System.out.printf(Locale.ROOT, "    %8s: %.4f %s expected %.4f%n", metric, score, ReproductionUtils.Constants.OKISH, expected);
+      case FAIL -> System.out.printf(Locale.ROOT, "    %8s: %.4f %s expected %.4f%n", metric, score, ReproductionUtils.Constants.FAIL, expected);
+    }
+  }
+
   public static class Config {
     @JsonProperty
     public List<Condition> conditions;
@@ -504,6 +504,10 @@ public class ReproduceFromPrebuiltIndexes {
 
     @JsonProperty
     public Map<String, Double> expected_scores;
+
+    /** Optional absolute tolerances keyed by metric; missing metrics default to zero. */
+    @JsonProperty
+    public Map<String, Double> tolerance;
 
     @JsonProperty
     public Map<String, String> metric_definitions;

--- a/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
@@ -307,7 +307,12 @@ public class ReproduceFromPrebuiltIndexes {
           if (!dryRun) {
             try {
               double score = runTrecEvalAndGetScore(metricDefinitions.get(metric), topic.eval_key, output);
-              printMetricResult(topic, metric, score);
+              double tolerance = topic.tolerance == null ? 0.0 : topic.tolerance.getOrDefault(metric, 0.0);
+              switch (ReproductionUtils.compareScores(expected.get(metric), score, tolerance)) {
+                case OK -> System.out.printf(Locale.ROOT, "    %8s: %.4f %s%n", metric, score, ReproductionUtils.Constants.OK);
+                case OKISH -> System.out.printf(Locale.ROOT, "    %8s: %.4f %s expected %.4f%n", metric, score, ReproductionUtils.Constants.OKISH, expected.get(metric));
+                case FAIL -> System.out.printf(Locale.ROOT, "    %8s: %.4f %s expected %.4f%n", metric, score, ReproductionUtils.Constants.FAIL, expected.get(metric));
+              }
             } catch (RuntimeException e) {
               System.out.println("    Evaluation command failed for metric: " + metric);
               System.out.println("    " + e.getMessage());
@@ -455,16 +460,6 @@ public class ReproduceFromPrebuiltIndexes {
     }
     summary.append(System.lineSeparator());
     return summary.toString();
-  }
-
-  static void printMetricResult(Topic topic, String metric, double score) {
-    double expected = topic.expected_scores.get(metric);
-    double tolerance = topic.tolerance == null ? 0.0 : topic.tolerance.getOrDefault(metric, 0.0);
-    switch (ReproductionUtils.compareScores(expected, score, tolerance)) {
-      case OK -> System.out.printf(Locale.ROOT, "    %8s: %.4f %s%n", metric, score, ReproductionUtils.Constants.OK);
-      case OKISH -> System.out.printf(Locale.ROOT, "    %8s: %.4f %s expected %.4f%n", metric, score, ReproductionUtils.Constants.OKISH, expected);
-      case FAIL -> System.out.printf(Locale.ROOT, "    %8s: %.4f %s expected %.4f%n", metric, score, ReproductionUtils.Constants.FAIL, expected);
-    }
   }
 
   public static class Config {

--- a/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
+++ b/src/main/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexes.java
@@ -307,7 +307,7 @@ public class ReproduceFromPrebuiltIndexes {
           if (!dryRun) {
             try {
               double score = runTrecEvalAndGetScore(metricDefinitions.get(metric), topic.eval_key, output);
-              double tolerance = topic.tolerance == null ? 0.0 : topic.tolerance.getOrDefault(metric, 0.0);
+              Double tolerance = topic.tolerance == null ? null : topic.tolerance.get(metric);
               switch (ReproductionUtils.compareScores(expected.get(metric), score, tolerance)) {
                 case OK -> System.out.printf(Locale.ROOT, "    %8s: %.4f %s%n", metric, score, ReproductionUtils.Constants.OK);
                 case OKISH -> System.out.printf(Locale.ROOT, "    %8s: %.4f %s expected %.4f%n", metric, score, ReproductionUtils.Constants.OKISH, expected.get(metric));
@@ -500,7 +500,7 @@ public class ReproduceFromPrebuiltIndexes {
     @JsonProperty
     public Map<String, Double> expected_scores;
 
-    /** Optional absolute tolerances keyed by metric; missing metrics default to zero. */
+    /** Optional absolute tolerances keyed by metric; missing metrics use the comparison fallback. */
     @JsonProperty
     public Map<String, Double> tolerance;
 

--- a/src/main/java/io/anserini/reproduce/ReproductionUtils.java
+++ b/src/main/java/io/anserini/reproduce/ReproductionUtils.java
@@ -46,6 +46,31 @@ public final class ReproductionUtils {
 
   private ReproductionUtils() {}
 
+  public enum Status {
+    OK, OKISH, FAIL
+  }
+
+  /** Absolute allowance for floating-point noise, independent of metric scale or display precision. */
+  public static final double NUMERICAL_TOLERANCE = 1e-9;
+
+  /**
+   * Classifies scores after any metric-specific rounding performed by the caller.
+   * Callers should pass zero when no tolerance is configured.
+   * Differences within the larger of the configured and numerical tolerances are OK.
+   * Otherwise, differences within 1.5 times the configured tolerance, improvements,
+   * and differences strictly below 0.0002 are OKish; all other results fail.
+   */
+  public static Status compareScores(double expected, double observed, double tolerance) {
+    double delta = Math.abs(observed - expected);
+    if (delta <= Math.max(tolerance, NUMERICAL_TOLERANCE)) {
+      return Status.OK;
+    }
+    if (delta <= 1.5 * tolerance || observed > expected || delta < 0.0002) {
+      return Status.OKISH;
+    }
+    return Status.FAIL;
+  }
+
   public static final class Constants {
     // ANSI escape code for red text
     private static final String RED = "\u001B[91m";

--- a/src/main/java/io/anserini/reproduce/ReproductionUtils.java
+++ b/src/main/java/io/anserini/reproduce/ReproductionUtils.java
@@ -36,6 +36,8 @@ import java.util.Locale;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
+import javax.annotation.Nullable;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -53,20 +55,35 @@ public final class ReproductionUtils {
   /** Absolute allowance for floating-point noise, independent of metric scale or display precision. */
   public static final double NUMERICAL_TOLERANCE = 1e-9;
 
+  /** Exclusive OKish threshold when no tolerance is configured. */
+  public static final double DEFAULT_OKISH_TOLERANCE = 0.0002;
+
   /**
-   * Classifies scores after any metric-specific rounding performed by the caller.
-   * Callers should pass null when no tolerance is configured; explicit zero disables the fallback.
-   * Differences within the larger of the configured and numerical tolerances are OK.
-   * Otherwise, improvements and differences within 1.5 times the configured tolerance are OKish.
-   * When no tolerance is configured, differences strictly below 0.0002 are also OKish.
-   * All other results fail.
+   * Classifies scores after any metric-specific rounding performed by the caller. 
+   * With {@code delta = abs(observed - expected)}, apply these checks in order:
+   * <ul>
+   *   <li><b>OK:</b> {@code delta <= max(tolerance, NUMERICAL_TOLERANCE)}, using zero for {@code null} tolerance in this calculation.</li>
+   *   <li><b>Otherwise, OKish:</b> any of:
+   *     <ul>
+   *       <li>{@code observed > expected}.</li>
+   *       <li>Tolerance is configured: {@code delta <= 1.5 * tolerance}.</li>
+   *       <li>Tolerance is absent ({@code null}): {@code delta < DEFAULT_OKISH_TOLERANCE}.</li>
+   *     </ul>
+   *   </li>
+   *   <li><b>Otherwise, FAIL.</b></li>
+   * </ul>
+   *
+   * @param expected expected reference score, after any metric-specific rounding
+   * @param observed observed score, after any metric-specific rounding
+   * @param tolerance configured absolute tolerance, or {@code null} when absent; explicit zero disables the {@code delta < DEFAULT_OKISH_TOLERANCE} fallback
+   * @return {@link Status#OK}, {@link Status#OKISH}, or {@link Status#FAIL} according to the decision tree above
    */
-  public static Status compareScores(double expected, double observed, Double tolerance) {
+  public static Status compareScores(double expected, double observed, @Nullable Double tolerance) {
     double delta = Math.abs(observed - expected);
     if (delta <= Math.max(tolerance == null ? 0.0 : tolerance, NUMERICAL_TOLERANCE)) {
       return Status.OK;
     }
-    if (observed > expected || (tolerance == null ? delta < 0.0002 : delta <= 1.5 * tolerance)) {
+    if (observed > expected || (tolerance == null ? delta < DEFAULT_OKISH_TOLERANCE : delta <= 1.5 * tolerance)) {
       return Status.OKISH;
     }
     return Status.FAIL;

--- a/src/main/java/io/anserini/reproduce/ReproductionUtils.java
+++ b/src/main/java/io/anserini/reproduce/ReproductionUtils.java
@@ -55,17 +55,18 @@ public final class ReproductionUtils {
 
   /**
    * Classifies scores after any metric-specific rounding performed by the caller.
-   * Callers should pass zero when no tolerance is configured.
+   * Callers should pass null when no tolerance is configured; explicit zero disables the fallback.
    * Differences within the larger of the configured and numerical tolerances are OK.
-   * Otherwise, differences within 1.5 times the configured tolerance, improvements,
-   * and differences strictly below 0.0002 are OKish; all other results fail.
+   * Otherwise, improvements and differences within 1.5 times the configured tolerance are OKish.
+   * When no tolerance is configured, differences strictly below 0.0002 are also OKish.
+   * All other results fail.
    */
-  public static Status compareScores(double expected, double observed, double tolerance) {
+  public static Status compareScores(double expected, double observed, Double tolerance) {
     double delta = Math.abs(observed - expected);
-    if (delta <= Math.max(tolerance, NUMERICAL_TOLERANCE)) {
+    if (delta <= Math.max(tolerance == null ? 0.0 : tolerance, NUMERICAL_TOLERANCE)) {
       return Status.OK;
     }
-    if (delta <= 1.5 * tolerance || observed > expected || delta < 0.0002) {
+    if (observed > expected || (tolerance == null ? delta < 0.0002 : delta <= 1.5 * tolerance)) {
       return Status.OKISH;
     }
     return Status.FAIL;

--- a/src/test/java/io/anserini/reproduce/ReproduceFromDocumentCollectionTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromDocumentCollectionTest.java
@@ -198,8 +198,7 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
     assertEvaluationStatus("inverted", 0.5, 0.4999, 4, "tolerance: {MAP: [0.00001]}", ReproductionUtils.Constants.OKISH);
   }
 
-  private void assertEvaluationStatus(String type, double expected, double actual, int precision,
-      String toleranceYaml, String status) throws Exception {
+  private void assertEvaluationStatus(String type, double expected, double actual, int precision, String toleranceYaml, String status) throws Exception {
     JsonNode yaml = new ObjectMapper(new YAMLFactory()).readTree("""
         corpus: test
         index_path: indexes/test
@@ -226,16 +225,18 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
     };
     Logger logger = (Logger) LogManager.getLogger(ReproduceFromDocumentCollection.class);
     Level previousLevel = logger.getLevel();
+    boolean previousAdditivity = logger.isAdditive();
     appender.start();
     logger.addAppender(appender);
+    logger.setAdditive(false);
     logger.setLevel(Level.INFO);
     try {
-      Method evaluate = ReproduceFromDocumentCollection.class.getDeclaredMethod("evaluateAndVerify",
-          JsonNode.class, ReproduceFromDocumentCollection.Args.class, long.class);
+      Method evaluate = ReproduceFromDocumentCollection.class.getDeclaredMethod("evaluateAndVerify", JsonNode.class, ReproduceFromDocumentCollection.Args.class, long.class);
       evaluate.setAccessible(true);
       evaluate.invoke(null, yaml, new ReproduceFromDocumentCollection.Args(), System.nanoTime());
     } finally {
       logger.setLevel(previousLevel);
+      logger.setAdditive(previousAdditivity);
       logger.removeAppender(appender);
       appender.stop();
     }
@@ -323,7 +324,7 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
 
       ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
       ReproduceFromDocumentCollection.Args args = new ReproduceFromDocumentCollection.Args();
-      Method resolveCorpusPath = ReproduceFromDocumentCollection.class.getDeclaredMethod("resolveCorpusPath", com.fasterxml.jackson.databind.JsonNode.class, ReproduceFromDocumentCollection.Args.class);
+      Method resolveCorpusPath = ReproduceFromDocumentCollection.class.getDeclaredMethod("resolveCorpusPath", JsonNode.class, ReproduceFromDocumentCollection.Args.class);
       resolveCorpusPath.setAccessible(true);
 
       String resolved = (String) resolveCorpusPath.invoke(null, mapper.readTree("""
@@ -408,11 +409,7 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
 
   private void assertTrecEvalP30(String qrelsPath, String runFile, String expectedP30) throws Exception {
     TrecEval trecEval = new TrecEval();
-    String[] args = new String[] {
-        "-m", "P.30",
-        qrelsPath,
-        runFile
-    };
+    String[] args = new String[] {"-m", "P.30", qrelsPath, runFile};
     String[][] output = trecEval.runAndGetOutput(args);
 
     assertNotNull(output);

--- a/src/test/java/io/anserini/reproduce/ReproduceFromDocumentCollectionTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromDocumentCollectionTest.java
@@ -183,20 +183,31 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
   }
 
   @Test
-  public void testAbsentAndZeroToleranceProduceSameStatuses() throws Exception {
-    for (String tolerance : new String[] {"", "tolerance: {MAP: [0.0]}", "tolerance: {P30: [0.1]}"}) {
-      assertEvaluationStatus("inverted", 0.5, 0.5, 4, tolerance, ReproductionUtils.Constants.OK);
-      assertEvaluationStatus("inverted", 0.5, 0.4999, 4, tolerance, ReproductionUtils.Constants.OKISH);
-      assertEvaluationStatus("inverted", 0.5, 0.6, 4, tolerance, ReproductionUtils.Constants.OKISH);
-      assertEvaluationStatus("inverted", 0.5, 0.4, 4, tolerance, ReproductionUtils.Constants.FAIL);
+  public void testAbsentAndZeroToleranceProduceDifferentStatuses() throws Exception {
+    for (String type : new String[] {"inverted", "flat", "hnsw"}) {
+      for (String tolerance : new String[] {"", "tolerance: {P30: [0.1]}"}) {
+        assertEvaluationStatus(type, 0.5, 0.5, 4, tolerance, ReproductionUtils.Constants.OK);
+        assertEvaluationStatus(type, 0.5, 0.4999, 4, tolerance, ReproductionUtils.Constants.OKISH);
+        assertEvaluationStatus(type, 0.5, 0.6, 4, tolerance, ReproductionUtils.Constants.OKISH);
+        assertEvaluationStatus(type, 0.5, 0.4, 4, tolerance, ReproductionUtils.Constants.FAIL);
+      }
+      String tolerance = "tolerance: {MAP: [0.0]}";
+      assertEvaluationStatus(type, 0.5, 0.5, 4, tolerance, ReproductionUtils.Constants.OK);
+      assertEvaluationStatus(type, 0.5, 0.4999, 4, tolerance, ReproductionUtils.Constants.FAIL);
+      assertEvaluationStatus(type, 0.5, 0.6, 4, tolerance, ReproductionUtils.Constants.OKISH);
+      assertEvaluationStatus(type, 0.5, 0.4, 4, tolerance, ReproductionUtils.Constants.FAIL);
     }
   }
 
   @Test
-  public void testMetricRoundingAndFallbackWithConfiguredTolerance() throws Exception {
+  public void testMetricRoundingAndConfiguredToleranceDisablesFallback() throws Exception {
     assertEvaluationStatus("inverted", 0.50004, 0.49996, 4, "", ReproductionUtils.Constants.OK);
     assertEvaluationStatus("inverted", 0.50004, 0.49996, 5, "", ReproductionUtils.Constants.OKISH);
-    assertEvaluationStatus("inverted", 0.5, 0.4999, 4, "tolerance: {MAP: [0.00001]}", ReproductionUtils.Constants.OKISH);
+    assertEvaluationStatus("inverted", 0.50004, 0.49996, 4, "tolerance: {MAP: [0.0]}", ReproductionUtils.Constants.OK);
+    assertEvaluationStatus("inverted", 0.50004, 0.49996, 5, "tolerance: {MAP: [0.0]}", ReproductionUtils.Constants.FAIL);
+    for (String type : new String[] {"inverted", "flat", "hnsw"}) {
+      assertEvaluationStatus(type, 0.5, 0.4999, 4, "tolerance: {MAP: [0.00001]}", ReproductionUtils.Constants.FAIL);
+    }
   }
 
   @Test

--- a/src/test/java/io/anserini/reproduce/ReproduceFromDocumentCollectionTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromDocumentCollectionTest.java
@@ -34,6 +34,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.After;
 import org.junit.Assume;
@@ -42,9 +45,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
+import io.anserini.CustomAppender;
 import io.anserini.eval.TrecEval;
 import io.anserini.index.AbstractIndexer;
 import io.anserini.index.IndexCollection;
@@ -165,6 +170,80 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
     assertNotNull(topics);
 
     ReproduceFromDocumentCollection.main(new String[] {"--config", "cacm", "--index", "--search", "--dry-run"});
+  }
+
+  @Test
+  public void testConfiguredToleranceAppliesToAllModelTypes() throws Exception {
+    for (String type : new String[] {"inverted", "flat", "hnsw"}) {
+      assertEvaluationStatus(type, 0.5, 0.4375, 5, "tolerance: {MAP: [0.0625]}", ReproductionUtils.Constants.OK);
+      assertEvaluationStatus(type, 0.5, 0.40625, 5, "tolerance: {MAP: [0.0625]}", ReproductionUtils.Constants.OKISH);
+      assertEvaluationStatus(type, 0.5, 0.375, 5, "tolerance: {MAP: [0.0625]}", ReproductionUtils.Constants.FAIL);
+    }
+  }
+
+  @Test
+  public void testAbsentAndZeroToleranceProduceSameStatuses() throws Exception {
+    for (String tolerance : new String[] {"", "tolerance: {MAP: [0.0]}", "tolerance: {P30: [0.1]}"}) {
+      assertEvaluationStatus("inverted", 0.5, 0.5, 4, tolerance, ReproductionUtils.Constants.OK);
+      assertEvaluationStatus("inverted", 0.5, 0.4999, 4, tolerance, ReproductionUtils.Constants.OKISH);
+      assertEvaluationStatus("inverted", 0.5, 0.6, 4, tolerance, ReproductionUtils.Constants.OKISH);
+      assertEvaluationStatus("inverted", 0.5, 0.4, 4, tolerance, ReproductionUtils.Constants.FAIL);
+    }
+  }
+
+  @Test
+  public void testMetricRoundingAndFallbackWithConfiguredTolerance() throws Exception {
+    assertEvaluationStatus("inverted", 0.50004, 0.49996, 4, "", ReproductionUtils.Constants.OK);
+    assertEvaluationStatus("inverted", 0.50004, 0.49996, 5, "", ReproductionUtils.Constants.OKISH);
+    assertEvaluationStatus("inverted", 0.5, 0.4999, 4, "tolerance: {MAP: [0.00001]}", ReproductionUtils.Constants.OKISH);
+  }
+
+  private void assertEvaluationStatus(String type, double expected, double actual, int precision,
+      String toleranceYaml, String status) throws Exception {
+    JsonNode yaml = new ObjectMapper(new YAMLFactory()).readTree("""
+        corpus: test
+        index_path: indexes/test
+        topics:
+          - id: test
+        metrics:
+          - metric: MAP
+            command: "echo %s"
+            separator: ' '
+            parse_index: 0
+            metric_precision: %d
+        models:
+          - name: test
+            type: %s
+            results: {MAP: [%s]}
+            %s
+        """.formatted(actual, precision, type, expected, toleranceYaml));
+    List<String> messages = new ArrayList<>();
+    CustomAppender appender = new CustomAppender("score-comparison") {
+      @Override
+      public void append(LogEvent event) {
+        messages.add(event.getMessage().getFormattedMessage());
+      }
+    };
+    Logger logger = (Logger) LogManager.getLogger(ReproduceFromDocumentCollection.class);
+    Level previousLevel = logger.getLevel();
+    appender.start();
+    logger.addAppender(appender);
+    logger.setLevel(Level.INFO);
+    try {
+      Method evaluate = ReproduceFromDocumentCollection.class.getDeclaredMethod("evaluateAndVerify",
+          JsonNode.class, ReproduceFromDocumentCollection.Args.class, long.class);
+      evaluate.setAccessible(true);
+      evaluate.invoke(null, yaml, new ReproduceFromDocumentCollection.Args(), System.nanoTime());
+    } finally {
+      logger.setLevel(previousLevel);
+      logger.removeAppender(appender);
+      appender.stop();
+    }
+    assertEquals(messages.toString(), 3, messages.size());
+    assertTrue(messages.toString(), messages.get(1).startsWith(status + "expected: "));
+    assertTrue(messages.toString(), messages.get(1).contains(" - metric: MAP      model: test topics: test"));
+    assertEquals(!"inverted".equals(type), messages.get(1).contains(", tolerance="));
+    assertTrue(messages.toString(), messages.get(2).startsWith(status + "Total elapsed time: "));
   }
 
   @Test

--- a/src/test/java/io/anserini/reproduce/ReproduceFromDocumentCollectionTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromDocumentCollectionTest.java
@@ -27,6 +27,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
@@ -198,8 +199,21 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
     assertEvaluationStatus("inverted", 0.5, 0.4999, 4, "tolerance: {MAP: [0.00001]}", ReproductionUtils.Constants.OKISH);
   }
 
+  @Test
+  public void testScoreComparisonWithLocalizedDigits() throws Exception {
+    Locale previousLocale = Locale.getDefault();
+    try {
+      Locale.setDefault(Locale.forLanguageTag("mzn-Arab-IR"));
+      assertEvaluationStatus("inverted", 0.5, 0.4375, 5, "tolerance: {MAP: [0.0625]}", ReproductionUtils.Constants.OK);
+      assertEvaluationStatus("inverted", 0.50004, 0.49996, 4, "", ReproductionUtils.Constants.OK);
+      assertEvaluationStatus("inverted", 0.50004, 0.49996, 5, "", ReproductionUtils.Constants.OKISH);
+    } finally {
+      Locale.setDefault(previousLocale);
+    }
+  }
+
   private void assertEvaluationStatus(String type, double expected, double actual, int precision, String toleranceYaml, String status) throws Exception {
-    JsonNode yaml = new ObjectMapper(new YAMLFactory()).readTree("""
+    JsonNode yaml = new ObjectMapper(new YAMLFactory()).readTree(String.format(Locale.ROOT, """
         corpus: test
         index_path: indexes/test
         topics:
@@ -215,7 +229,8 @@ public class ReproduceFromDocumentCollectionTest extends StdOutStdErrRedirectabl
             type: %s
             results: {MAP: [%s]}
             %s
-        """.formatted(actual, precision, type, expected, toleranceYaml));
+        """, actual, precision, type, expected, toleranceYaml));
+    assertEquals(precision, yaml.get("metrics").get(0).get("metric_precision").asInt());
     List<String> messages = new ArrayList<>();
     CustomAppender appender = new CustomAppender("score-comparison") {
       @Override

--- a/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.junit.After;
@@ -29,7 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
 import io.anserini.util.CacheDirectoryResolver;
@@ -177,8 +177,8 @@ public class ReproduceFromPrebuiltIndexesTest extends StdOutStdErrRedirectableLu
     assertTrue(output, output.contains("Run successfully completed!"));
     assertTrue(output, output.contains("Indexes referenced by this run (1 total):"));
     assertTrue(output, output.matches("(?s).*Total size across [01] of 1 indexes:.*"));
-    assertTrue(output, output.contains("MAP: 0.3123"));
-    assertTrue(output, output.contains("P30: 0.1942"));
+    assertTrue(output, output.contains("MAP: 0.3123 " + ReproductionUtils.Constants.OK));
+    assertTrue(output, output.contains("P30: 0.1942 " + ReproductionUtils.Constants.OK));
     assertTrue(output, output.matches("(?s).*Duration:\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}.*"));
     assertFalse(output.contains("NumberFormatException"));
     assertTrue(Files.exists(runsDirectory.resolve("run.cacm.bm25.cacm.txt")));
@@ -207,36 +207,28 @@ public class ReproduceFromPrebuiltIndexesTest extends StdOutStdErrRedirectableLu
   }
 
   @Test
-  public void testMetricResultWithoutToleranceMatchesExplicitZero() throws Exception {
-    for (double score : new double[] {0.5, 0.5000000001, 0.4999, 0.6, 0.4}) {
-      String absent = metricResult(score, "");
-      assertEquals(absent, metricResult(score, "tolerance: {MAP: 0.0}"));
-      assertEquals(absent, metricResult(score, "tolerance: {P30: 0.1}"));
+  public void testScoreComparisonEndToEnd() throws Exception {
+    Path runsDirectory = createTempDir("runs");
+    ReproduceFromPrebuiltIndexes.main(new String[] {
+        "--config", "score-comparison",
+        "--runs-directory", runsDirectory.toString()
+    });
+
+    String output = out.toString();
+    for (String metric : List.of("equal", "noise", "within")) {
+      assertTrue(output, output.contains(String.format(Locale.ROOT,
+          "    %8s: 0.3123 %s%n", metric, ReproductionUtils.Constants.OK)));
     }
-  }
-
-  @Test
-  public void testMetricResultStatusesAndFormatting() throws Exception {
-    assertEquals(String.format(Locale.ROOT, "    %8s: 0.5000 %s%n", "MAP", ReproductionUtils.Constants.OK),
-        metricResult(0.5, ""));
-    assertEquals(String.format(Locale.ROOT, "    %8s: 0.5000 %s%n", "MAP", ReproductionUtils.Constants.OK),
-        metricResult(0.5000000001, ""));
-    assertEquals(String.format(Locale.ROOT, "    %8s: 0.6000 %s expected 0.5000%n", "MAP", ReproductionUtils.Constants.OKISH),
-        metricResult(0.6, ""));
-    assertEquals(String.format(Locale.ROOT, "    %8s: 0.4000 %s expected 0.5000%n", "MAP", ReproductionUtils.Constants.FAIL),
-        metricResult(0.4, ""));
-    assertTrue(metricResult(0.4375, "tolerance: {MAP: 0.0625}").contains(ReproductionUtils.Constants.OK));
-    assertTrue(metricResult(0.40625, "tolerance: {MAP: 0.0625}").contains(ReproductionUtils.Constants.OKISH));
-    assertTrue(metricResult(0.375, "tolerance: {MAP: 0.0625}").contains(ReproductionUtils.Constants.FAIL));
-    assertTrue(metricResult(0.4999, "tolerance: {MAP: 0.00001}").contains(ReproductionUtils.Constants.OKISH));
-  }
-
-  private String metricResult(double score, String toleranceYaml) throws Exception {
-    ReproduceFromPrebuiltIndexes.Topic topic = new ObjectMapper(new YAMLFactory()).readValue(
-        "expected_scores: {MAP: 0.5}\n" + toleranceYaml, ReproduceFromPrebuiltIndexes.Topic.class);
-    out.reset();
-    ReproduceFromPrebuiltIndexes.printMetricResult(topic, "MAP", score);
-    return out.toString();
+    Map<String, Double> okish = Map.of("improved", 0.2, "absent", 0.3124, "zero", 0.3124,
+        "fallback", 0.3124, "relaxed", 0.4123);
+    for (Map.Entry<String, Double> entry : okish.entrySet()) {
+      assertTrue(output, output.contains(String.format(Locale.ROOT,
+          "    %8s: 0.3123 %s expected %.4f%n", entry.getKey(), ReproductionUtils.Constants.OKISH, entry.getValue())));
+    }
+    for (String metric : List.of("outside", "failed")) {
+      assertTrue(output, output.contains(String.format(Locale.ROOT,
+          "    %8s: 0.3123 %s expected 0.5000%n", metric, ReproductionUtils.Constants.FAIL)));
+    }
   }
 
   @Test

--- a/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
@@ -219,15 +219,15 @@ public class ReproduceFromPrebuiltIndexesTest extends StdOutStdErrRedirectableLu
       assertTrue(output, output.contains(String.format(Locale.ROOT,
           "    %8s: 0.3123 %s%n", metric, ReproductionUtils.Constants.OK)));
     }
-    Map<String, Double> okish = Map.of("improved", 0.2, "absent", 0.3124, "zero", 0.3124,
-        "fallback", 0.3124, "relaxed", 0.4123);
+    Map<String, Double> okish = Map.of("improved", 0.2, "absent", 0.3124, "relaxed", 0.4123);
     for (Map.Entry<String, Double> entry : okish.entrySet()) {
       assertTrue(output, output.contains(String.format(Locale.ROOT,
           "    %8s: 0.3123 %s expected %.4f%n", entry.getKey(), ReproductionUtils.Constants.OKISH, entry.getValue())));
     }
-    for (String metric : List.of("outside", "failed")) {
+    Map<String, Double> failed = Map.of("zero", 0.3124, "fallback", 0.3124, "outside", 0.5, "failed", 0.5);
+    for (Map.Entry<String, Double> entry : failed.entrySet()) {
       assertTrue(output, output.contains(String.format(Locale.ROOT,
-          "    %8s: 0.3123 %s expected 0.5000%n", metric, ReproductionUtils.Constants.FAIL)));
+          "    %8s: 0.3123 %s expected %.4f%n", entry.getKey(), ReproductionUtils.Constants.FAIL, entry.getValue())));
     }
   }
 

--- a/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproduceFromPrebuiltIndexesTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import io.anserini.StdOutStdErrRedirectableLuceneTestCase;
 import io.anserini.util.CacheDirectoryResolver;
@@ -203,6 +204,39 @@ public class ReproduceFromPrebuiltIndexesTest extends StdOutStdErrRedirectableLu
     assertFalse(output.contains("NumberFormatException"));
     assertFalse(Files.exists(runsDirectory.resolve("run.faulty.retrieval-fails.cacm.txt")));
     assertFalse(Files.exists(runsDirectory.resolve("run.faulty.missing-run-file.cacm.txt")));
+  }
+
+  @Test
+  public void testMetricResultWithoutToleranceMatchesExplicitZero() throws Exception {
+    for (double score : new double[] {0.5, 0.5000000001, 0.4999, 0.6, 0.4}) {
+      String absent = metricResult(score, "");
+      assertEquals(absent, metricResult(score, "tolerance: {MAP: 0.0}"));
+      assertEquals(absent, metricResult(score, "tolerance: {P30: 0.1}"));
+    }
+  }
+
+  @Test
+  public void testMetricResultStatusesAndFormatting() throws Exception {
+    assertEquals(String.format(Locale.ROOT, "    %8s: 0.5000 %s%n", "MAP", ReproductionUtils.Constants.OK),
+        metricResult(0.5, ""));
+    assertEquals(String.format(Locale.ROOT, "    %8s: 0.5000 %s%n", "MAP", ReproductionUtils.Constants.OK),
+        metricResult(0.5000000001, ""));
+    assertEquals(String.format(Locale.ROOT, "    %8s: 0.6000 %s expected 0.5000%n", "MAP", ReproductionUtils.Constants.OKISH),
+        metricResult(0.6, ""));
+    assertEquals(String.format(Locale.ROOT, "    %8s: 0.4000 %s expected 0.5000%n", "MAP", ReproductionUtils.Constants.FAIL),
+        metricResult(0.4, ""));
+    assertTrue(metricResult(0.4375, "tolerance: {MAP: 0.0625}").contains(ReproductionUtils.Constants.OK));
+    assertTrue(metricResult(0.40625, "tolerance: {MAP: 0.0625}").contains(ReproductionUtils.Constants.OKISH));
+    assertTrue(metricResult(0.375, "tolerance: {MAP: 0.0625}").contains(ReproductionUtils.Constants.FAIL));
+    assertTrue(metricResult(0.4999, "tolerance: {MAP: 0.00001}").contains(ReproductionUtils.Constants.OKISH));
+  }
+
+  private String metricResult(double score, String toleranceYaml) throws Exception {
+    ReproduceFromPrebuiltIndexes.Topic topic = new ObjectMapper(new YAMLFactory()).readValue(
+        "expected_scores: {MAP: 0.5}\n" + toleranceYaml, ReproduceFromPrebuiltIndexes.Topic.class);
+    out.reset();
+    ReproduceFromPrebuiltIndexes.printMetricResult(topic, "MAP", score);
+    return out.toString();
   }
 
   @Test

--- a/src/test/java/io/anserini/reproduce/ReproductionUtilsTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproductionUtilsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Anserini: A Lucene toolkit for reproducible information retrieval research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.reproduce;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static io.anserini.reproduce.ReproductionUtils.Status.FAIL;
+import static io.anserini.reproduce.ReproductionUtils.Status.OK;
+import static io.anserini.reproduce.ReproductionUtils.Status.OKISH;
+import static io.anserini.reproduce.ReproductionUtils.compareScores;
+
+public class ReproductionUtilsTest {
+  @Test
+  public void testEquality() {
+    assertEquals(OK, compareScores(0.0, 0.0, 0.0));
+    assertEquals(OK, compareScores(0.3123, 0.3123, 0.0));
+  }
+
+  @Test
+  public void testFloatingPointNoise() {
+    assertEquals(OK, compareScores(0.3, 0.1 + 0.2, 0.0));
+    assertEquals(OK, compareScores(0.1 + 0.2, 0.3, 0.0));
+    double allowance = ReproductionUtils.NUMERICAL_TOLERANCE;
+    assertEquals(OK, compareScores(allowance, 0.0, 0.0));
+    assertEquals(OK, compareScores(0.0, allowance, 0.0));
+    assertEquals(OKISH, compareScores(Math.nextUp(allowance), 0.0, 0.0));
+    assertEquals(OKISH, compareScores(0.0, Math.nextUp(allowance), 0.0));
+    // The numerical allowance is absolute, not relative to the score's scale.
+    assertEquals(OKISH, compareScores(100.00000001, 100.0, 0.0));
+  }
+
+  @Test
+  public void testNumericalToleranceDominatesSmallerConfiguredTolerance() {
+    assertEquals(OK, compareScores(1e-9, 0.0, 1e-10));
+    assertEquals(OKISH, compareScores(2e-9, 0.0, 1e-10));
+  }
+
+  @Test
+  public void testImprovements() {
+    assertEquals(OK, compareScores(0.5, 0.5625, 0.0625));
+    assertEquals(OKISH, compareScores(0.5, 0.75, 0.0625));
+    assertEquals(OKISH, compareScores(0.5, 0.75, 0.0));
+  }
+
+  @Test
+  public void testConfiguredToleranceBoundary() {
+    // Exactly representable binary fractions avoid subtraction noise at boundaries.
+    double tolerance = 0.0625;
+    assertEquals(OK, compareScores(Math.nextDown(tolerance), 0.0, tolerance));
+    assertEquals(OK, compareScores(tolerance, 0.0, tolerance));
+    assertEquals(OKISH, compareScores(Math.nextUp(tolerance), 0.0, tolerance));
+  }
+
+  @Test
+  public void testRelaxedToleranceBoundary() {
+    double tolerance = 0.0625;
+    double boundary = 1.5 * tolerance;
+    assertEquals(OKISH, compareScores(Math.nextDown(boundary), 0.0, tolerance));
+    assertEquals(OKISH, compareScores(boundary, 0.0, tolerance));
+    assertEquals(FAIL, compareScores(Math.nextUp(boundary), 0.0, tolerance));
+  }
+
+  @Test
+  public void testStrictFallbackWithAndWithoutConfiguredTolerance() {
+    for (double tolerance : new double[] {0.0, 0.00001}) {
+      assertEquals(OKISH, compareScores(Math.nextDown(0.0002), 0.0, tolerance));
+      assertEquals(FAIL, compareScores(0.0002, 0.0, tolerance));
+      assertEquals(FAIL, compareScores(Math.nextUp(0.0002), 0.0, tolerance));
+      assertEquals(FAIL, compareScores(0.5, 0.25, tolerance));
+    }
+  }
+}

--- a/src/test/java/io/anserini/reproduce/ReproductionUtilsTest.java
+++ b/src/test/java/io/anserini/reproduce/ReproductionUtilsTest.java
@@ -27,6 +27,8 @@ import static io.anserini.reproduce.ReproductionUtils.compareScores;
 public class ReproductionUtilsTest {
   @Test
   public void testEquality() {
+    assertEquals(OK, compareScores(0.0, 0.0, null));
+    assertEquals(OK, compareScores(0.3123, 0.3123, null));
     assertEquals(OK, compareScores(0.0, 0.0, 0.0));
     assertEquals(OK, compareScores(0.3123, 0.3123, 0.0));
   }
@@ -38,16 +40,18 @@ public class ReproductionUtilsTest {
     double allowance = ReproductionUtils.NUMERICAL_TOLERANCE;
     assertEquals(OK, compareScores(allowance, 0.0, 0.0));
     assertEquals(OK, compareScores(0.0, allowance, 0.0));
-    assertEquals(OKISH, compareScores(Math.nextUp(allowance), 0.0, 0.0));
+    assertEquals(FAIL, compareScores(Math.nextUp(allowance), 0.0, 0.0));
     assertEquals(OKISH, compareScores(0.0, Math.nextUp(allowance), 0.0));
     // The numerical allowance is absolute, not relative to the score's scale.
-    assertEquals(OKISH, compareScores(100.00000001, 100.0, 0.0));
+    assertEquals(FAIL, compareScores(100.00000001, 100.0, 0.0));
+    assertEquals(OK, compareScores(allowance, 0.0, null));
+    assertEquals(OKISH, compareScores(Math.nextUp(allowance), 0.0, null));
   }
 
   @Test
   public void testNumericalToleranceDominatesSmallerConfiguredTolerance() {
     assertEquals(OK, compareScores(1e-9, 0.0, 1e-10));
-    assertEquals(OKISH, compareScores(2e-9, 0.0, 1e-10));
+    assertEquals(FAIL, compareScores(2e-9, 0.0, 1e-10));
   }
 
   @Test
@@ -55,6 +59,7 @@ public class ReproductionUtilsTest {
     assertEquals(OK, compareScores(0.5, 0.5625, 0.0625));
     assertEquals(OKISH, compareScores(0.5, 0.75, 0.0625));
     assertEquals(OKISH, compareScores(0.5, 0.75, 0.0));
+    assertEquals(OKISH, compareScores(0.5, 0.75, null));
   }
 
   @Test
@@ -76,12 +81,27 @@ public class ReproductionUtilsTest {
   }
 
   @Test
-  public void testStrictFallbackWithAndWithoutConfiguredTolerance() {
-    for (double tolerance : new double[] {0.0, 0.00001}) {
-      assertEquals(OKISH, compareScores(Math.nextDown(0.0002), 0.0, tolerance));
-      assertEquals(FAIL, compareScores(0.0002, 0.0, tolerance));
-      assertEquals(FAIL, compareScores(Math.nextUp(0.0002), 0.0, tolerance));
-      assertEquals(FAIL, compareScores(0.5, 0.25, tolerance));
-    }
+  public void testStrictFallbackWithoutConfiguredTolerance() {
+    assertEquals(OKISH, compareScores(Math.nextDown(0.0002), 0.0, null));
+    assertEquals(FAIL, compareScores(0.0002, 0.0, null));
+    assertEquals(FAIL, compareScores(Math.nextUp(0.0002), 0.0, null));
+    assertEquals(FAIL, compareScores(0.5, 0.25, null));
+  }
+
+  @Test
+  public void testAbsentAndZeroToleranceProduceDifferentStatuses() {
+    assertEquals(OKISH, compareScores(0.0001, 0.0, null));
+    assertEquals(FAIL, compareScores(0.0001, 0.0, 0.0));
+  }
+
+  @Test
+  public void testConfiguredToleranceDisablesFallback() {
+    double tolerance = 0.0001;
+    double boundary = 1.5 * tolerance;
+    assertEquals(OK, compareScores(tolerance, 0.0, tolerance));
+    assertEquals(OKISH, compareScores(boundary, 0.0, tolerance));
+    assertEquals(FAIL, compareScores(Math.nextUp(boundary), 0.0, tolerance));
+    assertEquals(FAIL, compareScores(0.00018, 0.0, tolerance));
+    assertEquals(FAIL, compareScores(Math.nextDown(0.0002), 0.0, tolerance));
   }
 }

--- a/src/test/resources/reproduce/from-prebuilt-indexes/configs/score-comparison.yaml
+++ b/src/test/resources/reproduce/from-prebuilt-indexes/configs/score-comparison.yaml
@@ -1,0 +1,35 @@
+conditions:
+  - name: bm25
+    display: "Score comparison statuses using CACM MAP"
+    command: io.anserini.search.SearchCollection -threads $threads -index cacm -topics $topics -output $output -hits 1000 -bm25
+    topics:
+      - topic_key: cacm
+        eval_key: cacm
+        expected_scores:
+          equal: 0.3123
+          noise: 0.3123000001
+          improved: 0.2
+          absent: 0.3124
+          zero: 0.3124
+          fallback: 0.3124
+          within: 0.375
+          relaxed: 0.4123
+          outside: 0.5
+          failed: 0.5
+        tolerance:
+          zero: 0.0
+          fallback: 0.00001
+          within: 0.07
+          relaxed: 0.07
+          outside: 0.07
+        metric_definitions:
+          equal: "-c -m map"
+          noise: "-c -m map"
+          improved: "-c -m map"
+          absent: "-c -m map"
+          zero: "-c -m map"
+          fallback: "-c -m map"
+          within: "-c -m map"
+          relaxed: "-c -m map"
+          outside: "-c -m map"
+          failed: "-c -m map"


### PR DESCRIPTION
## Summary

- Centralize score classification in `ReproductionUtils`, returning shared `OK`, `OKISH`, and `FAIL` statuses with a documented absolute numerical tolerance of `1e-9`.
- Apply the shared rules in both runners, support optional per-metric prebuilt tolerances, and apply configured tolerances across all model types while preserving rounding and output formats.
- Add tests for comparison boundaries, improvements, absent/zero tolerances, rounding, and runner output.
- Isolate captured test logs from console output and make numeric YAML fixtures locale-independent, with regression coverage for localized digits.

Fixes #3425.

## Validation

- `mvn -Dtest=ReproduceFromDocumentCollectionTest -Dtests.seed=D5DC109D3569F15D -Dtests.locale=mzn-Arab-IR test` — 18 tests passed; no failures, errors, or skips.
- `git diff --check` — passed.

The full suite previously passed 1,171 tests; it has not been rerun after this locale-fixture update.
