### PR TITLE
Add to onboarding reproduction logs

### DIFF
--- a/docs/experiments-msmarco-passage.md
+++ b/docs/experiments-msmarco-passage.md
@@ -721,3 +721,4 @@ The BM25 run with default parameters `k1=0.9`, `b=0.4` roughly corresponds to th
 + Results reproduced by [@ParsaA2006](https://github.com/ParsaA2006) on 2026-09-04 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))
 + Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))
 + Results reproduced by [@kamrankhoxa](https://github.com/kamrankhoxa) on 2026-09-07 (commit [`30e0b11`](https://github.com/castorini/anserini/commit/30e0b113a5bbc5e4d5b7d573ee9ed5c903e6a204))
++ Results reproduced by [@tanvirsarao](https://github.com/tanvirsarao) on 2026-09-09 (commit [`6c25df5`](https://github.com/castorini/anserini/commit/6c25df51724f3afc75b0daf8791ec5c79975efbe))

--- a/docs/experiments-msmarco-passage2.md
+++ b/docs/experiments-msmarco-passage2.md
@@ -276,3 +276,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@ParsaA2006](https://github.com/ParsaA2006) on 2026-09-04 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))
 + Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))
 + Results reproduced by [@kamrankhoxa](https://github.com/kamrankhoxa) on 2026-09-07 (commit [`30e0b11`](https://github.com/castorini/anserini/commit/30e0b113a5bbc5e4d5b7d573ee9ed5c903e6a204))
++ Results reproduced by [@tanvirsarao](https://github.com/tanvirsarao) on 2026-09-09 (commit [`6c25df5`](https://github.com/castorini/anserini/commit/6c25df51724f3afc75b0daf8791ec5c79975efbe))

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -627,3 +627,4 @@ If you have any questions, look at previous pull requests for examples.
 + Results reproduced by [@ParsaA2006](https://github.com/ParsaA2006) on 2026-09-04 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))
 + Results reproduced by [@mentaltraffic](https://github.com/mentaltraffic) on 2026-09-05 (commit [`8af8d25`](https://github.com/castorini/anserini/commit/8af8d25810cdacf2a1f5d41c4a75f578bc4f96a9))
 + Results reproduced by [@kamrankhoxa](https://github.com/kamrankhoxa) on 2026-09-07 (commit [`30e0b11`](https://github.com/castorini/anserini/commit/30e0b113a5bbc5e4d5b7d573ee9ed5c903e6a204))
++ Results reproduced by [@tanvirsarao](https://github.com/tanvirsarao) on 2026-09-09 (commit [`6c25df5`](https://github.com/castorini/anserini/commit/6c25df51724f3afc75b0daf8791ec5c79975efbe))


### PR DESCRIPTION
Completed the Anserini exercises in the Foundations of Retrieval onboarding path on an Apple Silicon Mac with Java 21.

Successfully reproduced the following items:
- MS MARCO passage collection setup and preprocessing
- BM25 baseline
     ->  MRR@10: 0.1874
- Prebuilt BM25 baseline 
     ->  MRR@10: 0.1875
- BGE-base dense retrieval baseline 
     ->  MRR@10: 0.3521

Some interesting notes/findings:
- It was interesting to see the large (almost 2x!) improvement from BM25 to BGE-base dense retrieval. BM25 relies on lexical term matching, while the dense model can retrieve passages based on learned semantic similarity even when the query and passage use different wording. I found this to be quite interesting and worth noting!
- Working through the collection setup made the retrieval pipeline much more concrete: raw passages are transformed and indexed first, then queries are run against that representation to produce ranked results that can be evaluated against qrels.
- Looking at individual queries alongside MRR helped connect the aggregate metric to actual ranking behavior. A relevant passage at rank 1 contributes a reciprocal rank of 1, while pushing the first relevant result further down the ranking quickly reduces its contribution.