### PR TITLE
Make machine-readable numeric formatting locale-independent

### DIFF
--- a/src/main/java/io/anserini/cli/Search.java
+++ b/src/main/java/io/anserini/cli/Search.java
@@ -22,6 +22,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.logging.log4j.Level;
@@ -168,7 +169,7 @@ public final class Search {
       if (outputMode == OutputMode.TREC) {
         for (int rank = 0; rank < results.length; rank++) {
           ScoredDoc hit = results[rank];
-          System.out.printf("1 Q0 %s %d %.6f anserini%n", hit.docid, rank + 1, hit.score);
+          System.out.printf(Locale.ROOT, "1 Q0 %s %d %.6f anserini%n", hit.docid, rank + 1, hit.score);
         }
       } else {
         Map<String, Object> output = new LinkedHashMap<>();

--- a/src/main/java/io/anserini/collection/C4Collection.java
+++ b/src/main/java/io/anserini/collection/C4Collection.java
@@ -32,6 +32,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
@@ -148,7 +149,7 @@ public class C4Collection extends DocumentCollection<C4Collection.Document> {
       this.raw = json.toPrettyString();
       this.contents = json.get("text").asText();
 
-      this.id = String.format("c4-%s-%06d", filename, jsonLoc);
+      this.id = String.format(Locale.ROOT, "c4-%s-%06d", filename, jsonLoc);
       this.url = json.get("url").asText();
 
       String dateTime = json.get("timestamp").asText();

--- a/src/main/java/io/anserini/collection/C4NoCleanCollection.java
+++ b/src/main/java/io/anserini/collection/C4NoCleanCollection.java
@@ -21,9 +21,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
+import java.util.Locale;
 import java.util.NoSuchElementException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class C4NoCleanCollection extends C4Collection {
   public C4NoCleanCollection(Path path) {
@@ -82,7 +83,7 @@ public class C4NoCleanCollection extends C4Collection {
       try {
         this.id = json.get("docno").asText();
       } catch (Exception e) {
-        this.id = String.format("en.noclean.%s.%d", filename, jsonLoc);
+        this.id = String.format(Locale.ROOT, "en.noclean.%s.%d", filename, jsonLoc);
       }
     }
 

--- a/src/main/java/io/anserini/collection/Cord19ParagraphCollection.java
+++ b/src/main/java/io/anserini/collection/Cord19ParagraphCollection.java
@@ -33,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
@@ -180,7 +181,7 @@ public class Cord19ParagraphCollection extends DocumentCollection<Cord19Paragrap
       if (paragraphNumber == 0) {
         id = record.get("cord_uid");
       } else {
-        id = record.get("cord_uid") + "." + String.format("%05d", paragraphNumber);
+        id = record.get("cord_uid") + "." + String.format(Locale.ROOT, "%05d", paragraphNumber);
       }
 
       if (DUPLICATE_ABSTRACT) {

--- a/src/main/java/io/anserini/fusion/ScoredDocsFuser.java
+++ b/src/main/java/io/anserini/fusion/ScoredDocsFuser.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -281,7 +282,7 @@ public class ScoredDocsFuser {
     ScoredDocsFuser.sortScoredDocs(run);
     try (BufferedWriter writer = Files.newBufferedWriter(outputPath)) {
       for (int i = 0; i < run.lucene_documents.length; i++) {
-        writer.write(String.format("%s Q0 %s %d %.6f %s%n", 
+        writer.write(String.format(Locale.ROOT, "%s Q0 %s %d %.6f %s%n",
           run.lucene_documents[i].get(TOPIC), run.docids[i], run.lucene_docids[i], run.scores[i], tag));
       }
     }

--- a/src/main/java/io/anserini/search/SearchShardedHnswDenseVectors.java
+++ b/src/main/java/io/anserini/search/SearchShardedHnswDenseVectors.java
@@ -33,6 +33,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.IntStream;
 
 /**
@@ -120,7 +121,7 @@ public final class SearchShardedHnswDenseVectors<K extends Comparable<K>> implem
 
     List<String> shardOutputPaths = IntStream.range(0, searchers.size())
         .mapToObj(i -> {
-          String shardSuffix = ".shard" + String.format("%02d", i);
+          String shardSuffix = ".shard" + String.format(Locale.ROOT, "%02d", i);
           if (args.output.endsWith(".txt")) {
             return args.output.substring(0, args.output.length() - ".txt".length()) + shardSuffix + ".txt";
           }

--- a/src/main/java/io/anserini/util/ExtractDocumentLengths.java
+++ b/src/main/java/io/anserini/util/ExtractDocumentLengths.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.nio.file.Paths;
+import java.util.Locale;
 
 /**
  * Utility for extracting the document length and the number of unique terms from every document in the index using the
@@ -86,7 +87,7 @@ public class ExtractDocumentLengths {
         // TermVector for a zero-length document. Warn, but don't throw exception.
         String external_did = IndexReaderUtils.convertLuceneDocidToDocid(reader, i);
         System.err.println(String.format("Warning: TermVector not available for docid %s.", external_did));
-        out.println(String.format("%d\t%s\t0\t0\t0\t0", i, external_did));
+        out.println(String.format(Locale.ROOT, "%d\t%s\t0\t0\t0\t0", i, external_did));
         continue;
       }
 
@@ -97,7 +98,7 @@ public class ExtractDocumentLengths {
       // See https://github.com/apache/lucene-solr/blob/master/lucene/core/src/java/org/apache/lucene/search/similarities/BM25Similarity.java
       int lossyDoclength = SmallFloat.byte4ToInt(SmallFloat.intToByte4((int) exactDoclength));
       int lossyTermCount = SmallFloat.byte4ToInt(SmallFloat.intToByte4((int) exactTermCount));
-      out.println(String.format("%d\t%s\t%d\t%d\t%d\t%d", i, IndexReaderUtils.convertLuceneDocidToDocid(reader, i),
+      out.println(String.format(Locale.ROOT, "%d\t%s\t%d\t%d\t%d\t%d", i, IndexReaderUtils.convertLuceneDocidToDocid(reader, i),
               exactDoclength, exactTermCount, lossyDoclength, lossyTermCount));
       lossyTotalTerms += lossyDoclength;
       exactTotalTerms += exactDoclength;

--- a/src/main/java/io/anserini/util/ExtractNorms.java
+++ b/src/main/java/io/anserini/util/ExtractNorms.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.nio.file.Paths;
+import java.util.Locale;
 
 /**
  * Utility for extracting the norm of every document in the index. With Lucene's BM25 implementation, the norm is the
@@ -77,7 +78,7 @@ public class ExtractNorms {
         throw new NotStoredException("Norms do not appear to have been indexed!");
       }
       while (docValues.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-        out.println(String.format("%d\t%d", docValues.docID() + context.docBase,
+        out.println(String.format(Locale.ROOT, "%d\t%d", docValues.docID() + context.docBase,
             SmallFloat.byte4ToInt((byte) docValues.longValue())));
       }
     }

--- a/src/test/java/io/anserini/api/RestServerTest.java
+++ b/src/test/java/io/anserini/api/RestServerTest.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Scanner;
 
@@ -49,7 +50,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
     server = new RestServer(args);
     startServerQuietly(server);
 
-    baseUrl = String.format("http://127.0.0.1:%d", server.getPort());
+    baseUrl = String.format(Locale.ROOT, "http://127.0.0.1:%d", server.getPort());
   }
 
   @Override
@@ -160,7 +161,7 @@ public class RestServerTest extends StdOutStdErrRedirectableLuceneTestCase {
       aliasServer = new RestServer(args);
       startServerQuietly(aliasServer);
 
-      TestResponse response = sendGet(String.format("http://127.0.0.1:%d/v1/sample/search?query=text&hits=1", aliasServer.getPort()));
+      TestResponse response = sendGet(String.format(Locale.ROOT, "http://127.0.0.1:%d/v1/sample/search?query=text&hits=1", aliasServer.getPort()));
       assertEquals(200, response.statusCode);
 
       JsonNode body = JSON_MAPPER.readTree(response.body);

--- a/src/test/java/io/anserini/cli/SearchTest.java
+++ b/src/test/java/io/anserini/cli/SearchTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
@@ -132,6 +133,30 @@ public class SearchTest extends StdOutStdErrRedirectableLuceneTestCase {
     assertEquals(2, trecLines.size());
     assertTrue(isValidTrecLine(trecLines.get(0)));
     assertTrue(isValidTrecLine(trecLines.get(1)));
+  }
+
+  @Test
+  public void testSearchTrecOutputIsLocaleIndependent() {
+    Locale defaultLocale = Locale.getDefault();
+    try {
+      for (Locale locale : List.of(Locale.GERMANY, Locale.forLanguageTag("mzn-Arab-IR"))) {
+        Locale.setDefault(locale);
+        out.reset();
+        err.reset();
+
+        Search.main(new String[] {"--index", cacmIndexPath.toString(), "--query", "information retrieval", "--trec", "--hits", "2"});
+
+        List<String> trecLines = extractTrecLines(out.toString());
+        assertEquals(2, trecLines.size());
+        for (String line : trecLines) {
+          String[] fields = line.split("\\s+");
+          assertTrue(fields[3].matches("[0-9]+"));
+          assertTrue(fields[4].matches("[0-9]+\\.[0-9]{6}"));
+        }
+      }
+    } finally {
+      Locale.setDefault(defaultLocale);
+    }
   }
 
   @Test

--- a/src/test/java/io/anserini/collection/Cord19ParagraphCollectionTest.java
+++ b/src/test/java/io/anserini/collection/Cord19ParagraphCollectionTest.java
@@ -19,6 +19,7 @@ package io.anserini.collection;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.junit.Before;
@@ -47,7 +48,7 @@ public class Cord19ParagraphCollectionTest extends DocumentCollectionTest<Cord19
 
     // has paragraphs 1 ... 41
     for (int i = 1; i < 42; i++) {
-      String id = String.format("xqhn0vbp.%05d", i);
+      String id = String.format(Locale.ROOT, "xqhn0vbp.%05d", i);
       HashMap<String, String> doc = new HashMap<>();
       doc.put("id", id);
       expected.put(id, doc);
@@ -65,7 +66,7 @@ public class Cord19ParagraphCollectionTest extends DocumentCollectionTest<Cord19
 
     // has paragraphs 1 ... 32
     for (int i = 1; i < 33; i++) {
-      String id = String.format("a8cps3ko.%05d", i);
+      String id = String.format(Locale.ROOT, "a8cps3ko.%05d", i);
       HashMap<String, String> doc = new HashMap<>();
       doc.put("id", id);
       expected.put(id, doc);

--- a/src/test/java/io/anserini/collection/DocumentCollectionTest.java
+++ b/src/test/java/io/anserini/collection/DocumentCollectionTest.java
@@ -48,14 +48,13 @@ public abstract class DocumentCollectionTest<T extends SourceDocument> extends S
 
   // Holds the ground truth. Outer key is the docid, map is custom data based on subclass.
   Map<String, Map<String, String>> expected;
+  private Locale defaultLocale;
 
   @Before
   public void setUp() throws Exception {
     super.setUp();
-
-    // There's a non-deterministic bug that occurs when Arabic numerals in docids get "localized", and hence fail
-    // to match expected docids. This makes sure it doesn't happen.
-    Locale.setDefault(Locale.US);
+    defaultLocale = Locale.getDefault();
+    Locale.setDefault(Locale.forLanguageTag("mzn-Arab-IR"));
 
     segmentPaths = new HashSet<>();
     segmentDocCounts = new HashMap<>();
@@ -216,6 +215,10 @@ public abstract class DocumentCollectionTest<T extends SourceDocument> extends S
 
   @After
   public void tearDown() throws Exception {
-    super.tearDown();
+    try {
+      super.tearDown();
+    } finally {
+      Locale.setDefault(defaultLocale);
+    }
   }
 }

--- a/src/test/java/io/anserini/doc/DataModel.java
+++ b/src/test/java/io/anserini/doc/DataModel.java
@@ -20,6 +20,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -451,9 +452,9 @@ public class DataModel {
           int width = Math.max(display.length() + 5, 11);
           // 3 digits for HNSW, 4 otherwise:
           if ("hnsw".equals(getIndex_type())) {
-            builder.append(String.format(" %-" + width + ".3f|", model.getResults().get(eval.getMetric()).get(i)));
+            builder.append(String.format(Locale.ROOT, " %-" + width + ".3f|", model.getResults().get(eval.getMetric()).get(i)));
           } else {
-            builder.append(String.format(" %-" + width + ".4f|", model.getResults().get(eval.getMetric()).get(i)));
+            builder.append(String.format(Locale.ROOT, " %-" + width + ".4f|", model.getResults().get(eval.getMetric()).get(i)));
           }
         }
         builder.append("\n");

--- a/src/test/java/io/anserini/doc/GenerateReproductionDocsFromPrebuiltIndexesTest.java
+++ b/src/test/java/io/anserini/doc/GenerateReproductionDocsFromPrebuiltIndexesTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -162,9 +163,9 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
         }
       }
 
-      summary.append(String.format("| [%d](#condition-%d) | %s", sectionNumber, sectionNumber, condition.display));
+      summary.append(String.format(Locale.ROOT, "| [%d](#condition-%d) | %s", sectionNumber, sectionNumber, condition.display));
       for (Double score : scores) {
-        summary.append(" | ").append(score == null ? "" : String.format("%.4f", score));
+        summary.append(" | ").append(score == null ? "" : String.format(Locale.ROOT, "%.4f", score));
       }
       summary.append(" |\n");
       row++;
@@ -180,7 +181,7 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
     for (int i = 0; i < config.conditions.size(); i++) {
       Condition condition = config.conditions.get(i);
       String heading = condition.short_name == null ? condition.display : condition.short_name;
-      summary.append(" | ").append(String.format("[%s](#condition-%d)", heading, i + 1));
+      summary.append(" | ").append(String.format(Locale.ROOT, "[%s](#condition-%d)", heading, i + 1));
     }
     summary.append(" |\n");
 
@@ -200,7 +201,7 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
             break;
           }
         }
-        summary.append(" | ").append(score == null ? "" : String.format("%.4f", score));
+        summary.append(" | ").append(score == null ? "" : String.format(Locale.ROOT, "%.4f", score));
       }
       summary.append(" |\n");
     }
@@ -213,7 +214,7 @@ public class GenerateReproductionDocsFromPrebuiltIndexesTest {
     StringBuilder command = new StringBuilder();
     int row = 1;
     for (Condition condition : context.config().conditions) {
-      command.append(String.format("<a id=\"condition-%d\"></a>\n\n### %d. %s\n\n", row, row, condition.display));
+      command.append(String.format(Locale.ROOT, "<a id=\"condition-%d\"></a>\n\n### %d. %s\n\n", row, row, condition.display));
       command.append(String.format("**Config**: %s\n\n", context.configLink()));
       row++;
 

--- a/src/test/java/io/anserini/doc/JDIQ2018EffectivenessDocsTest.java
+++ b/src/test/java/io/anserini/doc/JDIQ2018EffectivenessDocsTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Scanner;
 
@@ -101,7 +102,7 @@ public class JDIQ2018EffectivenessDocsTest {
             builder.append(String.format("%1$-40s|", topic));
             for (Map.Entry<String, Object> entry4 : ((Map<String, Object>) entry3.getValue()).entrySet()) {
               Double value = (Double) entry4.getValue();
-              builder.append(String.format(" %-10.4f|", value));
+              builder.append(String.format(Locale.ROOT, " %-10.4f|", value));
             }
             builder.append("\n");
           }

--- a/src/test/java/io/anserini/fusion/ScoredDocsFuserTest.java
+++ b/src/test/java/io/anserini/fusion/ScoredDocsFuserTest.java
@@ -17,6 +17,7 @@
 package io.anserini.fusion;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -42,9 +43,6 @@ public class ScoredDocsFuserTest extends StdOutStdErrRedirectableLuceneTestCase 
 
   @Before
   public void setUp() throws Exception {
-    // Explictly set locale to US so that decimal points use '.' instead of ','
-    Locale.setDefault(Locale.US);
-
     redirectStdErr();
     super.setUp();
   }
@@ -91,6 +89,26 @@ public class ScoredDocsFuserTest extends StdOutStdErrRedirectableLuceneTestCase 
     }
     catch (Exception e) {
       System.err.println(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testSaveToTxtIsLocaleIndependent() throws Exception {
+    Locale defaultLocale = Locale.getDefault();
+    Path output = Files.createTempFile("anserini-fused-run", ".txt");
+    try {
+      for (Locale locale : List.of(Locale.GERMANY, Locale.forLanguageTag("mzn-Arab-IR"))) {
+        Locale.setDefault(locale);
+        ScoredDocs run = ScoredDocsFuser.readRun(Paths.get("src/test/resources/sample_runs/run3"), true);
+        ScoredDocsFuser.saveToTxt(output, "Anserini", run);
+
+        List<String> lines = Files.readAllLines(output);
+        assertEquals("query1 Q0 doc1 1 7.000000 Anserini", lines.get(0));
+        assertEquals("query2 Q0 doc3 3 12.000000 Anserini", lines.get(5));
+      }
+    } finally {
+      Locale.setDefault(defaultLocale);
+      Files.deleteIfExists(output);
     }
   }
 

--- a/src/test/java/io/anserini/search/SearchShardedHnswDenseVectorsTest.java
+++ b/src/test/java/io/anserini/search/SearchShardedHnswDenseVectorsTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Locale;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
@@ -87,11 +88,17 @@ public class SearchShardedHnswDenseVectorsTest {
         "-efSearch", "100", // Reduced from 1000 to reduce memory usage
         "-hits", "10" }; // Reduced hit count to reduce memory usage
 
-    SearchShardedHnswDenseVectors.main(searchArgs);
+    Locale defaultLocale = Locale.getDefault();
+    try {
+      Locale.setDefault(Locale.forLanguageTag("mzn-Arab-IR"));
+      SearchShardedHnswDenseVectors.main(searchArgs);
 
-    assertRunFileExistsAndNonEmpty(runfile);
-    assertRunFileExistsAndNonEmpty(runfile + ".shard00");
-    assertRunFileExistsAndNonEmpty(runfile + ".shard01");
+      assertRunFileExistsAndNonEmpty(runfile);
+      assertRunFileExistsAndNonEmpty(runfile + ".shard00");
+      assertRunFileExistsAndNonEmpty(runfile + ".shard01");
+    } finally {
+      Locale.setDefault(defaultLocale);
+    }
   }
 
   @Test

--- a/src/test/java/io/anserini/util/ExtractDocumentLengthsTest.java
+++ b/src/test/java/io/anserini/util/ExtractDocumentLengthsTest.java
@@ -66,22 +66,31 @@ public class ExtractDocumentLengthsTest extends IndexerWithEmptyDocumentTestBase
 
   @Test
   public void test() throws Exception {
-    // See: https://github.com/castorini/anserini/issues/903
-    Locale.setDefault(Locale.US);
-    redirectStdOut();
-    redirectStdErr(); // redirecting to be quiet
-    ExtractDocumentLengths.main(new String[] {"-index", tempDir1.toString(), "-output", randomFileName});
-    restoreStdOut();
-    restoreStdErr();
+    Locale defaultLocale = Locale.getDefault();
+    try {
+      Locale.setDefault(Locale.forLanguageTag("mzn-Arab-IR"));
+      redirectStdOut();
+      redirectStdErr(); // redirecting to be quiet
+      try {
+        ExtractDocumentLengths.main(new String[] {"-index", tempDir1.toString(), "-output", randomFileName});
+      } finally {
+        restoreStdOut();
+        restoreStdErr();
+      }
 
-    assertEquals("Total number of terms in collection (sum of doclengths):\nLossy: 12\nExact: 12\n",
-        super.out.toString());
+      assertEquals(List.of(
+          "Total number of terms in collection (sum of doclengths):",
+          "Lossy: 12",
+          "Exact: 12"), super.out.toString().lines().toList());
 
-    List<String> lines = Files.readAllLines(Paths.get(randomFileName));
-    assertEquals(5, lines.size());
-    assertEquals("0\tdoc1\t8\t5\t8\t5", lines.get(1));
-    assertEquals("1\tdoc2\t2\t2\t2\t2", lines.get(2));
-    assertEquals("2\tdoc3\t2\t2\t2\t2", lines.get(3));
-    assertEquals("3\tdoc4\t0\t0\t0\t0", lines.get(4));
+      List<String> lines = Files.readAllLines(Paths.get(randomFileName));
+      assertEquals(5, lines.size());
+      assertEquals("0\tdoc1\t8\t5\t8\t5", lines.get(1));
+      assertEquals("1\tdoc2\t2\t2\t2\t2", lines.get(2));
+      assertEquals("2\tdoc3\t2\t2\t2\t2", lines.get(3));
+      assertEquals("3\tdoc4\t0\t0\t0\t0", lines.get(4));
+    } finally {
+      Locale.setDefault(defaultLocale);
+    }
   }
 }

--- a/src/test/java/io/anserini/util/ExtractNormsTest.java
+++ b/src/test/java/io/anserini/util/ExtractNormsTest.java
@@ -66,17 +66,24 @@ public class ExtractNormsTest extends IndexerWithEmptyDocumentTestBase {
 
   @Test
   public void test() throws Exception {
-    // See: https://github.com/castorini/anserini/issues/903
-    Locale.setDefault(Locale.US);
-    redirectStdOut(); // redirecting to be quiet
-    ExtractNorms.main(new String[] {"-index", tempDir1.toString(), "-output", randomFileName});
-    restoreStdOut();
+    Locale defaultLocale = Locale.getDefault();
+    try {
+      Locale.setDefault(Locale.forLanguageTag("mzn-Arab-IR"));
+      redirectStdOut(); // redirecting to be quiet
+      try {
+        ExtractNorms.main(new String[] {"-index", tempDir1.toString(), "-output", randomFileName});
+      } finally {
+        restoreStdOut();
+      }
 
-    List<String> lines = Files.readAllLines(Paths.get(randomFileName));
-    assertEquals(5, lines.size());
-    assertEquals("0\t8", lines.get(1));
-    assertEquals("1\t2", lines.get(2));
-    assertEquals("2\t2", lines.get(3));
-    assertEquals("3\t0", lines.get(4));
+      List<String> lines = Files.readAllLines(Paths.get(randomFileName));
+      assertEquals(5, lines.size());
+      assertEquals("0\t8", lines.get(1));
+      assertEquals("1\t2", lines.get(2));
+      assertEquals("2\t2", lines.get(3));
+      assertEquals("3\t0", lines.get(4));
+    } finally {
+      Locale.setDefault(defaultLocale);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- use `Locale.ROOT` for TREC rows, generated document IDs, shard filenames, numeric TSV exports, test URLs, and generated documentation
- replace tests that forced `Locale.US` with regression coverage under `mzn-Arab-IR` and `de-DE`
- restore every temporary default-locale change in `finally`

## Testing

- `mvn -B clean package -Dslf4j.internal.verbosity=WARN` with Temurin 21 on Ubuntu: 1,162 tests passed
- targeted locale-related suite: 83 tests passed
- documentation generation: 12 tests passed under each locale, with identical SHA-256 hashes for all 780 generated files
- `git diff --check`

Fixes #3427